### PR TITLE
VP-3.44 Runtime Persistence Trusted RLS Transaction Binding

### DIFF
--- a/apps/api/src/common/prisma/rls-transaction.service.spec.ts
+++ b/apps/api/src/common/prisma/rls-transaction.service.spec.ts
@@ -4,6 +4,7 @@ import { Role } from '../types/request-user';
 import { PrismaService } from './prisma.service';
 import {
   deriveTrustedRlsContext,
+  normalizeTrustedRlsContext,
   RlsContextError,
   RlsTransactionService,
   type TrustedRlsContext,
@@ -16,6 +17,14 @@ const TRUSTED_USER: RequestUser = {
   orgId: 'org-rls-001',
   tenantId: 'tenant-rls-001',
   sessionId: 'session-rls-001',
+};
+
+const TRUSTED_CONTEXT: TrustedRlsContext = {
+  userId: TRUSTED_USER.id,
+  orgId: TRUSTED_USER.orgId!,
+  tenantId: TRUSTED_USER.tenantId!,
+  role: TRUSTED_USER.role,
+  sessionId: TRUSTED_USER.sessionId!,
 };
 
 function fixture() {
@@ -39,13 +48,7 @@ function fixture() {
 
 describe('RlsTransactionService', () => {
   it('derives the complete context only from trusted RequestUser fields', () => {
-    expect(deriveTrustedRlsContext(TRUSTED_USER)).toEqual({
-      userId: TRUSTED_USER.id,
-      orgId: TRUSTED_USER.orgId,
-      tenantId: TRUSTED_USER.tenantId,
-      role: TRUSTED_USER.role,
-      sessionId: TRUSTED_USER.sessionId,
-    });
+    expect(deriveTrustedRlsContext(TRUSTED_USER)).toEqual(TRUSTED_CONTEXT);
   });
 
   it.each([
@@ -70,7 +73,13 @@ describe('RlsTransactionService', () => {
     expect(test.transaction).not.toHaveBeenCalled();
   });
 
-  it('sets parameterized transaction-local user, organization, tenant, role and session context', async () => {
+  it('normalizes and freezes a trusted internal context', () => {
+    const normalized = normalizeTrustedRlsContext(TRUSTED_CONTEXT);
+    expect(normalized).toEqual(TRUSTED_CONTEXT);
+    expect(Object.isFrozen(normalized)).toBe(true);
+  });
+
+  it('sets parameterized transaction-local context before trusted user work', async () => {
     const test = fixture();
     const work = jest.fn(
       async (_tx: Prisma.TransactionClient, context: TrustedRlsContext) => context.userId,
@@ -80,13 +89,7 @@ describe('RlsTransactionService', () => {
 
     expect(test.transaction).toHaveBeenCalledTimes(1);
     expect(test.queryRaw).toHaveBeenCalledTimes(1);
-    expect(work).toHaveBeenCalledWith(test.tx, {
-      userId: TRUSTED_USER.id,
-      orgId: TRUSTED_USER.orgId,
-      tenantId: TRUSTED_USER.tenantId,
-      role: TRUSTED_USER.role,
-      sessionId: TRUSTED_USER.sessionId,
-    });
+    expect(work).toHaveBeenCalledWith(test.tx, TRUSTED_CONTEXT);
 
     const statement = test.queryRaw.mock.calls[0][0] as {
       strings: string[];
@@ -108,18 +111,24 @@ describe('RlsTransactionService', () => {
     ]);
   });
 
+  it('uses the same parameterized transaction boundary for trusted internal context', async () => {
+    const test = fixture();
+    const work = jest.fn(async () => 'internal-ok');
+
+    await expect(test.service.withContext(TRUSTED_CONTEXT, work)).resolves.toBe('internal-ok');
+    expect(test.transaction).toHaveBeenCalledTimes(1);
+    expect(test.queryRaw).toHaveBeenCalledTimes(1);
+    expect(work).toHaveBeenCalledWith(test.tx, TRUSTED_CONTEXT);
+  });
+
   it('uses bounded transaction defaults and accepts an explicit isolation level', async () => {
     const test = fixture();
 
-    await test.service.withTrustedContext(
-      TRUSTED_USER,
-      async () => 'ok',
-      {
-        maxWait: 1_000,
-        timeout: 2_000,
-        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-      },
-    );
+    await test.service.withTrustedContext(TRUSTED_USER, async () => 'ok', {
+      maxWait: 1_000,
+      timeout: 2_000,
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    });
 
     expect(test.transaction).toHaveBeenCalledWith(expect.any(Function), {
       maxWait: 1_000,
@@ -134,7 +143,7 @@ describe('RlsTransactionService', () => {
     test.queryRaw.mockRejectedValueOnce(databaseError);
     const work = jest.fn(async () => 'must-not-run');
 
-    await expect(test.service.withTrustedContext(TRUSTED_USER, work)).rejects.toBe(databaseError);
+    await expect(test.service.withContext(TRUSTED_CONTEXT, work)).rejects.toBe(databaseError);
     expect(work).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/common/prisma/rls-transaction.service.ts
+++ b/apps/api/src/common/prisma/rls-transaction.service.ts
@@ -32,29 +32,34 @@ export type RlsTransactionOptions = Readonly<{
   isolationLevel?: Prisma.TransactionIsolationLevel;
 }>;
 
-export function deriveTrustedRlsContext(user: RequestUser | undefined): TrustedRlsContext {
-  if (!user?.id?.trim()) {
-    throw new RlsContextError('authenticated_user_required');
-  }
-  if (!user.sessionId?.trim()) {
-    throw new RlsContextError('session_required');
-  }
-  if (!user.orgId?.trim()) {
-    throw new RlsContextError('organization_required');
-  }
-  if (!user.tenantId?.trim()) {
-    throw new RlsContextError('tenant_required');
-  }
-  if (user.role === Role.GUEST) {
-    throw new RlsContextError('guest_role_forbidden');
-  }
+function required(value: string | undefined, code: RlsContextErrorCode): string {
+  const normalized = value?.trim();
+  if (!normalized) throw new RlsContextError(code);
+  return normalized;
+}
+
+export function normalizeTrustedRlsContext(context: TrustedRlsContext): TrustedRlsContext {
+  const role = required(context.role, 'guest_role_forbidden');
+  if (role === Role.GUEST) throw new RlsContextError('guest_role_forbidden');
 
   return Object.freeze({
+    userId: required(context.userId, 'authenticated_user_required'),
+    orgId: required(context.orgId, 'organization_required'),
+    tenantId: required(context.tenantId, 'tenant_required'),
+    role,
+    sessionId: required(context.sessionId, 'session_required'),
+  });
+}
+
+export function deriveTrustedRlsContext(user: RequestUser | undefined): TrustedRlsContext {
+  if (!user) throw new RlsContextError('authenticated_user_required');
+
+  return normalizeTrustedRlsContext({
     userId: user.id,
-    orgId: user.orgId,
-    tenantId: user.tenantId,
+    orgId: user.orgId ?? '',
+    tenantId: user.tenantId ?? '',
     role: user.role,
-    sessionId: user.sessionId,
+    sessionId: user.sessionId ?? '',
   });
 }
 
@@ -62,27 +67,35 @@ export function deriveTrustedRlsContext(user: RequestUser | undefined): TrustedR
 export class RlsTransactionService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async withTrustedContext<T>(
+  withTrustedContext<T>(
     user: RequestUser | undefined,
     work: (tx: Prisma.TransactionClient, context: TrustedRlsContext) => Promise<T>,
     options: RlsTransactionOptions = {},
   ): Promise<T> {
-    const context = deriveTrustedRlsContext(user);
+    return this.withContext(deriveTrustedRlsContext(user), work, options);
+  }
+
+  async withContext<T>(
+    context: TrustedRlsContext,
+    work: (tx: Prisma.TransactionClient, context: TrustedRlsContext) => Promise<T>,
+    options: RlsTransactionOptions = {},
+  ): Promise<T> {
+    const trusted = normalizeTrustedRlsContext(context);
 
     return this.prisma.$transaction(
       async (tx) => {
         await tx.$queryRaw(
           Prisma.sql`
             SELECT
-              set_config('app.current_user_id', ${context.userId}, true),
-              set_config('app.current_org_id', ${context.orgId}, true),
-              set_config('app.current_tenant_id', ${context.tenantId}, true),
-              set_config('app.current_role', ${context.role}, true),
-              set_config('app.current_session_id', ${context.sessionId}, true)
+              set_config('app.current_user_id', ${trusted.userId}, true),
+              set_config('app.current_org_id', ${trusted.orgId}, true),
+              set_config('app.current_tenant_id', ${trusted.tenantId}, true),
+              set_config('app.current_role', ${trusted.role}, true),
+              set_config('app.current_session_id', ${trusted.sessionId}, true)
           `,
         );
 
-        return work(tx, context);
+        return work(tx, trusted);
       },
       {
         maxWait: options.maxWait ?? 5_000,

--- a/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts
+++ b/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts
@@ -1,3 +1,8 @@
+import type { Prisma } from '@prisma/client';
+import type {
+  RlsTransactionService,
+  TrustedRlsContext,
+} from '../../common/prisma/rls-transaction.service';
 import { PrismaRuntimePersistenceRepository } from './prisma-runtime-persistence.repository';
 import type { RuntimePersistenceWriteInput } from './runtime-persistence.repository';
 
@@ -12,13 +17,21 @@ const baseInput: RuntimePersistenceWriteInput = {
   runtimeStoreRecordId: 'runtime-record-1',
   runtimeStoreVersion: '1',
   actorId: 'user-1',
-  actorRole: 'operator',
+  actorRole: 'SUPPORT_MANAGER',
   tenantId: 'tenant-1',
   organizationId: 'org-1',
   correlationId: 'corr-1',
   auditId: 'audit-business-1',
   contractHash: 'hash-1',
   payload: { status: 'updated', amountKopecks: 1000 },
+};
+
+const expectedContext: TrustedRlsContext = {
+  userId: 'user-1',
+  orgId: 'org-1',
+  tenantId: 'tenant-1',
+  role: 'SUPPORT_MANAGER',
+  sessionId: 'runtime-persistence:corr-1',
 };
 
 function existingSnapshot(overrides: Record<string, unknown> = {}) {
@@ -35,31 +48,54 @@ function existingSnapshot(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function successfulPrisma() {
-  const outboxCreate = jest.fn().mockResolvedValue({ id: 'outbox-1' });
-  const auditCreate = jest.fn().mockResolvedValue({ id: 'audit-1' });
-  const snapshotCreate = jest.fn().mockResolvedValue({
-    id: 'record-1',
-    runtimeSnapshotId: 'snapshot-1',
-    idempotencyKey: 'idem-1',
-    state: 'fully_linked',
+function fixture(existing: ReturnType<typeof existingSnapshot> | null = null) {
+  const order: string[] = [];
+  const findUnique = jest.fn(async () => {
+    order.push('find-existing');
+    return existing;
   });
-  const attemptCreate = jest.fn().mockResolvedValue({ id: 'attempt-1' });
+  const outboxCreate = jest.fn(async () => {
+    order.push('outbox');
+    return { id: 'outbox-1' };
+  });
+  const auditCreate = jest.fn(async () => {
+    order.push('audit');
+    return { id: 'audit-1' };
+  });
+  const snapshotCreate = jest.fn(async () => {
+    order.push('snapshot');
+    return {
+      id: 'record-1',
+      runtimeSnapshotId: 'snapshot-1',
+      idempotencyKey: 'idem-1',
+      state: 'fully_linked',
+    };
+  });
+  const attemptCreate = jest.fn(async () => {
+    order.push('attempt');
+    return { id: 'attempt-1' };
+  });
   const tx = {
+    dealWorkspaceRuntimeSnapshot: { findUnique, create: snapshotCreate },
     outboxEntry: { create: outboxCreate },
     auditEvent: { create: auditCreate },
-    dealWorkspaceRuntimeSnapshot: { create: snapshotCreate },
     dealWorkspaceRuntimeTransactionAttempt: { create: attemptCreate },
-  };
-  const prisma = {
-    dealWorkspaceRuntimeSnapshot: {
-      findUnique: jest.fn().mockResolvedValue(null),
-    },
-    $transaction: jest.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
-  } as any;
+  } as unknown as Prisma.TransactionClient;
+  const withContext = jest.fn(
+    async <T>(
+      context: TrustedRlsContext,
+      work: (client: Prisma.TransactionClient, trusted: TrustedRlsContext) => Promise<T>,
+    ) => work(tx, context),
+  );
+  const rls = { withContext } as unknown as RlsTransactionService;
 
   return {
-    prisma,
+    repository: new PrismaRuntimePersistenceRepository(rls),
+    rls,
+    tx,
+    order,
+    withContext,
+    findUnique,
     outboxCreate,
     auditCreate,
     snapshotCreate,
@@ -67,19 +103,20 @@ function successfulPrisma() {
   };
 }
 
-describe('PrismaRuntimePersistenceRepository', () => {
-  it('persists outbox, audit, snapshot and committed attempt in one transaction', async () => {
-    const setup = successfulPrisma();
-    const repository = new PrismaRuntimePersistenceRepository(setup.prisma);
+describe('PrismaRuntimePersistenceRepository trusted transaction binding', () => {
+  it('performs lookup and atomic evidence writes through one trusted RLS callback', async () => {
+    const test = fixture();
     const maliciousInput = {
       ...baseInput,
       outboxEntryId: 'caller-outbox-id',
       auditEventId: 'caller-audit-id',
     } as any;
 
-    const receipt = await repository.write(maliciousInput);
+    const receipt = await test.repository.write(maliciousInput);
 
-    expect(setup.prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(test.withContext).toHaveBeenCalledTimes(1);
+    expect(test.withContext.mock.calls[0][0]).toEqual(expectedContext);
+    expect(test.order).toEqual(['find-existing', 'outbox', 'audit', 'snapshot', 'attempt']);
     expect(receipt).toEqual({
       status: 'persisted',
       runtimeSnapshotId: 'snapshot-1',
@@ -91,120 +128,73 @@ describe('PrismaRuntimePersistenceRepository', () => {
       transactionAttemptId: 'attempt-1',
     });
 
-    expect(setup.outboxCreate).toHaveBeenCalledTimes(1);
-    expect(setup.auditCreate).toHaveBeenCalledTimes(1);
-    expect(setup.snapshotCreate).toHaveBeenCalledTimes(1);
-    expect(setup.attemptCreate).toHaveBeenCalledTimes(1);
-
-    const snapshotData = setup.snapshotCreate.mock.calls[0][0].data;
-    expect(snapshotData.state).toBe('fully_linked');
+    const snapshotData = test.snapshotCreate.mock.calls[0][0].data;
     expect(snapshotData.outboxEntryId).toBe('outbox-1');
     expect(snapshotData.auditEventId).toBe('audit-1');
     expect(snapshotData.outboxEntryId).not.toBe('caller-outbox-id');
     expect(snapshotData.auditEventId).not.toBe('caller-audit-id');
-
-    const outboxData = setup.outboxCreate.mock.calls[0][0].data;
-    const auditData = setup.auditCreate.mock.calls[0][0].data;
-    expect(outboxData.runtimeSnapshotId).toBe('snapshot-1');
-    expect(auditData.runtimeSnapshotId).toBe('snapshot-1');
-    expect(auditData.tenantId).toBe('tenant-1');
-    expect(auditData.orgId).toBe('org-1');
   });
 
-  it('returns deterministic duplicate without starting a transaction', async () => {
-    const prisma = {
-      dealWorkspaceRuntimeSnapshot: {
-        findUnique: jest.fn().mockResolvedValue(existingSnapshot()),
-      },
-      $transaction: jest.fn(),
-    } as any;
-    const repository = new PrismaRuntimePersistenceRepository(prisma);
+  it('returns duplicate inside the trusted transaction without evidence writes', async () => {
+    const test = fixture(existingSnapshot());
 
-    await expect(repository.write(baseInput)).resolves.toEqual({
+    await expect(test.repository.write(baseInput)).resolves.toMatchObject({
       status: 'duplicate',
-      runtimeSnapshotId: 'snapshot-1',
-      idempotencyKey: 'idem-1',
-      state: 'fully_linked',
       recordId: 'record-1',
       outboxEntryId: 'outbox-1',
       auditEventId: 'audit-1',
-      transactionAttemptId: 'attempt-1',
     });
-    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(test.withContext).toHaveBeenCalledTimes(1);
+    expect(test.order).toEqual(['find-existing']);
+    expect(test.outboxCreate).not.toHaveBeenCalled();
   });
 
-  it('returns conflict for a reused idempotency key with another material identity', async () => {
-    const prisma = {
-      dealWorkspaceRuntimeSnapshot: {
-        findUnique: jest.fn().mockResolvedValue(
-          existingSnapshot({ runtimeSnapshotId: 'snapshot-other', contractHash: 'hash-other' }),
-        ),
-      },
-      $transaction: jest.fn(),
-    } as any;
-    const repository = new PrismaRuntimePersistenceRepository(prisma);
+  it('returns conflict inside the trusted transaction without evidence writes', async () => {
+    const test = fixture(
+      existingSnapshot({ runtimeSnapshotId: 'snapshot-other', contractHash: 'hash-other' }),
+    );
 
-    const receipt = await repository.write(baseInput);
-
-    expect(receipt.status).toBe('conflict');
-    expect(receipt.reasonCode).toBe('material_identity_conflict');
-    expect(prisma.$transaction).not.toHaveBeenCalled();
+    await expect(test.repository.write(baseInput)).resolves.toMatchObject({
+      status: 'conflict',
+      reasonCode: 'material_identity_conflict',
+    });
+    expect(test.withContext).toHaveBeenCalledTimes(1);
+    expect(test.order).toEqual(['find-existing']);
   });
 
-  it('classifies a concurrent P2002 winner as duplicate without a second transaction', async () => {
-    const findUnique = jest
-      .fn()
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(existingSnapshot());
-    const prisma = {
-      dealWorkspaceRuntimeSnapshot: { findUnique },
-      $transaction: jest.fn().mockRejectedValue({ code: 'P2002' }),
-    } as any;
-    const repository = new PrismaRuntimePersistenceRepository(prisma);
+  it('re-reads a concurrent P2002 winner through a second trusted transaction', async () => {
+    const test = fixture(existingSnapshot());
+    test.withContext
+      .mockRejectedValueOnce({ code: 'P2002' })
+      .mockImplementationOnce(async (context, work) => work(test.tx, context));
 
-    const receipt = await repository.write(baseInput);
+    const receipt = await test.repository.write(baseInput);
 
     expect(receipt.status).toBe('duplicate');
-    expect(findUnique).toHaveBeenCalledTimes(2);
-    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(test.withContext).toHaveBeenCalledTimes(2);
+    expect(test.withContext.mock.calls[1][0]).toEqual(expectedContext);
+    expect(test.findUnique).toHaveBeenCalledTimes(1);
   });
 
-  it('returns invalid_input without touching the database', async () => {
-    const setup = successfulPrisma();
-    const repository = new PrismaRuntimePersistenceRepository(setup.prisma);
+  it.each([
+    ['dealId', '   '],
+    ['tenantId', ''],
+    ['organizationId', undefined],
+  ] as const)('rejects missing %s before opening an RLS transaction', async (field, value) => {
+    const test = fixture();
 
-    const receipt = await repository.write({ ...baseInput, dealId: '   ' });
-
-    expect(receipt).toMatchObject({ status: 'failed', reasonCode: 'invalid_input' });
-    expect(setup.prisma.dealWorkspaceRuntimeSnapshot.findUnique).not.toHaveBeenCalled();
-    expect(setup.prisma.$transaction).not.toHaveBeenCalled();
-  });
-
-  it('keeps staged writes uncommitted when a transaction step fails', async () => {
-    const committed: string[] = [];
-    const outboxCreate = jest.fn(async () => ({ id: 'outbox-stage' }));
-    const auditCreate = jest.fn(async () => {
-      throw new Error('sensitive database failure');
+    await expect(test.repository.write({ ...baseInput, [field]: value })).resolves.toMatchObject({
+      status: 'failed',
+      reasonCode: 'invalid_input',
     });
-    const snapshotCreate = jest.fn();
-    const attemptCreate = jest.fn();
-    const tx = {
-      outboxEntry: { create: outboxCreate },
-      auditEvent: { create: auditCreate },
-      dealWorkspaceRuntimeSnapshot: { create: snapshotCreate },
-      dealWorkspaceRuntimeTransactionAttempt: { create: attemptCreate },
-    };
-    const prisma = {
-      dealWorkspaceRuntimeSnapshot: { findUnique: jest.fn().mockResolvedValue(null) },
-      $transaction: jest.fn(async (callback: (client: typeof tx) => unknown) => {
-        const result = await callback(tx);
-        committed.push('transaction-committed');
-        return result;
-      }),
-    } as any;
-    const repository = new PrismaRuntimePersistenceRepository(prisma);
+    expect(test.withContext).not.toHaveBeenCalled();
+  });
 
-    const receipt = await repository.write(baseInput);
+  it('returns sanitized failure when an atomic transaction step fails', async () => {
+    const test = fixture();
+    test.auditCreate.mockRejectedValueOnce(new Error('sensitive database failure'));
+
+    const receipt = await test.repository.write(baseInput);
 
     expect(receipt).toEqual({
       status: 'failed',
@@ -213,11 +203,9 @@ describe('PrismaRuntimePersistenceRepository', () => {
       state: 'ready_to_persist',
       reasonCode: 'database_write_failed',
     });
-    expect(committed).toEqual([]);
-    expect(outboxCreate).toHaveBeenCalledTimes(1);
-    expect(auditCreate).toHaveBeenCalledTimes(1);
-    expect(snapshotCreate).not.toHaveBeenCalled();
-    expect(attemptCreate).not.toHaveBeenCalled();
+    expect(test.order).toEqual(['find-existing', 'outbox', 'audit']);
+    expect(test.snapshotCreate).not.toHaveBeenCalled();
+    expect(test.attemptCreate).not.toHaveBeenCalled();
     expect(JSON.stringify(receipt)).not.toContain('sensitive database failure');
   });
 });

--- a/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts
+++ b/apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts
@@ -1,5 +1,9 @@
 import { Injectable, Optional } from '@nestjs/common';
-import { PrismaService } from '../../common/prisma/prisma.service';
+import type { Prisma } from '@prisma/client';
+import {
+  RlsTransactionService,
+  type TrustedRlsContext,
+} from '../../common/prisma/rls-transaction.service';
 import type {
   RuntimePersistenceDbState,
   RuntimePersistenceRepository,
@@ -29,6 +33,8 @@ const requiredStringFields: Array<keyof RuntimePersistenceWriteInput> = [
   'runtimeStoreVersion',
   'actorId',
   'actorRole',
+  'tenantId',
+  'organizationId',
   'correlationId',
   'auditId',
   'contractHash',
@@ -50,21 +56,31 @@ function isValidInput(input: RuntimePersistenceWriteInput): boolean {
   });
 }
 
+function trustedContext(input: RuntimePersistenceWriteInput): TrustedRlsContext {
+  return {
+    userId: input.actorId,
+    orgId: input.organizationId ?? '',
+    tenantId: input.tenantId ?? '',
+    role: input.actorRole,
+    sessionId: `runtime-persistence:${input.correlationId}`,
+  };
+}
+
 @Injectable()
 export class PrismaRuntimePersistenceRepository implements RuntimePersistenceRepository {
-  constructor(@Optional() private readonly prisma?: PrismaService) {
-    if (!this.prisma) {
+  constructor(@Optional() private readonly rls?: RlsTransactionService) {
+    if (!this.rls) {
       throw new Error(
-        'PrismaRuntimePersistenceRepository requires PrismaService; the Postgres runtime-persistence path is not active.',
+        'PrismaRuntimePersistenceRepository requires RlsTransactionService; the trusted Postgres path is not active.',
       );
     }
   }
 
-  private get db(): PrismaService {
-    if (!this.prisma) {
-      throw new Error('PrismaService unavailable; Postgres runtime-persistence path is not active.');
+  private get transaction(): RlsTransactionService {
+    if (!this.rls) {
+      throw new Error('RlsTransactionService unavailable; the trusted Postgres path is not active.');
     }
-    return this.prisma;
+    return this.rls;
   }
 
   private classifyExisting(
@@ -114,8 +130,11 @@ export class PrismaRuntimePersistenceRepository implements RuntimePersistenceRep
     };
   }
 
-  private async findExisting(idempotencyKey: string): Promise<ExistingRuntimeSnapshot | null> {
-    return this.db.dealWorkspaceRuntimeSnapshot.findUnique({
+  private findExisting(
+    tx: Prisma.TransactionClient,
+    idempotencyKey: string,
+  ): Promise<ExistingRuntimeSnapshot | null> {
+    return tx.dealWorkspaceRuntimeSnapshot.findUnique({
       where: { idempotencyKey },
       include: {
         attempts: {
@@ -132,13 +151,13 @@ export class PrismaRuntimePersistenceRepository implements RuntimePersistenceRep
       return this.failed(input, 'invalid_input');
     }
 
-    try {
-      const existing = await this.findExisting(input.idempotencyKey);
-      if (existing) {
-        return this.classifyExisting(input, existing);
-      }
+    const context = trustedContext(input);
 
-      return await this.db.$transaction(async (tx) => {
+    try {
+      return await this.transaction.withContext(context, async (tx) => {
+        const existing = await this.findExisting(tx, input.idempotencyKey);
+        if (existing) return this.classifyExisting(input, existing);
+
         const outbox = await tx.outboxEntry.create({
           data: {
             type: 'deal_workspace.runtime_snapshot.persisted',
@@ -239,10 +258,10 @@ export class PrismaRuntimePersistenceRepository implements RuntimePersistenceRep
     } catch (error) {
       if (isKnownUniqueConstraintError(error)) {
         try {
-          const concurrent = await this.findExisting(input.idempotencyKey);
-          if (concurrent) {
-            return this.classifyExisting(input, concurrent);
-          }
+          const concurrent = await this.transaction.withContext(context, (tx) =>
+            this.findExisting(tx, input.idempotencyKey),
+          );
+          if (concurrent) return this.classifyExisting(input, concurrent);
         } catch {
           return this.failed(input, 'database_write_failed');
         }

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence-repository.factory.ts
@@ -1,4 +1,4 @@
-import type { PrismaService } from '../../common/prisma/prisma.service';
+import type { RlsTransactionService } from '../../common/prisma/rls-transaction.service';
 import { PrismaRuntimePersistenceRepository } from './prisma-runtime-persistence.repository';
 import {
   DisabledRuntimePersistenceRepository,
@@ -8,16 +8,16 @@ import {
 /**
  * Selects the runtime-persistence repository without silent fallback.
  *
- * The Prisma path is active only for the exact `prisma` mode. Every other value
- * returns a fail-closed disabled repository and never writes to the process
- * runtime store.
+ * The Prisma path is active only for the exact `prisma` mode and requires the
+ * canonical transaction-local RLS service. Every other value returns a
+ * fail-closed disabled repository and never writes to process memory.
  */
 export function selectRuntimePersistenceRepository(
-  prisma?: PrismaService,
+  rls?: RlsTransactionService,
   mode: string | undefined = process.env.PLATFORM_V7_RUNTIME_PERSISTENCE_REPOSITORY,
 ): RuntimePersistenceRepository {
   if (mode === 'prisma') {
-    return new PrismaRuntimePersistenceRepository(prisma);
+    return new PrismaRuntimePersistenceRepository(rls);
   }
 
   return new DisabledRuntimePersistenceRepository();

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence-repository.spec.ts
@@ -1,3 +1,4 @@
+import type { RlsTransactionService } from '../../common/prisma/rls-transaction.service';
 import { PrismaRuntimePersistenceRepository } from './prisma-runtime-persistence.repository';
 import { selectRuntimePersistenceRepository } from './runtime-persistence-repository.factory';
 import {
@@ -16,7 +17,9 @@ const input: RuntimePersistenceWriteInput = {
   runtimeStoreRecordId: 'runtime-record-1',
   runtimeStoreVersion: '1',
   actorId: 'user-1',
-  actorRole: 'operator',
+  actorRole: 'SUPPORT_MANAGER',
+  tenantId: 'tenant-1',
+  organizationId: 'org-1',
   correlationId: 'corr-1',
   auditId: 'audit-business-1',
   contractHash: 'hash-1',
@@ -38,27 +41,27 @@ describe('runtime persistence repository selection', () => {
   });
 
   it('does not treat unrelated values as Prisma activation', () => {
-    const prisma = {} as any;
+    const rls = {} as RlsTransactionService;
 
-    expect(selectRuntimePersistenceRepository(prisma, 'true')).toBeInstanceOf(
+    expect(selectRuntimePersistenceRepository(rls, 'true')).toBeInstanceOf(
       DisabledRuntimePersistenceRepository,
     );
-    expect(selectRuntimePersistenceRepository(prisma, 'postgres')).toBeInstanceOf(
+    expect(selectRuntimePersistenceRepository(rls, 'postgres')).toBeInstanceOf(
       DisabledRuntimePersistenceRepository,
     );
   });
 
-  it('selects Prisma only for the exact prisma mode', () => {
-    const prisma = {} as any;
+  it('selects Prisma only for exact prisma mode with trusted RLS service', () => {
+    const rls = {} as RlsTransactionService;
 
-    expect(selectRuntimePersistenceRepository(prisma, 'prisma')).toBeInstanceOf(
+    expect(selectRuntimePersistenceRepository(rls, 'prisma')).toBeInstanceOf(
       PrismaRuntimePersistenceRepository,
     );
   });
 
-  it('fails loudly when Prisma mode is enabled without PrismaService', () => {
+  it('fails loudly when Prisma mode is enabled without trusted RLS service', () => {
     expect(() => selectRuntimePersistenceRepository(undefined, 'prisma')).toThrow(
-      /requires PrismaService/,
+      /requires RlsTransactionService/,
     );
   });
 });

--- a/apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts
+++ b/apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from '../../common/prisma/prisma.module';
-import { PrismaService } from '../../common/prisma/prisma.service';
+import { RlsTransactionService } from '../../common/prisma/rls-transaction.service';
 import { RuntimePersistenceCommandService } from './runtime-persistence-command.service';
 import { selectRuntimePersistenceRepository } from './runtime-persistence-repository.factory';
 import { RUNTIME_PERSISTENCE_REPOSITORY } from './runtime-persistence.repository';
@@ -13,8 +13,8 @@ import { RuntimePersistenceService } from './runtime-persistence.service';
     RuntimePersistenceCommandService,
     {
       provide: RUNTIME_PERSISTENCE_REPOSITORY,
-      inject: [PrismaService],
-      useFactory: (prisma: PrismaService) => selectRuntimePersistenceRepository(prisma),
+      inject: [RlsTransactionService],
+      useFactory: (rls: RlsTransactionService) => selectRuntimePersistenceRepository(rls),
     },
   ],
   exports: [


### PR DESCRIPTION
Закрыто как дубликат #2256.

#2256 сохраняет правильную границу доверия: RLS transaction открывается authenticated command boundary на основе verified RequestUser, а repository получает уже готовый TransactionClient.

Этот вариант не используется, поскольку он формирует trusted context внутри repository из persistence input и создаёт синтетический sessionId из correlationId, что смешивает authenticated session и operation correlation.