### PR TITLE
VP-3.34 Runtime Persistence Postgres Repository Adapter Plan

### DIFF
--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,51 +3,41 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "ready",
-  "current": "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.",
+  "current": "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.",
   "fullTzReadinessPercent": 80,
-  "openPr": "#2241",
-  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate."],
+  "openPr": "#2242",
+  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation."],
   "openBlockers": ["#2113", "#2115"],
   "blockerNotes": "#2113 repository settings cleanup. #2115 remains blocked by current auth-file write path.",
-  "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "broad backend/API/session/runtime/money/storage changes outside the exact VP-3.33 scope"],
+  "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "backend/API/runtime changes outside the exact future adapter scope"],
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md",
-    "apps/api/prisma/schema.prisma",
-    "apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql",
-    "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql",
-    "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql",
-    "apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts"
+    "docs/platform-v7/execution-queue.md"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md",
-    "apps/api/prisma/schema.prisma",
-    "apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql",
-    "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql",
-    "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql",
-    "apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts"
+    "docs/platform-v7/execution-queue.md"
   ],
-  "vp332RuntimePersistencePrismaSchemaMigrationFinalGate": {
-    "layer": "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate",
-    "closedPr": "#2240",
-    "status": "final-gate-docs-only-complete"
-  },
   "vp333RuntimePersistencePrismaSchemaMigrationImplementation": {
     "layer": "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
-    "openPr": "#2241",
-    "status": "prisma-schema-migration-implementation",
-    "changedImplementationFiles": [
-      "apps/api/prisma/schema.prisma",
-      "apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql",
-      "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql",
-      "apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql",
-      "apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts"
-    ]
+    "closedPr": "#2241",
+    "status": "prisma-schema-migration-implementation-complete"
   },
   "vp334RuntimePersistencePostgresRepositoryAdapterPlan": {
     "layer": "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan",
-    "status": "next-docs-only-plan"
+    "openPr": "#2242",
+    "status": "postgres-repository-adapter-plan-docs-only",
+    "candidateImplementationFiles": [
+      "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
+      "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
+      "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts",
+      "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts",
+      "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts"
+    ]
+  },
+  "vp335RuntimePersistencePostgresRepositoryAdapterScopeUnlock": {
+    "layer": "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock",
+    "status": "next-docs-only-scope-unlock"
   },
   "forbiddenZones": [
     "apps/landing",
@@ -62,6 +52,6 @@
     "pnpm-lock.yaml"
   ],
   "maturityLanguage": ["platform-temporarily-without-external-integrations"],
-  "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied"],
-  "readiness": "80% honest readiness. VP-3.33 adds the additive Prisma models, canonical outbox/audit linkage columns, migration SQL, operational rollback and validation guard. The migration file is prepared but has not been applied to a production database. Runtime persistence is not yet connected to a Postgres repository, and bank, FGIS and EDO live integrations remain unconfirmed."
+  "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied", "Postgres adapter active"],
+  "readiness": "80% honest readiness. VP-3.34 selects an API-side Prisma repository adapter with explicit fail-closed activation and atomic transaction semantics. No adapter code, AppModule/controller/web wiring or production migration execution occurs in this docs-only layer."
 }

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,50 +1,61 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.
+CURRENT: VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.
 
-GOAL: Реализовать additive Prisma schema и migration-контракт для DB-backed runtime persistence после merge #2240, не применяя migration к production DB и не подключая runtime repository к Postgres в этом слое.
+GOAL: Выбрать точный API-side Prisma repository adapter scope после merge #2241, без adapter code, AppModule/controller/web wiring и без применения migration к production DB.
 
 CURRENT STATUS:
 - VP-3.29 transaction/idempotency hardening is merged from #2237.
-- VP-3.30 Prisma schema/migration plan is merged from #2238.
-- VP-3.31 scope unlock is merged from #2239.
-- VP-3.32 final gate is merged from #2240.
-- VP-3.33 prepares schema, migration, rollback and validation guard in PR #2241.
+- VP-3.33 additive Prisma schema/migration implementation is merged from #2241.
+- Railway `brilliant-liberation - @pc/web` is green after #2241.
+- `PrismaService` already exists as a global NestJS provider in `apps/api`.
+- Prisma must not be imported into the Next.js client or shared browser bundle.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
-- apps/api/prisma/schema.prisma
-- apps/api/prisma/contracts/deal_workspace_runtime_snapshots.sql
-- apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql
-- apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/rollback.sql
-- apps/web/tests/unit/platformV7DealWorkspaceRuntimePrismaSchema.test.ts
 
-IMPLEMENTED:
-- Added canonical `DealWorkspaceRuntimeSnapshot` Prisma model.
-- Added append-only `DealWorkspaceRuntimeTransactionAttempt` Prisma model.
-- Reused canonical `Deal`, `OutboxEntry` and `AuditEvent`; no parallel evidence tables were introduced.
-- Added nullable correlation/runtime linkage columns to existing outbox and audit models.
-- Added unique keys for runtime snapshot, idempotency, outbox link, audit link and transaction identity.
-- Added restrictive foreign keys from runtime snapshot to deal/outbox/audit and from attempts to snapshot.
-- Added DB CHECK constraints for snapshot state, runtime state, version and transaction stage.
-- Added DB linkage consistency constraint:
-  - `ready_to_persist` and `outbox_required`: no evidence links;
-  - `audit_required`: outbox link only;
-  - `fully_linked`: outbox and audit links.
-- Added operational indexes for deal timeline, intent/state, correlation, recovery and evidence lookup.
-- Added dependency-safe operational `rollback.sql`.
-- Added unit guard that rejects duplicate runtime outbox/audit tables, missing constraints and destructive forward migration.
+CANDIDATE IMPLEMENTATION FILES FOR LATER CODE PR:
+- `apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts`
+- `apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts`
+- `apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts`
+- `apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts`
+- `apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts`
 
-IMPORTANT LIMITS:
-- Migration files are committed but are not an applied production migration.
-- No production database was modified by this layer.
-- Runtime repository still uses its current in-process/contract adapter path.
-- No live outbox/audit persistence, bank callbacks, FGIS or EDO integration is claimed.
+TARGET ADAPTER CONTRACT:
+- Repository is API-side and depends on the existing global `PrismaService`.
+- No browser/client import path may reference Prisma or the API repository implementation.
+- Activation is explicit only through `PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY=prisma`.
+- Default and unrelated flag values are fail-closed; there is no silent fallback to the process runtime store.
+- Missing PrismaService fails loudly before a write is attempted.
+- Public/API callers cannot supply trusted outbox or audit database IDs.
+- Input carries business identity and payload only: runtime snapshot identity, deal/intent, actor, correlation, audit identity, idempotency key and contract hash.
+
+ATOMIC WRITE SEMANTICS:
+- One `PrismaService.$transaction` owns snapshot, canonical outbox, canonical audit and transaction-attempt writes.
+- First successful write creates canonical outbox and audit rows, then a `fully_linked` runtime snapshot and a committed transaction attempt inside the same DB transaction.
+- Any failure rolls back all four writes; partial evidence is forbidden.
+- Existing idempotency key with identical runtimeSnapshotId and contractHash returns deterministic duplicate without additional rows.
+- Existing idempotency key with another runtimeSnapshotId or contractHash returns explicit conflict.
+- Existing accepted outbox/audit linkage cannot be replaced.
+- Repository result distinguishes `persisted`, `duplicate`, `conflict` and `failed`.
+- Database unique/FK/CHECK violations are mapped to controlled repository outcomes; raw database errors are not exposed to clients.
+
+TEST REQUIREMENTS:
+- factory defaults fail-closed and selects Prisma only for exact `prisma` mode;
+- PrismaService is mandatory for active mode;
+- successful path uses exactly one `$transaction`;
+- first write creates outbox, audit, snapshot and committed attempt;
+- duplicate path creates no rows;
+- conflict path creates no rows;
+- injected failure proves rollback/no partial writes;
+- caller cannot inject outboxEntryId/auditEventId as trusted evidence;
+- no package or lockfile change is required.
 
 STILL LOCKED:
-- runtime Postgres repository adapter;
-- runtime action/API Postgres wiring;
+- runtime persistence module/controller/API endpoint;
+- AppModule registration;
+- web server-action bridge;
 - production migration execution and rollback rehearsal;
 - auth/tenant enforcement changes;
 - UI/components;
@@ -52,18 +63,18 @@ STILL LOCKED:
 - live bank/FGIS/EDO integrations.
 
 NEXT:
-- Layer: VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.
-- Goal: select the exact Prisma-backed repository, transaction boundary and tests without writing adapter code.
+- Layer: VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.
+- Goal: docs-only unlock the exact five adapter/test files.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
 - Success criteria:
-  - VP-3.33 schema parses and validates;
-  - migration and rollback guard tests are green;
-  - no production migration application is claimed;
-  - critical forbidden zones remain unchanged;
-  - Railway `brilliant-liberation - @pc/web` is green after merge.
+  - adapter remains API-side;
+  - activation and failure behavior are explicit;
+  - transaction/idempotency invariants are complete;
+  - no adapter code is written in VP-3.34;
+  - guard, dry-run and security checks remain green.
 
 AFTER NEXT:
-- Layer: VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.
-- Goal: docs-only unlock the exact DB adapter implementation files after the plan is merged.
+- Layer: VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.
+- Goal: final docs-only gate before adapter implementation.


### PR DESCRIPTION
## Суть

Docs-only план API-side Prisma repository adapter для runtime persistence.

## Зафиксировано

- Prisma остаётся только в `apps/api`;
- exact five-file implementation scope;
- explicit `PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY=prisma` activation;
- fail-closed default, no silent process-store fallback;
- one `$transaction` for snapshot/outbox/audit/attempt;
- deterministic persisted/duplicate/conflict/failed outcomes;
- rollback/no-partial-write and caller evidence-injection tests;
- AppModule/controller/web wiring и production migration application остаются закрыты.

Adapter code в этом PR не пишется.