### PR TITLE
VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation

### DIFF
--- a/apps/web/lib/platform-v7/deal-workspace-runtime-db-repository.ts
+++ b/apps/web/lib/platform-v7/deal-workspace-runtime-db-repository.ts
@@ -5,7 +5,11 @@ import {
 } from './deal-workspace-runtime-db-contract';
 
 export type P7DealWorkspaceRuntimeRepositoryMaturity = 'repository-contract-adapter';
-export type P7DealWorkspaceRuntimeRepositoryReceiptStatus = 'persisted' | 'duplicate';
+export type P7DealWorkspaceRuntimeRepositoryReceiptStatus = 'persisted' | 'duplicate' | 'promoted' | 'conflict';
+export type P7DealWorkspaceRuntimeRepositoryConflictCode =
+  | 'IDEMPOTENCY_CONTRACT_MISMATCH'
+  | 'OUTBOX_LINKAGE_CONFLICT'
+  | 'AUDIT_LINKAGE_CONFLICT';
 
 export interface P7DealWorkspaceRuntimeRepositoryLinkage {
   readonly outboxEntryId?: string | null;
@@ -22,6 +26,8 @@ export interface P7DealWorkspaceRuntimeRepositoryReceipt {
   readonly auditEventId: string | null;
   readonly status: P7DealWorkspaceRuntimeRepositoryReceiptStatus;
   readonly maturity: P7DealWorkspaceRuntimeRepositoryMaturity;
+  readonly conflictCode?: P7DealWorkspaceRuntimeRepositoryConflictCode;
+  readonly conflictReason?: string;
 }
 
 export interface P7DealWorkspaceRuntimeRepositoryRecord extends P7DealWorkspaceRuntimeRepositoryReceipt {
@@ -35,7 +41,10 @@ export interface P7DealWorkspaceRuntimeRepositoryWriteInput {
 }
 
 export interface P7DealWorkspaceRuntimeRepository {
+  /** Backward-compatible duplicate-safe write used by the current action pipeline. */
   write(input: P7DealWorkspaceRuntimeRepositoryWriteInput): P7DealWorkspaceRuntimeRepositoryReceipt;
+  /** Strict write for transaction/idempotency hardening and monotonic linkage promotion. */
+  writeHardened(input: P7DealWorkspaceRuntimeRepositoryWriteInput): P7DealWorkspaceRuntimeRepositoryReceipt;
   findByIdempotencyKey(idempotencyKey: string): P7DealWorkspaceRuntimeRepositoryReceipt | null;
   list(): readonly P7DealWorkspaceRuntimeRepositoryRecord[];
 }
@@ -44,6 +53,13 @@ interface RepositoryState {
   readonly records: P7DealWorkspaceRuntimeRepositoryRecord[];
   readonly byIdempotencyKey: Map<string, P7DealWorkspaceRuntimeRepositoryRecord>;
 }
+
+const STATE_RANK: Record<P7DealWorkspaceRuntimeDbWriteState, number> = {
+  ready_to_persist: 0,
+  outbox_required: 1,
+  audit_required: 2,
+  fully_linked: 3,
+};
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -57,7 +73,11 @@ function buildRecordId(contract: P7DealWorkspaceRuntimeDbContract): string {
   return `p7-runtime-db:${safePart(contract.runtimeSnapshotId)}`;
 }
 
-function toReceipt(record: P7DealWorkspaceRuntimeRepositoryRecord, status: P7DealWorkspaceRuntimeRepositoryReceiptStatus): P7DealWorkspaceRuntimeRepositoryReceipt {
+function toReceipt(
+  record: P7DealWorkspaceRuntimeRepositoryRecord,
+  status: P7DealWorkspaceRuntimeRepositoryReceiptStatus,
+  conflict?: { readonly code: P7DealWorkspaceRuntimeRepositoryConflictCode; readonly reason: string },
+): P7DealWorkspaceRuntimeRepositoryReceipt {
   return {
     recordId: record.recordId,
     runtimeSnapshotId: record.runtimeSnapshotId,
@@ -68,7 +88,56 @@ function toReceipt(record: P7DealWorkspaceRuntimeRepositoryRecord, status: P7Dea
     auditEventId: record.auditEventId,
     status,
     maturity: record.maturity,
+    conflictCode: conflict?.code,
+    conflictReason: conflict?.reason,
   };
+}
+
+function materialContractFingerprint(contract: P7DealWorkspaceRuntimeDbContract): string {
+  return JSON.stringify({
+    runtimeSnapshotId: contract.runtimeSnapshotId,
+    dealId: contract.dealId,
+    intentId: contract.intentId,
+    runtimeStoreRecordId: contract.runtimeStoreRecordId,
+    runtimeStoreVersion: contract.runtimeStoreVersion,
+    outboxType: contract.outboxType,
+    auditAction: contract.auditAction,
+    actorId: contract.actorId,
+    actorRole: contract.actorRole,
+    correlationId: contract.correlationId,
+    auditId: contract.auditId,
+    idempotencyKey: contract.idempotencyKey,
+    snapshot: contract.payload.snapshot,
+  });
+}
+
+function sameMaterialContract(
+  existing: P7DealWorkspaceRuntimeDbContract,
+  incoming: P7DealWorkspaceRuntimeDbContract,
+): boolean {
+  return materialContractFingerprint(existing) === materialContractFingerprint(incoming);
+}
+
+function linkageConflict(
+  existing: P7DealWorkspaceRuntimeRepositoryRecord,
+  incoming: P7DealWorkspaceRuntimeRepositoryLinkage,
+): { readonly code: P7DealWorkspaceRuntimeRepositoryConflictCode; readonly reason: string } | null {
+  const incomingOutbox = incoming.outboxEntryId ?? null;
+  const incomingAudit = incoming.auditEventId ?? null;
+
+  if (existing.outboxEntryId && incomingOutbox && existing.outboxEntryId !== incomingOutbox) {
+    return {
+      code: 'OUTBOX_LINKAGE_CONFLICT',
+      reason: 'Existing outbox linkage cannot be replaced by another entry id.',
+    };
+  }
+  if (existing.auditEventId && incomingAudit && existing.auditEventId !== incomingAudit) {
+    return {
+      code: 'AUDIT_LINKAGE_CONFLICT',
+      reason: 'Existing audit linkage cannot be replaced by another event id.',
+    };
+  }
+  return null;
 }
 
 export function buildP7DealWorkspaceRuntimeRepositoryReceipt(input: P7DealWorkspaceRuntimeRepositoryWriteInput): P7DealWorkspaceRuntimeRepositoryReceipt {
@@ -90,6 +159,61 @@ export function buildP7DealWorkspaceRuntimeRepositoryReceipt(input: P7DealWorksp
   };
 }
 
+function persistNewRecord(
+  state: RepositoryState,
+  input: P7DealWorkspaceRuntimeRepositoryWriteInput,
+): P7DealWorkspaceRuntimeRepositoryReceipt {
+  const receipt = buildP7DealWorkspaceRuntimeRepositoryReceipt(input);
+  const record: P7DealWorkspaceRuntimeRepositoryRecord = {
+    ...receipt,
+    status: 'persisted',
+    contract: input.contract,
+  };
+
+  state.records.push(record);
+  state.byIdempotencyKey.set(input.contract.idempotencyKey, record);
+  return toReceipt(record, 'persisted');
+}
+
+function promoteExistingRecord(
+  state: RepositoryState,
+  existing: P7DealWorkspaceRuntimeRepositoryRecord,
+  input: P7DealWorkspaceRuntimeRepositoryWriteInput,
+): P7DealWorkspaceRuntimeRepositoryReceipt {
+  if (!sameMaterialContract(existing.contract, input.contract)) {
+    return toReceipt(existing, 'conflict', {
+      code: 'IDEMPOTENCY_CONTRACT_MISMATCH',
+      reason: 'The idempotency key is already bound to another runtime snapshot or material contract.',
+    });
+  }
+
+  const incomingLinkage = input.linkage ?? {};
+  const conflict = linkageConflict(existing, incomingLinkage);
+  if (conflict) return toReceipt(existing, 'conflict', conflict);
+
+  const mergedLinkage: P7DealWorkspaceRuntimeRepositoryLinkage = {
+    outboxEntryId: existing.outboxEntryId ?? incomingLinkage.outboxEntryId ?? null,
+    auditEventId: existing.auditEventId ?? incomingLinkage.auditEventId ?? null,
+  };
+  const nextState = p7RuntimeDbContractNextState(existing.contract, mergedLinkage);
+
+  if (STATE_RANK[nextState] <= STATE_RANK[existing.state]) {
+    return toReceipt(existing, 'duplicate');
+  }
+
+  const promoted: P7DealWorkspaceRuntimeRepositoryRecord = {
+    ...existing,
+    state: nextState,
+    outboxEntryId: mergedLinkage.outboxEntryId ?? null,
+    auditEventId: mergedLinkage.auditEventId ?? null,
+    status: 'persisted',
+  };
+  const index = state.records.findIndex((record) => record.recordId === existing.recordId);
+  if (index >= 0) state.records[index] = promoted;
+  state.byIdempotencyKey.set(existing.idempotencyKey, promoted);
+  return toReceipt(promoted, 'promoted');
+}
+
 export function createP7DealWorkspaceRuntimeRepository(): P7DealWorkspaceRuntimeRepository {
   const state: RepositoryState = {
     records: [],
@@ -100,18 +224,13 @@ export function createP7DealWorkspaceRuntimeRepository(): P7DealWorkspaceRuntime
     write(input) {
       const duplicate = state.byIdempotencyKey.get(input.contract.idempotencyKey);
       if (duplicate) return toReceipt(duplicate, 'duplicate');
+      return persistNewRecord(state, input);
+    },
 
-      const receipt = buildP7DealWorkspaceRuntimeRepositoryReceipt(input);
-      const record: P7DealWorkspaceRuntimeRepositoryRecord = {
-        ...receipt,
-        status: 'persisted',
-        contract: input.contract,
-      };
-
-      state.records.push(record);
-      state.byIdempotencyKey.set(input.contract.idempotencyKey, record);
-
-      return toReceipt(record, 'persisted');
+    writeHardened(input) {
+      const existing = state.byIdempotencyKey.get(input.contract.idempotencyKey);
+      if (!existing) return persistNewRecord(state, input);
+      return promoteExistingRecord(state, existing, input);
     },
 
     findByIdempotencyKey(idempotencyKey) {

--- a/apps/web/lib/platform-v7/deal-workspace-runtime-linkage.ts
+++ b/apps/web/lib/platform-v7/deal-workspace-runtime-linkage.ts
@@ -138,6 +138,12 @@ export function buildP7DealWorkspaceRuntimeLinkage(
   };
 }
 
+export function isP7DealWorkspaceRuntimeLinkageValid(
+  result: P7DealWorkspaceRuntimeLinkageResult,
+): boolean {
+  return result.issues.length === 0;
+}
+
 export function writeP7DealWorkspaceRuntimeWithLinkage(
   input: P7DealWorkspaceRuntimeLinkedRepositoryWriteInput,
 ): P7DealWorkspaceRuntimeLinkedRepositoryWriteResult {

--- a/apps/web/lib/platform-v7/deal-workspace-runtime-transaction.ts
+++ b/apps/web/lib/platform-v7/deal-workspace-runtime-transaction.ts
@@ -1,0 +1,199 @@
+import type { P7RuntimeTransactionContext } from './runtime/persistence-ports';
+import type { P7DealWorkspaceRuntimeDbContract } from './deal-workspace-runtime-db-contract';
+import type {
+  P7DealWorkspaceRuntimeRepository,
+  P7DealWorkspaceRuntimeRepositoryReceipt,
+} from './deal-workspace-runtime-db-repository';
+import {
+  isP7DealWorkspaceRuntimeLinkageValid,
+  type P7DealWorkspaceRuntimeLinkageResult,
+} from './deal-workspace-runtime-linkage';
+
+export type P7DealWorkspaceRuntimeTransactionMaturity = 'contract-transaction-coordinator';
+export type P7DealWorkspaceRuntimeTransactionStage =
+  | 'created'
+  | 'prepared'
+  | 'committed'
+  | 'rolled_back'
+  | 'failed';
+export type P7DealWorkspaceRuntimeTransactionFailureCode =
+  | 'INVALID_LINKAGE'
+  | 'TRANSACTION_CONTEXT_MISMATCH'
+  | 'INVALID_STAGE'
+  | 'REPOSITORY_CONFLICT'
+  | 'COMMIT_ERROR';
+
+export interface P7DealWorkspaceRuntimeTransactionFailure {
+  readonly code: P7DealWorkspaceRuntimeTransactionFailureCode;
+  readonly message: string;
+}
+
+export interface P7DealWorkspaceRuntimeTransactionResult {
+  readonly transaction: P7RuntimeTransactionContext;
+  readonly stage: P7DealWorkspaceRuntimeTransactionStage;
+  readonly replay: boolean;
+  readonly maturity: P7DealWorkspaceRuntimeTransactionMaturity;
+  readonly repositoryReceipt?: P7DealWorkspaceRuntimeRepositoryReceipt;
+  readonly failure?: P7DealWorkspaceRuntimeTransactionFailure;
+  readonly rollbackReason?: string;
+}
+
+export interface P7DealWorkspaceRuntimeTransactionInput {
+  readonly repository: P7DealWorkspaceRuntimeRepository;
+  readonly contract: P7DealWorkspaceRuntimeDbContract;
+  readonly linkageResult: P7DealWorkspaceRuntimeLinkageResult;
+  readonly transaction: P7RuntimeTransactionContext;
+  readonly savedAt?: string;
+  readonly beforeCommit?: () => void;
+}
+
+export interface P7DealWorkspaceRuntimeTransaction {
+  readonly transaction: P7RuntimeTransactionContext;
+  current(): P7DealWorkspaceRuntimeTransactionResult;
+  prepare(): P7DealWorkspaceRuntimeTransactionResult;
+  commit(): P7DealWorkspaceRuntimeTransactionResult;
+  rollback(reason: string): P7DealWorkspaceRuntimeTransactionResult;
+}
+
+function baseResult(
+  transaction: P7RuntimeTransactionContext,
+  stage: P7DealWorkspaceRuntimeTransactionStage,
+  replay = false,
+): P7DealWorkspaceRuntimeTransactionResult {
+  return {
+    transaction,
+    stage,
+    replay,
+    maturity: 'contract-transaction-coordinator',
+  };
+}
+
+function failedResult(
+  transaction: P7RuntimeTransactionContext,
+  code: P7DealWorkspaceRuntimeTransactionFailureCode,
+  message: string,
+): P7DealWorkspaceRuntimeTransactionResult {
+  return {
+    ...baseResult(transaction, 'failed'),
+    failure: { code, message },
+  };
+}
+
+function transactionContextMatchesContract(input: P7DealWorkspaceRuntimeTransactionInput): boolean {
+  const { transaction, contract } = input;
+  if (transaction.correlationId !== contract.correlationId) return false;
+  if (transaction.auditId && transaction.auditId !== contract.auditId) return false;
+  if (transaction.actorId && transaction.actorId !== contract.actorId) return false;
+  return true;
+}
+
+export function createP7DealWorkspaceRuntimeTransaction(
+  input: P7DealWorkspaceRuntimeTransactionInput,
+): P7DealWorkspaceRuntimeTransaction {
+  let currentResult: P7DealWorkspaceRuntimeTransactionResult = baseResult(input.transaction, 'created');
+
+  function replayCurrent(): P7DealWorkspaceRuntimeTransactionResult {
+    return { ...currentResult, replay: true };
+  }
+
+  return {
+    transaction: input.transaction,
+
+    current() {
+      return { ...currentResult };
+    },
+
+    prepare() {
+      if (currentResult.stage === 'prepared' || currentResult.stage === 'committed') {
+        return replayCurrent();
+      }
+      if (currentResult.stage === 'rolled_back' || currentResult.stage === 'failed') {
+        return replayCurrent();
+      }
+      if (!transactionContextMatchesContract(input)) {
+        currentResult = failedResult(
+          input.transaction,
+          'TRANSACTION_CONTEXT_MISMATCH',
+          'Transaction correlation, audit or actor identity does not match the runtime DB contract.',
+        );
+        return currentResult;
+      }
+      if (!isP7DealWorkspaceRuntimeLinkageValid(input.linkageResult)) {
+        currentResult = failedResult(
+          input.transaction,
+          'INVALID_LINKAGE',
+          'Runtime linkage evidence failed validation and cannot be prepared for commit.',
+        );
+        return currentResult;
+      }
+
+      currentResult = baseResult(input.transaction, 'prepared');
+      return currentResult;
+    },
+
+    commit() {
+      if (currentResult.stage === 'committed') return replayCurrent();
+      if (currentResult.stage !== 'prepared') {
+        if (currentResult.stage === 'rolled_back' || currentResult.stage === 'failed') return replayCurrent();
+        currentResult = failedResult(
+          input.transaction,
+          'INVALID_STAGE',
+          'Transaction must be prepared before commit.',
+        );
+        return currentResult;
+      }
+
+      try {
+        input.beforeCommit?.();
+        const repositoryReceipt = input.repository.writeHardened({
+          contract: input.contract,
+          linkage: input.linkageResult.linkage,
+          savedAt: input.savedAt,
+        });
+
+        if (repositoryReceipt.status === 'conflict') {
+          currentResult = {
+            ...failedResult(
+              input.transaction,
+              'REPOSITORY_CONFLICT',
+              repositoryReceipt.conflictReason ?? 'Repository rejected the idempotent write as a conflict.',
+            ),
+            repositoryReceipt,
+          };
+          return currentResult;
+        }
+
+        currentResult = {
+          ...baseResult(input.transaction, 'committed'),
+          repositoryReceipt,
+        };
+        return currentResult;
+      } catch (error) {
+        currentResult = failedResult(
+          input.transaction,
+          'COMMIT_ERROR',
+          error instanceof Error ? error.message : 'Unknown contract-level commit error.',
+        );
+        return currentResult;
+      }
+    },
+
+    rollback(reason) {
+      if (currentResult.stage === 'committed') {
+        currentResult = failedResult(
+          input.transaction,
+          'INVALID_STAGE',
+          'A committed contract-level transaction cannot be rolled back by this coordinator.',
+        );
+        return currentResult;
+      }
+      if (currentResult.stage === 'rolled_back' || currentResult.stage === 'failed') return replayCurrent();
+
+      currentResult = {
+        ...baseResult(input.transaction, 'rolled_back'),
+        rollbackReason: reason,
+      };
+      return currentResult;
+    },
+  };
+}

--- a/apps/web/tests/unit/platformV7DealWorkspaceRuntimeLinkage.test.ts
+++ b/apps/web/tests/unit/platformV7DealWorkspaceRuntimeLinkage.test.ts
@@ -3,6 +3,7 @@ import { buildP7DealWorkspaceRuntimeDbContract } from '@/lib/platform-v7/deal-wo
 import { createP7DealWorkspaceRuntimeRepository } from '@/lib/platform-v7/deal-workspace-runtime-db-repository';
 import {
   buildP7DealWorkspaceRuntimeLinkage,
+  isP7DealWorkspaceRuntimeLinkageValid,
   writeP7DealWorkspaceRuntimeWithLinkage,
 } from '@/lib/platform-v7/deal-workspace-runtime-linkage';
 import { buildP7DealWorkspaceRuntimeRefreshSnapshot } from '@/lib/platform-v7/deal-workspace-runtime-snapshot';
@@ -63,7 +64,7 @@ function auditEvidence() {
   };
 }
 
-describe('VP-3.21 runtime outbox audit linkage boundary', () => {
+describe('VP-3 runtime outbox audit linkage boundary', () => {
   it('keeps the contract outbox_required when no explicit evidence exists', () => {
     const result = buildP7DealWorkspaceRuntimeLinkage({ contract: contract() });
 
@@ -73,6 +74,7 @@ describe('VP-3.21 runtime outbox audit linkage boundary', () => {
     expect(result.acceptedOutboxEvidence).toBe(false);
     expect(result.acceptedAuditEvidence).toBe(false);
     expect(result.maturity).toBe('contract-linkage');
+    expect(isP7DealWorkspaceRuntimeLinkageValid(result)).toBe(true);
   });
 
   it('moves to audit_required only after valid outbox evidence is explicit', () => {
@@ -87,6 +89,7 @@ describe('VP-3.21 runtime outbox audit linkage boundary', () => {
     expect(result.acceptedOutboxEvidence).toBe(true);
     expect(result.acceptedAuditEvidence).toBe(false);
     expect(result.issues).toEqual([]);
+    expect(isP7DealWorkspaceRuntimeLinkageValid(result)).toBe(true);
   });
 
   it('allows fully_linked only when both matching outbox and audit evidence exist', () => {
@@ -102,6 +105,7 @@ describe('VP-3.21 runtime outbox audit linkage boundary', () => {
     expect(result.acceptedOutboxEvidence).toBe(true);
     expect(result.acceptedAuditEvidence).toBe(true);
     expect(result.issues).toEqual([]);
+    expect(isP7DealWorkspaceRuntimeLinkageValid(result)).toBe(true);
   });
 
   it('rejects mismatched evidence and never manufactures fully_linked state', () => {
@@ -120,6 +124,7 @@ describe('VP-3.21 runtime outbox audit linkage boundary', () => {
       'OUTBOX_IDEMPOTENCY_MISMATCH',
       'AUDIT_ACTOR_MISMATCH',
     ]);
+    expect(isP7DealWorkspaceRuntimeLinkageValid(result)).toBe(false);
   });
 
   it('writes only linkage ids accepted by the validation boundary', () => {
@@ -139,7 +144,7 @@ describe('VP-3.21 runtime outbox audit linkage boundary', () => {
     expect(repository.list()).toHaveLength(1);
   });
 
-  it('writes a blocked linkage state when supplied evidence fails validation', () => {
+  it('writes a blocked linkage state when supplied evidence fails validation on the legacy path', () => {
     const repository = createP7DealWorkspaceRuntimeRepository();
     const result = writeP7DealWorkspaceRuntimeWithLinkage({
       repository,

--- a/apps/web/tests/unit/platformV7DealWorkspaceRuntimeRepositoryAdapter.test.ts
+++ b/apps/web/tests/unit/platformV7DealWorkspaceRuntimeRepositoryAdapter.test.ts
@@ -42,7 +42,7 @@ function contract(idempotencyKey = 'idem-repo-1', dealId = 'DL-REPO-1') {
   });
 }
 
-describe('VP-3.13 runtime persistence repository adapter', () => {
+describe('VP-3 runtime persistence repository adapter', () => {
   it('builds a typed receipt from the DB contract without claiming live DB persistence', () => {
     const dbContract = contract('idem-receipt-1', 'DL-REPO-RECEIPT');
 
@@ -77,7 +77,7 @@ describe('VP-3.13 runtime persistence repository adapter', () => {
     }).state).toBe('outbox_required');
   });
 
-  it('treats duplicate idempotency keys as duplicate-safe reads without a second evidence write', () => {
+  it('keeps the backward-compatible write path duplicate-safe without replacing evidence', () => {
     const repository = createP7DealWorkspaceRuntimeRepository();
     const dbContract = contract('idem-duplicate-1', 'DL-REPO-DUP');
 
@@ -97,6 +97,89 @@ describe('VP-3.13 runtime persistence repository adapter', () => {
     expect(duplicate.recordId).toBe(first.recordId);
     expect(duplicate.outboxEntryId).toBe('outbox-1');
     expect(duplicate.auditEventId).toBe('audit-event-1');
+    expect(repository.list()).toHaveLength(1);
+  });
+
+  it('monotonically promotes one hardened record without changing identity or creation time', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const dbContract = contract('idem-promote-1', 'DL-REPO-PROMOTE');
+
+    const first = repository.writeHardened({
+      contract: dbContract,
+      savedAt: '2026-07-09T12:10:00.000Z',
+    });
+    const outboxLinked = repository.writeHardened({
+      contract: dbContract,
+      linkage: { outboxEntryId: 'outbox-promote-1' },
+      savedAt: '2026-07-09T12:11:00.000Z',
+    });
+    const fullyLinked = repository.writeHardened({
+      contract: dbContract,
+      linkage: { outboxEntryId: 'outbox-promote-1', auditEventId: 'audit-promote-1' },
+      savedAt: '2026-07-09T12:12:00.000Z',
+    });
+
+    expect(first.status).toBe('persisted');
+    expect(first.state).toBe('outbox_required');
+    expect(outboxLinked.status).toBe('promoted');
+    expect(outboxLinked.state).toBe('audit_required');
+    expect(fullyLinked.status).toBe('promoted');
+    expect(fullyLinked.state).toBe('fully_linked');
+    expect(outboxLinked.recordId).toBe(first.recordId);
+    expect(fullyLinked.recordId).toBe(first.recordId);
+    expect(outboxLinked.savedAt).toBe(first.savedAt);
+    expect(fullyLinked.savedAt).toBe(first.savedAt);
+    expect(repository.list()).toHaveLength(1);
+  });
+
+  it('never regresses a hardened record when replay has weaker linkage', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const dbContract = contract('idem-no-regress-1', 'DL-REPO-NO-REGRESS');
+
+    repository.writeHardened({
+      contract: dbContract,
+      linkage: { outboxEntryId: 'outbox-stable-1', auditEventId: 'audit-stable-1' },
+    });
+    const replay = repository.writeHardened({ contract: dbContract });
+
+    expect(replay.status).toBe('duplicate');
+    expect(replay.state).toBe('fully_linked');
+    expect(replay.outboxEntryId).toBe('outbox-stable-1');
+    expect(replay.auditEventId).toBe('audit-stable-1');
+    expect(repository.list()).toHaveLength(1);
+  });
+
+  it('returns conflict when one idempotency key is reused for another runtime snapshot', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const firstContract = contract('idem-conflict-1', 'DL-REPO-CONFLICT-A');
+    const conflictingContract = contract('idem-conflict-1', 'DL-REPO-CONFLICT-B');
+
+    const first = repository.writeHardened({ contract: firstContract });
+    const conflict = repository.writeHardened({ contract: conflictingContract });
+
+    expect(first.status).toBe('persisted');
+    expect(conflict.status).toBe('conflict');
+    expect(conflict.conflictCode).toBe('IDEMPOTENCY_CONTRACT_MISMATCH');
+    expect(conflict.recordId).toBe(first.recordId);
+    expect(repository.list()).toHaveLength(1);
+  });
+
+  it('rejects replacement of an already accepted linkage id', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const dbContract = contract('idem-link-conflict-1', 'DL-REPO-LINK-CONFLICT');
+
+    repository.writeHardened({
+      contract: dbContract,
+      linkage: { outboxEntryId: 'outbox-original' },
+    });
+    const conflict = repository.writeHardened({
+      contract: dbContract,
+      linkage: { outboxEntryId: 'outbox-replacement' },
+    });
+
+    expect(conflict.status).toBe('conflict');
+    expect(conflict.conflictCode).toBe('OUTBOX_LINKAGE_CONFLICT');
+    expect(conflict.outboxEntryId).toBe('outbox-original');
     expect(repository.list()).toHaveLength(1);
   });
 

--- a/apps/web/tests/unit/platformV7DealWorkspaceRuntimeTransaction.test.ts
+++ b/apps/web/tests/unit/platformV7DealWorkspaceRuntimeTransaction.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest';
+import { buildP7DealWorkspaceRuntimeDbContract } from '@/lib/platform-v7/deal-workspace-runtime-db-contract';
+import { createP7DealWorkspaceRuntimeRepository } from '@/lib/platform-v7/deal-workspace-runtime-db-repository';
+import { buildP7DealWorkspaceRuntimeLinkage } from '@/lib/platform-v7/deal-workspace-runtime-linkage';
+import { buildP7DealWorkspaceRuntimeRefreshSnapshot } from '@/lib/platform-v7/deal-workspace-runtime-snapshot';
+import type { P7DealWorkspaceRuntimeStoreReceipt } from '@/lib/platform-v7/deal-workspace-runtime-store';
+import { createP7DealWorkspaceRuntimeTransaction } from '@/lib/platform-v7/deal-workspace-runtime-transaction';
+
+function runtimeStoreReceipt(dealId: string): P7DealWorkspaceRuntimeStoreReceipt {
+  return {
+    recordId: `${dealId}:start_document_review:p7-runtime-store-v1`,
+    dealId,
+    intentId: 'start_document_review',
+    version: 'p7-runtime-store-v1',
+    savedAt: '2026-07-10T05:00:00.000Z',
+    maturity: 'manual-process-runtime-store',
+    historyCount: 1,
+  };
+}
+
+function contract(dealId = 'DL-TX-1', idempotencyKey = 'idem-tx-1') {
+  return buildP7DealWorkspaceRuntimeDbContract({
+    snapshot: buildP7DealWorkspaceRuntimeRefreshSnapshot({
+      dealId,
+      intentId: 'start_document_review',
+      ok: true,
+      status: 'success',
+      duplicate: false,
+      auditPayloadCount: 1,
+      boundaryStatus: 'allowed',
+    }),
+    receipt: runtimeStoreReceipt(dealId),
+    actorId: 'operator-tx-1',
+    actorRole: 'operator',
+    correlationId: `corr-${dealId}`,
+    auditId: `audit-${dealId}`,
+    idempotencyKey,
+    createdAt: '2026-07-10T05:00:00.000Z',
+  });
+}
+
+function outboxEvidence(dbContract = contract()) {
+  return {
+    entryId: 'outbox-tx-1',
+    eventType: dbContract.outboxType,
+    correlationId: dbContract.correlationId,
+    idempotencyKey: dbContract.idempotencyKey,
+    createdAt: '2026-07-10T05:00:01.000Z',
+  };
+}
+
+function auditEvidence(dbContract = contract()) {
+  return {
+    eventId: 'audit-event-tx-1',
+    action: dbContract.auditAction,
+    correlationId: dbContract.correlationId,
+    actorId: dbContract.actorId,
+    createdAt: '2026-07-10T05:00:02.000Z',
+  };
+}
+
+function transactionContext(dbContract = contract(), transactionId = 'tx-1') {
+  return {
+    transactionId,
+    startedAt: '2026-07-10T05:00:00.000Z',
+    correlationId: dbContract.correlationId,
+    auditId: dbContract.auditId,
+    actorId: dbContract.actorId,
+  };
+}
+
+describe('VP-3.29 runtime persistence transaction coordinator', () => {
+  it('requires prepare before commit and commits one hardened repository write', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const dbContract = contract();
+    const linkageResult = buildP7DealWorkspaceRuntimeLinkage({ contract: dbContract });
+    const transaction = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: dbContract,
+      linkageResult,
+      transaction: transactionContext(dbContract),
+      savedAt: '2026-07-10T05:00:03.000Z',
+    });
+
+    expect(transaction.current().stage).toBe('created');
+    expect(transaction.prepare().stage).toBe('prepared');
+    const committed = transaction.commit();
+
+    expect(committed.stage).toBe('committed');
+    expect(committed.repositoryReceipt?.status).toBe('persisted');
+    expect(committed.repositoryReceipt?.state).toBe('outbox_required');
+    expect(committed.maturity).toBe('contract-transaction-coordinator');
+    expect(repository.list()).toHaveLength(1);
+  });
+
+  it('replays a committed transaction deterministically without a second write', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const dbContract = contract('DL-TX-REPLAY', 'idem-tx-replay');
+    const transaction = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: dbContract,
+      linkageResult: buildP7DealWorkspaceRuntimeLinkage({ contract: dbContract }),
+      transaction: transactionContext(dbContract, 'tx-replay'),
+    });
+
+    transaction.prepare();
+    const firstCommit = transaction.commit();
+    const replay = transaction.commit();
+
+    expect(firstCommit.stage).toBe('committed');
+    expect(replay.stage).toBe('committed');
+    expect(replay.replay).toBe(true);
+    expect(replay.repositoryReceipt?.recordId).toBe(firstCommit.repositoryReceipt?.recordId);
+    expect(repository.list()).toHaveLength(1);
+  });
+
+  it('rolls back before commit without exposing a repository record', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const dbContract = contract('DL-TX-ROLLBACK', 'idem-tx-rollback');
+    const transaction = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: dbContract,
+      linkageResult: buildP7DealWorkspaceRuntimeLinkage({ contract: dbContract }),
+      transaction: transactionContext(dbContract, 'tx-rollback'),
+    });
+
+    transaction.prepare();
+    const rolledBack = transaction.rollback('operator cancelled before commit');
+    const commitAfterRollback = transaction.commit();
+
+    expect(rolledBack.stage).toBe('rolled_back');
+    expect(rolledBack.rollbackReason).toBe('operator cancelled before commit');
+    expect(commitAfterRollback.stage).toBe('rolled_back');
+    expect(commitAfterRollback.replay).toBe(true);
+    expect(commitAfterRollback.repositoryReceipt).toBeUndefined();
+    expect(repository.list()).toHaveLength(0);
+  });
+
+  it('fails preparation for invalid linkage and performs no write', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const dbContract = contract('DL-TX-INVALID', 'idem-tx-invalid');
+    const invalidLinkage = buildP7DealWorkspaceRuntimeLinkage({
+      contract: dbContract,
+      outbox: { ...outboxEvidence(dbContract), correlationId: 'wrong-correlation' },
+    });
+    const transaction = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: dbContract,
+      linkageResult: invalidLinkage,
+      transaction: transactionContext(dbContract, 'tx-invalid'),
+    });
+
+    const prepared = transaction.prepare();
+    const commit = transaction.commit();
+
+    expect(prepared.stage).toBe('failed');
+    expect(prepared.failure?.code).toBe('INVALID_LINKAGE');
+    expect(commit.stage).toBe('failed');
+    expect(commit.repositoryReceipt).toBeUndefined();
+    expect(repository.list()).toHaveLength(0);
+  });
+
+  it('does not commit when transaction identity differs from the contract', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const dbContract = contract('DL-TX-CONTEXT', 'idem-tx-context');
+    const transaction = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: dbContract,
+      linkageResult: buildP7DealWorkspaceRuntimeLinkage({ contract: dbContract }),
+      transaction: { ...transactionContext(dbContract, 'tx-context'), correlationId: 'wrong-correlation' },
+    });
+
+    const prepared = transaction.prepare();
+
+    expect(prepared.stage).toBe('failed');
+    expect(prepared.failure?.code).toBe('TRANSACTION_CONTEXT_MISMATCH');
+    expect(repository.list()).toHaveLength(0);
+  });
+
+  it('supports deterministic retry after a pre-commit failure without partial state', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const dbContract = contract('DL-TX-RETRY', 'idem-tx-retry');
+    const linkageResult = buildP7DealWorkspaceRuntimeLinkage({ contract: dbContract });
+    const failing = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: dbContract,
+      linkageResult,
+      transaction: transactionContext(dbContract, 'tx-retry-1'),
+      beforeCommit: () => {
+        throw new Error('transient pre-commit failure');
+      },
+    });
+
+    failing.prepare();
+    const failedCommit = failing.commit();
+    expect(failedCommit.stage).toBe('failed');
+    expect(failedCommit.failure?.code).toBe('COMMIT_ERROR');
+    expect(failedCommit.repositoryReceipt).toBeUndefined();
+    expect(repository.list()).toHaveLength(0);
+
+    const retry = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: dbContract,
+      linkageResult,
+      transaction: transactionContext(dbContract, 'tx-retry-2'),
+    });
+    retry.prepare();
+    const committed = retry.commit();
+
+    expect(committed.stage).toBe('committed');
+    expect(committed.repositoryReceipt?.status).toBe('persisted');
+    expect(repository.list()).toHaveLength(1);
+  });
+
+  it('monotonically promotes the same record across hardened transactions', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const dbContract = contract('DL-TX-PROMOTE', 'idem-tx-promote');
+
+    const first = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: dbContract,
+      linkageResult: buildP7DealWorkspaceRuntimeLinkage({ contract: dbContract }),
+      transaction: transactionContext(dbContract, 'tx-promote-1'),
+      savedAt: '2026-07-10T05:10:00.000Z',
+    });
+    first.prepare();
+    const firstCommit = first.commit();
+
+    const outbox = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: dbContract,
+      linkageResult: buildP7DealWorkspaceRuntimeLinkage({
+        contract: dbContract,
+        outbox: outboxEvidence(dbContract),
+      }),
+      transaction: transactionContext(dbContract, 'tx-promote-2'),
+    });
+    outbox.prepare();
+    const outboxCommit = outbox.commit();
+
+    const audit = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: dbContract,
+      linkageResult: buildP7DealWorkspaceRuntimeLinkage({
+        contract: dbContract,
+        outbox: outboxEvidence(dbContract),
+        audit: auditEvidence(dbContract),
+      }),
+      transaction: transactionContext(dbContract, 'tx-promote-3'),
+    });
+    audit.prepare();
+    const auditCommit = audit.commit();
+
+    expect(firstCommit.repositoryReceipt?.state).toBe('outbox_required');
+    expect(outboxCommit.repositoryReceipt?.status).toBe('promoted');
+    expect(outboxCommit.repositoryReceipt?.state).toBe('audit_required');
+    expect(auditCommit.repositoryReceipt?.status).toBe('promoted');
+    expect(auditCommit.repositoryReceipt?.state).toBe('fully_linked');
+    expect(auditCommit.repositoryReceipt?.recordId).toBe(firstCommit.repositoryReceipt?.recordId);
+    expect(auditCommit.repositoryReceipt?.savedAt).toBe(firstCommit.repositoryReceipt?.savedAt);
+    expect(repository.list()).toHaveLength(1);
+  });
+
+  it('returns failed conflict instead of committing another contract under the same key', () => {
+    const repository = createP7DealWorkspaceRuntimeRepository();
+    const firstContract = contract('DL-TX-CONFLICT-A', 'idem-tx-conflict');
+    const otherContract = contract('DL-TX-CONFLICT-B', 'idem-tx-conflict');
+
+    const first = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: firstContract,
+      linkageResult: buildP7DealWorkspaceRuntimeLinkage({ contract: firstContract }),
+      transaction: transactionContext(firstContract, 'tx-conflict-1'),
+    });
+    first.prepare();
+    first.commit();
+
+    const conflict = createP7DealWorkspaceRuntimeTransaction({
+      repository,
+      contract: otherContract,
+      linkageResult: buildP7DealWorkspaceRuntimeLinkage({ contract: otherContract }),
+      transaction: transactionContext(otherContract, 'tx-conflict-2'),
+    });
+    conflict.prepare();
+    const conflictResult = conflict.commit();
+
+    expect(conflictResult.stage).toBe('failed');
+    expect(conflictResult.failure?.code).toBe('REPOSITORY_CONFLICT');
+    expect(conflictResult.repositoryReceipt?.status).toBe('conflict');
+    expect(conflictResult.repositoryReceipt?.conflictCode).toBe('IDEMPOTENCY_CONTRACT_MISMATCH');
+    expect(repository.list()).toHaveLength(1);
+  });
+});

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,46 +3,43 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "ready",
-  "current": "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.",
-  "fullTzReadinessPercent": 77,
-  "openPr": "#2236",
-  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock."],
+  "current": "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.",
+  "fullTzReadinessPercent": 78,
+  "openPr": "#2237",
+  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate."],
   "openBlockers": ["#2113", "#2115"],
   "blockerNotes": "#2113 repository settings cleanup. #2115 remains blocked by current auth-file write path.",
   "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "broad backend/API/DB/session/runtime/money/storage changes"],
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md"
+    "docs/platform-v7/execution-queue.md",
+    "apps/web/lib/platform-v7/deal-workspace-runtime-db-repository.ts",
+    "apps/web/lib/platform-v7/deal-workspace-runtime-linkage.ts",
+    "apps/web/lib/platform-v7/deal-workspace-runtime-transaction.ts",
+    "apps/web/tests/unit/platformV7DealWorkspaceRuntimeRepositoryAdapter.test.ts",
+    "apps/web/tests/unit/platformV7DealWorkspaceRuntimeLinkage.test.ts",
+    "apps/web/tests/unit/platformV7DealWorkspaceRuntimeTransaction.test.ts"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md"
+    "docs/platform-v7/execution-queue.md",
+    "apps/web/lib/platform-v7/deal-workspace-runtime-db-repository.ts",
+    "apps/web/lib/platform-v7/deal-workspace-runtime-linkage.ts",
+    "apps/web/lib/platform-v7/deal-workspace-runtime-transaction.ts",
+    "apps/web/tests/unit/platformV7DealWorkspaceRuntimeRepositoryAdapter.test.ts",
+    "apps/web/tests/unit/platformV7DealWorkspaceRuntimeLinkage.test.ts",
+    "apps/web/tests/unit/platformV7DealWorkspaceRuntimeTransaction.test.ts"
   ],
-  "vp327RuntimePersistenceTransactionIdempotencyScopeUnlock": {
-    "layer": "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock",
-    "closedPr": "#2235",
-    "status": "transaction-idempotency-scope-unlock-docs-only-complete"
-  },
   "vp328RuntimePersistenceTransactionIdempotencyFinalGate": {
     "layer": "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate",
-    "openPr": "#2236",
-    "status": "final-gate-docs-only",
-    "implementationBranchInstruction": "The next manual code PR must set current to VP-3.29 and allowedCurrentScope to docs plus exactly the six approved hardening files before writing code.",
-    "hardeningFilesUnlockedForManualCodePr": [
-      "apps/web/lib/platform-v7/deal-workspace-runtime-db-repository.ts",
-      "apps/web/lib/platform-v7/deal-workspace-runtime-linkage.ts",
-      "apps/web/lib/platform-v7/deal-workspace-runtime-transaction.ts",
-      "apps/web/tests/unit/platformV7DealWorkspaceRuntimeRepositoryAdapter.test.ts",
-      "apps/web/tests/unit/platformV7DealWorkspaceRuntimeLinkage.test.ts",
-      "apps/web/tests/unit/platformV7DealWorkspaceRuntimeTransaction.test.ts"
-    ]
+    "closedPr": "#2236",
+    "status": "final-gate-docs-only-complete"
   },
   "vp329RuntimePersistenceTransactionIdempotencyHardeningImplementation": {
     "layer": "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation",
-    "status": "manual-code-pr-next-after-final-gate",
-    "requiredAllowedScopeForManualCodePr": [
-      "docs/platform-v7/autopilot/autopilot-state.json",
-      "docs/platform-v7/execution-queue.md",
+    "openPr": "#2237",
+    "status": "transaction-idempotency-hardening-implementation",
+    "changedImplementationFiles": [
       "apps/web/lib/platform-v7/deal-workspace-runtime-db-repository.ts",
       "apps/web/lib/platform-v7/deal-workspace-runtime-linkage.ts",
       "apps/web/lib/platform-v7/deal-workspace-runtime-transaction.ts",
@@ -50,6 +47,10 @@
       "apps/web/tests/unit/platformV7DealWorkspaceRuntimeLinkage.test.ts",
       "apps/web/tests/unit/platformV7DealWorkspaceRuntimeTransaction.test.ts"
     ]
+  },
+  "vp330RuntimePersistencePrismaSchemaMigrationPlan": {
+    "layer": "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan",
+    "status": "next-docs-only-plan"
   },
   "forbiddenZones": [
     "apps/landing",
@@ -65,5 +66,5 @@
   ],
   "maturityLanguage": ["platform-temporarily-without-external-integrations"],
   "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database transaction complete"],
-  "readiness": "77% honest readiness. VP-3.28 is the final docs-only gate before contract-level transaction and idempotency hardening. It does not implement a database transaction, live outbox/audit persistence, production DB persistence, Prisma schema, migration, bank, FGIS or EDO live integration."
+  "readiness": "78% honest readiness. VP-3.29 implements contract-level monotonic linkage promotion, idempotency conflict protection and explicit prepare, commit, rollback, failure and deterministic retry semantics. The current action pipeline still uses the backward-compatible repository write path until stable DB-backed snapshot identity exists. This is not a database transaction and does not implement live outbox/audit persistence, production DB persistence, Prisma migration, bank, FGIS or EDO live integration."
 }

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,37 +1,49 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.
+CURRENT: VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.
 
-GOAL: Финально зафиксировать manual code PR gate для contract-level monotonic linkage promotion, idempotency conflict detection, transaction coordination, retry и partial-failure semantics после merge #2235, без Prisma/migrations и без claims о реальной DB-транзакции.
+GOAL: Реализовать contract-level monotonic linkage promotion, idempotency conflict detection, transaction coordination, retry и partial-failure semantics после merge #2236, без Prisma/migrations и без claims о реальной DB-транзакции.
 
 CURRENT STATUS:
 - VP-3.25 validated pipeline linkage binding is merged from #2233.
 - VP-3.26 transaction and idempotency hardening plan is merged from #2234.
-- VP-3.27 hardening scope unlock is merged from #2235.
-- Current repository still requires monotonic promotion and contract conflict protection.
+- VP-3.28 final hardening gate is merged from #2236.
+- VP-3.29 adds a strict hardened repository path and a separate contract-level transaction coordinator.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
+- apps/web/lib/platform-v7/deal-workspace-runtime-db-repository.ts
+- apps/web/lib/platform-v7/deal-workspace-runtime-linkage.ts
+- apps/web/lib/platform-v7/deal-workspace-runtime-transaction.ts
+- apps/web/tests/unit/platformV7DealWorkspaceRuntimeRepositoryAdapter.test.ts
+- apps/web/tests/unit/platformV7DealWorkspaceRuntimeLinkage.test.ts
+- apps/web/tests/unit/platformV7DealWorkspaceRuntimeTransaction.test.ts
 
-MANUAL CODE PR SCOPE AFTER THIS GATE:
-- `apps/web/lib/platform-v7/deal-workspace-runtime-db-repository.ts`
-- `apps/web/lib/platform-v7/deal-workspace-runtime-linkage.ts`
-- `apps/web/lib/platform-v7/deal-workspace-runtime-transaction.ts`
-- `apps/web/tests/unit/platformV7DealWorkspaceRuntimeRepositoryAdapter.test.ts`
-- `apps/web/tests/unit/platformV7DealWorkspaceRuntimeLinkage.test.ts`
-- `apps/web/tests/unit/platformV7DealWorkspaceRuntimeTransaction.test.ts`
+IMPLEMENTED:
+- Backward-compatible `repository.write` remains duplicate-safe for the current runtime action pipeline.
+- Strict `repository.writeHardened` supports one-record monotonic promotion:
+  - `outbox_required` → `audit_required` → `fully_linked`.
+- Promotion preserves original record identity and creation timestamp.
+- Weaker replay cannot regress state or remove accepted linkage evidence.
+- Accepted outbox and audit IDs cannot be replaced by different IDs.
+- Same idempotency key with another runtime snapshot or material contract returns explicit conflict.
+- Transaction coordinator exposes deterministic stages:
+  - `created`;
+  - `prepared`;
+  - `committed`;
+  - `rolled_back`;
+  - `failed`.
+- Prepare validates transaction correlation, audit and actor identity plus linkage validity.
+- Commit uses the strict hardened repository path.
+- Commit replay returns the same committed receipt without a second write.
+- Rollback and pre-commit failure create no repository record.
+- Deterministic retry after failure can commit using the original idempotency identity.
 
-MANDATORY IMPLEMENTATION RULES:
-- Same idempotency key and same runtime snapshot may only promote one existing record monotonically.
-- Promotion must preserve record identity and original creation timestamp.
-- State and accepted evidence IDs must never regress or be replaced.
-- Same idempotency key with different snapshot or material contract mismatch must return conflict.
-- Duplicate replay without stronger evidence remains read-only.
-- Prepare, commit, rollback and failed outcomes must be explicit.
-- Partial failure must not expose a committed receipt.
-- Retry after rollback must be deterministic.
-- Implementation remains contract-level and must not claim database atomicity.
+KNOWN LIMITATION:
+- The current server action pipeline still uses backward-compatible `repository.write` because the process runtime store creates a new runtime snapshot version on every replay.
+- Strict `writeHardened` is used by the new transaction coordinator and tests, but should not replace the action path until stable DB-backed snapshot identity is implemented.
+- This layer does not provide database atomicity. It is a contract-level coordinator and in-process repository implementation.
 
 STILL LOCKED:
 - `apps/api/prisma/schema.prisma`
@@ -43,18 +55,14 @@ STILL LOCKED:
 - package and lockfiles
 
 NEXT:
-- Layer: VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.
-- Goal: prepare the manual implementation layer after this final gate is merged.
+- Layer: VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.
+- Goal: select exact production DB tables, columns, indexes, constraints, migration and rollback scope after VP-3.29 is merged and tested.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
 - Success criteria:
-  - final gate closes without hardening code changes;
-  - next manual code PR explicitly expands current scope to the six approved files;
+  - VP-3.29 hardening is merged and tested;
+  - no Prisma schema or migration changes occur in VP-3.29;
   - critical forbidden zones remain unchanged;
-  - Prisma schema and migrations remain locked;
+  - guard, dry-run, web-unit, CI and security checks stay green;
   - maturity language remains platform-temporarily-without-external-integrations.
-
-AFTER NEXT:
-- Layer: VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.
-- Goal: assess exact production DB schema, indexes, constraints and migration scope after hardening implementation is merged.


### PR DESCRIPTION
## Суть

VP-3.29 реализует contract-level hardening для repository idempotency и transaction coordination.

## Реализовано

- strict `writeHardened` с monotonic promotion одной записи;
- состояния `persisted`, `duplicate`, `promoted`, `conflict`;
- conflict при повторном использовании ключа для другого snapshot/material contract;
- запрет замены уже принятых outbox/audit IDs;
- запрет регресса linkage state;
- стабильные recordId и original savedAt при promotion;
- transaction coordinator со стадиями created/prepared/committed/rolled_back/failed;
- проверка transaction identity и linkage validity;
- rollback и pre-commit failure без repository mutation;
- deterministic retry и commit replay;
- unit tests для promotion, conflicts, rollback, failure и retry.

## Ограничение

Текущий runtime action pipeline сохраняет backward-compatible `repository.write`, поскольку process runtime store формирует новый snapshot version на replay. Strict hardening подключён к transaction coordinator и не выдаётся за DB atomicity.

## Не сделано

- Prisma schema/migrations;
- live Postgres transaction;
- live outbox/audit persistence;
- DB-backed runtime store;
- изменения action/UI/API/auth/package/lockfiles;
- bank/ФГИС/ЭДО live integration.