### PR TITLE
VP-3.41 Runtime Persistence Internal Service Wiring Implementation

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -51,6 +51,7 @@ import { KafkaModule } from './common/kafka/kafka.module';
 import { VaultModule } from './common/vault/vault.module';
 import { AiInsightsModule } from './modules/ai-insights/ai-insights.module';
 import { RuntimeSnapshotModule } from './modules/runtime-snapshot/runtime-snapshot.module';
+import { RuntimePersistenceModule } from './modules/runtime-persistence/runtime-persistence.module';
 
 @Module({
   imports: [
@@ -100,6 +101,7 @@ import { RuntimeSnapshotModule } from './modules/runtime-snapshot/runtime-snapsh
     VaultModule,
     AiInsightsModule,
     RuntimeSnapshotModule,
+    RuntimePersistenceModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../common/prisma/prisma.module';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { selectRuntimePersistenceRepository } from './runtime-persistence-repository.factory';
+import { RUNTIME_PERSISTENCE_REPOSITORY } from './runtime-persistence.repository';
+import { RuntimePersistenceService } from './runtime-persistence.service';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [
+    RuntimePersistenceService,
+    {
+      provide: RUNTIME_PERSISTENCE_REPOSITORY,
+      inject: [PrismaService],
+      useFactory: (prisma: PrismaService) => selectRuntimePersistenceRepository(prisma),
+    },
+  ],
+  exports: [RuntimePersistenceService, RUNTIME_PERSISTENCE_REPOSITORY],
+})
+export class RuntimePersistenceModule {}

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts
@@ -1,0 +1,125 @@
+import { Test } from '@nestjs/testing';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { RuntimePersistenceModule } from './runtime-persistence.module';
+import {
+  RUNTIME_PERSISTENCE_REPOSITORY,
+  type RuntimePersistenceRepository,
+  type RuntimePersistenceWriteInput,
+  type RuntimePersistenceWriteReceipt,
+} from './runtime-persistence.repository';
+import { RuntimePersistenceService } from './runtime-persistence.service';
+
+const CANONICAL_RUNTIME_TEST_DEAL: RuntimePersistenceWriteInput = {
+  runtimeSnapshotId: 'runtime-snapshot:deal-canonical-001:start_document_review:v1',
+  idempotencyKey: 'runtime-persistence:deal-canonical-001:start_document_review:v1',
+  transactionId: 'runtime-transaction:deal-canonical-001:start_document_review:v1',
+  dealId: 'deal-canonical-001',
+  intentId: 'start_document_review',
+  snapshotState: 'updated',
+  statusLabel: 'document_review_started',
+  runtimeStoreRecordId: 'runtime-store:deal-canonical-001:start_document_review:v1',
+  runtimeStoreVersion: 'v1',
+  actorId: 'operator-canonical-001',
+  actorRole: 'operator',
+  tenantId: 'tenant-canonical-001',
+  organizationId: 'organization-canonical-001',
+  correlationId: 'correlation-canonical-001',
+  auditId: 'audit-canonical-001',
+  contractHash: 'sha256:canonical-runtime-contract-001',
+  payload: {
+    dealId: 'deal-canonical-001',
+    intentId: 'start_document_review',
+    state: 'updated',
+  },
+};
+
+const PERSISTED_RECEIPT: RuntimePersistenceWriteReceipt = {
+  status: 'persisted',
+  runtimeSnapshotId: CANONICAL_RUNTIME_TEST_DEAL.runtimeSnapshotId,
+  idempotencyKey: CANONICAL_RUNTIME_TEST_DEAL.idempotencyKey,
+  state: 'fully_linked',
+  recordId: 'runtime-record-canonical-001',
+  outboxEntryId: 'outbox-canonical-001',
+  auditEventId: 'audit-canonical-001',
+  transactionAttemptId: 'attempt-canonical-001',
+};
+
+describe('RuntimePersistenceService', () => {
+  it('delegates the canonical deal exactly once and returns the receipt unchanged', async () => {
+    const repository: RuntimePersistenceRepository = {
+      write: jest.fn().mockResolvedValue(PERSISTED_RECEIPT),
+    };
+    const service = new RuntimePersistenceService(repository);
+
+    await expect(service.persist(CANONICAL_RUNTIME_TEST_DEAL)).resolves.toBe(PERSISTED_RECEIPT);
+    expect(repository.write).toHaveBeenCalledTimes(1);
+    expect(repository.write).toHaveBeenCalledWith(CANONICAL_RUNTIME_TEST_DEAL);
+    expect(CANONICAL_RUNTIME_TEST_DEAL).not.toHaveProperty('outboxEntryId');
+    expect(CANONICAL_RUNTIME_TEST_DEAL).not.toHaveProperty('auditEventId');
+  });
+
+  it('keeps a disabled repository receipt failed', async () => {
+    const failedReceipt: RuntimePersistenceWriteReceipt = {
+      status: 'failed',
+      runtimeSnapshotId: CANONICAL_RUNTIME_TEST_DEAL.runtimeSnapshotId,
+      idempotencyKey: CANONICAL_RUNTIME_TEST_DEAL.idempotencyKey,
+      state: 'ready_to_persist',
+      reasonCode: 'repository_not_enabled',
+    };
+    const repository: RuntimePersistenceRepository = {
+      write: jest.fn().mockResolvedValue(failedReceipt),
+    };
+    const service = new RuntimePersistenceService(repository);
+
+    await expect(service.persist(CANONICAL_RUNTIME_TEST_DEAL)).resolves.toBe(failedReceipt);
+  });
+
+  it('propagates repository exceptions instead of returning false success', async () => {
+    const repository: RuntimePersistenceRepository = {
+      write: jest.fn().mockRejectedValue(new Error('controlled repository failure')),
+    };
+    const service = new RuntimePersistenceService(repository);
+
+    await expect(service.persist(CANONICAL_RUNTIME_TEST_DEAL)).rejects.toThrow(
+      'controlled repository failure',
+    );
+  });
+});
+
+describe('RuntimePersistenceModule', () => {
+  const originalMode = process.env.PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY;
+
+  afterEach(() => {
+    if (originalMode === undefined) {
+      delete process.env.PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY;
+    } else {
+      process.env.PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY = originalMode;
+    }
+  });
+
+  it('has no controller or public route', () => {
+    expect(Reflect.getMetadata('controllers', RuntimePersistenceModule) ?? []).toEqual([]);
+  });
+
+  it('resolves the internal service and remains fail-closed by default', async () => {
+    delete process.env.PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY;
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [RuntimePersistenceModule],
+    })
+      .overrideProvider(PrismaService)
+      .useValue({})
+      .compile();
+
+    const service = moduleRef.get(RuntimePersistenceService);
+    const repository = moduleRef.get<RuntimePersistenceRepository>(RUNTIME_PERSISTENCE_REPOSITORY);
+
+    expect(service).toBeDefined();
+    expect(repository).toBeDefined();
+    await expect(service.persist(CANONICAL_RUNTIME_TEST_DEAL)).resolves.toMatchObject({
+      status: 'failed',
+      state: 'ready_to_persist',
+      reasonCode: 'repository_not_enabled',
+    });
+  });
+});

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  RUNTIME_PERSISTENCE_REPOSITORY,
+  type RuntimePersistenceRepository,
+  type RuntimePersistenceWriteInput,
+  type RuntimePersistenceWriteReceipt,
+} from './runtime-persistence.repository';
+
+@Injectable()
+export class RuntimePersistenceService {
+  constructor(
+    @Inject(RUNTIME_PERSISTENCE_REPOSITORY)
+    private readonly repository: RuntimePersistenceRepository,
+  ) {}
+
+  persist(input: RuntimePersistenceWriteInput): Promise<RuntimePersistenceWriteReceipt> {
+    return this.repository.write(input);
+  }
+}

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,40 +3,49 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "ready",
-  "current": "VP-3.38 Runtime Persistence Internal Service Wiring Plan.",
-  "fullTzReadinessPercent": 82,
-  "openPr": "#2246",
-  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.", "#2242", "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.", "#2243", "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.", "#2244", "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.", "#2245", "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation."],
+  "current": "VP-3.41 Runtime Persistence Internal Service Wiring Implementation.",
+  "fullTzReadinessPercent": 83,
+  "openPr": "#2250",
+  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.", "#2242", "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.", "#2243", "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.", "#2244", "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.", "#2245", "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation.", "#2246", "VP-3.38 Runtime Persistence Internal Service Wiring Plan."],
   "openBlockers": ["#2113", "#2115"],
   "blockerNotes": "#2113 repository settings cleanup. #2115 remains blocked by current auth-file write path.",
   "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "controller/API/web wiring", "production migration execution"],
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md"
+    "docs/platform-v7/execution-queue.md",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts",
+    "apps/api/src/app.module.ts"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
-    "docs/platform-v7/execution-queue.md"
+    "docs/platform-v7/execution-queue.md",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts",
+    "apps/api/src/app.module.ts"
   ],
-  "vp337RuntimePersistencePostgresRepositoryAdapterImplementation": {
-    "layer": "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
-    "closedPr": "#2245",
-    "status": "postgres-repository-adapter-implementation-complete"
-  },
   "vp338RuntimePersistenceInternalServiceWiringPlan": {
     "layer": "VP-3.38 Runtime Persistence Internal Service Wiring Plan",
-    "openPr": "#2246",
-    "status": "internal-service-wiring-plan-docs-only",
-    "candidateImplementationFiles": [
+    "closedPr": "#2246",
+    "status": "internal-service-wiring-plan-complete"
+  },
+  "vp341RuntimePersistenceInternalServiceWiringImplementation": {
+    "layer": "VP-3.41 Runtime Persistence Internal Service Wiring Implementation",
+    "openPr": "#2250",
+    "status": "internal-service-wiring-implementation",
+    "changedImplementationFiles": [
       "apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts",
       "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts",
       "apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts",
       "apps/api/src/app.module.ts"
-    ]
+    ],
+    "canonicalTestDealId": "deal-canonical-001"
   },
-  "vp339RuntimePersistenceInternalServiceWiringScopeUnlock": {
-    "layer": "VP-3.39 Runtime Persistence Internal Service Wiring Scope Unlock",
-    "status": "next-docs-only-scope-unlock"
+  "vp342RuntimePersistenceAuthenticatedCommandBoundary": {
+    "layer": "VP-3.42 Runtime Persistence Authenticated Internal Command Boundary",
+    "status": "next-manual-code-scope-after-read-only-audit"
   },
   "forbiddenZones": [
     "apps/landing",
@@ -52,5 +61,5 @@
   ],
   "maturityLanguage": ["platform-temporarily-without-external-integrations"],
   "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied", "runtime persistence externally exposed"],
-  "readiness": "82% honest readiness. VP-3.38 selects four exact server-only module/service wiring files. The future module has no controller, remains fail-closed unless the exact Prisma flag is enabled, and does not expose runtime persistence through an API or web route."
+  "readiness": "83% honest readiness. VP-3.41 registers a fail-closed server-only runtime persistence module and verifies one canonical internal deal path. It does not expose a controller or web bridge, derive request auth/tenant context, apply the production migration or prove active production Postgres writes."
 }

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -50,7 +50,7 @@ GUARDRAILS:
 NEXT:
 - Layer: VP-3.42 Runtime Persistence Authenticated Internal Command Boundary.
 - Goal: after #2250 merge, perform a read-only audit of existing server auth/RLS context and open one manually scoped code PR that derives actor, role, tenant and organization exclusively from trusted server context before invoking `RuntimePersistenceService`.
-- Autopilot-safe allowed files before that manual scope is selected:
+- Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
 - Execution rule:

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,65 +1,65 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.38 Runtime Persistence Internal Service Wiring Plan.
+CURRENT: VP-3.41 Runtime Persistence Internal Service Wiring Implementation.
 
-GOAL: Выбрать точный server-only Nest service/module scope после merge #2245, без controller/API/web route и без применения migration к production DB.
+GOAL: Реализовать и проверить server-only контур `AppModule → RuntimePersistenceModule → RuntimePersistenceService → repository` без controller/API/web route и без применения migration к production DB.
 
 CURRENT STATUS:
 - VP-3.33 additive Prisma schema/migration is merged from #2241.
 - VP-3.37 API-side Postgres repository adapter is merged from #2245.
-- Railway `brilliant-liberation - @pc/web` is green after #2245.
-- `PrismaModule` is global and already imported by `AppModule`.
-- `AppAuthGuard` is global, but this layer intentionally creates no controller.
+- VP-3.38 internal service wiring plan is merged from #2246.
+- Duplicate docs-only scope PRs #2248 and #2249 are closed without merge.
+- PR #2250 implements the working internal service path directly.
+- Railway `brilliant-liberation - @pc/web` is green after #2246.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
+- apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts
+- apps/api/src/app.module.ts
 
-CANDIDATE IMPLEMENTATION FILES FOR LATER CODE PR:
-- `apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts`
-- `apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts`
-- `apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts`
-- `apps/api/src/app.module.ts`
-
-TARGET INTERNAL WIRING:
-- `RuntimePersistenceService` injects `RUNTIME_PERSISTENCE_REPOSITORY` and delegates one internal `persist` operation.
-- Service accepts only the typed internal repository input; it does not accept HTTP request objects or client-provided evidence IDs.
-- `RuntimePersistenceModule` creates the repository provider with the existing global `PrismaService` and `selectRuntimePersistenceRepository`.
-- Module exports `RuntimePersistenceService` and the repository token for future server-only consumers.
-- `AppModule` imports `RuntimePersistenceModule` so dependency graph/startup validation occurs in deployed API builds.
-- No controller, route, DTO, public decorator, SSE stream or web server action is added.
-- Default startup remains safe because non-`prisma` mode binds the disabled fail-closed repository.
-- Exact `prisma` mode with missing PrismaService fails startup rather than silently degrading.
-
-TEST REQUIREMENTS:
-- Service delegates the exact typed input once and returns repository receipt unchanged.
-- Service does not synthesize or accept trusted evidence IDs.
-- Disabled repository result remains visible to internal caller; service must not convert it into success.
-- Repository exception is not swallowed or reclassified as a successful receipt.
-- API typecheck confirms AppModule import and provider graph compile without package changes.
+IMPLEMENTED:
+- `RuntimePersistenceService` injects `RUNTIME_PERSISTENCE_REPOSITORY` and delegates one typed `persist` operation.
+- `RuntimePersistenceModule` uses existing global `PrismaService` and `selectRuntimePersistenceRepository`.
+- Module exports the internal service and repository token and declares no controller.
+- `AppModule` imports `RuntimePersistenceModule` for server dependency-graph/startup validation.
+- Default mode remains disabled and fail-closed; exact `prisma` feature flag remains required.
+- One canonical test deal `deal-canonical-001` validates the internal service path.
+- Tests verify exact delegation, unchanged receipts, failed receipt preservation, exception propagation, no caller evidence IDs, no controllers and default fail-closed provider graph.
 
 STILL LOCKED:
-- controller/API endpoint;
+- controller or external API endpoint;
 - web server-action bridge;
 - production migration execution and rollback rehearsal;
-- request auth/tenant derivation;
+- request-derived actor/tenant/organization enforcement;
 - UI/components;
 - package and lockfiles;
 - live bank/FGIS/EDO integrations.
 
+GUARDRAILS:
+- No HTTP request object enters the persistence service.
+- No caller-supplied outbox/audit database IDs.
+- No disabled or failed receipt is converted into success.
+- No repository exception is swallowed.
+- No process-memory fallback.
+- No production Postgres activation claim.
+- Critical forbidden zones remain unchanged.
+
 NEXT:
-- Layer: VP-3.39 Runtime Persistence Internal Service Wiring Scope Unlock.
-- Goal: docs-only unlock the exact four service/module/test/AppModule files.
-- Allowed files:
+- Layer: VP-3.42 Runtime Persistence Authenticated Internal Command Boundary.
+- Goal: after #2250 merge, perform a read-only audit of existing server auth/RLS context and open one manually scoped code PR that derives actor, role, tenant and organization exclusively from trusted server context before invoking `RuntimePersistenceService`.
+- Autopilot-safe allowed files before that manual scope is selected:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
-- Success criteria:
-  - future module has no controllers;
-  - AppModule registration is server-only;
-  - fail-closed activation remains unchanged;
-  - no implementation files change in VP-3.38;
-  - guard, dry-run and security checks remain green.
+- Execution rule:
+  - no separate docs-only gate PR;
+  - exact code files are selected by read-only audit and added to the code branch state before writes;
+  - no controller or web route until authenticated command tests are green;
+  - production migration remains unapplied.
 
 AFTER NEXT:
-- Layer: VP-3.40 Runtime Persistence Internal Service Wiring Final Gate.
-- Goal: final docs-only gate before internal wiring implementation.
+- Production migration dry-run and rollback rehearsal against a controlled non-production PostgreSQL database.
+- DB-backed runtime action bridge with concurrency, retry and recovery tests.
+- Removal of process runtime store only after parity and rollback evidence are complete.


### PR DESCRIPTION
## Суть

Реализован server-only внутренний Nest-контур runtime persistence без публичного controller/API/web route.

## Реализовано

- `RuntimePersistenceService` делегирует typed input в repository token без преобразования receipt;
- `RuntimePersistenceModule` подключает существующий repository selector через global `PrismaService`;
- default mode остаётся fail-closed, Prisma path активируется только точным feature flag;
- `AppModule` регистрирует внутренний модуль без нового публичного surface;
- единый canonical test deal проверяет delegation, disabled receipt, exception propagation и отсутствие caller-supplied evidence IDs;
- module test подтверждает отсутствие controllers/routes и fail-closed provider graph.

## Ограничение зрелости

Production migration не применена. Публичный API, web bridge и request auth/tenant derivation не реализованы. Postgres writes не считаются активными в production.