### PR TITLE
VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate

### DIFF
--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,10 +3,10 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "ready",
-  "current": "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.",
+  "current": "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.",
   "fullTzReadinessPercent": 80,
-  "openPr": "#2243",
-  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.", "#2242", "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan."],
+  "openPr": "#2244",
+  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.", "#2242", "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.", "#2243", "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock."],
   "openBlockers": ["#2113", "#2115"],
   "blockerNotes": "#2113 repository settings cleanup. #2115 remains blocked by current auth-file write path.",
   "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "backend/API/runtime changes outside the exact future adapter scope"],
@@ -18,16 +18,17 @@
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md"
   ],
-  "vp334RuntimePersistencePostgresRepositoryAdapterPlan": {
-    "layer": "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan",
-    "closedPr": "#2242",
-    "status": "postgres-repository-adapter-plan-docs-only-complete"
-  },
   "vp335RuntimePersistencePostgresRepositoryAdapterScopeUnlock": {
     "layer": "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock",
-    "openPr": "#2243",
-    "status": "postgres-repository-adapter-scope-unlock-docs-only",
-    "unlockedImplementationFilesForLater": [
+    "closedPr": "#2243",
+    "status": "postgres-repository-adapter-scope-unlock-docs-only-complete"
+  },
+  "vp336RuntimePersistencePostgresRepositoryAdapterFinalGate": {
+    "layer": "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate",
+    "openPr": "#2244",
+    "status": "postgres-repository-adapter-final-gate-docs-only",
+    "implementationBranchInstruction": "The next manual code PR must set current to VP-3.37 and allowedCurrentScope to docs plus exactly the five approved API-side repository/test files before writing code.",
+    "implementationFilesUnlockedForManualCodePr": [
       "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
       "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
       "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts",
@@ -35,9 +36,9 @@
       "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts"
     ]
   },
-  "vp336RuntimePersistencePostgresRepositoryAdapterFinalGate": {
-    "layer": "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate",
-    "status": "next-docs-only-final-gate"
+  "vp337RuntimePersistencePostgresRepositoryAdapterImplementation": {
+    "layer": "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
+    "status": "manual-code-pr-next-after-final-gate"
   },
   "forbiddenZones": [
     "apps/landing",
@@ -53,5 +54,5 @@
   ],
   "maturityLanguage": ["platform-temporarily-without-external-integrations"],
   "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied", "Postgres adapter active"],
-  "readiness": "80% honest readiness. VP-3.35 is a docs-only unlock for five exact API-side repository and test files. It does not write adapter code, apply the migration, register a module or expose an API endpoint."
+  "readiness": "80% honest readiness. VP-3.36 is the final docs-only gate before writing five API-side repository/test files. It does not implement or activate the adapter, apply the migration, register a module or expose an API endpoint."
 }

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,37 +1,38 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.
+CURRENT: VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.
 
-GOAL: Docs-only разблокировать пять точных API-side repository/test файлов после merge #2242, не создавая adapter code и не применяя migration.
+GOAL: Финально зафиксировать manual code PR gate для пяти API-side repository/test файлов после merge #2243, без adapter code, module/controller/API wiring и production migration application.
 
 CURRENT STATUS:
 - VP-3.33 additive Prisma schema/migration is merged from #2241.
-- VP-3.34 Postgres repository adapter plan is merged from #2242.
-- Railway `brilliant-liberation - @pc/web` is green after #2242.
-- Adapter remains server-only under `apps/api`.
+- VP-3.34 adapter plan is merged from #2242.
+- VP-3.35 scope unlock is merged from #2243.
+- Railway `brilliant-liberation - @pc/web` is green after #2243.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
 
-UNLOCKED IMPLEMENTATION FILES FOR LATER CODE PR:
+MANUAL CODE PR SCOPE AFTER THIS GATE:
 - `apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts`
 - `apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts`
 - `apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts`
 - `apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts`
 - `apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts`
 
-MANDATORY IMPLEMENTATION RULES:
-- API-side only; no Prisma import through web/browser paths.
-- Explicit activation only with `PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY=prisma`.
-- Default and unrelated modes fail closed; no silent runtime-store fallback.
-- Active Prisma adapter requires `PrismaService` and fails loudly when unavailable.
-- Caller input contains no trusted `outboxEntryId` or `auditEventId`.
-- One `$transaction` owns canonical outbox, audit, snapshot and attempt creation.
-- Successful first write is `fully_linked` only after both canonical evidence rows exist inside the same transaction.
-- Duplicate and conflict paths create no additional evidence rows.
-- Any write failure rolls back all transaction writes.
-- Controlled outcomes do not expose raw DB errors.
+FINAL IMPLEMENTATION INVARIANTS:
+- API-side only; Prisma is never imported by web/browser code.
+- Exact `PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY=prisma` activation.
+- Default and unrelated modes are fail-closed with no silent process-store fallback.
+- Missing PrismaService fails before a write.
+- Caller cannot submit trusted evidence database IDs.
+- One `$transaction` owns canonical outbox, audit, snapshot and attempt writes.
+- First write becomes `fully_linked` only inside that successful transaction.
+- Identical replay returns duplicate with no additional rows.
+- Material identity mismatch returns conflict with no additional rows.
+- Transaction failure leaves no partial evidence.
+- Raw database errors are not exposed.
 
 STILL LOCKED:
 - runtime persistence module/controller/API endpoint;
@@ -44,17 +45,17 @@ STILL LOCKED:
 - live bank/FGIS/EDO integrations.
 
 NEXT:
-- Layer: VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.
-- Goal: final docs-only gate before writing adapter code.
+- Layer: VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation.
+- Goal: prepare the manual code implementation after this gate is merged.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
 - Success criteria:
-  - the five implementation files remain unchanged in VP-3.35;
-  - transaction, idempotency and fail-closed rules remain explicit;
+  - final gate closes without adapter code changes;
+  - next manual code PR explicitly expands current scope to the exact five files;
   - critical forbidden zones remain unchanged;
-  - guard, dry-run and security checks remain green.
+  - maturity language does not claim an active Postgres adapter.
 
 AFTER NEXT:
-- Layer: VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation.
-- Goal: implement the exact five API-side repository/test files after the final gate is merged.
+- Layer: VP-3.38 Runtime Persistence Internal Service Wiring Plan.
+- Goal: select server-only module/service provider wiring after the repository adapter implementation is merged and validated.


### PR DESCRIPTION
## Суть

Финальный docs-only gate перед API-side Postgres repository adapter implementation.

Зафиксированы exact five-file scope, server-only Prisma boundary, explicit feature flag, fail-closed default, one-transaction atomicity, duplicate/conflict semantics, rollback/no-partial-write и запрет caller-supplied evidence IDs.

Adapter code, module/controller/API wiring и production migration application отсутствуют.