### PR TITLE
VP-3.38 Runtime Persistence Internal Service Wiring Plan

### DIFF
--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,51 +3,49 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "ready",
-  "current": "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation.",
+  "current": "VP-3.38 Runtime Persistence Internal Service Wiring Plan.",
   "fullTzReadinessPercent": 82,
-  "openPr": "#2245",
-  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.", "#2242", "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.", "#2243", "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.", "#2244", "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate."],
+  "openPr": "#2246",
+  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.", "#2242", "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.", "#2243", "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.", "#2244", "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.", "#2245", "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation."],
   "openBlockers": ["#2113", "#2115"],
   "blockerNotes": "#2113 repository settings cleanup. #2115 remains blocked by current auth-file write path.",
   "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "module/controller/API/web wiring", "production migration execution"],
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
-    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts",
-    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts"
+    "docs/platform-v7/execution-queue.md"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
-    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts",
-    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts"
+    "docs/platform-v7/execution-queue.md"
   ],
-  "vp336RuntimePersistencePostgresRepositoryAdapterFinalGate": {
-    "layer": "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate",
-    "closedPr": "#2244",
-    "status": "postgres-repository-adapter-final-gate-complete"
-  },
   "vp337RuntimePersistencePostgresRepositoryAdapterImplementation": {
     "layer": "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
-    "openPr": "#2245",
-    "status": "postgres-repository-adapter-implementation",
-    "changedImplementationFiles": [
-      "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
-      "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
-      "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts",
-      "apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts",
-      "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts"
-    ]
+    "closedPr": "#2245",
+    "status": "postgres-repository-adapter-implementation-complete"
   },
   "vp338RuntimePersistenceInternalServiceWiringPlan": {
     "layer": "VP-3.38 Runtime Persistence Internal Service Wiring Plan",
-    "status": "next-docs-only-plan"
+    "openPr": "#2246",
+    "status": "internal-service-wiring-plan-docs-only",
+    "candidateImplementationFiles": [
+      "apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts",
+      "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts",
+      "apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts",
+      "apps/api/src/modules/runtime-persistence/runtime-persistence.module.spec.ts"
+    ],
+    "stillLocked": [
+      "apps/api/src/app.module.ts",
+      "apps/api/src/modules/runtime-persistence/runtime-persistence.controller.ts",
+      "apps/web/app/platform-v7/**",
+      "apps/api/prisma/migrations/**",
+      "package.json",
+      "package-lock.json",
+      "pnpm-lock.yaml"
+    ]
+  },
+  "vp339RuntimePersistenceInternalServiceWiringScopeUnlock": {
+    "layer": "VP-3.39 Runtime Persistence Internal Service Wiring Scope Unlock",
+    "status": "next-docs-only-scope-unlock"
   },
   "forbiddenZones": [
     "apps/landing",
@@ -63,5 +61,5 @@
   ],
   "maturityLanguage": ["platform-temporarily-without-external-integrations"],
   "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied", "Postgres adapter active in runtime"],
-  "readiness": "82% honest readiness. VP-3.37 implements an API-side Prisma repository boundary with explicit fail-closed selection, atomic snapshot/outbox/audit/attempt transaction semantics, deterministic duplicate/conflict classification and controlled failure mapping. It is not registered in a Nest module, not exposed by API or web wiring, and the production migration is not applied."
+  "readiness": "82% honest readiness. VP-3.38 selects internal Nest module/service wiring scope only. It does not register the module in AppModule, expose an endpoint, connect web runtime or apply the production migration."
 }

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,71 +1,59 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation.
+CURRENT: VP-3.38 Runtime Persistence Internal Service Wiring Plan.
 
-GOAL: Реализовать API-side Prisma repository adapter после merge #2244, без module/controller/API/web wiring и без применения migration к production DB.
+GOAL: Выбрать точный server-only scope для Nest service/module wiring после merge #2245, без AppModule registration, controller/API endpoint, web bridge и production migration application.
 
 CURRENT STATUS:
 - VP-3.33 additive Prisma schema/migration is merged from #2241.
-- VP-3.36 final gate is merged from #2244.
-- VP-3.37 implements the repository contract, Prisma adapter, explicit factory and unit tests in PR #2245.
+- VP-3.37 API-side Prisma repository adapter is merged from #2245.
+- Railway `brilliant-liberation - @pc/web` is green after #2245.
+- Repository adapter exists but is not registered in a Nest provider graph.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
-- apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts
-- apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts
-- apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts
-- apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts
-- apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts
 
-IMPLEMENTED:
-- Typed API-side repository contract and injection token.
-- Fail-closed disabled repository; no process-store fallback.
-- Exact `PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY=prisma` activation.
-- Missing PrismaService fails loudly before writes.
-- Caller input has no trusted outbox/audit database IDs.
-- Existing idempotency identity is read before write:
-  - matching snapshot/hash returns deterministic `duplicate`;
-  - different snapshot/hash returns `conflict`.
-- First write runs one Prisma `$transaction` and creates:
-  - canonical `outbox_entries` evidence;
-  - canonical `audit_events` evidence;
-  - `fully_linked` runtime snapshot referencing generated evidence IDs;
-  - committed transaction attempt.
-- Any transaction failure returns controlled `database_write_failed`; raw DB errors are not exposed.
-- Concurrent P2002 is re-read and classified as duplicate or conflict.
-- Tests cover fail-closed selection, exact activation, atomic success, caller evidence injection, duplicate, conflict, concurrent winner, invalid input and rollback simulation.
+CANDIDATE IMPLEMENTATION FILES FOR LATER PR:
+- `apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts`
+- `apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts`
+- `apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts`
+- `apps/api/src/modules/runtime-persistence/runtime-persistence.module.spec.ts`
 
-IMPORTANT LIMITS:
-- The adapter is implemented but not registered in a Nest module or active runtime path.
-- Production migration is not applied.
-- No controller, API endpoint or web action calls this repository.
-- Tenant/auth identity is accepted by the internal contract but enforcement remains a later server wiring layer.
-- No live bank callbacks, FGIS or EDO integration is claimed.
+WIRING REQUIREMENTS:
+- `RuntimePersistenceService` depends only on the repository injection token.
+- `RuntimePersistenceModule` provides the token through the existing repository selector and global `PrismaService`.
+- Exact `PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY=prisma` activation remains required.
+- Disabled mode remains fail-closed and never writes to process memory.
+- Service validates internal caller context before delegating.
+- No controller or externally callable route is introduced.
+- No AppModule registration is introduced in the implementation layer.
+- Raw database errors and Prisma details remain hidden.
+- Unit tests verify disabled mode, Prisma mode, missing Prisma failure and delegation behavior.
 
 STILL LOCKED:
-- runtime persistence module/service/controller/API endpoint;
-- AppModule registration;
+- `apps/api/src/app.module.ts`;
+- runtime persistence controller or public endpoint;
 - web server-action bridge;
 - production migration execution and rollback rehearsal;
-- auth/tenant enforcement changes;
+- auth/tenant enforcement changes outside internal input validation;
 - UI/components;
 - package and lockfiles;
 - live bank/FGIS/EDO integrations.
 
 NEXT:
-- Layer: VP-3.38 Runtime Persistence Internal Service Wiring Plan.
-- Goal: select exact server-only module/service/provider wiring after VP-3.37 is merged and tested.
+- Layer: VP-3.39 Runtime Persistence Internal Service Wiring Scope Unlock.
+- Goal: docs-only unlock the exact four service/module/test files.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
 - Success criteria:
-  - API and unit tests validate adapter behavior;
-  - TypeScript and Prisma delegates compile;
-  - no module/controller/web wiring occurs in VP-3.37;
-  - no production migration application is claimed;
-  - Railway `brilliant-liberation - @pc/web` is green after merge.
+  - candidate files are exact and minimal;
+  - AppModule/controller/API/web files remain locked;
+  - critical forbidden zones remain unchanged;
+  - production migration remains unapplied;
+  - maturity language does not claim active runtime wiring.
 
 AFTER NEXT:
-- Layer: VP-3.39 Runtime Persistence Internal Service Wiring Scope Unlock.
-- Goal: docs-only unlock exact provider/module/service files after the plan is merged.
+- Layer: VP-3.40 Runtime Persistence Internal Service Wiring Final Gate.
+- Goal: final docs-only gate before writing the four internal wiring files.


### PR DESCRIPTION
## Суть

Docs-only план server-side Nest wiring для уже смерженного Postgres repository adapter.

## Выбран будущий scope

- `apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts`
- `apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts`
- `apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts`
- `apps/api/src/modules/runtime-persistence/runtime-persistence.module.spec.ts`

## Защитные границы

- без `AppModule` registration;
- без controller/API endpoint;
- без web bridge;
- без применения production migration;
- explicit `prisma` activation и fail-closed disabled mode сохраняются;
- Prisma остаётся только на API-side;
- critical forbidden zones не изменены.