### PR TITLE
VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock

### DIFF
--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,10 +3,10 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "ready",
-  "current": "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.",
+  "current": "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.",
   "fullTzReadinessPercent": 78,
-  "openPr": "#2238",
-  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation."],
+  "openPr": "#2239",
+  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan."],
   "openBlockers": ["#2113", "#2115"],
   "blockerNotes": "#2113 repository settings cleanup. #2115 remains blocked by current auth-file write path.",
   "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "broad backend/API/session/runtime/money/storage changes"],
@@ -18,16 +18,16 @@
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md"
   ],
-  "vp329RuntimePersistenceTransactionIdempotencyHardeningImplementation": {
-    "layer": "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation",
-    "closedPr": "#2237",
-    "status": "transaction-idempotency-hardening-implementation-complete"
-  },
   "vp330RuntimePersistencePrismaSchemaMigrationPlan": {
     "layer": "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan",
-    "openPr": "#2238",
-    "status": "prisma-schema-migration-plan-docs-only",
-    "candidateImplementationFiles": [
+    "closedPr": "#2238",
+    "status": "prisma-schema-migration-plan-docs-only-complete"
+  },
+  "vp331RuntimePersistencePrismaSchemaMigrationScopeUnlock": {
+    "layer": "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock",
+    "openPr": "#2239",
+    "status": "prisma-schema-migration-scope-unlock-docs-only",
+    "unlockedImplementationFilesForLater": [
       "apps/api/prisma/schema.prisma",
       "apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql",
       "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql",
@@ -35,9 +35,9 @@
       "apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts"
     ]
   },
-  "vp331RuntimePersistencePrismaSchemaMigrationScopeUnlock": {
-    "layer": "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock",
-    "status": "next-docs-only-scope-unlock"
+  "vp332RuntimePersistencePrismaSchemaMigrationFinalGate": {
+    "layer": "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate",
+    "status": "next-docs-only-final-gate"
   },
   "forbiddenZones": [
     "apps/landing",
@@ -53,5 +53,5 @@
   ],
   "maturityLanguage": ["platform-temporarily-without-external-integrations"],
   "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied"],
-  "readiness": "78% honest readiness. VP-3.30 selects the exact additive Prisma schema, migration, rollback and validation-test scope. It does not change schema.prisma, create an applied migration, connect the runtime repository to Postgres, or complete bank, FGIS or EDO integrations."
+  "readiness": "78% honest readiness. VP-3.31 is docs-only scope unlock for the additive Prisma schema, migration, rollback and validation test. It does not change schema.prisma, create or apply a migration, connect runtime persistence to Postgres, or complete bank, FGIS or EDO integrations."
 }

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,99 +1,55 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.
+CURRENT: VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.
 
-GOAL: Выбрать точную additive Prisma schema и migration-модель для DB-backed runtime persistence после merge #2237, не применяя migration и не подключая runtime repository к Postgres в этом слое.
+GOAL: Docs-only разблокировать точные schema, migration, rollback и validation files после merge #2238, не меняя их содержимое в этом слое и не заявляя применённую production migration.
 
 CURRENT STATUS:
-- VP-3.29 contract-level transaction and idempotency hardening is merged from #2237.
-- Existing Prisma schema already contains canonical `Deal`, `OutboxEntry` and `AuditEvent` models.
-- Existing `apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql` is contract-only and has not been applied as a production migration.
-- A parallel outbox or audit table is forbidden; runtime persistence must link to the existing canonical tables.
+- VP-3.29 transaction/idempotency hardening is merged from #2237.
+- VP-3.30 Prisma schema and migration plan is merged from #2238.
+- Existing canonical Deal, OutboxEntry and AuditEvent models must be reused.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
 
-CANDIDATE IMPLEMENTATION FILES FOR LATER CODE PR:
+UNLOCKED IMPLEMENTATION FILES FOR LATER CODE PR:
 - `apps/api/prisma/schema.prisma`
 - `apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql`
 - `apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql`
 - `apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql`
 - `apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts`
 
-TARGET DATA MODEL:
-- New canonical model/table `DealWorkspaceRuntimeSnapshot` / `deal_workspace_runtime_snapshots`.
-- New append-only model/table `DealWorkspaceRuntimeTransactionAttempt` / `deal_workspace_runtime_transaction_attempts`.
-- `DealWorkspaceRuntimeSnapshot` links to existing:
-  - `Deal` through `dealId`;
-  - `OutboxEntry` through optional unique `outboxEntryId`;
-  - `AuditEvent` through optional unique `auditEventId`.
-- `OutboxEntry` and `AuditEvent` receive additive correlation/runtime linkage fields rather than duplicate replacement tables.
-
-REQUIRED SNAPSHOT FIELDS:
-- internal primary key;
-- unique `runtimeSnapshotId`;
-- unique `idempotencyKey`;
-- `dealId`, `intentId`, `state`, `snapshotState`, `statusLabel`;
-- `runtimeStoreRecordId`, `runtimeStoreVersion`;
-- `actorId`, `actorRole`, `correlationId`, `auditId`;
-- material `contractHash` for DB conflict detection;
-- JSON payload;
-- optional unique outbox/audit foreign keys;
-- optimistic `version` greater than zero;
-- immutable `createdAt` and mutable `updatedAt`.
-
-REQUIRED TRANSACTION ATTEMPT FIELDS:
-- unique `transactionId`;
-- snapshot foreign key;
-- idempotency and correlation identity;
-- stage/outcome/failure code/failure reason;
-- replay flag;
-- started/completed timestamps;
-- JSON metadata for operational recovery.
-
-DATABASE CONSTRAINTS:
-- state CHECK: `ready_to_persist | outbox_required | audit_required | fully_linked`.
-- snapshot state CHECK: `updated | blocked | duplicate | failed`.
-- transaction stage CHECK: `created | prepared | committed | rolled_back | failed`.
-- linkage consistency CHECK:
-  - no audit link without outbox link;
-  - `ready_to_persist` and `outbox_required` have no links;
-  - `audit_required` has outbox and no audit;
-  - `fully_linked` has both links.
-- unique runtime snapshot, idempotency key, outbox link, audit link and transaction id.
-- foreign keys use restrictive deletion for evidence preservation.
-- indexes cover deal timeline, intent/state, correlation, transaction stage and retry/recovery lookup.
-
-MIGRATION RULES:
-- Additive only; no destructive rename or drop.
-- Existing deals/outbox/audit rows require no backfill to deploy the new tables.
-- Added columns on existing outbox/audit tables must be nullable initially and indexed where operationally required.
-- Migration SQL must be idempotency-aware and include explicit CHECK/FK/index names.
-- `rollback.sql` is operational documentation and must remove only objects introduced by this migration in dependency-safe order.
-- Applying migration to production is a separate controlled deployment step with backup, dry-run and rollback readiness.
+MANDATORY IMPLEMENTATION RULES:
+- Migration is additive and reuses existing Deal/OutboxEntry/AuditEvent tables.
+- New runtime snapshot and transaction attempt tables require explicit checks, foreign keys, unique keys and operational indexes.
+- No audit link without an outbox link.
+- Linkage columns and state must be DB-consistent.
+- Foreign keys preserve evidence with restrictive deletion.
+- Existing outbox/audit rows need no data backfill.
+- Rollback removes only migration-owned objects in dependency-safe order.
+- Merge of migration files does not mean production migration has been applied.
 
 STILL LOCKED:
-- runtime repository Postgres adapter;
+- runtime Postgres repository adapter;
 - runtime action/API wiring;
-- auth and tenant enforcement changes;
+- auth/tenant enforcement changes;
 - UI/components;
 - package and lockfiles;
 - live bank/FGIS/EDO integrations.
 
 NEXT:
-- Layer: VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.
-- Goal: docs-only unlock the exact five schema/migration validation files.
+- Layer: VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.
+- Goal: final docs-only gate before writing schema and migration code.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
 - Success criteria:
-  - schema and migration files remain unchanged in VP-3.30;
-  - existing canonical Deal/OutboxEntry/AuditEvent models are reused;
+  - unlocked implementation files remain unchanged in VP-3.31;
   - critical forbidden zones remain unchanged;
   - guard, dry-run and security checks remain green;
-  - maturity language does not claim an applied production migration.
+  - maturity language does not claim an applied migration.
 
 AFTER NEXT:
-- Layer: VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.
-- Goal: final docs-only gate before schema/migration implementation.
+- Layer: VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.
+- Candidate code files are the five exact files listed above.


### PR DESCRIPTION
## Суть

Docs-only разблокировка точного schema/migration scope.

Разблокированы для будущего code PR Prisma schema, SQL contract, additive migration, operational rollback и validation test. Existing Deal/OutboxEntry/AuditEvent models должны переиспользоваться; production migration не считается применённой после merge файлов.

Следующий слой — VP-3.32 final gate.