### PR TITLE
VP-3.42 Runtime Persistence Authenticated Internal Command Boundary

### DIFF
--- a/apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts
@@ -1,0 +1,131 @@
+import { RequestUser, Role } from '../../common/types/request-user';
+import {
+  RuntimePersistenceCommandContextError,
+  RuntimePersistenceCommandService,
+  type RuntimePersistenceAuthenticatedCommandInput,
+} from './runtime-persistence-command.service';
+import type { RuntimePersistenceWriteReceipt } from './runtime-persistence.repository';
+import { RuntimePersistenceService } from './runtime-persistence.service';
+
+const TRUSTED_USER: RequestUser = {
+  id: 'user-authenticated-001',
+  email: 'operator@example.test',
+  role: Role.SUPPORT_MANAGER,
+  orgId: 'organization-trusted-001',
+  tenantId: 'tenant-trusted-001',
+  sessionId: 'session-trusted-001',
+};
+
+const COMMAND: RuntimePersistenceAuthenticatedCommandInput = {
+  runtimeSnapshotId: 'runtime-snapshot:deal-canonical-001:start_document_review:v2',
+  idempotencyKey: 'runtime-persistence:deal-canonical-001:start_document_review:v2',
+  transactionId: 'runtime-transaction:deal-canonical-001:start_document_review:v2',
+  dealId: 'deal-canonical-001',
+  intentId: 'start_document_review',
+  snapshotState: 'updated',
+  statusLabel: 'document_review_started',
+  runtimeStoreRecordId: 'runtime-store:deal-canonical-001:start_document_review:v2',
+  runtimeStoreVersion: 'v2',
+  correlationId: 'correlation-canonical-002',
+  auditId: 'audit-canonical-002',
+  contractHash: 'sha256:canonical-runtime-contract-002',
+  payload: {
+    dealId: 'deal-canonical-001',
+    intentId: 'start_document_review',
+    state: 'updated',
+  },
+};
+
+const RECEIPT: RuntimePersistenceWriteReceipt = {
+  status: 'persisted',
+  runtimeSnapshotId: COMMAND.runtimeSnapshotId,
+  idempotencyKey: COMMAND.idempotencyKey,
+  state: 'fully_linked',
+  recordId: 'runtime-record-canonical-002',
+};
+
+function fixture() {
+  const persistence = {
+    persist: jest.fn().mockResolvedValue(RECEIPT),
+  } as unknown as RuntimePersistenceService;
+  return {
+    persistence,
+    service: new RuntimePersistenceCommandService(persistence),
+  };
+}
+
+describe('RuntimePersistenceCommandService', () => {
+  it('derives actor, role, tenant and organization only from trusted RequestUser', async () => {
+    const test = fixture();
+
+    await expect(test.service.persistAuthenticated(TRUSTED_USER, COMMAND)).resolves.toBe(RECEIPT);
+    expect(test.persistence.persist).toHaveBeenCalledTimes(1);
+    expect(test.persistence.persist).toHaveBeenCalledWith({
+      ...COMMAND,
+      actorId: TRUSTED_USER.id,
+      actorRole: TRUSTED_USER.role,
+      tenantId: TRUSTED_USER.tenantId,
+      organizationId: TRUSTED_USER.orgId,
+    });
+  });
+
+  it('overrides malicious identity fields supplied through an untyped payload', async () => {
+    const test = fixture();
+    const maliciousCommand = {
+      ...COMMAND,
+      actorId: 'attacker-user',
+      actorRole: Role.ADMIN,
+      tenantId: 'attacker-tenant',
+      organizationId: 'attacker-org',
+      outboxEntryId: 'attacker-outbox',
+      auditEventId: 'attacker-audit',
+    } as unknown as RuntimePersistenceAuthenticatedCommandInput;
+
+    await test.service.persistAuthenticated(TRUSTED_USER, maliciousCommand);
+
+    const delegated = (test.persistence.persist as jest.Mock).mock.calls[0][0];
+    expect(delegated).toMatchObject({
+      actorId: TRUSTED_USER.id,
+      actorRole: TRUSTED_USER.role,
+      tenantId: TRUSTED_USER.tenantId,
+      organizationId: TRUSTED_USER.orgId,
+    });
+    expect(delegated.actorId).not.toBe('attacker-user');
+    expect(delegated.actorRole).not.toBe(Role.ADMIN);
+    expect(delegated.tenantId).not.toBe('attacker-tenant');
+    expect(delegated.organizationId).not.toBe('attacker-org');
+  });
+
+  it.each([
+    ['authenticated_user_required', undefined],
+    ['session_required', { ...TRUSTED_USER, sessionId: undefined }],
+    ['organization_required', { ...TRUSTED_USER, orgId: '' }],
+    ['tenant_required', { ...TRUSTED_USER, tenantId: undefined }],
+    ['guest_role_forbidden', { ...TRUSTED_USER, role: Role.GUEST }],
+  ] as const)('blocks %s before repository delegation', async (expectedCode, user) => {
+    const test = fixture();
+
+    await expect(test.service.persistAuthenticated(user, COMMAND)).rejects.toEqual(
+      expect.objectContaining<Partial<RuntimePersistenceCommandContextError>>({
+        name: 'RuntimePersistenceCommandContextError',
+        code: expectedCode,
+        message: 'Trusted runtime persistence context is incomplete.',
+      }),
+    );
+    expect(test.persistence.persist).not.toHaveBeenCalled();
+  });
+
+  it('returns failed repository receipts unchanged', async () => {
+    const test = fixture();
+    const failed: RuntimePersistenceWriteReceipt = {
+      status: 'failed',
+      runtimeSnapshotId: COMMAND.runtimeSnapshotId,
+      idempotencyKey: COMMAND.idempotencyKey,
+      state: 'ready_to_persist',
+      reasonCode: 'repository_not_enabled',
+    };
+    (test.persistence.persist as jest.Mock).mockResolvedValueOnce(failed);
+
+    await expect(test.service.persistAuthenticated(TRUSTED_USER, COMMAND)).resolves.toBe(failed);
+  });
+});

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@nestjs/common';
+import { RequestUser, Role } from '../../common/types/request-user';
+import type {
+  RuntimePersistenceWriteInput,
+  RuntimePersistenceWriteReceipt,
+} from './runtime-persistence.repository';
+import { RuntimePersistenceService } from './runtime-persistence.service';
+
+export type RuntimePersistenceAuthenticatedCommandInput = Omit<
+  RuntimePersistenceWriteInput,
+  'actorId' | 'actorRole' | 'tenantId' | 'organizationId'
+>;
+
+export type RuntimePersistenceCommandContextErrorCode =
+  | 'authenticated_user_required'
+  | 'session_required'
+  | 'organization_required'
+  | 'tenant_required'
+  | 'guest_role_forbidden';
+
+export class RuntimePersistenceCommandContextError extends Error {
+  constructor(readonly code: RuntimePersistenceCommandContextErrorCode) {
+    super('Trusted runtime persistence context is incomplete.');
+    this.name = 'RuntimePersistenceCommandContextError';
+  }
+}
+
+function requireTrustedContext(user: RequestUser | undefined): Readonly<RequestUser> {
+  if (!user?.id) {
+    throw new RuntimePersistenceCommandContextError('authenticated_user_required');
+  }
+  if (!user.sessionId) {
+    throw new RuntimePersistenceCommandContextError('session_required');
+  }
+  if (!user.orgId) {
+    throw new RuntimePersistenceCommandContextError('organization_required');
+  }
+  if (!user.tenantId) {
+    throw new RuntimePersistenceCommandContextError('tenant_required');
+  }
+  if (user.role === Role.GUEST) {
+    throw new RuntimePersistenceCommandContextError('guest_role_forbidden');
+  }
+  return user;
+}
+
+@Injectable()
+export class RuntimePersistenceCommandService {
+  constructor(private readonly persistence: RuntimePersistenceService) {}
+
+  persistAuthenticated(
+    user: RequestUser | undefined,
+    command: RuntimePersistenceAuthenticatedCommandInput,
+  ): Promise<RuntimePersistenceWriteReceipt> {
+    const trusted = requireTrustedContext(user);
+
+    return this.persistence.persist({
+      ...command,
+      actorId: trusted.id,
+      actorRole: trusted.role,
+      tenantId: trusted.tenantId,
+      organizationId: trusted.orgId,
+    });
+  }
+}

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from '../../common/prisma/prisma.module';
 import { PrismaService } from '../../common/prisma/prisma.service';
+import { RuntimePersistenceCommandService } from './runtime-persistence-command.service';
 import { selectRuntimePersistenceRepository } from './runtime-persistence-repository.factory';
 import { RUNTIME_PERSISTENCE_REPOSITORY } from './runtime-persistence.repository';
 import { RuntimePersistenceService } from './runtime-persistence.service';
@@ -9,12 +10,17 @@ import { RuntimePersistenceService } from './runtime-persistence.service';
   imports: [PrismaModule],
   providers: [
     RuntimePersistenceService,
+    RuntimePersistenceCommandService,
     {
       provide: RUNTIME_PERSISTENCE_REPOSITORY,
       inject: [PrismaService],
       useFactory: (prisma: PrismaService) => selectRuntimePersistenceRepository(prisma),
     },
   ],
-  exports: [RuntimePersistenceService, RUNTIME_PERSISTENCE_REPOSITORY],
+  exports: [
+    RuntimePersistenceService,
+    RuntimePersistenceCommandService,
+    RUNTIME_PERSISTENCE_REPOSITORY,
+  ],
 })
 export class RuntimePersistenceModule {}

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,48 +3,45 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "ready",
-  "current": "VP-3.41 Runtime Persistence Internal Service Wiring Implementation.",
-  "fullTzReadinessPercent": 83,
-  "openPr": "#2250",
-  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.", "#2242", "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.", "#2243", "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.", "#2244", "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.", "#2245", "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation.", "#2246", "VP-3.38 Runtime Persistence Internal Service Wiring Plan."],
+  "current": "VP-3.42 Runtime Persistence Authenticated Internal Command Boundary.",
+  "fullTzReadinessPercent": 84,
+  "openPr": "#2252",
+  "lastClosed": ["#2038", "#2040", "#2041", "#2042", "#2045", "#2046", "#2048", "#2049", "#2051", "#2053", "#2055", "#2056", "#2057", "#2058", "#2059", "#2065", "#2067", "#2070", "#2071", "#2072", "#2075", "#2076", "#2077", "#2078", "#2079", "#2080", "root-entry-redirect", "#2111", "#2117", "#2119", "#2120", "#2121", "#2122", "#2123", "#2124", "#2125", "#2126", "#2127", "#2128", "#2129", "#2130", "#2131", "#2132", "#2133", "#2134", "#2135", "VP-2.5-vitest-green", "#2208", "#2210", "#2211", "#2212", "#2213", "VP-3.5 Runtime DB Contract.", "#2214", "VP-3.6 Runtime Persistence Repository Adapter Scope Selection.", "#2215", "VP-3.7 Runtime Persistence Repository Adapter Contract Plan.", "#2216", "VP-3.8 Runtime Persistence Repository Adapter Implementation Scope Request.", "#2217", "VP-3.9 Runtime Persistence Repository Adapter Implementation Preflight.", "#2218", "VP-3.10 Runtime Persistence Repository Adapter Implementation Activation.", "#2219", "VP-3.11 Runtime Persistence Repository Adapter Implementation Scope Unlock.", "#2220", "VP-3.12 Runtime Persistence Repository Adapter Implementation Final Gate.", "#2221", "VP-3.13 Runtime Persistence Repository Adapter Implementation.", "#2222", "VP-3.14 Runtime Persistence Repository Adapter Pipeline Binding Plan.", "#2223", "VP-3.15 Runtime Persistence Repository Adapter Pipeline Binding Scope Unlock.", "#2224", "VP-3.16 Runtime Persistence Repository Adapter Pipeline Binding Final Gate.", "#2225", "VP-3.17 Runtime Persistence Repository Adapter Pipeline Binding Implementation.", "#2226", "VP-3.18 Runtime Persistence Outbox Audit Linkage Plan.", "#2227", "VP-3.19 Runtime Persistence Outbox Audit Linkage Scope Unlock.", "#2228", "VP-3.20 Runtime Persistence Outbox Audit Linkage Final Gate.", "#2229", "VP-3.21 Runtime Persistence Outbox Audit Linkage Implementation.", "#2230", "VP-3.22 Runtime Persistence Pipeline Linkage Binding Plan.", "#2231", "VP-3.23 Runtime Persistence Pipeline Linkage Binding Scope Unlock.", "#2232", "VP-3.24 Runtime Persistence Pipeline Linkage Binding Final Gate.", "#2233", "VP-3.25 Runtime Persistence Pipeline Linkage Binding Implementation.", "#2234", "VP-3.26 Runtime Persistence Transaction and Idempotency Hardening Plan.", "#2235", "VP-3.27 Runtime Persistence Transaction and Idempotency Scope Unlock.", "#2236", "VP-3.28 Runtime Persistence Transaction and Idempotency Final Gate.", "#2237", "VP-3.29 Runtime Persistence Transaction and Idempotency Hardening Implementation.", "#2238", "VP-3.30 Runtime Persistence Prisma Schema and Migration Plan.", "#2239", "VP-3.31 Runtime Persistence Prisma Schema and Migration Scope Unlock.", "#2240", "VP-3.32 Runtime Persistence Prisma Schema and Migration Final Gate.", "#2241", "VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation.", "#2242", "VP-3.34 Runtime Persistence Postgres Repository Adapter Plan.", "#2243", "VP-3.35 Runtime Persistence Postgres Repository Adapter Scope Unlock.", "#2244", "VP-3.36 Runtime Persistence Postgres Repository Adapter Final Gate.", "#2245", "VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation.", "#2246", "VP-3.38 Runtime Persistence Internal Service Wiring Plan.", "#2250", "VP-3.41 Runtime Persistence Internal Service Wiring Implementation."],
   "openBlockers": ["#2113", "#2115"],
-  "blockerNotes": "#2113 repository settings cleanup. #2115 remains blocked by current auth-file write path.",
-  "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "controller/API/web wiring", "production migration execution"],
+  "blockerNotes": "#2113 repository settings cleanup. #2115 remains blocked by current auth-file write path. Draft #2251 is merge-blocked by bank, tenant and fake-live invariant violations.",
+  "lockedUntilCurrentGreen": ["apps/landing changes", "package or lockfile changes", "controller/API/web wiring", "production migration execution", "money confirmation commands"],
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts",
-    "apps/api/src/app.module.ts"
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts",
-    "apps/api/src/app.module.ts"
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts"
   ],
-  "vp338RuntimePersistenceInternalServiceWiringPlan": {
-    "layer": "VP-3.38 Runtime Persistence Internal Service Wiring Plan",
-    "closedPr": "#2246",
-    "status": "internal-service-wiring-plan-complete"
-  },
   "vp341RuntimePersistenceInternalServiceWiringImplementation": {
     "layer": "VP-3.41 Runtime Persistence Internal Service Wiring Implementation",
-    "openPr": "#2250",
-    "status": "internal-service-wiring-implementation",
-    "changedImplementationFiles": [
-      "apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts",
-      "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts",
-      "apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts",
-      "apps/api/src/app.module.ts"
-    ],
+    "closedPr": "#2250",
+    "status": "internal-service-wiring-implementation-complete",
     "canonicalTestDealId": "deal-canonical-001"
   },
   "vp342RuntimePersistenceAuthenticatedCommandBoundary": {
     "layer": "VP-3.42 Runtime Persistence Authenticated Internal Command Boundary",
+    "openPr": "#2252",
+    "status": "authenticated-command-boundary-implementation",
+    "changedImplementationFiles": [
+      "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts",
+      "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts",
+      "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts"
+    ]
+  },
+  "vp343RlsTrustedContextHardening": {
+    "layer": "VP-3.43 RLS Trusted Context Hardening",
     "status": "next-manual-code-scope-after-read-only-audit"
   },
   "forbiddenZones": [
@@ -60,6 +57,6 @@
     "pnpm-lock.yaml"
   ],
   "maturityLanguage": ["platform-temporarily-without-external-integrations"],
-  "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied", "runtime persistence externally exposed"],
-  "readiness": "83% honest readiness. VP-3.41 registers a fail-closed server-only runtime persistence module and verifies one canonical internal deal path. It does not expose a controller or web bridge, derive request auth/tenant context, apply the production migration or prove active production Postgres writes."
+  "forbiddenClaims": ["maturity uplift beyond evidence", "external integration completion", "production DB runtime persistence complete", "live outbox audit persistence complete", "database migration applied", "runtime persistence externally exposed", "bank confirmation from user command"],
+  "readiness": "84% honest readiness. VP-3.42 derives actor, role, tenant and organization exclusively from trusted RequestUser and blocks incomplete or guest context before repository delegation. It does not expose a controller/web route, apply the production migration, complete persistent identity or permit user-driven bank confirmation."
 }

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,65 +1,66 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.41 Runtime Persistence Internal Service Wiring Implementation.
+CURRENT: VP-3.42 Runtime Persistence Authenticated Internal Command Boundary.
 
-GOAL: Реализовать и проверить server-only контур `AppModule → RuntimePersistenceModule → RuntimePersistenceService → repository` без controller/API/web route и без применения migration к production DB.
+GOAL: Добавить trusted server-auth boundary перед `RuntimePersistenceService`, чтобы actor, role, tenant и organization не принимались из command payload и неполный контекст блокировался до repository write.
 
 CURRENT STATUS:
 - VP-3.33 additive Prisma schema/migration is merged from #2241.
 - VP-3.37 API-side Postgres repository adapter is merged from #2245.
-- VP-3.38 internal service wiring plan is merged from #2246.
-- Duplicate docs-only scope PRs #2248 and #2249 are closed without merge.
-- PR #2250 implements the working internal service path directly.
-- Railway `brilliant-liberation - @pc/web` is green after #2246.
+- VP-3.41 internal service/module wiring is merged from #2250.
+- Railway `brilliant-liberation - @pc/web` is green after #2250.
+- Draft #2251 is merge-blocked: it permits user-driven bank confirmations, synthetic bank references and cross-tenant visibility.
+- PR #2252 implements only the safe authenticated internal boundary and no public route.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
-- apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts
 - apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts
-- apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts
-- apps/api/src/app.module.ts
 
 IMPLEMENTED:
-- `RuntimePersistenceService` injects `RUNTIME_PERSISTENCE_REPOSITORY` and delegates one typed `persist` operation.
-- `RuntimePersistenceModule` uses existing global `PrismaService` and `selectRuntimePersistenceRepository`.
-- Module exports the internal service and repository token and declares no controller.
-- `AppModule` imports `RuntimePersistenceModule` for server dependency-graph/startup validation.
-- Default mode remains disabled and fail-closed; exact `prisma` feature flag remains required.
-- One canonical test deal `deal-canonical-001` validates the internal service path.
-- Tests verify exact delegation, unchanged receipts, failed receipt preservation, exception propagation, no caller evidence IDs, no controllers and default fail-closed provider graph.
+- Command input omits `actorId`, `actorRole`, `tenantId` and `organizationId` at the type boundary.
+- Trusted identity fields are populated only from verified `RequestUser`.
+- Runtime identity fields supplied through an untyped payload are overwritten by trusted context.
+- Missing authenticated user, session, organization or tenant blocks before repository delegation.
+- `GUEST` role blocks before repository delegation.
+- Failed repository receipts remain failed and are returned unchanged.
+- `RuntimePersistenceCommandService` is internal, registered in `RuntimePersistenceModule` and has no controller/route.
 
 STILL LOCKED:
 - controller or external API endpoint;
 - web server-action bridge;
+- bank reserve/release confirmation from user commands;
 - production migration execution and rollback rehearsal;
-- request-derived actor/tenant/organization enforcement;
+- persistent identity/session/MFA implementation;
 - UI/components;
 - package and lockfiles;
 - live bank/FGIS/EDO integrations.
 
 GUARDRAILS:
-- No HTTP request object enters the persistence service.
-- No caller-supplied outbox/audit database IDs.
-- No disabled or failed receipt is converted into success.
-- No repository exception is swallowed.
-- No process-memory fallback.
-- No production Postgres activation claim.
+- No HTTP request object enters the repository layer.
+- No caller-supplied identity or evidence database IDs.
+- No missing tenant/session fallback.
+- No `ACCOUNTING → bank` authority substitution.
+- No synthetic bank references.
+- No disabled/failed receipt conversion to success.
 - Critical forbidden zones remain unchanged.
 
 NEXT:
-- Layer: VP-3.42 Runtime Persistence Authenticated Internal Command Boundary.
-- Goal: after #2250 merge, perform a read-only audit of existing server auth/RLS context and open one manually scoped code PR that derives actor, role, tenant and organization exclusively from trusted server context before invoking `RuntimePersistenceService`.
+- Layer: VP-3.43 RLS Trusted Context Hardening.
+- Goal: fix the existing RLS middleware so it reads `orgId`, eliminates `$executeRawUnsafe`, stops silently ignoring context failure and establishes transaction-safe trusted context semantics.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
 - Execution rule:
   - no separate docs-only gate PR;
-  - exact code files are selected by read-only audit and added to the code branch state before writes;
-  - no controller or web route until authenticated command tests are green;
-  - production migration remains unapplied.
+  - exact middleware/context/test files are selected by read-only audit and added to one manually scoped code PR;
+  - auth source-of-truth files remain locked until blocker #2115 is resolved;
+  - no controller or money command is introduced.
 
 AFTER NEXT:
-- Production migration dry-run and rollback rehearsal against a controlled non-production PostgreSQL database.
-- DB-backed runtime action bridge with concurrency, retry and recovery tests.
-- Removal of process runtime store only after parity and rollback evidence are complete.
+- Persistent identity/session/revocation/MFA source of truth.
+- Controlled non-production migration dry-run and rollback rehearsal.
+- Authenticated DB-backed runtime action bridge without direct bank confirmation.
+- Concurrency, retry, recovery, load and restore acceptance gates.


### PR DESCRIPTION
## Суть

Добавлен внутренний authenticated command boundary перед runtime persistence service.

## Реализовано

- actorId, actorRole, tenantId и organizationId формируются только из trusted `RequestUser`;
- command input на уровне типов не содержит identity-полей;
- untyped malicious identity fields перезаписываются trusted context;
- отсутствие user/session/org/tenant и роль GUEST блокируют вызов до repository;
- failed repository receipt возвращается без превращения в success;
- service зарегистрирован и экспортирован внутренним RuntimePersistenceModule.

## Ограничение зрелости

Controller/API/web route отсутствуют. Production migration не применена. Текущие JWT должны содержать trusted tenantId и sessionId, иначе команда закономерно блокируется.