### PR TITLE
VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation

### DIFF
--- a/apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql
+++ b/apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql
@@ -75,13 +75,13 @@ CREATE TABLE IF NOT EXISTS "deal_workspace_runtime_transaction_attempts" (
 );
 
 CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_deal_created_idx"
-  ON "deal_workspace_runtime_snapshots" ("dealId", "createdAt" DESC);
+  ON "deal_workspace_runtime_snapshots" ("dealId", "createdAt");
 CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_intent_state_idx"
   ON "deal_workspace_runtime_snapshots" ("intentId", "state");
 CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_correlation_idx"
   ON "deal_workspace_runtime_snapshots" ("correlationId");
 CREATE INDEX IF NOT EXISTS "dw_runtime_attempts_snapshot_started_idx"
-  ON "deal_workspace_runtime_transaction_attempts" ("snapshotId", "startedAt" DESC);
+  ON "deal_workspace_runtime_transaction_attempts" ("snapshotId", "startedAt");
 CREATE INDEX IF NOT EXISTS "dw_runtime_attempts_stage_started_idx"
   ON "deal_workspace_runtime_transaction_attempts" ("stage", "startedAt");
 

--- a/apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql
+++ b/apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql
@@ -1,42 +1,93 @@
--- VP-3.5 Deal Workspace Runtime Persistence DB Contract
--- Status: contract only. Not an applied production migration.
--- Purpose: define the Postgres-backed persistence shape for runtime snapshots before wiring live DB writes.
+-- VP-3.33 Deal Workspace Runtime Persistence DB Contract
+-- Status: canonical contract aligned with the additive migration.
+-- Important: presence in the repository does not mean the production migration is applied.
 
-CREATE TABLE IF NOT EXISTS deal_workspace_runtime_snapshots (
-  id TEXT PRIMARY KEY,
-  runtime_snapshot_id TEXT NOT NULL UNIQUE,
-  deal_id TEXT NOT NULL,
-  intent_id TEXT NOT NULL,
-  state TEXT NOT NULL CHECK (state IN ('ready_to_persist', 'outbox_required', 'audit_required', 'fully_linked')),
-  snapshot_state TEXT NOT NULL CHECK (snapshot_state IN ('updated', 'blocked', 'duplicate', 'failed')),
-  status_label TEXT NOT NULL,
-  runtime_store_record_id TEXT NOT NULL,
-  runtime_store_version TEXT NOT NULL,
-  maturity TEXT NOT NULL DEFAULT 'postgres-contract',
-  payload JSONB NOT NULL,
-  correlation_id TEXT NOT NULL,
-  audit_id TEXT NOT NULL,
-  idempotency_key TEXT NOT NULL UNIQUE,
-  outbox_entry_id TEXT NULL,
-  audit_event_id TEXT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+-- Existing canonical evidence tables are extended; no parallel outbox or audit tables are created.
+ALTER TABLE "outbox_entries"
+  ADD COLUMN IF NOT EXISTS "correlationId" TEXT,
+  ADD COLUMN IF NOT EXISTS "auditId" TEXT,
+  ADD COLUMN IF NOT EXISTS "runtimeSnapshotId" TEXT,
+  ADD COLUMN IF NOT EXISTS "runtimeIdempotencyKey" TEXT;
+
+ALTER TABLE "audit_events"
+  ADD COLUMN IF NOT EXISTS "correlationId" TEXT,
+  ADD COLUMN IF NOT EXISTS "runtimeSnapshotId" TEXT,
+  ADD COLUMN IF NOT EXISTS "runtimeIdempotencyKey" TEXT;
+
+CREATE TABLE IF NOT EXISTS "deal_workspace_runtime_snapshots" (
+  "id" TEXT PRIMARY KEY,
+  "runtimeSnapshotId" TEXT NOT NULL UNIQUE,
+  "idempotencyKey" TEXT NOT NULL UNIQUE,
+  "dealId" TEXT NOT NULL,
+  "intentId" TEXT NOT NULL,
+  "state" TEXT NOT NULL CHECK (
+    "state" IN ('ready_to_persist', 'outbox_required', 'audit_required', 'fully_linked')
+  ),
+  "snapshotState" TEXT NOT NULL CHECK (
+    "snapshotState" IN ('updated', 'blocked', 'duplicate', 'failed')
+  ),
+  "statusLabel" TEXT NOT NULL,
+  "runtimeStoreRecordId" TEXT NOT NULL,
+  "runtimeStoreVersion" TEXT NOT NULL,
+  "actorId" TEXT NOT NULL,
+  "actorRole" TEXT NOT NULL,
+  "correlationId" TEXT NOT NULL,
+  "auditId" TEXT NOT NULL,
+  "contractHash" TEXT NOT NULL,
+  "payload" JSONB NOT NULL,
+  "outboxEntryId" TEXT UNIQUE,
+  "auditEventId" TEXT UNIQUE,
+  "version" INTEGER NOT NULL DEFAULT 1 CHECK ("version" > 0),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "dw_runtime_snapshots_linkage_check" CHECK (
+    ("state" IN ('ready_to_persist', 'outbox_required') AND "outboxEntryId" IS NULL AND "auditEventId" IS NULL)
+    OR ("state" = 'audit_required' AND "outboxEntryId" IS NOT NULL AND "auditEventId" IS NULL)
+    OR ("state" = 'fully_linked' AND "outboxEntryId" IS NOT NULL AND "auditEventId" IS NOT NULL)
+  ),
+  CONSTRAINT "dw_runtime_snapshots_deal_fkey"
+    FOREIGN KEY ("dealId") REFERENCES "deals"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "dw_runtime_snapshots_outbox_fkey"
+    FOREIGN KEY ("outboxEntryId") REFERENCES "outbox_entries"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "dw_runtime_snapshots_audit_fkey"
+    FOREIGN KEY ("auditEventId") REFERENCES "audit_events"("id") ON DELETE RESTRICT ON UPDATE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_dw_runtime_snapshots_deal_created
-  ON deal_workspace_runtime_snapshots (deal_id, created_at DESC);
+CREATE TABLE IF NOT EXISTS "deal_workspace_runtime_transaction_attempts" (
+  "id" TEXT PRIMARY KEY,
+  "transactionId" TEXT NOT NULL UNIQUE,
+  "snapshotId" TEXT NOT NULL,
+  "idempotencyKey" TEXT NOT NULL,
+  "correlationId" TEXT NOT NULL,
+  "auditId" TEXT NOT NULL,
+  "stage" TEXT NOT NULL CHECK (
+    "stage" IN ('created', 'prepared', 'committed', 'rolled_back', 'failed')
+  ),
+  "outcome" TEXT,
+  "failureCode" TEXT,
+  "failureReason" TEXT,
+  "isReplay" BOOLEAN NOT NULL DEFAULT false,
+  "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "completedAt" TIMESTAMP(3),
+  "metadata" JSONB,
+  CONSTRAINT "dw_runtime_attempts_snapshot_fkey"
+    FOREIGN KEY ("snapshotId") REFERENCES "deal_workspace_runtime_snapshots"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
 
-CREATE INDEX IF NOT EXISTS idx_dw_runtime_snapshots_intent_state
-  ON deal_workspace_runtime_snapshots (intent_id, state);
-
-CREATE INDEX IF NOT EXISTS idx_dw_runtime_snapshots_outbox
-  ON deal_workspace_runtime_snapshots (outbox_entry_id);
-
-CREATE INDEX IF NOT EXISTS idx_dw_runtime_snapshots_audit
-  ON deal_workspace_runtime_snapshots (audit_event_id);
+CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_deal_created_idx"
+  ON "deal_workspace_runtime_snapshots" ("dealId", "createdAt" DESC);
+CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_intent_state_idx"
+  ON "deal_workspace_runtime_snapshots" ("intentId", "state");
+CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_correlation_idx"
+  ON "deal_workspace_runtime_snapshots" ("correlationId");
+CREATE INDEX IF NOT EXISTS "dw_runtime_attempts_snapshot_started_idx"
+  ON "deal_workspace_runtime_transaction_attempts" ("snapshotId", "startedAt" DESC);
+CREATE INDEX IF NOT EXISTS "dw_runtime_attempts_stage_started_idx"
+  ON "deal_workspace_runtime_transaction_attempts" ("stage", "startedAt");
 
 -- Linkage contract:
--- 1. Insert runtime snapshot in state='ready_to_persist'.
--- 2. Insert outbox_entries row with type='deal_workspace.runtime_snapshot.persisted'.
--- 3. Insert audit_events row with action='deal_workspace.runtime_snapshot.persisted'.
--- 4. Update this row to state='fully_linked' only when both outbox_entry_id and audit_event_id are set.
+-- 1. Persist one canonical runtime snapshot row using runtimeSnapshotId and idempotencyKey.
+-- 2. Create the canonical outbox_entries row and link it before state becomes audit_required.
+-- 3. Create the canonical audit_events row and link it before state becomes fully_linked.
+-- 4. A row cannot regress or replace accepted evidence identifiers at the repository layer.
+-- 5. Transaction attempts are append-only operational evidence for prepare/commit/rollback/failure/replay.

--- a/apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql
+++ b/apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql
@@ -64,7 +64,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS "dw_runtime_snapshots_outbox_entry_id_key"
 CREATE UNIQUE INDEX IF NOT EXISTS "dw_runtime_snapshots_audit_event_id_key"
   ON "deal_workspace_runtime_snapshots" ("auditEventId");
 CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_deal_created_idx"
-  ON "deal_workspace_runtime_snapshots" ("dealId", "createdAt" DESC);
+  ON "deal_workspace_runtime_snapshots" ("dealId", "createdAt");
 CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_intent_state_idx"
   ON "deal_workspace_runtime_snapshots" ("intentId", "state");
 CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_correlation_idx"
@@ -75,7 +75,7 @@ CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_state_updated_idx"
 CREATE UNIQUE INDEX IF NOT EXISTS "dw_runtime_attempts_transaction_id_key"
   ON "deal_workspace_runtime_transaction_attempts" ("transactionId");
 CREATE INDEX IF NOT EXISTS "dw_runtime_attempts_snapshot_started_idx"
-  ON "deal_workspace_runtime_transaction_attempts" ("snapshotId", "startedAt" DESC);
+  ON "deal_workspace_runtime_transaction_attempts" ("snapshotId", "startedAt");
 CREATE INDEX IF NOT EXISTS "dw_runtime_attempts_stage_started_idx"
   ON "deal_workspace_runtime_transaction_attempts" ("stage", "startedAt");
 CREATE INDEX IF NOT EXISTS "dw_runtime_attempts_idempotency_idx"

--- a/apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql
+++ b/apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql
@@ -1,0 +1,172 @@
+-- VP-3.33 Deal Workspace Runtime Persistence
+-- Additive PostgreSQL migration. Merging this file does not apply it to production.
+
+ALTER TABLE "outbox_entries"
+  ADD COLUMN IF NOT EXISTS "correlationId" TEXT,
+  ADD COLUMN IF NOT EXISTS "auditId" TEXT,
+  ADD COLUMN IF NOT EXISTS "runtimeSnapshotId" TEXT,
+  ADD COLUMN IF NOT EXISTS "runtimeIdempotencyKey" TEXT;
+
+ALTER TABLE "audit_events"
+  ADD COLUMN IF NOT EXISTS "correlationId" TEXT,
+  ADD COLUMN IF NOT EXISTS "runtimeSnapshotId" TEXT,
+  ADD COLUMN IF NOT EXISTS "runtimeIdempotencyKey" TEXT;
+
+CREATE TABLE IF NOT EXISTS "deal_workspace_runtime_snapshots" (
+  "id" TEXT NOT NULL,
+  "runtimeSnapshotId" TEXT NOT NULL,
+  "idempotencyKey" TEXT NOT NULL,
+  "dealId" TEXT NOT NULL,
+  "intentId" TEXT NOT NULL,
+  "state" TEXT NOT NULL,
+  "snapshotState" TEXT NOT NULL,
+  "statusLabel" TEXT NOT NULL,
+  "runtimeStoreRecordId" TEXT NOT NULL,
+  "runtimeStoreVersion" TEXT NOT NULL,
+  "actorId" TEXT NOT NULL,
+  "actorRole" TEXT NOT NULL,
+  "correlationId" TEXT NOT NULL,
+  "auditId" TEXT NOT NULL,
+  "contractHash" TEXT NOT NULL,
+  "payload" JSONB NOT NULL,
+  "outboxEntryId" TEXT,
+  "auditEventId" TEXT,
+  "version" INTEGER NOT NULL DEFAULT 1,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "deal_workspace_runtime_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "deal_workspace_runtime_transaction_attempts" (
+  "id" TEXT NOT NULL,
+  "transactionId" TEXT NOT NULL,
+  "snapshotId" TEXT NOT NULL,
+  "idempotencyKey" TEXT NOT NULL,
+  "correlationId" TEXT NOT NULL,
+  "auditId" TEXT NOT NULL,
+  "stage" TEXT NOT NULL,
+  "outcome" TEXT,
+  "failureCode" TEXT,
+  "failureReason" TEXT,
+  "isReplay" BOOLEAN NOT NULL DEFAULT false,
+  "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "completedAt" TIMESTAMP(3),
+  "metadata" JSONB,
+  CONSTRAINT "deal_workspace_runtime_transaction_attempts_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "dw_runtime_snapshots_runtime_snapshot_id_key"
+  ON "deal_workspace_runtime_snapshots" ("runtimeSnapshotId");
+CREATE UNIQUE INDEX IF NOT EXISTS "dw_runtime_snapshots_idempotency_key_key"
+  ON "deal_workspace_runtime_snapshots" ("idempotencyKey");
+CREATE UNIQUE INDEX IF NOT EXISTS "dw_runtime_snapshots_outbox_entry_id_key"
+  ON "deal_workspace_runtime_snapshots" ("outboxEntryId");
+CREATE UNIQUE INDEX IF NOT EXISTS "dw_runtime_snapshots_audit_event_id_key"
+  ON "deal_workspace_runtime_snapshots" ("auditEventId");
+CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_deal_created_idx"
+  ON "deal_workspace_runtime_snapshots" ("dealId", "createdAt" DESC);
+CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_intent_state_idx"
+  ON "deal_workspace_runtime_snapshots" ("intentId", "state");
+CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_correlation_idx"
+  ON "deal_workspace_runtime_snapshots" ("correlationId");
+CREATE INDEX IF NOT EXISTS "dw_runtime_snapshots_state_updated_idx"
+  ON "deal_workspace_runtime_snapshots" ("state", "updatedAt");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "dw_runtime_attempts_transaction_id_key"
+  ON "deal_workspace_runtime_transaction_attempts" ("transactionId");
+CREATE INDEX IF NOT EXISTS "dw_runtime_attempts_snapshot_started_idx"
+  ON "deal_workspace_runtime_transaction_attempts" ("snapshotId", "startedAt" DESC);
+CREATE INDEX IF NOT EXISTS "dw_runtime_attempts_stage_started_idx"
+  ON "deal_workspace_runtime_transaction_attempts" ("stage", "startedAt");
+CREATE INDEX IF NOT EXISTS "dw_runtime_attempts_idempotency_idx"
+  ON "deal_workspace_runtime_transaction_attempts" ("idempotencyKey");
+CREATE INDEX IF NOT EXISTS "dw_runtime_attempts_correlation_idx"
+  ON "deal_workspace_runtime_transaction_attempts" ("correlationId");
+
+CREATE INDEX IF NOT EXISTS "outbox_entries_runtime_snapshot_idx"
+  ON "outbox_entries" ("runtimeSnapshotId");
+CREATE INDEX IF NOT EXISTS "outbox_entries_runtime_correlation_idx"
+  ON "outbox_entries" ("correlationId");
+CREATE INDEX IF NOT EXISTS "audit_events_runtime_snapshot_idx"
+  ON "audit_events" ("runtimeSnapshotId");
+CREATE INDEX IF NOT EXISTS "audit_events_runtime_correlation_idx"
+  ON "audit_events" ("correlationId");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'dw_runtime_snapshots_state_check'
+  ) THEN
+    ALTER TABLE "deal_workspace_runtime_snapshots"
+      ADD CONSTRAINT "dw_runtime_snapshots_state_check"
+      CHECK ("state" IN ('ready_to_persist', 'outbox_required', 'audit_required', 'fully_linked'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'dw_runtime_snapshots_snapshot_state_check'
+  ) THEN
+    ALTER TABLE "deal_workspace_runtime_snapshots"
+      ADD CONSTRAINT "dw_runtime_snapshots_snapshot_state_check"
+      CHECK ("snapshotState" IN ('updated', 'blocked', 'duplicate', 'failed'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'dw_runtime_snapshots_version_check'
+  ) THEN
+    ALTER TABLE "deal_workspace_runtime_snapshots"
+      ADD CONSTRAINT "dw_runtime_snapshots_version_check"
+      CHECK ("version" > 0);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'dw_runtime_snapshots_linkage_check'
+  ) THEN
+    ALTER TABLE "deal_workspace_runtime_snapshots"
+      ADD CONSTRAINT "dw_runtime_snapshots_linkage_check"
+      CHECK (
+        ("state" IN ('ready_to_persist', 'outbox_required') AND "outboxEntryId" IS NULL AND "auditEventId" IS NULL)
+        OR ("state" = 'audit_required' AND "outboxEntryId" IS NOT NULL AND "auditEventId" IS NULL)
+        OR ("state" = 'fully_linked' AND "outboxEntryId" IS NOT NULL AND "auditEventId" IS NOT NULL)
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'dw_runtime_attempts_stage_check'
+  ) THEN
+    ALTER TABLE "deal_workspace_runtime_transaction_attempts"
+      ADD CONSTRAINT "dw_runtime_attempts_stage_check"
+      CHECK ("stage" IN ('created', 'prepared', 'committed', 'rolled_back', 'failed'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'dw_runtime_snapshots_deal_fkey'
+  ) THEN
+    ALTER TABLE "deal_workspace_runtime_snapshots"
+      ADD CONSTRAINT "dw_runtime_snapshots_deal_fkey"
+      FOREIGN KEY ("dealId") REFERENCES "deals"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'dw_runtime_snapshots_outbox_fkey'
+  ) THEN
+    ALTER TABLE "deal_workspace_runtime_snapshots"
+      ADD CONSTRAINT "dw_runtime_snapshots_outbox_fkey"
+      FOREIGN KEY ("outboxEntryId") REFERENCES "outbox_entries"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'dw_runtime_snapshots_audit_fkey'
+  ) THEN
+    ALTER TABLE "deal_workspace_runtime_snapshots"
+      ADD CONSTRAINT "dw_runtime_snapshots_audit_fkey"
+      FOREIGN KEY ("auditEventId") REFERENCES "audit_events"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'dw_runtime_attempts_snapshot_fkey'
+  ) THEN
+    ALTER TABLE "deal_workspace_runtime_transaction_attempts"
+      ADD CONSTRAINT "dw_runtime_attempts_snapshot_fkey"
+      FOREIGN KEY ("snapshotId") REFERENCES "deal_workspace_runtime_snapshots"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql
+++ b/apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql
@@ -1,0 +1,22 @@
+-- VP-3.33 operational rollback
+-- Run only under an approved maintenance procedure after verifying that no runtime
+-- snapshot data must be retained. This file is not executed automatically by Prisma.
+
+DROP TABLE IF EXISTS "deal_workspace_runtime_transaction_attempts";
+DROP TABLE IF EXISTS "deal_workspace_runtime_snapshots";
+
+DROP INDEX IF EXISTS "outbox_entries_runtime_snapshot_idx";
+DROP INDEX IF EXISTS "outbox_entries_runtime_correlation_idx";
+DROP INDEX IF EXISTS "audit_events_runtime_snapshot_idx";
+DROP INDEX IF EXISTS "audit_events_runtime_correlation_idx";
+
+ALTER TABLE "outbox_entries"
+  DROP COLUMN IF EXISTS "runtimeIdempotencyKey",
+  DROP COLUMN IF EXISTS "runtimeSnapshotId",
+  DROP COLUMN IF EXISTS "auditId",
+  DROP COLUMN IF EXISTS "correlationId";
+
+ALTER TABLE "audit_events"
+  DROP COLUMN IF EXISTS "runtimeIdempotencyKey",
+  DROP COLUMN IF EXISTS "runtimeSnapshotId",
+  DROP COLUMN IF EXISTS "correlationId";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -130,6 +130,7 @@ model Deal {
   dealEvents       DealEvent[]
   acceptanceRecords AcceptanceRecord[]
   bankOperations   BankOperation[]
+  runtimeSnapshots DealWorkspaceRuntimeSnapshot[] @relation("RuntimeSnapshotDeal")
 
   @@index([sellerOrgId])
   @@index([buyerOrgId])
@@ -329,23 +330,31 @@ model LabTest {
 // ── Outbox ────────────────────────────────────────────────────────────────────
 
 model OutboxEntry {
-  id             String   @id @default(cuid())
-  type           String
-  dealId         String?
-  payload        Json
-  status         String   @default("PENDING") // PENDING | SENT | CONFIRMED | FAILED | DEAD
-  idempotencyKey String?  @unique
-  maxRetries     Int      @default(5)
-  retryCount     Int      @default(0)
-  nextRetryAt    DateTime @default(now())
-  lastError      String?
-  createdAt      DateTime @default(now())
-  sentAt         DateTime?
-  confirmedAt    DateTime?
-  failedAt       DateTime?
+  id                    String   @id @default(cuid())
+  type                  String
+  dealId                String?
+  payload               Json
+  status                String   @default("PENDING") // PENDING | SENT | CONFIRMED | FAILED | DEAD
+  idempotencyKey        String?  @unique
+  maxRetries            Int      @default(5)
+  retryCount            Int      @default(0)
+  nextRetryAt           DateTime @default(now())
+  lastError             String?
+  correlationId         String?
+  auditId               String?
+  runtimeSnapshotId     String?
+  runtimeIdempotencyKey String?
+  createdAt             DateTime @default(now())
+  sentAt                DateTime?
+  confirmedAt           DateTime?
+  failedAt              DateTime?
+
+  runtimeSnapshot       DealWorkspaceRuntimeSnapshot? @relation("RuntimeSnapshotOutbox")
 
   @@index([status, nextRetryAt])
   @@index([dealId])
+  @@index([runtimeSnapshotId], map: "outbox_entries_runtime_snapshot_idx")
+  @@index([correlationId], map: "outbox_entries_runtime_correlation_idx")
   @@map("outbox_entries")
 }
 
@@ -439,31 +448,37 @@ model EvidenceFile {
 // ── Audit Events (append-only, hash chain) ────────────────────────────────────
 
 model AuditEvent {
-  id          String   @id @default(cuid())
-  action      String
-  actorUserId String
-  actorRole   String
-  tenantId    String?
-  orgId       String?
-  dealId      String?
-  disputeId   String?
-  objectType  String?
-  objectId    String?
-  beforeState Json?    // snapshot before change
-  afterState  Json?    // snapshot after change
-  outcome     String
-  reason      String?
-  metadata    Json?    // ip, userAgent, sessionId
-  hash        String   @default("") // SHA-256(all fields + prevHash)
-  prevHash    String?
-  createdAt   DateTime @default(now())
+  id                    String   @id @default(cuid())
+  action                String
+  actorUserId           String
+  actorRole             String
+  tenantId              String?
+  orgId                 String?
+  dealId                String?
+  disputeId             String?
+  objectType            String?
+  objectId              String?
+  beforeState           Json?    // snapshot before change
+  afterState            Json?    // snapshot after change
+  outcome               String
+  reason                String?
+  metadata              Json?    // ip, userAgent, sessionId
+  correlationId         String?
+  runtimeSnapshotId     String?
+  runtimeIdempotencyKey String?
+  hash                  String   @default("") // SHA-256(all fields + prevHash)
+  prevHash              String?
+  createdAt             DateTime @default(now())
 
-  dispute     Dispute? @relation(fields: [disputeId], references: [id])
+  dispute               Dispute? @relation(fields: [disputeId], references: [id])
+  runtimeSnapshot       DealWorkspaceRuntimeSnapshot? @relation("RuntimeSnapshotAudit")
 
   @@index([dealId])
   @@index([actorUserId])
   @@index([action])
   @@index([tenantId])
+  @@index([runtimeSnapshotId], map: "audit_events_runtime_snapshot_idx")
+  @@index([correlationId], map: "audit_events_runtime_correlation_idx")
   @@map("audit_events")
 }
 
@@ -657,4 +672,71 @@ model Account {
 
   @@index([orgId])
   @@map("accounts")
+}
+
+// ── Deal Workspace Runtime Persistence ────────────────────────────────────────
+
+model DealWorkspaceRuntimeSnapshot {
+  id                   String   @id @default(cuid())
+  runtimeSnapshotId    String
+  idempotencyKey       String
+  dealId               String
+  intentId             String
+  state                String
+  snapshotState        String
+  statusLabel          String
+  runtimeStoreRecordId String
+  runtimeStoreVersion  String
+  actorId              String
+  actorRole            String
+  correlationId        String
+  auditId              String
+  contractHash         String
+  payload              Json
+  outboxEntryId        String?
+  auditEventId         String?
+  version              Int      @default(1)
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  deal                 Deal      @relation("RuntimeSnapshotDeal", fields: [dealId], references: [id], onDelete: Restrict, map: "dw_runtime_snapshots_deal_fkey")
+  outboxEntry          OutboxEntry? @relation("RuntimeSnapshotOutbox", fields: [outboxEntryId], references: [id], onDelete: Restrict, map: "dw_runtime_snapshots_outbox_fkey")
+  auditEvent           AuditEvent? @relation("RuntimeSnapshotAudit", fields: [auditEventId], references: [id], onDelete: Restrict, map: "dw_runtime_snapshots_audit_fkey")
+  attempts             DealWorkspaceRuntimeTransactionAttempt[]
+
+  @@unique([runtimeSnapshotId], map: "dw_runtime_snapshots_runtime_snapshot_id_key")
+  @@unique([idempotencyKey], map: "dw_runtime_snapshots_idempotency_key_key")
+  @@unique([outboxEntryId], map: "dw_runtime_snapshots_outbox_entry_id_key")
+  @@unique([auditEventId], map: "dw_runtime_snapshots_audit_event_id_key")
+  @@index([dealId, createdAt], map: "dw_runtime_snapshots_deal_created_idx")
+  @@index([intentId, state], map: "dw_runtime_snapshots_intent_state_idx")
+  @@index([correlationId], map: "dw_runtime_snapshots_correlation_idx")
+  @@index([state, updatedAt], map: "dw_runtime_snapshots_state_updated_idx")
+  @@map("deal_workspace_runtime_snapshots")
+}
+
+model DealWorkspaceRuntimeTransactionAttempt {
+  id             String   @id @default(cuid())
+  transactionId  String
+  snapshotId     String
+  idempotencyKey String
+  correlationId  String
+  auditId        String
+  stage          String
+  outcome        String?
+  failureCode    String?
+  failureReason  String?
+  isReplay       Boolean  @default(false)
+  startedAt      DateTime @default(now())
+  completedAt    DateTime?
+  metadata       Json?
+
+  snapshot       DealWorkspaceRuntimeSnapshot @relation(fields: [snapshotId], references: [id], onDelete: Restrict, map: "dw_runtime_attempts_snapshot_fkey")
+
+  @@unique([transactionId], map: "dw_runtime_attempts_transaction_id_key")
+  @@index([snapshotId, startedAt], map: "dw_runtime_attempts_snapshot_started_idx")
+  @@index([stage, startedAt], map: "dw_runtime_attempts_stage_started_idx")
+  @@index([idempotencyKey], map: "dw_runtime_attempts_idempotency_idx")
+  @@index([correlationId], map: "dw_runtime_attempts_correlation_idx")
+  @@map("deal_workspace_runtime_transaction_attempts")
 }

--- a/apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts
+++ b/apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts
@@ -1,0 +1,87 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoFile = (relativePath: string) =>
+  fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+
+const schema = repoFile('apps/api/prisma/schema.prisma');
+const contract = repoFile('apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql');
+const migration = repoFile(
+  'apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql',
+);
+const rollback = repoFile(
+  'apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql',
+);
+
+describe('VP-3.33 runtime persistence Prisma schema and migration', () => {
+  it('declares canonical runtime snapshot and transaction-attempt models', () => {
+    expect(schema).toContain('model DealWorkspaceRuntimeSnapshot');
+    expect(schema).toContain('model DealWorkspaceRuntimeTransactionAttempt');
+    expect(schema).toContain('@@map("deal_workspace_runtime_snapshots")');
+    expect(schema).toContain('@@map("deal_workspace_runtime_transaction_attempts")');
+
+    for (const field of [
+      'runtimeSnapshotId',
+      'idempotencyKey',
+      'contractHash',
+      'outboxEntryId',
+      'auditEventId',
+      'correlationId',
+      'auditId',
+    ]) {
+      expect(schema, `${field} must remain in the runtime snapshot model`).toContain(field);
+    }
+  });
+
+  it('reuses canonical outbox and audit tables instead of creating substitutes', () => {
+    expect(migration).toContain('ALTER TABLE "outbox_entries"');
+    expect(migration).toContain('ALTER TABLE "audit_events"');
+    expect(migration).not.toContain('CREATE TABLE IF NOT EXISTS "runtime_outbox');
+    expect(migration).not.toContain('CREATE TABLE IF NOT EXISTS "runtime_audit');
+    expect(schema).not.toContain('model DealWorkspaceRuntimeOutbox');
+    expect(schema).not.toContain('model DealWorkspaceRuntimeAudit');
+  });
+
+  it('enforces linkage consistency, evidence preservation and idempotency in SQL', () => {
+    for (const requiredTerm of [
+      'dw_runtime_snapshots_linkage_check',
+      "'outbox_required'",
+      "'audit_required'",
+      "'fully_linked'",
+      'dw_runtime_snapshots_deal_fkey',
+      'dw_runtime_snapshots_outbox_fkey',
+      'dw_runtime_snapshots_audit_fkey',
+      'dw_runtime_attempts_snapshot_fkey',
+      'ON DELETE RESTRICT',
+      'dw_runtime_snapshots_runtime_snapshot_id_key',
+      'dw_runtime_snapshots_idempotency_key_key',
+      'dw_runtime_attempts_transaction_id_key',
+    ]) {
+      expect(migration, `${requiredTerm} must remain in the migration`).toContain(requiredTerm);
+    }
+
+    expect(migration).toContain('CHECK ("version" > 0)');
+    expect(migration).toContain("'created', 'prepared', 'committed', 'rolled_back', 'failed'");
+  });
+
+  it('keeps the migration additive and production application explicit', () => {
+    expect(migration).not.toMatch(/DROP\s+(TABLE|COLUMN)/i);
+    expect(migration).toContain('Merging this file does not apply it to production');
+    expect(contract).toContain('does not mean the production migration is applied');
+  });
+
+  it('provides dependency-safe operational rollback for migration-owned objects', () => {
+    const attemptDrop = rollback.indexOf('DROP TABLE IF EXISTS "deal_workspace_runtime_transaction_attempts"');
+    const snapshotDrop = rollback.indexOf('DROP TABLE IF EXISTS "deal_workspace_runtime_snapshots"');
+    const outboxAlter = rollback.indexOf('ALTER TABLE "outbox_entries"');
+    const auditAlter = rollback.indexOf('ALTER TABLE "audit_events"');
+
+    expect(attemptDrop).toBeGreaterThanOrEqual(0);
+    expect(snapshotDrop).toBeGreaterThan(attemptDrop);
+    expect(outboxAlter).toBeGreaterThan(snapshotDrop);
+    expect(auditAlter).toBeGreaterThan(snapshotDrop);
+    expect(rollback).toContain('DROP COLUMN IF EXISTS "runtimeSnapshotId"');
+    expect(rollback).toContain('Run only under an approved maintenance procedure');
+  });
+});

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,32 +3,41 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "ready",
-  "current": "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.",
-  "fullTzReadinessPercent": 78,
-  "openPr": "#2240",
-  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock."],
+  "current": "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.",
+  "fullTzReadinessPercent": 80,
+  "openPr": "#2241",
+  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate."],
   "openBlockers": ["#2113", "#2115"],
   "blockerNotes": "#2113 repository settings cleanup. #2115 remains blocked by current auth-file write path.",
-  "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "broad backend/API/session/runtime/money/storage changes"],
+  "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "broad backend/API/session/runtime/money/storage changes outside the exact VP-3.33 scope"],
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md"
+    "docs/platform-v7/execution-queue.md",
+    "apps/api/prisma/schema.prisma",
+    "apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql",
+    "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql",
+    "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql",
+    "apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md"
+    "docs/platform-v7/execution-queue.md",
+    "apps/api/prisma/schema.prisma",
+    "apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql",
+    "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql",
+    "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql",
+    "apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts"
   ],
-  "vp331RuntimePersistencePrismaSchemaMigrationScopeUnlock": {
-    "layer": "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock",
-    "closedPr": "#2239",
-    "status": "prisma-schema-migration-scope-unlock-docs-only-complete"
-  },
   "vp332RuntimePersistencePrismaSchemaMigrationFinalGate": {
     "layer": "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate",
-    "openPr": "#2240",
-    "status": "final-gate-docs-only",
-    "implementationBranchInstruction": "The next manual code PR must set current to VP-3.33 and allowedCurrentScope to docs plus exactly the five approved schema, migration, rollback and validation files before writing code.",
-    "implementationFilesUnlockedForManualCodePr": [
+    "closedPr": "#2240",
+    "status": "final-gate-docs-only-complete"
+  },
+  "vp333RuntimePersistencePrismaSchemaMigrationImplementation": {
+    "layer": "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
+    "openPr": "#2241",
+    "status": "prisma-schema-migration-implementation",
+    "changedImplementationFiles": [
       "apps/api/prisma/schema.prisma",
       "apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql",
       "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql",
@@ -36,9 +45,9 @@
       "apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts"
     ]
   },
-  "vp333RuntimePersistencePrismaSchemaMigrationImplementation": {
-    "layer": "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
-    "status": "manual-code-pr-next-after-final-gate"
+  "vp334RuntimePersistencePostgresRepositoryAdapterPlan": {
+    "layer": "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan",
+    "status": "next-docs-only-plan"
   },
   "forbiddenZones": [
     "apps/landing",
@@ -54,5 +63,5 @@
   ],
   "maturityLanguage": ["platform-temporarily-without-external-integrations"],
   "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied"],
-  "readiness": "78% honest readiness. VP-3.32 is the final docs-only gate before additive Prisma schema and migration implementation. It does not change or apply a migration, connect runtime persistence to Postgres, or complete bank, FGIS or EDO integrations."
+  "readiness": "80% honest readiness. VP-3.33 adds the additive Prisma models, canonical outbox/audit linkage columns, migration SQL, operational rollback and validation guard. The migration file is prepared but has not been applied to a production database. Runtime persistence is not yet connected to a Postgres repository, and bank, FGIS and EDO live integrations remain unconfirmed."
 }

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,54 +1,69 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.
+CURRENT: VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.
 
-GOAL: Финально зафиксировать manual code PR gate для additive Prisma schema, migration, rollback и validation test после merge #2239, без применения migration и без runtime Postgres wiring.
+GOAL: Реализовать additive Prisma schema и migration-контракт для DB-backed runtime persistence после merge #2240, не применяя migration к production DB и не подключая runtime repository к Postgres в этом слое.
 
 CURRENT STATUS:
 - VP-3.29 transaction/idempotency hardening is merged from #2237.
 - VP-3.30 Prisma schema/migration plan is merged from #2238.
-- VP-3.31 schema/migration scope unlock is merged from #2239.
+- VP-3.31 scope unlock is merged from #2239.
+- VP-3.32 final gate is merged from #2240.
+- VP-3.33 prepares schema, migration, rollback and validation guard in PR #2241.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
+- apps/api/prisma/schema.prisma
+- apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql
+- apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql
+- apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql
+- apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts
 
-MANUAL CODE PR SCOPE AFTER THIS GATE:
-- `apps/api/prisma/schema.prisma`
-- `apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql`
-- `apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql`
-- `apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql`
-- `apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts`
+IMPLEMENTED:
+- Added canonical `DealWorkspaceRuntimeSnapshot` Prisma model.
+- Added append-only `DealWorkspaceRuntimeTransactionAttempt` Prisma model.
+- Reused canonical `Deal`, `OutboxEntry` and `AuditEvent`; no parallel evidence tables were introduced.
+- Added nullable correlation/runtime linkage columns to existing outbox and audit models.
+- Added unique keys for runtime snapshot, idempotency, outbox link, audit link and transaction identity.
+- Added restrictive foreign keys from runtime snapshot to deal/outbox/audit and from attempts to snapshot.
+- Added DB CHECK constraints for snapshot state, runtime state, version and transaction stage.
+- Added DB linkage consistency constraint:
+  - `ready_to_persist` and `outbox_required`: no evidence links;
+  - `audit_required`: outbox link only;
+  - `fully_linked`: outbox and audit links.
+- Added operational indexes for deal timeline, intent/state, correlation, recovery and evidence lookup.
+- Added dependency-safe operational `rollback.sql`.
+- Added unit guard that rejects duplicate runtime outbox/audit tables, missing constraints and destructive forward migration.
 
-MANDATORY RULES:
-- Additive schema only; canonical Deal/OutboxEntry/AuditEvent are reused.
-- Runtime snapshot and append-only transaction attempt models require explicit unique, check, foreign-key and index constraints.
-- Linkage state and outbox/audit foreign keys must be DB-consistent.
-- Restrictive deletion preserves evidence.
-- Existing data requires no mandatory backfill for deployment.
-- Rollback removes only migration-owned objects in dependency-safe order.
-- Merged migration files are not an applied production migration.
+IMPORTANT LIMITS:
+- Migration files are committed but are not an applied production migration.
+- No production database was modified by this layer.
+- Runtime repository still uses its current in-process/contract adapter path.
+- No live outbox/audit persistence, bank callbacks, FGIS or EDO integration is claimed.
 
 STILL LOCKED:
 - runtime Postgres repository adapter;
-- runtime action/API wiring;
+- runtime action/API Postgres wiring;
+- production migration execution and rollback rehearsal;
 - auth/tenant enforcement changes;
 - UI/components;
 - package and lockfiles;
 - live bank/FGIS/EDO integrations.
 
 NEXT:
-- Layer: VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.
-- Goal: prepare the manual schema/migration implementation layer after this gate is merged.
+- Layer: VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.
+- Goal: select the exact Prisma-backed repository, transaction boundary and tests without writing adapter code.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
 - Success criteria:
-  - final gate closes without schema/migration code changes;
-  - next manual code PR explicitly expands current scope to the five approved files;
+  - VP-3.33 schema parses and validates;
+  - migration and rollback guard tests are green;
+  - no production migration application is claimed;
   - critical forbidden zones remain unchanged;
-  - maturity language does not claim an applied production migration.
+  - Railway `brilliant-liberation - @pc/web` is green after merge.
 
 AFTER NEXT:
-- Layer: VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.
-- Goal: select exact DB-backed repository adapter scope after schema/migration implementation is merged and validated.
+- Layer: VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.
+- Goal: docs-only unlock the exact DB adapter implementation files after the plan is merged.


### PR DESCRIPTION
## Суть

Реализован additive Prisma schema/migration слой для Deal Workspace runtime persistence.

## Реализовано

- canonical `DealWorkspaceRuntimeSnapshot`;
- append-only `DealWorkspaceRuntimeTransactionAttempt`;
- reuse existing `Deal`, `OutboxEntry`, `AuditEvent` models;
- nullable correlation/runtime linkage columns on canonical outbox/audit tables;
- unique runtime snapshot, idempotency, outbox, audit and transaction identities;
- restrictive foreign keys for evidence preservation;
- DB CHECK constraints for runtime state, snapshot state, version, transaction stage and linkage consistency;
- operational indexes for timeline, correlation and recovery;
- additive migration and dependency-safe operational rollback;
- unit guard against duplicate evidence tables, destructive forward migration and missing constraints.

## Ограничение зрелости

Migration подготовлена в репозитории, но не применена к production DB. Runtime repository ещё не подключён к Prisma/Postgres. Live bank callbacks, ФГИС и ЭДО не подтверждены.

## Scope

Ровно семь файлов: Prisma schema, SQL contract, migration, rollback, validation test и два state/queue документа. UI/API/auth/package/lockfiles не менялись.