### PR TITLE
fix mobile visual regressions

### DIFF
--- a/apps/web/components/platform-v7/SupportHeaderIcon.tsx
+++ b/apps/web/components/platform-v7/SupportHeaderIcon.tsx
@@ -55,6 +55,7 @@ export function SupportHeaderIcon() {
         .pc-v4-main{padding-bottom:calc(env(safe-area-inset-bottom) + 98px)!important}
         @media(max-width:767px){
           .pc-v4-search{display:none!important}
+          .pc-v4-main{padding-bottom:calc(env(safe-area-inset-bottom) + 176px)!important}
           .pc-v4-header-inner{position:relative!important}
           .pc-v4-top{position:relative!important;width:100%!important;display:grid!important;grid-template-columns:52px 52px minmax(0,1fr)!important;gap:8px!important;align-items:center!important;min-height:44px!important}
           .pc-v4-top > button[aria-label='Открыть меню']{grid-column:1!important;justify-self:start!important;display:inline-flex!important;visibility:visible!important;opacity:1!important}
@@ -69,7 +70,7 @@ export function SupportHeaderIcon() {
           .p7-role-support.pc-v4-iconbtn{width:42px!important;min-width:42px!important;max-width:42px!important;height:42px!important;min-height:42px!important;border-radius:13px!important}
           .pc-v4-drawer{width:min(344px,84vw)!important;max-width:84vw!important;border-top-right-radius:24px!important;border-bottom-right-radius:24px!important;overflow:hidden!important}
           .pc-v4-drawer[data-open='true']{box-shadow:14px 0 34px rgba(15,23,42,.08)!important}
-          .pc-v7-role-dock{padding:7px 10px calc(env(safe-area-inset-bottom) + 7px)!important;background:color-mix(in srgb,var(--pc-bg-header) 98%,transparent)!important;backdrop-filter:blur(18px)!important;border-top:1px solid var(--pc-border)!important;box-shadow:0 -10px 28px rgba(3,8,7,.10)!important}
+          .pc-v7-role-dock{bottom:calc(env(safe-area-inset-bottom) + 72px)!important;padding:7px 10px calc(env(safe-area-inset-bottom) + 7px)!important;background:color-mix(in srgb,var(--pc-bg-header) 98%,transparent)!important;backdrop-filter:blur(18px)!important;border-top:1px solid var(--pc-border)!important;box-shadow:0 -10px 28px rgba(3,8,7,.10)!important}
         }
         @media(max-width:374px){.pc-v4-actions{right:6px!important;gap:5px!important;max-width:calc(100vw - 124px)!important}.p7-role-support.pc-v4-iconbtn,.pc-v4-actions button[aria-label='Идентификация и настройки']{width:40px!important;min-width:40px!important;max-width:40px!important;height:40px!important;min-height:40px!important}}
       ` }} />

--- a/apps/web/styles/platform-v7-entry-fix.css
+++ b/apps/web/styles/platform-v7-entry-fix.css
@@ -51,7 +51,10 @@ html body .pc-v7-entry-exact .entry-trust-chart i:nth-child(1){height:13px;opaci
 html body .pc-v4-header{display:block!important;position:fixed!important;inset:0 0 auto 0!important;z-index:520!important;opacity:1!important;visibility:visible!important}
 html body .pc-v4-bottomnav{display:none!important}
 html body .pc-v7-role-dock{display:block!important;position:fixed!important;left:0!important;right:0!important;bottom:0!important;z-index:500!important;opacity:1!important;visibility:visible!important}
+html body [data-platform-v7-seller-cockpit-pass='true'] > div:first-child{display:none!important}
 @media(max-width:767px){
+  html body .pc-v7-role-dock{bottom:calc(env(safe-area-inset-bottom) + 72px)!important}
+  html body .pc-v4-main{padding-bottom:calc(env(safe-area-inset-bottom) + 176px)!important}
   html body .pc-v4-search,html body .pc-v4-theme-toggle,html body .pc-v4-actions button[aria-label='Открыть уведомления']{display:none!important}
   html body .pc-v4-actions{overflow:visible!important}
   html body .p7-calc-widget{display:inline-flex!important;order:30!important;visibility:visible!important;opacity:1!important}

--- a/apps/web/styles/platform-v7-public-entry-stable.css
+++ b/apps/web/styles/platform-v7-public-entry-stable.css
@@ -31,15 +31,12 @@
   }
 
   .pc-v7-public-entry .entry-process-row {
-    display: flex !important;
-    grid-template-columns: none !important;
-    overflow-x: auto !important;
-    overflow-y: hidden !important;
-    gap: 10px !important;
-    padding-bottom: 8px !important;
-    scroll-snap-type: x mandatory !important;
-    -webkit-overflow-scrolling: touch !important;
-    scrollbar-width: none !important;
+    display: grid !important;
+    grid-template-columns: 1fr !important;
+    overflow: visible !important;
+    gap: 12px !important;
+    padding-bottom: 0 !important;
+    scroll-snap-type: none !important;
   }
 
   .pc-v7-public-entry .entry-process-row::-webkit-scrollbar {
@@ -47,17 +44,37 @@
   }
 
   .pc-v7-public-entry .entry-process-tile {
-    flex: 0 0 calc((100vw - 64px) / 3) !important;
-    width: calc((100vw - 64px) / 3) !important;
-    min-width: 104px !important;
-    max-width: 132px !important;
-    min-height: 176px !important;
-    padding: 14px 10px !important;
-    scroll-snap-align: start !important;
+    flex: none !important;
+    width: 100% !important;
+    min-width: 0 !important;
+    max-width: none !important;
+    min-height: auto !important;
+    display: grid !important;
+    grid-template-columns: auto auto minmax(0, 1fr) !important;
+    align-items: center !important;
+    justify-items: start !important;
+    text-align: left !important;
+    padding: 16px !important;
+    scroll-snap-align: none !important;
   }
 
   .pc-v7-public-entry .entry-process-tile:not(:last-child)::after {
     display: none !important;
+  }
+
+  .pc-v7-public-entry .entry-process-index {
+    grid-column: 1 !important;
+  }
+
+  .pc-v7-public-entry .entry-process-icon {
+    grid-column: 2 !important;
+  }
+
+  .pc-v7-public-entry .entry-process-tile strong,
+  .pc-v7-public-entry .entry-process-tile small {
+    grid-column: 3 !important;
+    max-width: 100% !important;
+    overflow-wrap: anywhere !important;
   }
 }
 
@@ -95,8 +112,7 @@
   }
 
   .pc-v7-public-entry .entry-process-tile {
-    flex-basis: calc((100vw - 52px) / 3) !important;
-    width: calc((100vw - 52px) / 3) !important;
-    min-width: 96px !important;
+    width: 100% !important;
+    min-width: 0 !important;
   }
 }

--- a/apps/web/tests/unit/platformV7FinalShellStaticGate.test.ts
+++ b/apps/web/tests/unit/platformV7FinalShellStaticGate.test.ts
@@ -9,6 +9,7 @@ const clientLayout = read('apps/web/components/platform-v7/PlatformV7LayoutClien
 const shellUx = read('apps/web/components/platform-v7/PlatformV7ShellUxController.tsx');
 const supportHeader = read('apps/web/components/platform-v7/SupportHeaderIcon.tsx');
 const entryFixCss = read('apps/web/styles/platform-v7-entry-fix.css');
+const publicEntryStableCss = read('apps/web/styles/platform-v7-public-entry-stable.css');
 const shellRoutes = read('apps/web/lib/platform-v7/shellRoutes.ts');
 const statusPage = read('apps/web/app/platform-v7/status/page.tsx');
 
@@ -44,6 +45,13 @@ describe('platform-v7 final shell static gate', () => {
     expect(shellUx).toContain('.pc-v7-role-dock{position:fixed;left:0;right:0;bottom:0;');
   });
 
+  it('keeps mobile role dock above mobile browser chrome', () => {
+    expect(entryFixCss).toContain('.pc-v7-role-dock{bottom:calc(env(safe-area-inset-bottom) + 72px)!important');
+    expect(supportHeader).toContain('.pc-v7-role-dock{bottom:calc(env(safe-area-inset-bottom) + 72px)!important');
+    expect(entryFixCss).toContain('.pc-v4-main{padding-bottom:calc(env(safe-area-inset-bottom) + 176px)!important}');
+    expect(supportHeader).toContain('.pc-v4-main{padding-bottom:calc(env(safe-area-inset-bottom) + 176px)!important}');
+  });
+
   it('keeps utility actions out of the lower role dock', () => {
     const dock = roleDockBlock();
     expect(dock).toContain('dockLinks.map');
@@ -71,6 +79,18 @@ describe('platform-v7 final shell static gate', () => {
     expect(entryFixCss).toContain('order:30!important');
     expect(entryFixCss).toContain('.p7-calc-widget .pc-v4-iconbtn{display:inline-flex!important');
     expect(supportHeader).not.toContain('.p7-calc-widget{display:none');
+  });
+
+  it('keeps public process cards readable instead of clipped horizontal cards', () => {
+    expect(publicEntryStableCss).toContain('.pc-v7-public-entry .entry-process-row {');
+    expect(publicEntryStableCss).toContain('grid-template-columns: 1fr !important');
+    expect(publicEntryStableCss).toContain('overflow: visible !important');
+    expect(publicEntryStableCss).not.toContain('overflow-x: auto !important');
+    expect(publicEntryStableCss).not.toContain('flex: 0 0 calc');
+  });
+
+  it('keeps seller cockpit from showing the legacy API status banner above the hero', () => {
+    expect(entryFixCss).toContain("[data-platform-v7-seller-cockpit-pass='true'] > div:first-child{display:none!important}");
   });
 
   it('keeps header help on an existing shared route', () => {

--- a/docs/platform-v7/audits/mobile-visual-regression-fix-2026-06-19.md
+++ b/docs/platform-v7/audits/mobile-visual-regression-fix-2026-06-19.md
@@ -1,0 +1,13 @@
+# Mobile visual regression fix — 2026-06-19
+
+Scope: platform-v7 mobile shell and public entry readability.
+
+Fixed:
+
+- public entry process cards no longer render as clipped 3-card horizontal strips on mobile;
+- process cards are full-width stacked cards on mobile;
+- protected role dock is lifted above mobile browser bottom chrome;
+- protected content gets additional bottom padding so the dock does not cover content;
+- seller cockpit hides the legacy API status banner above the main hero.
+
+Maturity remains controlled-pilot / pre-integration. No API, DB, live integration, banking or landing changes.


### PR DESCRIPTION
Fixes the issues shown in the latest mobile screenshots.

Changed:
- public entry process cards no longer render as clipped horizontal cards on mobile
- role dock is lifted above mobile browser bottom chrome
- protected content gets extra bottom padding
- seller cockpit hides the legacy API status banner above the hero
- static gate added for these regressions

No API, DB, live integration, banking or landing changes.