### PR TITLE
VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock

### DIFF
--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,10 +3,10 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "ready",
-  "current": "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.",
+  "current": "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.",
   "fullTzReadinessPercent": 80,
-  "openPr": "#2242",
-  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation."],
+  "openPr": "#2243",
+  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.", "#2242", "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan."],
   "openBlockers": ["#2113", "#2115"],
   "blockerNotes": "#2113 repository settings cleanup. #2115 remains blocked by current auth-file write path.",
   "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "backend/API/runtime changes outside the exact future adapter scope"],
@@ -18,16 +18,16 @@
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md"
   ],
-  "vp333RuntimePersistencePrismaSchemaMigrationImplementation": {
-    "layer": "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
-    "closedPr": "#2241",
-    "status": "prisma-schema-migration-implementation-complete"
-  },
   "vp334RuntimePersistencePostgresRepositoryAdapterPlan": {
     "layer": "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan",
-    "openPr": "#2242",
-    "status": "postgres-repository-adapter-plan-docs-only",
-    "candidateImplementationFiles": [
+    "closedPr": "#2242",
+    "status": "postgres-repository-adapter-plan-docs-only-complete"
+  },
+  "vp335RuntimePersistencePostgresRepositoryAdapterScopeUnlock": {
+    "layer": "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock",
+    "openPr": "#2243",
+    "status": "postgres-repository-adapter-scope-unlock-docs-only",
+    "unlockedImplementationFilesForLater": [
       "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
       "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
       "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts",
@@ -35,9 +35,9 @@
       "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts"
     ]
   },
-  "vp335RuntimePersistencePostgresRepositoryAdapterScopeUnlock": {
-    "layer": "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock",
-    "status": "next-docs-only-scope-unlock"
+  "vp336RuntimePersistencePostgresRepositoryAdapterFinalGate": {
+    "layer": "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate",
+    "status": "next-docs-only-final-gate"
   },
   "forbiddenZones": [
     "apps/landing",
@@ -53,5 +53,5 @@
   ],
   "maturityLanguage": ["platform-temporarily-without-external-integrations"],
   "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied", "Postgres adapter active"],
-  "readiness": "80% honest readiness. VP-3.34 selects an API-side Prisma repository adapter with explicit fail-closed activation and atomic transaction semantics. No adapter code, AppModule/controller/web wiring or production migration execution occurs in this docs-only layer."
+  "readiness": "80% honest readiness. VP-3.35 is a docs-only unlock for five exact API-side repository and test files. It does not write adapter code, apply the migration, register a module or expose an API endpoint."
 }

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,56 +1,37 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.
+CURRENT: VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.
 
-GOAL: Выбрать точный API-side Prisma repository adapter scope после merge #2241, без adapter code, AppModule/controller/web wiring и без применения migration к production DB.
+GOAL: Docs-only разблокировать пять точных API-side repository/test файлов после merge #2242, не создавая adapter code и не применяя migration.
 
 CURRENT STATUS:
-- VP-3.29 transaction/idempotency hardening is merged from #2237.
-- VP-3.33 additive Prisma schema/migration implementation is merged from #2241.
-- Railway `brilliant-liberation - @pc/web` is green after #2241.
-- `PrismaService` already exists as a global NestJS provider in `apps/api`.
-- Prisma must not be imported into the Next.js client or shared browser bundle.
+- VP-3.33 additive Prisma schema/migration is merged from #2241.
+- VP-3.34 Postgres repository adapter plan is merged from #2242.
+- Railway `brilliant-liberation - @pc/web` is green after #2242.
+- Adapter remains server-only under `apps/api`.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
 
-CANDIDATE IMPLEMENTATION FILES FOR LATER CODE PR:
+UNLOCKED IMPLEMENTATION FILES FOR LATER CODE PR:
 - `apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts`
 - `apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts`
 - `apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts`
 - `apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts`
 - `apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts`
 
-TARGET ADAPTER CONTRACT:
-- Repository is API-side and depends on the existing global `PrismaService`.
-- No browser/client import path may reference Prisma or the API repository implementation.
-- Activation is explicit only through `PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY=prisma`.
-- Default and unrelated flag values are fail-closed; there is no silent fallback to the process runtime store.
-- Missing PrismaService fails loudly before a write is attempted.
-- Public/API callers cannot supply trusted outbox or audit database IDs.
-- Input carries business identity and payload only: runtime snapshot identity, deal/intent, actor, correlation, audit identity, idempotency key and contract hash.
-
-ATOMIC WRITE SEMANTICS:
-- One `PrismaService.$transaction` owns snapshot, canonical outbox, canonical audit and transaction-attempt writes.
-- First successful write creates canonical outbox and audit rows, then a `fully_linked` runtime snapshot and a committed transaction attempt inside the same DB transaction.
-- Any failure rolls back all four writes; partial evidence is forbidden.
-- Existing idempotency key with identical runtimeSnapshotId and contractHash returns deterministic duplicate without additional rows.
-- Existing idempotency key with another runtimeSnapshotId or contractHash returns explicit conflict.
-- Existing accepted outbox/audit linkage cannot be replaced.
-- Repository result distinguishes `persisted`, `duplicate`, `conflict` and `failed`.
-- Database unique/FK/CHECK violations are mapped to controlled repository outcomes; raw database errors are not exposed to clients.
-
-TEST REQUIREMENTS:
-- factory defaults fail-closed and selects Prisma only for exact `prisma` mode;
-- PrismaService is mandatory for active mode;
-- successful path uses exactly one `$transaction`;
-- first write creates outbox, audit, snapshot and committed attempt;
-- duplicate path creates no rows;
-- conflict path creates no rows;
-- injected failure proves rollback/no partial writes;
-- caller cannot inject outboxEntryId/auditEventId as trusted evidence;
-- no package or lockfile change is required.
+MANDATORY IMPLEMENTATION RULES:
+- API-side only; no Prisma import through web/browser paths.
+- Explicit activation only with `PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY=prisma`.
+- Default and unrelated modes fail closed; no silent runtime-store fallback.
+- Active Prisma adapter requires `PrismaService` and fails loudly when unavailable.
+- Caller input contains no trusted `outboxEntryId` or `auditEventId`.
+- One `$transaction` owns canonical outbox, audit, snapshot and attempt creation.
+- Successful first write is `fully_linked` only after both canonical evidence rows exist inside the same transaction.
+- Duplicate and conflict paths create no additional evidence rows.
+- Any write failure rolls back all transaction writes.
+- Controlled outcomes do not expose raw DB errors.
 
 STILL LOCKED:
 - runtime persistence module/controller/API endpoint;
@@ -63,18 +44,17 @@ STILL LOCKED:
 - live bank/FGIS/EDO integrations.
 
 NEXT:
-- Layer: VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.
-- Goal: docs-only unlock the exact five adapter/test files.
+- Layer: VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.
+- Goal: final docs-only gate before writing adapter code.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
 - Success criteria:
-  - adapter remains API-side;
-  - activation and failure behavior are explicit;
-  - transaction/idempotency invariants are complete;
-  - no adapter code is written in VP-3.34;
+  - the five implementation files remain unchanged in VP-3.35;
+  - transaction, idempotency and fail-closed rules remain explicit;
+  - critical forbidden zones remain unchanged;
   - guard, dry-run and security checks remain green.
 
 AFTER NEXT:
-- Layer: VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.
-- Goal: final docs-only gate before adapter implementation.
+- Layer: VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation.
+- Goal: implement the exact five API-side repository/test files after the final gate is merged.


### PR DESCRIPTION
## Суть

Docs-only разблокировка пяти точных API-side repository/test файлов.

Фиксируются server-only Prisma boundary, explicit feature flag, fail-closed behavior, one-transaction atomicity, deterministic duplicate/conflict semantics и запрет caller-supplied evidence IDs.

Adapter code, module/controller/API wiring и production migration application в этом PR отсутствуют.