### PR TITLE
Hotfix VP-3.42 synchronous trusted-context tests

### DIFF
--- a/apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts
@@ -3,6 +3,7 @@ import {
   RuntimePersistenceCommandContextError,
   RuntimePersistenceCommandService,
   type RuntimePersistenceAuthenticatedCommandInput,
+  type RuntimePersistenceCommandContextErrorCode,
 } from './runtime-persistence-command.service';
 import type { RuntimePersistenceWriteReceipt } from './runtime-persistence.repository';
 import { RuntimePersistenceService } from './runtime-persistence.service';
@@ -54,6 +55,16 @@ function fixture() {
   };
 }
 
+function captureContextError(run: () => unknown): RuntimePersistenceCommandContextError {
+  try {
+    run();
+  } catch (error) {
+    expect(error).toBeInstanceOf(RuntimePersistenceCommandContextError);
+    return error as RuntimePersistenceCommandContextError;
+  }
+  throw new Error('Expected RuntimePersistenceCommandContextError.');
+}
+
 describe('RuntimePersistenceCommandService', () => {
   it('derives actor, role, tenant and organization only from trusted RequestUser', async () => {
     const test = fixture();
@@ -102,16 +113,13 @@ describe('RuntimePersistenceCommandService', () => {
     ['organization_required', { ...TRUSTED_USER, orgId: '' }],
     ['tenant_required', { ...TRUSTED_USER, tenantId: undefined }],
     ['guest_role_forbidden', { ...TRUSTED_USER, role: Role.GUEST }],
-  ] as const)('blocks %s before repository delegation', async (expectedCode, user) => {
+  ] as const)('blocks %s before repository delegation', (expectedCode, user) => {
     const test = fixture();
+    const error = captureContextError(() => test.service.persistAuthenticated(user, COMMAND));
 
-    await expect(test.service.persistAuthenticated(user, COMMAND)).rejects.toEqual(
-      expect.objectContaining<Partial<RuntimePersistenceCommandContextError>>({
-        name: 'RuntimePersistenceCommandContextError',
-        code: expectedCode,
-        message: 'Trusted runtime persistence context is incomplete.',
-      }),
-    );
+    expect(error.name).toBe('RuntimePersistenceCommandContextError');
+    expect(error.code).toBe(expectedCode as RuntimePersistenceCommandContextErrorCode);
+    expect(error.message).toBe('Trusted runtime persistence context is incomplete.');
     expect(test.persistence.persist).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Причина

#2252 был смержен автоматикой до попадания исправленного тестового commit. Production boundary корректно выбрасывает trusted-context error синхронно до repository write, но тест ошибочно проверял его как rejected Promise.

## Исправление

- production-код не меняется;
- тест перехватывает синхронный `RuntimePersistenceCommandContextError`;
- проверяет тип, код, безопасное сообщение и отсутствие repository delegation;
- scope: один test-файл.