### PR TITLE
VP-3.44 Runtime Persistence Trusted Transaction Binding

### DIFF
--- a/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts
+++ b/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client';
 import { PrismaRuntimePersistenceRepository } from './prisma-runtime-persistence.repository';
 import type { RuntimePersistenceWriteInput } from './runtime-persistence.repository';
 
@@ -35,7 +36,8 @@ function existingSnapshot(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function successfulPrisma() {
+function transactionFixture(existing: unknown = null) {
+  const findUnique = jest.fn().mockResolvedValue(existing);
   const outboxCreate = jest.fn().mockResolvedValue({ id: 'outbox-1' });
   const auditCreate = jest.fn().mockResolvedValue({ id: 'audit-1' });
   const snapshotCreate = jest.fn().mockResolvedValue({
@@ -48,18 +50,13 @@ function successfulPrisma() {
   const tx = {
     outboxEntry: { create: outboxCreate },
     auditEvent: { create: auditCreate },
-    dealWorkspaceRuntimeSnapshot: { create: snapshotCreate },
+    dealWorkspaceRuntimeSnapshot: { findUnique, create: snapshotCreate },
     dealWorkspaceRuntimeTransactionAttempt: { create: attemptCreate },
-  };
-  const prisma = {
-    dealWorkspaceRuntimeSnapshot: {
-      findUnique: jest.fn().mockResolvedValue(null),
-    },
-    $transaction: jest.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
-  } as any;
+  } as unknown as Prisma.TransactionClient;
 
   return {
-    prisma,
+    tx,
+    findUnique,
     outboxCreate,
     auditCreate,
     snapshotCreate,
@@ -67,19 +64,49 @@ function successfulPrisma() {
   };
 }
 
-describe('PrismaRuntimePersistenceRepository', () => {
-  it('persists outbox, audit, snapshot and committed attempt in one transaction', async () => {
-    const setup = successfulPrisma();
-    const repository = new PrismaRuntimePersistenceRepository(setup.prisma);
+function repositoryFixture() {
+  const rootFindUnique = jest.fn();
+  const transaction = jest.fn();
+  const prisma = {
+    dealWorkspaceRuntimeSnapshot: { findUnique: rootFindUnique },
+    $transaction: transaction,
+  } as any;
+  return {
+    prisma,
+    rootFindUnique,
+    transaction,
+    repository: new PrismaRuntimePersistenceRepository(prisma),
+  };
+}
+
+describe('PrismaRuntimePersistenceRepository trusted transaction path', () => {
+  it('uses the supplied transaction for pre-read, outbox, audit, snapshot and attempt', async () => {
+    const root = repositoryFixture();
+    const test = transactionFixture();
     const maliciousInput = {
       ...baseInput,
       outboxEntryId: 'caller-outbox-id',
       auditEventId: 'caller-audit-id',
     } as any;
 
-    const receipt = await repository.write(maliciousInput);
+    const receipt = await root.repository.writeWithinTransaction(test.tx, maliciousInput);
 
-    expect(setup.prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(root.transaction).not.toHaveBeenCalled();
+    expect(root.rootFindUnique).not.toHaveBeenCalled();
+    expect(test.findUnique).toHaveBeenCalledWith({
+      where: { idempotencyKey: baseInput.idempotencyKey },
+      include: {
+        attempts: {
+          orderBy: { startedAt: 'desc' },
+          take: 1,
+          select: { id: true },
+        },
+      },
+    });
+    expect(test.outboxCreate).toHaveBeenCalledTimes(1);
+    expect(test.auditCreate).toHaveBeenCalledTimes(1);
+    expect(test.snapshotCreate).toHaveBeenCalledTimes(1);
+    expect(test.attemptCreate).toHaveBeenCalledTimes(1);
     expect(receipt).toEqual({
       status: 'persisted',
       runtimeSnapshotId: 'snapshot-1',
@@ -91,36 +118,22 @@ describe('PrismaRuntimePersistenceRepository', () => {
       transactionAttemptId: 'attempt-1',
     });
 
-    expect(setup.outboxCreate).toHaveBeenCalledTimes(1);
-    expect(setup.auditCreate).toHaveBeenCalledTimes(1);
-    expect(setup.snapshotCreate).toHaveBeenCalledTimes(1);
-    expect(setup.attemptCreate).toHaveBeenCalledTimes(1);
-
-    const snapshotData = setup.snapshotCreate.mock.calls[0][0].data;
-    expect(snapshotData.state).toBe('fully_linked');
+    const snapshotData = (test.snapshotCreate as jest.Mock).mock.calls[0][0].data;
     expect(snapshotData.outboxEntryId).toBe('outbox-1');
     expect(snapshotData.auditEventId).toBe('audit-1');
     expect(snapshotData.outboxEntryId).not.toBe('caller-outbox-id');
     expect(snapshotData.auditEventId).not.toBe('caller-audit-id');
 
-    const outboxData = setup.outboxCreate.mock.calls[0][0].data;
-    const auditData = setup.auditCreate.mock.calls[0][0].data;
-    expect(outboxData.runtimeSnapshotId).toBe('snapshot-1');
-    expect(auditData.runtimeSnapshotId).toBe('snapshot-1');
+    const auditData = (test.auditCreate as jest.Mock).mock.calls[0][0].data;
     expect(auditData.tenantId).toBe('tenant-1');
     expect(auditData.orgId).toBe('org-1');
   });
 
-  it('returns deterministic duplicate without starting a transaction', async () => {
-    const prisma = {
-      dealWorkspaceRuntimeSnapshot: {
-        findUnique: jest.fn().mockResolvedValue(existingSnapshot()),
-      },
-      $transaction: jest.fn(),
-    } as any;
-    const repository = new PrismaRuntimePersistenceRepository(prisma);
+  it('classifies an existing matching record as duplicate inside the supplied transaction', async () => {
+    const root = repositoryFixture();
+    const test = transactionFixture(existingSnapshot());
 
-    await expect(repository.write(baseInput)).resolves.toEqual({
+    await expect(root.repository.writeWithinTransaction(test.tx, baseInput)).resolves.toEqual({
       status: 'duplicate',
       runtimeSnapshotId: 'snapshot-1',
       idempotencyKey: 'idem-1',
@@ -130,81 +143,102 @@ describe('PrismaRuntimePersistenceRepository', () => {
       auditEventId: 'audit-1',
       transactionAttemptId: 'attempt-1',
     });
-    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(root.transaction).not.toHaveBeenCalled();
+    expect(test.outboxCreate).not.toHaveBeenCalled();
   });
 
-  it('returns conflict for a reused idempotency key with another material identity', async () => {
-    const prisma = {
-      dealWorkspaceRuntimeSnapshot: {
-        findUnique: jest.fn().mockResolvedValue(
-          existingSnapshot({ runtimeSnapshotId: 'snapshot-other', contractHash: 'hash-other' }),
-        ),
-      },
-      $transaction: jest.fn(),
-    } as any;
-    const repository = new PrismaRuntimePersistenceRepository(prisma);
+  it('classifies reused idempotency with another material identity as conflict', async () => {
+    const root = repositoryFixture();
+    const test = transactionFixture(
+      existingSnapshot({ runtimeSnapshotId: 'snapshot-other', contractHash: 'hash-other' }),
+    );
 
-    const receipt = await repository.write(baseInput);
+    const receipt = await root.repository.classifyExistingWithinTransaction(test.tx, baseInput);
 
-    expect(receipt.status).toBe('conflict');
-    expect(receipt.reasonCode).toBe('material_identity_conflict');
-    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(receipt).toMatchObject({
+      status: 'conflict',
+      reasonCode: 'material_identity_conflict',
+      recordId: 'record-1',
+    });
+    expect(root.transaction).not.toHaveBeenCalled();
   });
 
-  it('classifies a concurrent P2002 winner as duplicate without a second transaction', async () => {
-    const findUnique = jest
-      .fn()
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(existingSnapshot());
-    const prisma = {
-      dealWorkspaceRuntimeSnapshot: { findUnique },
-      $transaction: jest.fn().mockRejectedValue({ code: 'P2002' }),
-    } as any;
-    const repository = new PrismaRuntimePersistenceRepository(prisma);
+  it('returns null when no concurrent winner exists in the supplied transaction', async () => {
+    const root = repositoryFixture();
+    const test = transactionFixture(null);
 
-    const receipt = await repository.write(baseInput);
-
-    expect(receipt.status).toBe('duplicate');
-    expect(findUnique).toHaveBeenCalledTimes(2);
-    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    await expect(
+      root.repository.classifyExistingWithinTransaction(test.tx, baseInput),
+    ).resolves.toBeNull();
   });
 
-  it('returns invalid_input without touching the database', async () => {
-    const setup = successfulPrisma();
-    const repository = new PrismaRuntimePersistenceRepository(setup.prisma);
+  it('returns invalid_input without a database read or write', async () => {
+    const root = repositoryFixture();
+    const test = transactionFixture();
 
-    const receipt = await repository.write({ ...baseInput, dealId: '   ' });
+    const receipt = await root.repository.writeWithinTransaction(test.tx, {
+      ...baseInput,
+      dealId: '   ',
+    });
 
     expect(receipt).toMatchObject({ status: 'failed', reasonCode: 'invalid_input' });
-    expect(setup.prisma.dealWorkspaceRuntimeSnapshot.findUnique).not.toHaveBeenCalled();
-    expect(setup.prisma.$transaction).not.toHaveBeenCalled();
+    expect(test.findUnique).not.toHaveBeenCalled();
+    expect(test.outboxCreate).not.toHaveBeenCalled();
+    expect(root.transaction).not.toHaveBeenCalled();
   });
 
-  it('keeps staged writes uncommitted when a transaction step fails', async () => {
-    const committed: string[] = [];
-    const outboxCreate = jest.fn(async () => ({ id: 'outbox-stage' }));
-    const auditCreate = jest.fn(async () => {
-      throw new Error('sensitive database failure');
-    });
-    const snapshotCreate = jest.fn();
-    const attemptCreate = jest.fn();
-    const tx = {
-      outboxEntry: { create: outboxCreate },
-      auditEvent: { create: auditCreate },
-      dealWorkspaceRuntimeSnapshot: { create: snapshotCreate },
-      dealWorkspaceRuntimeTransactionAttempt: { create: attemptCreate },
-    };
-    const prisma = {
-      dealWorkspaceRuntimeSnapshot: { findUnique: jest.fn().mockResolvedValue(null) },
-      $transaction: jest.fn(async (callback: (client: typeof tx) => unknown) => {
-        const result = await callback(tx);
-        committed.push('transaction-committed');
-        return result;
-      }),
-    } as any;
-    const repository = new PrismaRuntimePersistenceRepository(prisma);
+  it('propagates P2002 so the owning trusted boundary can rollback and reclassify', async () => {
+    const root = repositoryFixture();
+    const test = transactionFixture();
+    (test.outboxCreate as jest.Mock).mockRejectedValueOnce({ code: 'P2002' });
 
-    const receipt = await repository.write(baseInput);
+    await expect(root.repository.writeWithinTransaction(test.tx, baseInput)).rejects.toMatchObject({
+      code: 'P2002',
+    });
+    expect(test.auditCreate).not.toHaveBeenCalled();
+    expect(test.snapshotCreate).not.toHaveBeenCalled();
+    expect(test.attemptCreate).not.toHaveBeenCalled();
+    expect(root.transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe('PrismaRuntimePersistenceRepository compatibility path', () => {
+  it('opens one root transaction and delegates all work to its transaction client', async () => {
+    const root = repositoryFixture();
+    const test = transactionFixture();
+    root.transaction.mockImplementationOnce(
+      async (work: (tx: Prisma.TransactionClient) => Promise<unknown>) => work(test.tx),
+    );
+
+    await expect(root.repository.write(baseInput)).resolves.toMatchObject({ status: 'persisted' });
+    expect(root.transaction).toHaveBeenCalledTimes(1);
+    expect(root.rootFindUnique).not.toHaveBeenCalled();
+    expect(test.findUnique).toHaveBeenCalledTimes(1);
+  });
+
+  it('reclassifies a concurrent P2002 winner in a second transaction', async () => {
+    const root = repositoryFixture();
+    const first = transactionFixture();
+    const second = transactionFixture(existingSnapshot());
+    (first.outboxCreate as jest.Mock).mockRejectedValueOnce({ code: 'P2002' });
+    root.transaction
+      .mockImplementationOnce(
+        async (work: (tx: Prisma.TransactionClient) => Promise<unknown>) => work(first.tx),
+      )
+      .mockImplementationOnce(
+        async (work: (tx: Prisma.TransactionClient) => Promise<unknown>) => work(second.tx),
+      );
+
+    await expect(root.repository.write(baseInput)).resolves.toMatchObject({ status: 'duplicate' });
+    expect(root.transaction).toHaveBeenCalledTimes(2);
+    expect(second.findUnique).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a sanitized failed receipt when transaction work fails', async () => {
+    const root = repositoryFixture();
+    root.transaction.mockRejectedValueOnce(new Error('sensitive database failure'));
+
+    const receipt = await root.repository.write(baseInput);
 
     expect(receipt).toEqual({
       status: 'failed',
@@ -213,11 +247,6 @@ describe('PrismaRuntimePersistenceRepository', () => {
       state: 'ready_to_persist',
       reasonCode: 'database_write_failed',
     });
-    expect(committed).toEqual([]);
-    expect(outboxCreate).toHaveBeenCalledTimes(1);
-    expect(auditCreate).toHaveBeenCalledTimes(1);
-    expect(snapshotCreate).not.toHaveBeenCalled();
-    expect(attemptCreate).not.toHaveBeenCalled();
     expect(JSON.stringify(receipt)).not.toContain('sensitive database failure');
   });
 });

--- a/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts
+++ b/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable, Optional } from '@nestjs/common';
+import type { Prisma } from '@prisma/client';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import type {
   RuntimePersistenceDbState,
@@ -7,7 +8,7 @@ import type {
   RuntimePersistenceWriteReceipt,
 } from './runtime-persistence.repository';
 
-type ExistingRuntimeSnapshot = {
+export type ExistingRuntimeSnapshot = {
   id: string;
   runtimeSnapshotId: string;
   idempotencyKey: string;
@@ -34,7 +35,7 @@ const requiredStringFields: Array<keyof RuntimePersistenceWriteInput> = [
   'contractHash',
 ];
 
-function isKnownUniqueConstraintError(error: unknown): boolean {
+export function isRuntimePersistenceUniqueConstraintError(error: unknown): boolean {
   return Boolean(
     error &&
       typeof error === 'object' &&
@@ -114,8 +115,11 @@ export class PrismaRuntimePersistenceRepository implements RuntimePersistenceRep
     };
   }
 
-  private async findExisting(idempotencyKey: string): Promise<ExistingRuntimeSnapshot | null> {
-    return this.db.dealWorkspaceRuntimeSnapshot.findUnique({
+  private findExisting(
+    tx: Prisma.TransactionClient,
+    idempotencyKey: string,
+  ): Promise<ExistingRuntimeSnapshot | null> {
+    return tx.dealWorkspaceRuntimeSnapshot.findUnique({
       where: { idempotencyKey },
       include: {
         attempts: {
@@ -127,122 +131,143 @@ export class PrismaRuntimePersistenceRepository implements RuntimePersistenceRep
     });
   }
 
+  async classifyExistingWithinTransaction(
+    tx: Prisma.TransactionClient,
+    input: RuntimePersistenceWriteInput,
+  ): Promise<RuntimePersistenceWriteReceipt | null> {
+    if (!isValidInput(input)) {
+      return this.failed(input, 'invalid_input');
+    }
+
+    const existing = await this.findExisting(tx, input.idempotencyKey);
+    return existing ? this.classifyExisting(input, existing) : null;
+  }
+
+  async writeWithinTransaction(
+    tx: Prisma.TransactionClient,
+    input: RuntimePersistenceWriteInput,
+  ): Promise<RuntimePersistenceWriteReceipt> {
+    if (!isValidInput(input)) {
+      return this.failed(input, 'invalid_input');
+    }
+
+    const existing = await this.findExisting(tx, input.idempotencyKey);
+    if (existing) {
+      return this.classifyExisting(input, existing);
+    }
+
+    const outbox = await tx.outboxEntry.create({
+      data: {
+        type: 'deal_workspace.runtime_snapshot.persisted',
+        dealId: input.dealId,
+        status: 'PENDING',
+        idempotencyKey: `runtime-outbox:${input.idempotencyKey}`,
+        correlationId: input.correlationId,
+        auditId: input.auditId,
+        runtimeSnapshotId: input.runtimeSnapshotId,
+        runtimeIdempotencyKey: input.idempotencyKey,
+        payload: {
+          runtimeSnapshotId: input.runtimeSnapshotId,
+          idempotencyKey: input.idempotencyKey,
+          intentId: input.intentId,
+          correlationId: input.correlationId,
+          auditId: input.auditId,
+          snapshot: input.payload,
+        },
+      },
+    });
+
+    const audit = await tx.auditEvent.create({
+      data: {
+        action: 'deal_workspace.runtime_snapshot.persisted',
+        actorUserId: input.actorId,
+        actorRole: input.actorRole,
+        tenantId: input.tenantId,
+        orgId: input.organizationId,
+        dealId: input.dealId,
+        objectType: 'deal_workspace_runtime_snapshot',
+        objectId: input.runtimeSnapshotId,
+        afterState: input.payload,
+        outcome: 'SUCCESS',
+        correlationId: input.correlationId,
+        runtimeSnapshotId: input.runtimeSnapshotId,
+        runtimeIdempotencyKey: input.idempotencyKey,
+        metadata: {
+          auditId: input.auditId,
+          transactionId: input.transactionId,
+          contractHash: input.contractHash,
+        },
+      },
+    });
+
+    const snapshot = await tx.dealWorkspaceRuntimeSnapshot.create({
+      data: {
+        runtimeSnapshotId: input.runtimeSnapshotId,
+        idempotencyKey: input.idempotencyKey,
+        dealId: input.dealId,
+        intentId: input.intentId,
+        state: 'fully_linked',
+        snapshotState: input.snapshotState,
+        statusLabel: input.statusLabel,
+        runtimeStoreRecordId: input.runtimeStoreRecordId,
+        runtimeStoreVersion: input.runtimeStoreVersion,
+        actorId: input.actorId,
+        actorRole: input.actorRole,
+        correlationId: input.correlationId,
+        auditId: input.auditId,
+        contractHash: input.contractHash,
+        payload: input.payload,
+        outboxEntryId: outbox.id,
+        auditEventId: audit.id,
+        version: 1,
+      },
+    });
+
+    const attempt = await tx.dealWorkspaceRuntimeTransactionAttempt.create({
+      data: {
+        transactionId: input.transactionId,
+        snapshotId: snapshot.id,
+        idempotencyKey: input.idempotencyKey,
+        correlationId: input.correlationId,
+        auditId: input.auditId,
+        stage: 'committed',
+        outcome: 'persisted',
+        isReplay: false,
+        completedAt: new Date(),
+        metadata: {
+          runtimeSnapshotId: input.runtimeSnapshotId,
+          outboxEntryId: outbox.id,
+          auditEventId: audit.id,
+        },
+      },
+    });
+
+    return {
+      status: 'persisted',
+      runtimeSnapshotId: snapshot.runtimeSnapshotId,
+      idempotencyKey: snapshot.idempotencyKey,
+      state: snapshot.state as RuntimePersistenceDbState,
+      recordId: snapshot.id,
+      outboxEntryId: outbox.id,
+      auditEventId: audit.id,
+      transactionAttemptId: attempt.id,
+    };
+  }
+
   async write(input: RuntimePersistenceWriteInput): Promise<RuntimePersistenceWriteReceipt> {
     if (!isValidInput(input)) {
       return this.failed(input, 'invalid_input');
     }
 
     try {
-      const existing = await this.findExisting(input.idempotencyKey);
-      if (existing) {
-        return this.classifyExisting(input, existing);
-      }
-
-      return await this.db.$transaction(async (tx) => {
-        const outbox = await tx.outboxEntry.create({
-          data: {
-            type: 'deal_workspace.runtime_snapshot.persisted',
-            dealId: input.dealId,
-            status: 'PENDING',
-            idempotencyKey: `runtime-outbox:${input.idempotencyKey}`,
-            correlationId: input.correlationId,
-            auditId: input.auditId,
-            runtimeSnapshotId: input.runtimeSnapshotId,
-            runtimeIdempotencyKey: input.idempotencyKey,
-            payload: {
-              runtimeSnapshotId: input.runtimeSnapshotId,
-              idempotencyKey: input.idempotencyKey,
-              intentId: input.intentId,
-              correlationId: input.correlationId,
-              auditId: input.auditId,
-              snapshot: input.payload,
-            },
-          },
-        });
-
-        const audit = await tx.auditEvent.create({
-          data: {
-            action: 'deal_workspace.runtime_snapshot.persisted',
-            actorUserId: input.actorId,
-            actorRole: input.actorRole,
-            tenantId: input.tenantId,
-            orgId: input.organizationId,
-            dealId: input.dealId,
-            objectType: 'deal_workspace_runtime_snapshot',
-            objectId: input.runtimeSnapshotId,
-            afterState: input.payload,
-            outcome: 'SUCCESS',
-            correlationId: input.correlationId,
-            runtimeSnapshotId: input.runtimeSnapshotId,
-            runtimeIdempotencyKey: input.idempotencyKey,
-            metadata: {
-              auditId: input.auditId,
-              transactionId: input.transactionId,
-              contractHash: input.contractHash,
-            },
-          },
-        });
-
-        const snapshot = await tx.dealWorkspaceRuntimeSnapshot.create({
-          data: {
-            runtimeSnapshotId: input.runtimeSnapshotId,
-            idempotencyKey: input.idempotencyKey,
-            dealId: input.dealId,
-            intentId: input.intentId,
-            state: 'fully_linked',
-            snapshotState: input.snapshotState,
-            statusLabel: input.statusLabel,
-            runtimeStoreRecordId: input.runtimeStoreRecordId,
-            runtimeStoreVersion: input.runtimeStoreVersion,
-            actorId: input.actorId,
-            actorRole: input.actorRole,
-            correlationId: input.correlationId,
-            auditId: input.auditId,
-            contractHash: input.contractHash,
-            payload: input.payload,
-            outboxEntryId: outbox.id,
-            auditEventId: audit.id,
-            version: 1,
-          },
-        });
-
-        const attempt = await tx.dealWorkspaceRuntimeTransactionAttempt.create({
-          data: {
-            transactionId: input.transactionId,
-            snapshotId: snapshot.id,
-            idempotencyKey: input.idempotencyKey,
-            correlationId: input.correlationId,
-            auditId: input.auditId,
-            stage: 'committed',
-            outcome: 'persisted',
-            isReplay: false,
-            completedAt: new Date(),
-            metadata: {
-              runtimeSnapshotId: input.runtimeSnapshotId,
-              outboxEntryId: outbox.id,
-              auditEventId: audit.id,
-            },
-          },
-        });
-
-        return {
-          status: 'persisted',
-          runtimeSnapshotId: snapshot.runtimeSnapshotId,
-          idempotencyKey: snapshot.idempotencyKey,
-          state: snapshot.state as RuntimePersistenceDbState,
-          recordId: snapshot.id,
-          outboxEntryId: outbox.id,
-          auditEventId: audit.id,
-          transactionAttemptId: attempt.id,
-        } satisfies RuntimePersistenceWriteReceipt;
-      });
+      return await this.db.$transaction((tx) => this.writeWithinTransaction(tx, input));
     } catch (error) {
-      if (isKnownUniqueConstraintError(error)) {
+      if (isRuntimePersistenceUniqueConstraintError(error)) {
         try {
-          const concurrent = await this.findExisting(input.idempotencyKey);
-          if (concurrent) {
-            return this.classifyExisting(input, concurrent);
-          }
+          const classified = await this.db.$transaction((tx) =>
+            this.classifyExistingWithinTransaction(tx, input),
+          );
+          if (classified) return classified;
         } catch {
           return this.failed(input, 'database_write_failed');
         }

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts
@@ -1,9 +1,13 @@
+import type { Prisma } from '@prisma/client';
+import {
+  RlsContextError,
+  type TrustedRlsContext,
+  RlsTransactionService,
+} from '../../common/prisma/rls-transaction.service';
 import { RequestUser, Role } from '../../common/types/request-user';
 import {
-  RuntimePersistenceCommandContextError,
   RuntimePersistenceCommandService,
   type RuntimePersistenceAuthenticatedCommandInput,
-  type RuntimePersistenceCommandContextErrorCode,
 } from './runtime-persistence-command.service';
 import type { RuntimePersistenceWriteReceipt } from './runtime-persistence.repository';
 import { RuntimePersistenceService } from './runtime-persistence.service';
@@ -45,33 +49,57 @@ const RECEIPT: RuntimePersistenceWriteReceipt = {
   recordId: 'runtime-record-canonical-002',
 };
 
+const DUPLICATE: RuntimePersistenceWriteReceipt = {
+  status: 'duplicate',
+  runtimeSnapshotId: COMMAND.runtimeSnapshotId,
+  idempotencyKey: COMMAND.idempotencyKey,
+  state: 'fully_linked',
+  recordId: 'runtime-record-canonical-002',
+};
+
 function fixture() {
+  const tx = { trusted: true } as unknown as Prisma.TransactionClient;
+  const context: TrustedRlsContext = {
+    userId: TRUSTED_USER.id,
+    orgId: TRUSTED_USER.orgId!,
+    tenantId: TRUSTED_USER.tenantId!,
+    role: TRUSTED_USER.role,
+    sessionId: TRUSTED_USER.sessionId!,
+  };
   const persistence = {
-    persist: jest.fn().mockResolvedValue(RECEIPT),
+    persistWithinTransaction: jest.fn().mockResolvedValue(RECEIPT),
+    classifyExistingWithinTransaction: jest.fn().mockResolvedValue(null),
   } as unknown as RuntimePersistenceService;
+  const rlsTransactions = {
+    withTrustedContext: jest.fn(
+      async (
+        _user: RequestUser,
+        work: (client: Prisma.TransactionClient, trusted: TrustedRlsContext) => Promise<unknown>,
+      ) => work(tx, context),
+    ),
+  } as unknown as RlsTransactionService;
+
   return {
+    tx,
     persistence,
-    service: new RuntimePersistenceCommandService(persistence),
+    rlsTransactions,
+    service: new RuntimePersistenceCommandService(persistence, rlsTransactions),
   };
 }
 
-function captureContextError(run: () => unknown): RuntimePersistenceCommandContextError {
-  try {
-    run();
-  } catch (error) {
-    expect(error).toBeInstanceOf(RuntimePersistenceCommandContextError);
-    return error as RuntimePersistenceCommandContextError;
-  }
-  throw new Error('Expected RuntimePersistenceCommandContextError.');
-}
-
 describe('RuntimePersistenceCommandService', () => {
-  it('derives actor, role, tenant and organization only from trusted RequestUser', async () => {
+  it('derives identity only from trusted RequestUser and uses the RLS transaction client', async () => {
     const test = fixture();
 
     await expect(test.service.persistAuthenticated(TRUSTED_USER, COMMAND)).resolves.toBe(RECEIPT);
-    expect(test.persistence.persist).toHaveBeenCalledTimes(1);
-    expect(test.persistence.persist).toHaveBeenCalledWith({
+
+    expect(test.rlsTransactions.withTrustedContext).toHaveBeenCalledTimes(1);
+    expect(test.rlsTransactions.withTrustedContext).toHaveBeenCalledWith(
+      TRUSTED_USER,
+      expect.any(Function),
+    );
+    expect(test.persistence.persistWithinTransaction).toHaveBeenCalledTimes(1);
+    expect(test.persistence.persistWithinTransaction).toHaveBeenCalledWith(test.tx, {
       ...COMMAND,
       actorId: TRUSTED_USER.id,
       actorRole: TRUSTED_USER.role,
@@ -94,7 +122,7 @@ describe('RuntimePersistenceCommandService', () => {
 
     await test.service.persistAuthenticated(TRUSTED_USER, maliciousCommand);
 
-    const delegated = (test.persistence.persist as jest.Mock).mock.calls[0][0];
+    const delegated = (test.persistence.persistWithinTransaction as jest.Mock).mock.calls[0][1];
     expect(delegated).toMatchObject({
       actorId: TRUSTED_USER.id,
       actorRole: TRUSTED_USER.role,
@@ -113,14 +141,16 @@ describe('RuntimePersistenceCommandService', () => {
     ['organization_required', { ...TRUSTED_USER, orgId: '' }],
     ['tenant_required', { ...TRUSTED_USER, tenantId: undefined }],
     ['guest_role_forbidden', { ...TRUSTED_USER, role: Role.GUEST }],
-  ] as const)('blocks %s before repository delegation', (expectedCode, user) => {
+  ] as const)('blocks %s before opening an RLS transaction', async (expectedCode, user) => {
     const test = fixture();
-    const error = captureContextError(() => test.service.persistAuthenticated(user, COMMAND));
 
-    expect(error.name).toBe('RuntimePersistenceCommandContextError');
-    expect(error.code).toBe(expectedCode as RuntimePersistenceCommandContextErrorCode);
-    expect(error.message).toBe('Trusted runtime persistence context is incomplete.');
-    expect(test.persistence.persist).not.toHaveBeenCalled();
+    await expect(test.service.persistAuthenticated(user, COMMAND)).rejects.toMatchObject({
+      name: 'RuntimePersistenceCommandContextError',
+      code: expectedCode,
+      message: 'Trusted runtime persistence context is incomplete.',
+    });
+    expect(test.rlsTransactions.withTrustedContext).not.toHaveBeenCalled();
+    expect(test.persistence.persistWithinTransaction).not.toHaveBeenCalled();
   });
 
   it('returns failed repository receipts unchanged', async () => {
@@ -132,8 +162,65 @@ describe('RuntimePersistenceCommandService', () => {
       state: 'ready_to_persist',
       reasonCode: 'repository_not_enabled',
     };
-    (test.persistence.persist as jest.Mock).mockResolvedValueOnce(failed);
+    (test.persistence.persistWithinTransaction as jest.Mock).mockResolvedValueOnce(failed);
 
     await expect(test.service.persistAuthenticated(TRUSTED_USER, COMMAND)).resolves.toBe(failed);
+  });
+
+  it('does not execute persistence when RLS initialization fails', async () => {
+    const test = fixture();
+    (test.rlsTransactions.withTrustedContext as jest.Mock).mockRejectedValueOnce(
+      new Error('sensitive set_config failure'),
+    );
+
+    await expect(test.service.persistAuthenticated(TRUSTED_USER, COMMAND)).resolves.toEqual({
+      status: 'failed',
+      runtimeSnapshotId: COMMAND.runtimeSnapshotId,
+      idempotencyKey: COMMAND.idempotencyKey,
+      state: 'ready_to_persist',
+      reasonCode: 'database_write_failed',
+    });
+    expect(test.persistence.persistWithinTransaction).not.toHaveBeenCalled();
+  });
+
+  it('re-enters a trusted transaction to classify a concurrent P2002 winner', async () => {
+    const test = fixture();
+    (test.persistence.persistWithinTransaction as jest.Mock).mockRejectedValueOnce({ code: 'P2002' });
+    (test.persistence.classifyExistingWithinTransaction as jest.Mock).mockResolvedValueOnce(DUPLICATE);
+
+    await expect(test.service.persistAuthenticated(TRUSTED_USER, COMMAND)).resolves.toBe(DUPLICATE);
+
+    expect(test.rlsTransactions.withTrustedContext).toHaveBeenCalledTimes(2);
+    expect(test.persistence.classifyExistingWithinTransaction).toHaveBeenCalledWith(test.tx, {
+      ...COMMAND,
+      actorId: TRUSTED_USER.id,
+      actorRole: TRUSTED_USER.role,
+      tenantId: TRUSTED_USER.tenantId,
+      organizationId: TRUSTED_USER.orgId,
+    });
+  });
+
+  it('returns a sanitized failure when a P2002 winner cannot be classified', async () => {
+    const test = fixture();
+    (test.persistence.persistWithinTransaction as jest.Mock).mockRejectedValueOnce({ code: 'P2002' });
+    (test.persistence.classifyExistingWithinTransaction as jest.Mock).mockResolvedValueOnce(null);
+
+    const receipt = await test.service.persistAuthenticated(TRUSTED_USER, COMMAND);
+
+    expect(receipt).toMatchObject({ status: 'failed', reasonCode: 'database_write_failed' });
+    expect(JSON.stringify(receipt)).not.toContain('P2002');
+  });
+
+  it('maps trusted-context failures without opening repository work', async () => {
+    const test = fixture();
+    (test.rlsTransactions.withTrustedContext as jest.Mock).mockRejectedValueOnce(
+      new RlsContextError('tenant_required'),
+    );
+
+    await expect(test.service.persistAuthenticated(TRUSTED_USER, COMMAND)).rejects.toMatchObject({
+      name: 'RuntimePersistenceCommandContextError',
+      code: 'tenant_required',
+    });
+    expect(test.persistence.persistWithinTransaction).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts
@@ -1,4 +1,9 @@
 import { Injectable } from '@nestjs/common';
+import type { Prisma } from '@prisma/client';
+import {
+  RlsContextError,
+  RlsTransactionService,
+} from '../../common/prisma/rls-transaction.service';
 import { RequestUser, Role } from '../../common/types/request-user';
 import type {
   RuntimePersistenceWriteInput,
@@ -26,16 +31,16 @@ export class RuntimePersistenceCommandContextError extends Error {
 }
 
 function requireTrustedContext(user: RequestUser | undefined): Readonly<RequestUser> {
-  if (!user?.id) {
+  if (!user?.id?.trim()) {
     throw new RuntimePersistenceCommandContextError('authenticated_user_required');
   }
-  if (!user.sessionId) {
+  if (!user.sessionId?.trim()) {
     throw new RuntimePersistenceCommandContextError('session_required');
   }
-  if (!user.orgId) {
+  if (!user.orgId?.trim()) {
     throw new RuntimePersistenceCommandContextError('organization_required');
   }
-  if (!user.tenantId) {
+  if (!user.tenantId?.trim()) {
     throw new RuntimePersistenceCommandContextError('tenant_required');
   }
   if (user.role === Role.GUEST) {
@@ -44,22 +49,76 @@ function requireTrustedContext(user: RequestUser | undefined): Readonly<RequestU
   return user;
 }
 
+function isUniqueConstraintError(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as { code?: unknown }).code === 'P2002',
+  );
+}
+
+function databaseFailure(
+  input: RuntimePersistenceAuthenticatedCommandInput,
+): RuntimePersistenceWriteReceipt {
+  return {
+    status: 'failed',
+    runtimeSnapshotId: input.runtimeSnapshotId,
+    idempotencyKey: input.idempotencyKey,
+    state: 'ready_to_persist',
+    reasonCode: 'database_write_failed',
+  };
+}
+
+function mapRlsContextError(error: RlsContextError): RuntimePersistenceCommandContextError {
+  return new RuntimePersistenceCommandContextError(error.code);
+}
+
 @Injectable()
 export class RuntimePersistenceCommandService {
-  constructor(private readonly persistence: RuntimePersistenceService) {}
+  constructor(
+    private readonly persistence: RuntimePersistenceService,
+    private readonly rlsTransactions: RlsTransactionService,
+  ) {}
 
-  persistAuthenticated(
+  async persistAuthenticated(
     user: RequestUser | undefined,
     command: RuntimePersistenceAuthenticatedCommandInput,
   ): Promise<RuntimePersistenceWriteReceipt> {
     const trusted = requireTrustedContext(user);
-
-    return this.persistence.persist({
+    const input: RuntimePersistenceWriteInput = {
       ...command,
       actorId: trusted.id,
       actorRole: trusted.role,
       tenantId: trusted.tenantId,
       organizationId: trusted.orgId,
-    });
+    };
+
+    try {
+      return await this.rlsTransactions.withTrustedContext(trusted, (tx) =>
+        this.persistence.persistWithinTransaction(tx, input),
+      );
+    } catch (error) {
+      if (error instanceof RlsContextError) {
+        throw mapRlsContextError(error);
+      }
+      if (!isUniqueConstraintError(error)) {
+        return databaseFailure(command);
+      }
+    }
+
+    try {
+      const classified = await this.rlsTransactions.withTrustedContext(
+        trusted,
+        (tx: Prisma.TransactionClient) =>
+          this.persistence.classifyExistingWithinTransaction(tx, input),
+      );
+      return classified ?? databaseFailure(command);
+    } catch (error) {
+      if (error instanceof RlsContextError) {
+        throw mapRlsContextError(error);
+      }
+      return databaseFailure(command);
+    }
   }
 }

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts
@@ -47,7 +47,34 @@ export interface RuntimePersistenceWriteReceipt {
 }
 
 export interface RuntimePersistenceRepository {
+  /**
+   * Compatibility entry point for internal callers that do not yet own a
+   * trusted transaction. Authenticated command paths must use
+   * writeWithinTransaction instead.
+   */
   write(input: RuntimePersistenceWriteInput): Promise<RuntimePersistenceWriteReceipt>;
+
+  /** Executes lookup and all writes on the supplied trusted transaction. */
+  writeWithinTransaction(
+    tx: Prisma.TransactionClient,
+    input: RuntimePersistenceWriteInput,
+  ): Promise<RuntimePersistenceWriteReceipt>;
+
+  /** Reclassifies a concurrent idempotency winner inside a new trusted transaction. */
+  classifyExistingWithinTransaction(
+    tx: Prisma.TransactionClient,
+    input: RuntimePersistenceWriteInput,
+  ): Promise<RuntimePersistenceWriteReceipt | null>;
+}
+
+function disabledReceipt(input: RuntimePersistenceWriteInput): RuntimePersistenceWriteReceipt {
+  return {
+    status: 'failed',
+    runtimeSnapshotId: input.runtimeSnapshotId,
+    idempotencyKey: input.idempotencyKey,
+    state: 'ready_to_persist',
+    reasonCode: 'repository_not_enabled',
+  };
 }
 
 /**
@@ -56,12 +83,20 @@ export interface RuntimePersistenceRepository {
  */
 export class DisabledRuntimePersistenceRepository implements RuntimePersistenceRepository {
   async write(input: RuntimePersistenceWriteInput): Promise<RuntimePersistenceWriteReceipt> {
-    return {
-      status: 'failed',
-      runtimeSnapshotId: input.runtimeSnapshotId,
-      idempotencyKey: input.idempotencyKey,
-      state: 'ready_to_persist',
-      reasonCode: 'repository_not_enabled',
-    };
+    return disabledReceipt(input);
+  }
+
+  async writeWithinTransaction(
+    _tx: Prisma.TransactionClient,
+    input: RuntimePersistenceWriteInput,
+  ): Promise<RuntimePersistenceWriteReceipt> {
+    return disabledReceipt(input);
+  }
+
+  async classifyExistingWithinTransaction(
+    _tx: Prisma.TransactionClient,
+    _input: RuntimePersistenceWriteInput,
+  ): Promise<RuntimePersistenceWriteReceipt | null> {
+    return null;
   }
 }

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client';
 import { Test } from '@nestjs/testing';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { RuntimePersistenceModule } from './runtime-persistence.module';
@@ -44,11 +45,18 @@ const PERSISTED_RECEIPT: RuntimePersistenceWriteReceipt = {
   transactionAttemptId: 'attempt-canonical-001',
 };
 
+function repositoryFixture(overrides: Partial<RuntimePersistenceRepository> = {}) {
+  return {
+    write: jest.fn().mockResolvedValue(PERSISTED_RECEIPT),
+    writeWithinTransaction: jest.fn().mockResolvedValue(PERSISTED_RECEIPT),
+    classifyExistingWithinTransaction: jest.fn().mockResolvedValue(null),
+    ...overrides,
+  } as RuntimePersistenceRepository;
+}
+
 describe('RuntimePersistenceService', () => {
-  it('delegates the canonical deal exactly once and returns the receipt unchanged', async () => {
-    const repository: RuntimePersistenceRepository = {
-      write: jest.fn().mockResolvedValue(PERSISTED_RECEIPT),
-    };
+  it('delegates the compatibility path exactly once and returns the receipt unchanged', async () => {
+    const repository = repositoryFixture();
     const service = new RuntimePersistenceService(repository);
 
     await expect(service.persist(CANONICAL_RUNTIME_TEST_DEAL)).resolves.toBe(PERSISTED_RECEIPT);
@@ -56,6 +64,38 @@ describe('RuntimePersistenceService', () => {
     expect(repository.write).toHaveBeenCalledWith(CANONICAL_RUNTIME_TEST_DEAL);
     expect(CANONICAL_RUNTIME_TEST_DEAL).not.toHaveProperty('outboxEntryId');
     expect(CANONICAL_RUNTIME_TEST_DEAL).not.toHaveProperty('auditEventId');
+  });
+
+  it('delegates transaction-bound persistence on the exact supplied client', async () => {
+    const repository = repositoryFixture();
+    const service = new RuntimePersistenceService(repository);
+    const tx = { trusted: true } as unknown as Prisma.TransactionClient;
+
+    await expect(
+      service.persistWithinTransaction(tx, CANONICAL_RUNTIME_TEST_DEAL),
+    ).resolves.toBe(PERSISTED_RECEIPT);
+    expect(repository.writeWithinTransaction).toHaveBeenCalledWith(
+      tx,
+      CANONICAL_RUNTIME_TEST_DEAL,
+    );
+    expect(repository.write).not.toHaveBeenCalled();
+  });
+
+  it('delegates concurrent-winner classification on the exact supplied client', async () => {
+    const duplicate = { ...PERSISTED_RECEIPT, status: 'duplicate' as const };
+    const repository = repositoryFixture({
+      classifyExistingWithinTransaction: jest.fn().mockResolvedValue(duplicate),
+    });
+    const service = new RuntimePersistenceService(repository);
+    const tx = { trusted: true } as unknown as Prisma.TransactionClient;
+
+    await expect(
+      service.classifyExistingWithinTransaction(tx, CANONICAL_RUNTIME_TEST_DEAL),
+    ).resolves.toBe(duplicate);
+    expect(repository.classifyExistingWithinTransaction).toHaveBeenCalledWith(
+      tx,
+      CANONICAL_RUNTIME_TEST_DEAL,
+    );
   });
 
   it('keeps a disabled repository receipt failed', async () => {
@@ -66,23 +106,24 @@ describe('RuntimePersistenceService', () => {
       state: 'ready_to_persist',
       reasonCode: 'repository_not_enabled',
     };
-    const repository: RuntimePersistenceRepository = {
+    const repository = repositoryFixture({
       write: jest.fn().mockResolvedValue(failedReceipt),
-    };
+    });
     const service = new RuntimePersistenceService(repository);
 
     await expect(service.persist(CANONICAL_RUNTIME_TEST_DEAL)).resolves.toBe(failedReceipt);
   });
 
-  it('propagates repository exceptions instead of returning false success', async () => {
-    const repository: RuntimePersistenceRepository = {
-      write: jest.fn().mockRejectedValue(new Error('controlled repository failure')),
-    };
+  it('propagates transaction repository exceptions for the owning boundary to classify', async () => {
+    const repository = repositoryFixture({
+      writeWithinTransaction: jest.fn().mockRejectedValue({ code: 'P2002' }),
+    });
     const service = new RuntimePersistenceService(repository);
+    const tx = {} as Prisma.TransactionClient;
 
-    await expect(service.persist(CANONICAL_RUNTIME_TEST_DEAL)).rejects.toThrow(
-      'controlled repository failure',
-    );
+    await expect(
+      service.persistWithinTransaction(tx, CANONICAL_RUNTIME_TEST_DEAL),
+    ).rejects.toMatchObject({ code: 'P2002' });
   });
 });
 

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import type { Prisma } from '@prisma/client';
 import {
   RUNTIME_PERSISTENCE_REPOSITORY,
   type RuntimePersistenceRepository,
@@ -15,5 +16,19 @@ export class RuntimePersistenceService {
 
   persist(input: RuntimePersistenceWriteInput): Promise<RuntimePersistenceWriteReceipt> {
     return this.repository.write(input);
+  }
+
+  persistWithinTransaction(
+    tx: Prisma.TransactionClient,
+    input: RuntimePersistenceWriteInput,
+  ): Promise<RuntimePersistenceWriteReceipt> {
+    return this.repository.writeWithinTransaction(tx, input);
+  }
+
+  classifyExistingWithinTransaction(
+    tx: Prisma.TransactionClient,
+    input: RuntimePersistenceWriteInput,
+  ): Promise<RuntimePersistenceWriteReceipt | null> {
+    return this.repository.classifyExistingWithinTransaction(tx, input);
   }
 }

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,14 +3,15 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "in_progress",
-  "current": "VP-3.43 Transaction-Local Trusted RLS Context.",
+  "current": "VP-3.44 Runtime Persistence Trusted Transaction Binding.",
   "fullTzReadinessPercent": 85,
-  "openPr": "#2254",
+  "openPr": null,
   "lastClosed": [
     "#2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
     "#2245 VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
     "#2250 VP-3.41 Runtime Persistence Internal Service Wiring Implementation",
-    "#2252 VP-3.42 Runtime Persistence Authenticated Internal Command Boundary"
+    "#2252 VP-3.42 Runtime Persistence Authenticated Internal Command Boundary",
+    "#2254 VP-3.43 Transaction-Local Trusted RLS Context"
   ],
   "openBlockers": ["#2113", "#2115", "#2251"],
   "blockerNotes": "#2113 repository settings cleanup. #2115 blocks persistent auth-file changes. Draft #2251 remains merge-blocked by user-driven bank confirmations, synthetic bank references, cross-tenant visibility and unresolved conflicts.",
@@ -24,50 +25,52 @@
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "apps/api/src/app.module.ts",
-    "apps/api/src/common/middleware/rls-context.middleware.ts",
-    "apps/api/src/common/prisma/prisma.module.ts",
     "apps/api/src/common/prisma/rls-transaction.service.ts",
-    "apps/api/src/common/prisma/rls-transaction.service.spec.ts"
+    "apps/api/src/common/prisma/rls-transaction.service.spec.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
+    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
+    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "apps/api/src/app.module.ts",
-    "apps/api/src/common/middleware/rls-context.middleware.ts",
-    "apps/api/src/common/prisma/prisma.module.ts",
     "apps/api/src/common/prisma/rls-transaction.service.ts",
-    "apps/api/src/common/prisma/rls-transaction.service.spec.ts"
+    "apps/api/src/common/prisma/rls-transaction.service.spec.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
+    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
+    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts",
+    "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts"
   ],
-  "vp342RuntimePersistenceAuthenticatedCommandBoundary": {
-    "layer": "VP-3.42 Runtime Persistence Authenticated Internal Command Boundary",
-    "closedPr": "#2252",
-    "status": "merged"
-  },
   "vp343TransactionLocalTrustedRlsContext": {
     "layer": "VP-3.43 Transaction-Local Trusted RLS Context",
-    "openPr": "#2254",
-    "status": "in_progress",
-    "invariants": [
-      "trusted RequestUser only",
-      "user, organization, tenant, role and session required",
-      "GUEST forbidden",
-      "parameterized Prisma SQL only",
-      "set_config is transaction-local",
-      "RLS initialization errors fail closed",
-      "business callback runs on the same transaction client"
-    ],
-    "changedImplementationFiles": [
-      "apps/api/src/app.module.ts",
-      "apps/api/src/common/middleware/rls-context.middleware.ts",
-      "apps/api/src/common/prisma/prisma.module.ts",
-      "apps/api/src/common/prisma/rls-transaction.service.ts",
-      "apps/api/src/common/prisma/rls-transaction.service.spec.ts"
-    ]
+    "closedPr": "#2254",
+    "status": "merged"
   },
   "vp344RuntimePersistenceTrustedTransactionBinding": {
     "layer": "VP-3.44 Runtime Persistence Trusted Transaction Binding",
-    "status": "next-after-vp343-green"
+    "status": "in_progress",
+    "invariants": [
+      "authenticated runtime persistence enters through RlsTransactionService",
+      "existing-record lookup uses the trusted transaction client",
+      "snapshot, outbox, audit and attempt use the same transaction client",
+      "no nested transaction inside the trusted callback",
+      "P2002 recovery re-enters a new trusted transaction",
+      "RLS initialization failure executes no persistence operation",
+      "database failures return sanitized failed receipts"
+    ]
+  },
+  "vp345PhysicalRlsPolicyAlignment": {
+    "layer": "VP-3.45 Physical Table RLS Policy Alignment and Rehearsal",
+    "status": "next-after-vp344-green"
   },
   "forbiddenZones": [
     "apps/landing",
@@ -91,5 +94,5 @@
     "bank confirmation from user command",
     "production scale proven"
   ],
-  "readiness": "85% honest architectural readiness. VP-3.43 removes the unsafe pre-auth session-level RLS middleware and introduces a parameterized transaction-local trusted context primitive. It does not yet bind every repository, apply production policies or migrations, complete persistent identity, or expose a controller/web route."
+  "readiness": "85% honest architectural readiness. VP-3.44 binds authenticated runtime persistence to the transaction-local trusted RLS primitive. Production policies, migration application, persistent identity, external integrations and scale proof remain unconfirmed."
 }

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -5,7 +5,7 @@
   "currentStatus": "in_progress",
   "current": "VP-3.44 Runtime Persistence Trusted Transaction Binding.",
   "fullTzReadinessPercent": 85,
-  "openPr": null,
+  "openPr": "#2256",
   "lastClosed": [
     "#2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
     "#2245 VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
@@ -57,6 +57,7 @@
   },
   "vp344RuntimePersistenceTrustedTransactionBinding": {
     "layer": "VP-3.44 Runtime Persistence Trusted Transaction Binding",
+    "openPr": "#2256",
     "status": "in_progress",
     "invariants": [
       "authenticated runtime persistence enters through RlsTransactionService",

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,73 +1,70 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.43 Transaction-Local Trusted RLS Context.
+CURRENT: VP-3.44 Runtime Persistence Trusted Transaction Binding.
 
-GOAL: Удалить небезопасную pre-auth/session-level установку PostgreSQL RLS context и ввести одну fail-closed transaction boundary, которая принимает только trusted `RequestUser` после аутентификации.
+GOAL: Выполнить authenticated runtime persistence полностью внутри transaction-local RLS boundary, чтобы pre-read, outbox, audit, snapshot и transaction-attempt использовали один trusted Prisma transaction client.
 
-CURRENT STATUS:
-- VP-3.33 additive Prisma schema/migration merged in #2241.
-- VP-3.37 API-side Postgres repository adapter merged in #2245.
-- VP-3.41 internal runtime persistence service/module wiring merged in #2250.
-- VP-3.42 authenticated internal command boundary merged in #2252.
-- Draft #2251 remains merge-blocked by user-driven bank confirmations, synthetic bank references, cross-tenant visibility and unresolved conflicts.
-- PR #2254 implements the transaction-local RLS primitive and removes the unsafe middleware.
+CURRENT ALLOWED:
+- docs/platform-v7/autopilot/autopilot-state.json
+- docs/platform-v7/execution-queue.md
+- apps/api/src/common/prisma/rls-transaction.service.ts
+- apps/api/src/common/prisma/rls-transaction.service.spec.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts
+- apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts
+- apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts
+- apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts
 
-IMPLEMENTED IN #2254:
-- `RlsTransactionService` derives userId, orgId, tenantId, role and sessionId only from trusted `RequestUser`.
-- Missing user/session/org/tenant and `GUEST` fail before a database transaction is opened.
-- RLS values are parameterized through `Prisma.sql`; `$executeRawUnsafe` is not used.
-- `set_config(..., true)` scopes all values to the current transaction and prevents pooled-connection context leakage.
-- RLS initialization failure propagates and prevents business work.
-- Transaction max-wait, timeout and isolation level are explicit and bounded.
-- `RlsTransactionService` is registered and exported by the global `PrismaModule`.
-- The old Nest middleware is deleted because it ran before `AppAuthGuard`, read `organizationId` instead of `orgId`, used session-level context and swallowed all database errors.
-- Unit tests cover trusted derivation, fail-closed validation, parameterization, transaction-local flags, callback binding, transaction options and error propagation.
+CURRENT CRITERIA:
+- authenticated command enters through `RlsTransactionService`;
+- existing-record lookup occurs on the trusted transaction client;
+- outbox, audit, snapshot and attempt writes share that exact client;
+- repository opens no nested transaction inside the trusted callback;
+- concurrent P2002 recovery re-enters a new trusted transaction before classification;
+- RLS initialization failure executes no persistence read or write;
+- errors do not leak sensitive database details;
+- failed receipts remain failed;
+- no controller, web bridge or user-driven bank confirmation is introduced.
 
-STILL LOCKED:
-- controller or external API endpoint;
-- web/server-action bridge;
+DONE:
+- #2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation
+- #2245 VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation
+- #2250 VP-3.41 Runtime Persistence Internal Service Wiring Implementation
+- #2252 VP-3.42 Runtime Persistence Authenticated Internal Command Boundary
+- #2254 VP-3.43 Transaction-Local Trusted RLS Context
+
+LOCKED:
+- production migration execution;
+- production RLS policy application;
+- persistent identity/session/revocation/MFA files;
+- controller/API/web wiring;
 - bank reserve/release confirmation from user commands;
-- production migration execution or RLS policy application;
-- persistent identity/session/revocation/MFA implementation;
-- UI/components;
 - live bank/FGIS/EDO integrations.
 
-GUARDRAILS:
-- No HTTP request object enters the repository layer.
-- No caller-supplied actor, role, tenant, organization or session identity.
-- No context fallback when trusted identity is incomplete.
-- No session-level PostgreSQL context outside the transaction callback.
-- No unsafe interpolated SQL.
-- No swallowed RLS initialization error.
-- No synthetic bank confirmation or bank reference.
-
 NEXT:
-- Layer: VP-3.44 Runtime Persistence Trusted Transaction Binding.
+- Layer: VP-3.45 Physical Table RLS Policy Alignment and Rehearsal.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
-  - apps/api/src/common/prisma/rls-transaction.service.ts
+  - infra/sql/production-rls-policies.sql
+  - apps/api/prisma/migrations/**
   - apps/api/src/common/prisma/rls-transaction.service.spec.ts
-  - apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts
-  - apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts
-  - apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts
-  - apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts
-  - apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts
-  - apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts
-  - apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts
-  - apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts
+  - scripts/platform-v7-rls-*.mjs
+  - scripts/platform-v7-rls-*.sh
 - Success criteria:
-  - runtime snapshot, outbox, audit and transaction-attempt writes use the same trusted transaction client;
-  - no repository pre-read occurs outside the trusted transaction;
-  - no nested Prisma transaction is opened inside the trusted boundary;
-  - duplicate and material-identity conflict classification remain deterministic under concurrency;
-  - RLS initialization failure leaves snapshot, outbox, audit and attempt unchanged;
-  - failed repository receipts remain failed;
-  - controller, web and user-driven bank confirmation routes remain absent.
+  - RLS policies reference canonical physical PostgreSQL table names from Prisma mappings;
+  - tenant, organization, role and user policies are explicit per protected table;
+  - policy SQL is idempotent and fail-closed;
+  - non-production apply and rollback rehearsal scripts exist;
+  - no production database is modified by CI;
+  - migration and policy drift is detected automatically;
+  - production-enabled claims remain forbidden until controlled application evidence exists.
 - Readiness remains 85% honest architectural readiness.
 
 AFTER NEXT:
-- Canonical physical-table RLS policy audit and controlled non-production application rehearsal.
-- Persistent identity/session/revocation/MFA source of truth.
+- Persistent identity/session/revocation/MFA source of truth after blocker #2115.
 - Authenticated DB-backed runtime action bridge without direct bank confirmation.
 - Concurrency, retry, recovery, load, restore and security acceptance gates.


### PR DESCRIPTION
## Суть

Authenticated runtime persistence теперь выполняется внутри transaction-local RLS boundary: pre-read, outbox, audit, snapshot и transaction-attempt используют один trusted Prisma transaction client.

## Реализовано

- расширен repository contract методами `writeWithinTransaction` и `classifyExistingWithinTransaction`;
- `PrismaRuntimePersistenceRepository` больше не открывает вложенную транзакцию внутри trusted path;
- idempotency pre-read выполняется на переданном transaction client;
- все четыре записи выполняются на том же client;
- `P2002` выходит наружу для rollback и повторной классификации;
- authenticated command входит через `RlsTransactionService`;
- конкурентный winner классифицируется в новой trusted RLS transaction;
- отсутствие winner или database failure возвращает только sanitized failed receipt;
- caller-supplied identity и evidence IDs не получают authority;
- disabled repository остаётся fail-closed;
- публичный controller, web bridge и пользовательские bank confirmations не добавлены.

## Проверки

Добавлены тесты на:
- exact transaction-client binding;
- отсутствие root pre-read и nested transaction;
- atomic write sequence;
- duplicate/conflict classification;
- P2002 rollback/recovery;
- RLS initialization failure without persistence work;
- identity override protection;
- sanitized failures;
- сохранение failed receipts.

## Граница зрелости

Production RLS policies и migrations не применялись. Persistent identity/session/MFA и live bank/ФГИС/ЭДО integrations не заявляются.