### PR TITLE
VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation

### DIFF
--- a/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts
+++ b/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts
@@ -1,0 +1,223 @@
+import { PrismaRuntimePersistenceRepository } from './prisma-runtime-persistence.repository';
+import type { RuntimePersistenceWriteInput } from './runtime-persistence.repository';
+
+const baseInput: RuntimePersistenceWriteInput = {
+  runtimeSnapshotId: 'snapshot-1',
+  idempotencyKey: 'idem-1',
+  transactionId: 'tx-1',
+  dealId: 'deal-1',
+  intentId: 'intent-1',
+  snapshotState: 'updated',
+  statusLabel: 'Updated',
+  runtimeStoreRecordId: 'runtime-record-1',
+  runtimeStoreVersion: '1',
+  actorId: 'user-1',
+  actorRole: 'operator',
+  tenantId: 'tenant-1',
+  organizationId: 'org-1',
+  correlationId: 'corr-1',
+  auditId: 'audit-business-1',
+  contractHash: 'hash-1',
+  payload: { status: 'updated', amountKopecks: 1000 },
+};
+
+function existingSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'record-1',
+    runtimeSnapshotId: 'snapshot-1',
+    idempotencyKey: 'idem-1',
+    contractHash: 'hash-1',
+    state: 'fully_linked',
+    outboxEntryId: 'outbox-1',
+    auditEventId: 'audit-1',
+    attempts: [{ id: 'attempt-1' }],
+    ...overrides,
+  };
+}
+
+function successfulPrisma() {
+  const outboxCreate = jest.fn().mockResolvedValue({ id: 'outbox-1' });
+  const auditCreate = jest.fn().mockResolvedValue({ id: 'audit-1' });
+  const snapshotCreate = jest.fn().mockResolvedValue({
+    id: 'record-1',
+    runtimeSnapshotId: 'snapshot-1',
+    idempotencyKey: 'idem-1',
+    state: 'fully_linked',
+  });
+  const attemptCreate = jest.fn().mockResolvedValue({ id: 'attempt-1' });
+  const tx = {
+    outboxEntry: { create: outboxCreate },
+    auditEvent: { create: auditCreate },
+    dealWorkspaceRuntimeSnapshot: { create: snapshotCreate },
+    dealWorkspaceRuntimeTransactionAttempt: { create: attemptCreate },
+  };
+  const prisma = {
+    dealWorkspaceRuntimeSnapshot: {
+      findUnique: jest.fn().mockResolvedValue(null),
+    },
+    $transaction: jest.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+  } as any;
+
+  return {
+    prisma,
+    outboxCreate,
+    auditCreate,
+    snapshotCreate,
+    attemptCreate,
+  };
+}
+
+describe('PrismaRuntimePersistenceRepository', () => {
+  it('persists outbox, audit, snapshot and committed attempt in one transaction', async () => {
+    const setup = successfulPrisma();
+    const repository = new PrismaRuntimePersistenceRepository(setup.prisma);
+    const maliciousInput = {
+      ...baseInput,
+      outboxEntryId: 'caller-outbox-id',
+      auditEventId: 'caller-audit-id',
+    } as any;
+
+    const receipt = await repository.write(maliciousInput);
+
+    expect(setup.prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(receipt).toEqual({
+      status: 'persisted',
+      runtimeSnapshotId: 'snapshot-1',
+      idempotencyKey: 'idem-1',
+      state: 'fully_linked',
+      recordId: 'record-1',
+      outboxEntryId: 'outbox-1',
+      auditEventId: 'audit-1',
+      transactionAttemptId: 'attempt-1',
+    });
+
+    expect(setup.outboxCreate).toHaveBeenCalledTimes(1);
+    expect(setup.auditCreate).toHaveBeenCalledTimes(1);
+    expect(setup.snapshotCreate).toHaveBeenCalledTimes(1);
+    expect(setup.attemptCreate).toHaveBeenCalledTimes(1);
+
+    const snapshotData = setup.snapshotCreate.mock.calls[0][0].data;
+    expect(snapshotData.state).toBe('fully_linked');
+    expect(snapshotData.outboxEntryId).toBe('outbox-1');
+    expect(snapshotData.auditEventId).toBe('audit-1');
+    expect(snapshotData.outboxEntryId).not.toBe('caller-outbox-id');
+    expect(snapshotData.auditEventId).not.toBe('caller-audit-id');
+
+    const outboxData = setup.outboxCreate.mock.calls[0][0].data;
+    const auditData = setup.auditCreate.mock.calls[0][0].data;
+    expect(outboxData.runtimeSnapshotId).toBe('snapshot-1');
+    expect(auditData.runtimeSnapshotId).toBe('snapshot-1');
+    expect(auditData.tenantId).toBe('tenant-1');
+    expect(auditData.orgId).toBe('org-1');
+  });
+
+  it('returns deterministic duplicate without starting a transaction', async () => {
+    const prisma = {
+      dealWorkspaceRuntimeSnapshot: {
+        findUnique: jest.fn().mockResolvedValue(existingSnapshot()),
+      },
+      $transaction: jest.fn(),
+    } as any;
+    const repository = new PrismaRuntimePersistenceRepository(prisma);
+
+    await expect(repository.write(baseInput)).resolves.toEqual({
+      status: 'duplicate',
+      runtimeSnapshotId: 'snapshot-1',
+      idempotencyKey: 'idem-1',
+      state: 'fully_linked',
+      recordId: 'record-1',
+      outboxEntryId: 'outbox-1',
+      auditEventId: 'audit-1',
+      transactionAttemptId: 'attempt-1',
+    });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('returns conflict for a reused idempotency key with another material identity', async () => {
+    const prisma = {
+      dealWorkspaceRuntimeSnapshot: {
+        findUnique: jest.fn().mockResolvedValue(
+          existingSnapshot({ runtimeSnapshotId: 'snapshot-other', contractHash: 'hash-other' }),
+        ),
+      },
+      $transaction: jest.fn(),
+    } as any;
+    const repository = new PrismaRuntimePersistenceRepository(prisma);
+
+    const receipt = await repository.write(baseInput);
+
+    expect(receipt.status).toBe('conflict');
+    expect(receipt.reasonCode).toBe('material_identity_conflict');
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('classifies a concurrent P2002 winner as duplicate without a second transaction', async () => {
+    const findUnique = jest
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(existingSnapshot());
+    const prisma = {
+      dealWorkspaceRuntimeSnapshot: { findUnique },
+      $transaction: jest.fn().mockRejectedValue({ code: 'P2002' }),
+    } as any;
+    const repository = new PrismaRuntimePersistenceRepository(prisma);
+
+    const receipt = await repository.write(baseInput);
+
+    expect(receipt.status).toBe('duplicate');
+    expect(findUnique).toHaveBeenCalledTimes(2);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns invalid_input without touching the database', async () => {
+    const setup = successfulPrisma();
+    const repository = new PrismaRuntimePersistenceRepository(setup.prisma);
+
+    const receipt = await repository.write({ ...baseInput, dealId: '   ' });
+
+    expect(receipt).toMatchObject({ status: 'failed', reasonCode: 'invalid_input' });
+    expect(setup.prisma.dealWorkspaceRuntimeSnapshot.findUnique).not.toHaveBeenCalled();
+    expect(setup.prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('keeps staged writes uncommitted when a transaction step fails', async () => {
+    const committed: string[] = [];
+    const outboxCreate = jest.fn(async () => ({ id: 'outbox-stage' }));
+    const auditCreate = jest.fn(async () => {
+      throw new Error('sensitive database failure');
+    });
+    const snapshotCreate = jest.fn();
+    const attemptCreate = jest.fn();
+    const tx = {
+      outboxEntry: { create: outboxCreate },
+      auditEvent: { create: auditCreate },
+      dealWorkspaceRuntimeSnapshot: { create: snapshotCreate },
+      dealWorkspaceRuntimeTransactionAttempt: { create: attemptCreate },
+    };
+    const prisma = {
+      dealWorkspaceRuntimeSnapshot: { findUnique: jest.fn().mockResolvedValue(null) },
+      $transaction: jest.fn(async (callback: (client: typeof tx) => unknown) => {
+        const result = await callback(tx);
+        committed.push('transaction-committed');
+        return result;
+      }),
+    } as any;
+    const repository = new PrismaRuntimePersistenceRepository(prisma);
+
+    const receipt = await repository.write(baseInput);
+
+    expect(receipt).toEqual({
+      status: 'failed',
+      runtimeSnapshotId: 'snapshot-1',
+      idempotencyKey: 'idem-1',
+      state: 'ready_to_persist',
+      reasonCode: 'database_write_failed',
+    });
+    expect(committed).toEqual([]);
+    expect(outboxCreate).toHaveBeenCalledTimes(1);
+    expect(auditCreate).toHaveBeenCalledTimes(1);
+    expect(snapshotCreate).not.toHaveBeenCalled();
+    expect(attemptCreate).not.toHaveBeenCalled();
+    expect(JSON.stringify(receipt)).not.toContain('sensitive database failure');
+  });
+});

--- a/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts
+++ b/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts
@@ -1,0 +1,254 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import type {
+  RuntimePersistenceDbState,
+  RuntimePersistenceRepository,
+  RuntimePersistenceWriteInput,
+  RuntimePersistenceWriteReceipt,
+} from './runtime-persistence.repository';
+
+type ExistingRuntimeSnapshot = {
+  id: string;
+  runtimeSnapshotId: string;
+  idempotencyKey: string;
+  contractHash: string;
+  state: string;
+  outboxEntryId: string | null;
+  auditEventId: string | null;
+  attempts?: Array<{ id: string }>;
+};
+
+const requiredStringFields: Array<keyof RuntimePersistenceWriteInput> = [
+  'runtimeSnapshotId',
+  'idempotencyKey',
+  'transactionId',
+  'dealId',
+  'intentId',
+  'statusLabel',
+  'runtimeStoreRecordId',
+  'runtimeStoreVersion',
+  'actorId',
+  'actorRole',
+  'correlationId',
+  'auditId',
+  'contractHash',
+];
+
+function isKnownUniqueConstraintError(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as { code?: unknown }).code === 'P2002',
+  );
+}
+
+function isValidInput(input: RuntimePersistenceWriteInput): boolean {
+  return requiredStringFields.every((field) => {
+    const value = input[field];
+    return typeof value === 'string' && value.trim().length > 0;
+  });
+}
+
+@Injectable()
+export class PrismaRuntimePersistenceRepository implements RuntimePersistenceRepository {
+  constructor(@Optional() private readonly prisma?: PrismaService) {
+    if (!this.prisma) {
+      throw new Error(
+        'PrismaRuntimePersistenceRepository requires PrismaService; the Postgres runtime-persistence path is not active.',
+      );
+    }
+  }
+
+  private get db(): PrismaService {
+    if (!this.prisma) {
+      throw new Error('PrismaService unavailable; Postgres runtime-persistence path is not active.');
+    }
+    return this.prisma;
+  }
+
+  private classifyExisting(
+    input: RuntimePersistenceWriteInput,
+    existing: ExistingRuntimeSnapshot,
+  ): RuntimePersistenceWriteReceipt {
+    const sameMaterialIdentity =
+      existing.runtimeSnapshotId === input.runtimeSnapshotId &&
+      existing.contractHash === input.contractHash;
+
+    if (!sameMaterialIdentity) {
+      return {
+        status: 'conflict',
+        runtimeSnapshotId: input.runtimeSnapshotId,
+        idempotencyKey: input.idempotencyKey,
+        state: existing.state as RuntimePersistenceDbState,
+        recordId: existing.id,
+        outboxEntryId: existing.outboxEntryId ?? undefined,
+        auditEventId: existing.auditEventId ?? undefined,
+        transactionAttemptId: existing.attempts?.[0]?.id,
+        reasonCode: 'material_identity_conflict',
+      };
+    }
+
+    return {
+      status: 'duplicate',
+      runtimeSnapshotId: existing.runtimeSnapshotId,
+      idempotencyKey: existing.idempotencyKey,
+      state: existing.state as RuntimePersistenceDbState,
+      recordId: existing.id,
+      outboxEntryId: existing.outboxEntryId ?? undefined,
+      auditEventId: existing.auditEventId ?? undefined,
+      transactionAttemptId: existing.attempts?.[0]?.id,
+    };
+  }
+
+  private failed(
+    input: RuntimePersistenceWriteInput,
+    reasonCode: 'invalid_input' | 'database_write_failed',
+  ): RuntimePersistenceWriteReceipt {
+    return {
+      status: 'failed',
+      runtimeSnapshotId: input.runtimeSnapshotId,
+      idempotencyKey: input.idempotencyKey,
+      state: 'ready_to_persist',
+      reasonCode,
+    };
+  }
+
+  private async findExisting(idempotencyKey: string): Promise<ExistingRuntimeSnapshot | null> {
+    return this.db.dealWorkspaceRuntimeSnapshot.findUnique({
+      where: { idempotencyKey },
+      include: {
+        attempts: {
+          orderBy: { startedAt: 'desc' },
+          take: 1,
+          select: { id: true },
+        },
+      },
+    });
+  }
+
+  async write(input: RuntimePersistenceWriteInput): Promise<RuntimePersistenceWriteReceipt> {
+    if (!isValidInput(input)) {
+      return this.failed(input, 'invalid_input');
+    }
+
+    try {
+      const existing = await this.findExisting(input.idempotencyKey);
+      if (existing) {
+        return this.classifyExisting(input, existing);
+      }
+
+      return await this.db.$transaction(async (tx) => {
+        const outbox = await tx.outboxEntry.create({
+          data: {
+            type: 'deal_workspace.runtime_snapshot.persisted',
+            dealId: input.dealId,
+            status: 'PENDING',
+            idempotencyKey: `runtime-outbox:${input.idempotencyKey}`,
+            correlationId: input.correlationId,
+            auditId: input.auditId,
+            runtimeSnapshotId: input.runtimeSnapshotId,
+            runtimeIdempotencyKey: input.idempotencyKey,
+            payload: {
+              runtimeSnapshotId: input.runtimeSnapshotId,
+              idempotencyKey: input.idempotencyKey,
+              intentId: input.intentId,
+              correlationId: input.correlationId,
+              auditId: input.auditId,
+              snapshot: input.payload,
+            },
+          },
+        });
+
+        const audit = await tx.auditEvent.create({
+          data: {
+            action: 'deal_workspace.runtime_snapshot.persisted',
+            actorUserId: input.actorId,
+            actorRole: input.actorRole,
+            tenantId: input.tenantId,
+            orgId: input.organizationId,
+            dealId: input.dealId,
+            objectType: 'deal_workspace_runtime_snapshot',
+            objectId: input.runtimeSnapshotId,
+            afterState: input.payload,
+            outcome: 'SUCCESS',
+            correlationId: input.correlationId,
+            runtimeSnapshotId: input.runtimeSnapshotId,
+            runtimeIdempotencyKey: input.idempotencyKey,
+            metadata: {
+              auditId: input.auditId,
+              transactionId: input.transactionId,
+              contractHash: input.contractHash,
+            },
+          },
+        });
+
+        const snapshot = await tx.dealWorkspaceRuntimeSnapshot.create({
+          data: {
+            runtimeSnapshotId: input.runtimeSnapshotId,
+            idempotencyKey: input.idempotencyKey,
+            dealId: input.dealId,
+            intentId: input.intentId,
+            state: 'fully_linked',
+            snapshotState: input.snapshotState,
+            statusLabel: input.statusLabel,
+            runtimeStoreRecordId: input.runtimeStoreRecordId,
+            runtimeStoreVersion: input.runtimeStoreVersion,
+            actorId: input.actorId,
+            actorRole: input.actorRole,
+            correlationId: input.correlationId,
+            auditId: input.auditId,
+            contractHash: input.contractHash,
+            payload: input.payload,
+            outboxEntryId: outbox.id,
+            auditEventId: audit.id,
+            version: 1,
+          },
+        });
+
+        const attempt = await tx.dealWorkspaceRuntimeTransactionAttempt.create({
+          data: {
+            transactionId: input.transactionId,
+            snapshotId: snapshot.id,
+            idempotencyKey: input.idempotencyKey,
+            correlationId: input.correlationId,
+            auditId: input.auditId,
+            stage: 'committed',
+            outcome: 'persisted',
+            isReplay: false,
+            completedAt: new Date(),
+            metadata: {
+              runtimeSnapshotId: input.runtimeSnapshotId,
+              outboxEntryId: outbox.id,
+              auditEventId: audit.id,
+            },
+          },
+        });
+
+        return {
+          status: 'persisted',
+          runtimeSnapshotId: snapshot.runtimeSnapshotId,
+          idempotencyKey: snapshot.idempotencyKey,
+          state: snapshot.state as RuntimePersistenceDbState,
+          recordId: snapshot.id,
+          outboxEntryId: outbox.id,
+          auditEventId: audit.id,
+          transactionAttemptId: attempt.id,
+        } satisfies RuntimePersistenceWriteReceipt;
+      });
+    } catch (error) {
+      if (isKnownUniqueConstraintError(error)) {
+        try {
+          const concurrent = await this.findExisting(input.idempotencyKey);
+          if (concurrent) {
+            return this.classifyExisting(input, concurrent);
+          }
+        } catch {
+          return this.failed(input, 'database_write_failed');
+        }
+      }
+
+      return this.failed(input, 'database_write_failed');
+    }
+  }
+}

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts
@@ -1,0 +1,24 @@
+import type { PrismaService } from '../../common/prisma/prisma.service';
+import { PrismaRuntimePersistenceRepository } from './prisma-runtime-persistence.repository';
+import {
+  DisabledRuntimePersistenceRepository,
+  type RuntimePersistenceRepository,
+} from './runtime-persistence.repository';
+
+/**
+ * Selects the runtime-persistence repository without silent fallback.
+ *
+ * The Prisma path is active only for the exact `prisma` mode. Every other value
+ * returns a fail-closed disabled repository and never writes to the process
+ * runtime store.
+ */
+export function selectRuntimePersistenceRepository(
+  prisma?: PrismaService,
+  mode: string | undefined = process.env.PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY,
+): RuntimePersistenceRepository {
+  if (mode === 'prisma') {
+    return new PrismaRuntimePersistenceRepository(prisma);
+  }
+
+  return new DisabledRuntimePersistenceRepository();
+}

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts
@@ -1,0 +1,64 @@
+import { PrismaRuntimePersistenceRepository } from './prisma-runtime-persistence.repository';
+import { selectRuntimePersistenceRepository } from './runtime-persistence-repository.factory';
+import {
+  DisabledRuntimePersistenceRepository,
+  type RuntimePersistenceWriteInput,
+} from './runtime-persistence.repository';
+
+const input: RuntimePersistenceWriteInput = {
+  runtimeSnapshotId: 'snapshot-1',
+  idempotencyKey: 'idem-1',
+  transactionId: 'tx-1',
+  dealId: 'deal-1',
+  intentId: 'intent-1',
+  snapshotState: 'updated',
+  statusLabel: 'Updated',
+  runtimeStoreRecordId: 'runtime-record-1',
+  runtimeStoreVersion: '1',
+  actorId: 'user-1',
+  actorRole: 'operator',
+  correlationId: 'corr-1',
+  auditId: 'audit-business-1',
+  contractHash: 'hash-1',
+  payload: { status: 'updated' },
+};
+
+describe('runtime persistence repository selection', () => {
+  it('defaults to a fail-closed disabled repository', async () => {
+    const repository = selectRuntimePersistenceRepository(undefined, undefined);
+
+    expect(repository).toBeInstanceOf(DisabledRuntimePersistenceRepository);
+    await expect(repository.write(input)).resolves.toEqual({
+      status: 'failed',
+      runtimeSnapshotId: 'snapshot-1',
+      idempotencyKey: 'idem-1',
+      state: 'ready_to_persist',
+      reasonCode: 'repository_not_enabled',
+    });
+  });
+
+  it('does not treat unrelated values as Prisma activation', () => {
+    const prisma = {} as any;
+
+    expect(selectRuntimePersistenceRepository(prisma, 'true')).toBeInstanceOf(
+      DisabledRuntimePersistenceRepository,
+    );
+    expect(selectRuntimePersistenceRepository(prisma, 'postgres')).toBeInstanceOf(
+      DisabledRuntimePersistenceRepository,
+    );
+  });
+
+  it('selects Prisma only for the exact prisma mode', () => {
+    const prisma = {} as any;
+
+    expect(selectRuntimePersistenceRepository(prisma, 'prisma')).toBeInstanceOf(
+      PrismaRuntimePersistenceRepository,
+    );
+  });
+
+  it('fails loudly when Prisma mode is enabled without PrismaService', () => {
+    expect(() => selectRuntimePersistenceRepository(undefined, 'prisma')).toThrow(
+      /requires PrismaService/,
+    );
+  });
+});

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts
@@ -1,0 +1,67 @@
+import type { Prisma } from '@prisma/client';
+
+export const RUNTIME_PERSISTENCE_REPOSITORY = Symbol('RUNTIME_PERSISTENCE_REPOSITORY');
+
+export type RuntimePersistenceSnapshotState = 'updated' | 'blocked' | 'duplicate' | 'failed';
+export type RuntimePersistenceDbState =
+  | 'ready_to_persist'
+  | 'outbox_required'
+  | 'audit_required'
+  | 'fully_linked';
+export type RuntimePersistenceWriteStatus = 'persisted' | 'duplicate' | 'conflict' | 'failed';
+
+export interface RuntimePersistenceWriteInput {
+  runtimeSnapshotId: string;
+  idempotencyKey: string;
+  transactionId: string;
+  dealId: string;
+  intentId: string;
+  snapshotState: RuntimePersistenceSnapshotState;
+  statusLabel: string;
+  runtimeStoreRecordId: string;
+  runtimeStoreVersion: string;
+  actorId: string;
+  actorRole: string;
+  tenantId?: string;
+  organizationId?: string;
+  correlationId: string;
+  auditId: string;
+  contractHash: string;
+  payload: Prisma.InputJsonValue;
+}
+
+export interface RuntimePersistenceWriteReceipt {
+  status: RuntimePersistenceWriteStatus;
+  runtimeSnapshotId: string;
+  idempotencyKey: string;
+  state: RuntimePersistenceDbState;
+  recordId?: string;
+  outboxEntryId?: string;
+  auditEventId?: string;
+  transactionAttemptId?: string;
+  reasonCode?:
+    | 'repository_not_enabled'
+    | 'invalid_input'
+    | 'material_identity_conflict'
+    | 'database_write_failed';
+}
+
+export interface RuntimePersistenceRepository {
+  write(input: RuntimePersistenceWriteInput): Promise<RuntimePersistenceWriteReceipt>;
+}
+
+/**
+ * Safe default for environments where the Postgres runtime-persistence path is
+ * not explicitly enabled. It never falls back to the process runtime store.
+ */
+export class DisabledRuntimePersistenceRepository implements RuntimePersistenceRepository {
+  async write(input: RuntimePersistenceWriteInput): Promise<RuntimePersistenceWriteReceipt> {
+    return {
+      status: 'failed',
+      runtimeSnapshotId: input.runtimeSnapshotId,
+      idempotencyKey: input.idempotencyKey,
+      state: 'ready_to_persist',
+      reasonCode: 'repository_not_enabled',
+    };
+  }
+}

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,32 +3,41 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "ready",
-  "current": "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.",
-  "fullTzReadinessPercent": 80,
-  "openPr": "#2244",
-  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.", "#2242", "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.", "#2243", "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock."],
+  "current": "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation.",
+  "fullTzReadinessPercent": 82,
+  "openPr": "#2245",
+  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.", "#2242", "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.", "#2243", "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.", "#2244", "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate."],
   "openBlockers": ["#2113", "#2115"],
   "blockerNotes": "#2113 repository settings cleanup. #2115 remains blocked by current auth-file write path.",
-  "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "backend/API/runtime changes outside the exact future adapter scope"],
+  "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "module/controller/API/web wiring", "production migration execution"],
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md"
+    "docs/platform-v7/execution-queue.md",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
+    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts",
+    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md"
+    "docs/platform-v7/execution-queue.md",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
+    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts",
+    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts"
   ],
-  "vp335RuntimePersistencePostgresRepositoryAdapterScopeUnlock": {
-    "layer": "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock",
-    "closedPr": "#2243",
-    "status": "postgres-repository-adapter-scope-unlock-docs-only-complete"
-  },
   "vp336RuntimePersistencePostgresRepositoryAdapterFinalGate": {
     "layer": "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate",
-    "openPr": "#2244",
-    "status": "postgres-repository-adapter-final-gate-docs-only",
-    "implementationBranchInstruction": "The next manual code PR must set current to VP-3.37 and allowedCurrentScope to docs plus exactly the five approved API-side repository/test files before writing code.",
-    "implementationFilesUnlockedForManualCodePr": [
+    "closedPr": "#2244",
+    "status": "postgres-repository-adapter-final-gate-complete"
+  },
+  "vp337RuntimePersistencePostgresRepositoryAdapterImplementation": {
+    "layer": "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
+    "openPr": "#2245",
+    "status": "postgres-repository-adapter-implementation",
+    "changedImplementationFiles": [
       "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
       "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
       "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts",
@@ -36,9 +45,9 @@
       "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts"
     ]
   },
-  "vp337RuntimePersistencePostgresRepositoryAdapterImplementation": {
-    "layer": "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
-    "status": "manual-code-pr-next-after-final-gate"
+  "vp338RuntimePersistenceInternalServiceWiringPlan": {
+    "layer": "VP-3.38 Runtime Persistence Internal Service Wiring Plan",
+    "status": "next-docs-only-plan"
   },
   "forbiddenZones": [
     "apps/landing",
@@ -53,6 +62,6 @@
     "pnpm-lock.yaml"
   ],
   "maturityLanguage": ["platform-temporarily-without-external-integrations"],
-  "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied", "Postgres adapter active"],
-  "readiness": "80% honest readiness. VP-3.36 is the final docs-only gate before writing five API-side repository/test files. It does not implement or activate the adapter, apply the migration, register a module or expose an API endpoint."
+  "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied", "Postgres adapter active in runtime"],
+  "readiness": "82% honest readiness. VP-3.37 implements an API-side Prisma repository boundary with explicit fail-closed selection, atomic snapshot/outbox/audit/attempt transaction semantics, deterministic duplicate/conflict classification and controlled failure mapping. It is not registered in a Nest module, not exposed by API or web wiring, and the production migration is not applied."
 }

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,41 +1,50 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.
+CURRENT: VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation.
 
-GOAL: Финально зафиксировать manual code PR gate для пяти API-side repository/test файлов после merge #2243, без adapter code, module/controller/API wiring и production migration application.
+GOAL: Реализовать API-side Prisma repository adapter после merge #2244, без module/controller/API/web wiring и без применения migration к production DB.
 
 CURRENT STATUS:
 - VP-3.33 additive Prisma schema/migration is merged from #2241.
-- VP-3.34 adapter plan is merged from #2242.
-- VP-3.35 scope unlock is merged from #2243.
-- Railway `brilliant-liberation - @pc/web` is green after #2243.
+- VP-3.36 final gate is merged from #2244.
+- VP-3.37 implements the repository contract, Prisma adapter, explicit factory and unit tests in PR #2245.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
+- apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts
+- apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts
+- apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts
 
-MANUAL CODE PR SCOPE AFTER THIS GATE:
-- `apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts`
-- `apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts`
-- `apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts`
-- `apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts`
-- `apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts`
-
-FINAL IMPLEMENTATION INVARIANTS:
-- API-side only; Prisma is never imported by web/browser code.
+IMPLEMENTED:
+- Typed API-side repository contract and injection token.
+- Fail-closed disabled repository; no process-store fallback.
 - Exact `PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY=prisma` activation.
-- Default and unrelated modes are fail-closed with no silent process-store fallback.
-- Missing PrismaService fails before a write.
-- Caller cannot submit trusted evidence database IDs.
-- One `$transaction` owns canonical outbox, audit, snapshot and attempt writes.
-- First write becomes `fully_linked` only inside that successful transaction.
-- Identical replay returns duplicate with no additional rows.
-- Material identity mismatch returns conflict with no additional rows.
-- Transaction failure leaves no partial evidence.
-- Raw database errors are not exposed.
+- Missing PrismaService fails loudly before writes.
+- Caller input has no trusted outbox/audit database IDs.
+- Existing idempotency identity is read before write:
+  - matching snapshot/hash returns deterministic `duplicate`;
+  - different snapshot/hash returns `conflict`.
+- First write runs one Prisma `$transaction` and creates:
+  - canonical `outbox_entries` evidence;
+  - canonical `audit_events` evidence;
+  - `fully_linked` runtime snapshot referencing generated evidence IDs;
+  - committed transaction attempt.
+- Any transaction failure returns controlled `database_write_failed`; raw DB errors are not exposed.
+- Concurrent P2002 is re-read and classified as duplicate or conflict.
+- Tests cover fail-closed selection, exact activation, atomic success, caller evidence injection, duplicate, conflict, concurrent winner, invalid input and rollback simulation.
+
+IMPORTANT LIMITS:
+- The adapter is implemented but not registered in a Nest module or active runtime path.
+- Production migration is not applied.
+- No controller, API endpoint or web action calls this repository.
+- Tenant/auth identity is accepted by the internal contract but enforcement remains a later server wiring layer.
+- No live bank callbacks, FGIS or EDO integration is claimed.
 
 STILL LOCKED:
-- runtime persistence module/controller/API endpoint;
+- runtime persistence module/service/controller/API endpoint;
 - AppModule registration;
 - web server-action bridge;
 - production migration execution and rollback rehearsal;
@@ -45,17 +54,18 @@ STILL LOCKED:
 - live bank/FGIS/EDO integrations.
 
 NEXT:
-- Layer: VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation.
-- Goal: prepare the manual code implementation after this gate is merged.
+- Layer: VP-3.38 Runtime Persistence Internal Service Wiring Plan.
+- Goal: select exact server-only module/service/provider wiring after VP-3.37 is merged and tested.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
 - Success criteria:
-  - final gate closes without adapter code changes;
-  - next manual code PR explicitly expands current scope to the exact five files;
-  - critical forbidden zones remain unchanged;
-  - maturity language does not claim an active Postgres adapter.
+  - API and unit tests validate adapter behavior;
+  - TypeScript and Prisma delegates compile;
+  - no module/controller/web wiring occurs in VP-3.37;
+  - no production migration application is claimed;
+  - Railway `brilliant-liberation - @pc/web` is green after merge.
 
 AFTER NEXT:
-- Layer: VP-3.38 Runtime Persistence Internal Service Wiring Plan.
-- Goal: select server-only module/service provider wiring after the repository adapter implementation is merged and validated.
+- Layer: VP-3.39 Runtime Persistence Internal Service Wiring Scope Unlock.
+- Goal: docs-only unlock exact provider/module/service files after the plan is merged.


### PR DESCRIPTION
## Суть

Реализован API-side Prisma repository adapter для atomic runtime persistence.

## Реализовано

- typed repository contract и injection token;
- fail-closed disabled adapter без process-store fallback;
- exact `PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY=prisma` activation;
- обязательный PrismaService для активного режима;
- одна `$transaction` для canonical outbox, audit, fully-linked snapshot и committed attempt;
- caller не передаёт доверенные evidence DB IDs;
- deterministic duplicate/conflict classification;
- concurrent P2002 re-read;
- controlled failed result без раскрытия DB errors;
- tests для activation, atomic success, evidence injection, duplicate, conflict, race, invalid input и rollback simulation.

## Ограничение зрелости

Adapter реализован, но не зарегистрирован в Nest module, не подключён к API/web runtime и не активен. Production migration не применена. Live bank/ФГИС/ЭДО integrations не подтверждены.