### PR TITLE
VP-3.45 Physical Table RLS Policy Alignment and Rehearsal

### DIFF
--- a/apps/api/src/common/prisma/rls-transaction.service.spec.ts
+++ b/apps/api/src/common/prisma/rls-transaction.service.spec.ts
@@ -1,3 +1,6 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 import { Prisma } from '@prisma/client';
 import type { RequestUser } from '../types/request-user';
 import { Role } from '../types/request-user';
@@ -35,6 +38,16 @@ function fixture() {
     transaction,
     service: new RlsTransactionService(prisma),
   };
+}
+
+function repositoryPath(...segments: string[]): string {
+  const candidates = [
+    path.resolve(process.cwd(), ...segments),
+    path.resolve(process.cwd(), '../..', ...segments),
+  ];
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) throw new Error(`Repository path not found: ${segments.join('/')}`);
+  return found;
 }
 
 describe('RlsTransactionService', () => {
@@ -136,5 +149,33 @@ describe('RlsTransactionService', () => {
 
     await expect(test.service.withTrustedContext(TRUSTED_USER, work)).rejects.toBe(databaseError);
     expect(work).not.toHaveBeenCalled();
+  });
+});
+
+describe('platform-v7 RLS deployment artifacts', () => {
+  it('passes canonical Prisma/RLS drift validation', () => {
+    const validator = repositoryPath('scripts/platform-v7-rls-validate.mjs');
+    const result = JSON.parse(execFileSync(process.execPath, [validator], { encoding: 'utf8' })) as {
+      valid: boolean;
+      errors: string[];
+      policies: number;
+    };
+
+    expect(result).toMatchObject({ valid: true, errors: [] });
+    expect(result.policies).toBeGreaterThanOrEqual(16);
+  });
+
+  it('keeps apply and rollback rehearsals isolated and rollback-only', () => {
+    for (const scriptName of [
+      'platform-v7-rls-apply-rehearsal.sh',
+      'platform-v7-rls-rollback-rehearsal.sh',
+    ]) {
+      const source = readFileSync(repositoryPath('scripts', scriptName), 'utf8');
+      expect(source).toContain('RLS_REHEARSAL_DATABASE_URL');
+      expect(source).toContain('NODE_ENV=production');
+      expect(source).toContain('rehearsal URL equals DATABASE_URL');
+      expect(source).toContain('ROLLBACK;');
+      expect(source).not.toContain('COMMIT;');
+    }
   });
 });

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -3,75 +3,65 @@
   "mode": "variant-b",
   "status": "active",
   "currentStatus": "in_progress",
-  "current": "VP-3.44 Runtime Persistence Trusted Transaction Binding.",
+  "current": "VP-3.45 Physical Table RLS Policy Alignment and Rehearsal.",
   "fullTzReadinessPercent": 85,
-  "openPr": "#2256",
+  "openPr": null,
   "lastClosed": [
     "#2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
     "#2245 VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
     "#2250 VP-3.41 Runtime Persistence Internal Service Wiring Implementation",
     "#2252 VP-3.42 Runtime Persistence Authenticated Internal Command Boundary",
-    "#2254 VP-3.43 Transaction-Local Trusted RLS Context"
+    "#2254 VP-3.43 Transaction-Local Trusted RLS Context",
+    "#2256 VP-3.44 Runtime Persistence Trusted Transaction Binding"
   ],
   "openBlockers": ["#2113", "#2115", "#2251"],
   "blockerNotes": "#2113 repository settings cleanup. #2115 blocks persistent auth-file changes. Draft #2251 remains merge-blocked by user-driven bank confirmations, synthetic bank references, cross-tenant visibility and unresolved conflicts.",
   "lockedUntilCurrentGreen": [
-    "controller/API/web wiring",
     "production migration execution",
     "production RLS policy application",
+    "controller/API/web wiring",
     "money confirmation commands",
     "persistent identity/session/MFA changes"
   ],
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "apps/api/src/common/prisma/rls-transaction.service.ts",
+    "infra/sql/production-rls-policies.sql",
     "apps/api/src/common/prisma/rls-transaction.service.spec.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
-    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
-    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts"
+    "scripts/platform-v7-rls-validate.mjs",
+    "scripts/platform-v7-rls-apply-rehearsal.sh",
+    "scripts/platform-v7-rls-rollback-rehearsal.sh"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "apps/api/src/common/prisma/rls-transaction.service.ts",
+    "infra/sql/production-rls-policies.sql",
     "apps/api/src/common/prisma/rls-transaction.service.spec.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts",
-    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts",
-    "apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts",
-    "apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts"
+    "scripts/platform-v7-rls-validate.mjs",
+    "scripts/platform-v7-rls-apply-rehearsal.sh",
+    "scripts/platform-v7-rls-rollback-rehearsal.sh"
   ],
-  "vp343TransactionLocalTrustedRlsContext": {
-    "layer": "VP-3.43 Transaction-Local Trusted RLS Context",
-    "closedPr": "#2254",
-    "status": "merged"
-  },
   "vp344RuntimePersistenceTrustedTransactionBinding": {
     "layer": "VP-3.44 Runtime Persistence Trusted Transaction Binding",
-    "openPr": "#2256",
-    "status": "in_progress",
-    "invariants": [
-      "authenticated runtime persistence enters through RlsTransactionService",
-      "existing-record lookup uses the trusted transaction client",
-      "snapshot, outbox, audit and attempt use the same transaction client",
-      "no nested transaction inside the trusted callback",
-      "P2002 recovery re-enters a new trusted transaction",
-      "RLS initialization failure executes no persistence operation",
-      "database failures return sanitized failed receipts"
-    ]
+    "closedPr": "#2256",
+    "status": "merged"
   },
   "vp345PhysicalRlsPolicyAlignment": {
     "layer": "VP-3.45 Physical Table RLS Policy Alignment and Rehearsal",
-    "status": "next-after-vp344-green"
+    "status": "in_progress",
+    "invariants": [
+      "policies target canonical Prisma physical table names",
+      "RLS is enabled and forced on protected tables",
+      "policy creation is idempotent on PostgreSQL 16",
+      "legacy session-level context helper is removed",
+      "transaction-local five-field context remains canonical",
+      "production database is never modified by CI or rehearsal scripts",
+      "policy drift is statically detectable"
+    ]
+  },
+  "vp346RlsIntegrationHarness": {
+    "layer": "VP-3.46 Ephemeral PostgreSQL RLS Integration Harness",
+    "status": "next-after-vp345-green"
   },
   "forbiddenZones": [
     "apps/landing",
@@ -95,5 +85,5 @@
     "bank confirmation from user command",
     "production scale proven"
   ],
-  "readiness": "85% honest architectural readiness. VP-3.44 binds authenticated runtime persistence to the transaction-local trusted RLS primitive. Production policies, migration application, persistent identity, external integrations and scale proof remain unconfirmed."
+  "readiness": "85% honest architectural readiness. VP-3.45 repairs policy SQL and adds non-production rehearsal controls. No production database or policy application is claimed."
 }

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -5,7 +5,7 @@
   "currentStatus": "in_progress",
   "current": "VP-3.45 Physical Table RLS Policy Alignment and Rehearsal.",
   "fullTzReadinessPercent": 85,
-  "openPr": null,
+  "openPr": "#2258",
   "lastClosed": [
     "#2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
     "#2245 VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
@@ -48,6 +48,7 @@
   },
   "vp345PhysicalRlsPolicyAlignment": {
     "layer": "VP-3.45 Physical Table RLS Policy Alignment and Rehearsal",
+    "openPr": "#2258",
     "status": "in_progress",
     "invariants": [
       "policies target canonical Prisma physical table names",

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,33 +1,28 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.44 Runtime Persistence Trusted Transaction Binding.
+CURRENT: VP-3.45 Physical Table RLS Policy Alignment and Rehearsal.
 
-GOAL: Выполнить authenticated runtime persistence полностью внутри transaction-local RLS boundary, чтобы pre-read, outbox, audit, snapshot и transaction-attempt использовали один trusted Prisma transaction client.
+GOAL: Привести PostgreSQL RLS SQL к реальным physical table names Prisma, сделать политику идемпотентной и fail-closed, удалить legacy session-level context helper и добавить только rollback-safe non-production rehearsal.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
-- apps/api/src/common/prisma/rls-transaction.service.ts
+- infra/sql/production-rls-policies.sql
 - apps/api/src/common/prisma/rls-transaction.service.spec.ts
-- apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.ts
-- apps/api/src/modules/runtime-persistence/runtime-persistence-command.service.spec.ts
-- apps/api/src/modules/runtime-persistence/runtime-persistence.service.ts
-- apps/api/src/modules/runtime-persistence/runtime-persistence.service.spec.ts
-- apps/api/src/modules/runtime-persistence/runtime-persistence.repository.ts
-- apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.ts
-- apps/api/src/modules/runtime-persistence/prisma-runtime-persistence.repository.spec.ts
-- apps/api/src/modules/runtime-persistence/runtime-persistence.module.ts
+- scripts/platform-v7-rls-validate.mjs
+- scripts/platform-v7-rls-apply-rehearsal.sh
+- scripts/platform-v7-rls-rollback-rehearsal.sh
 
 CURRENT CRITERIA:
-- authenticated command enters through `RlsTransactionService`;
-- existing-record lookup occurs on the trusted transaction client;
-- outbox, audit, snapshot and attempt writes share that exact client;
-- repository opens no nested transaction inside the trusted callback;
-- concurrent P2002 recovery re-enters a new trusted transaction before classification;
-- RLS initialization failure executes no persistence read or write;
-- errors do not leak sensitive database details;
-- failed receipts remain failed;
-- no controller, web bridge or user-driven bank confirmation is introduced.
+- policy SQL targets `deals`, `organizations`, `audit_events`, `ledger_entries`, `integration_events`, `outbox_entries`, `deal_workspace_runtime_snapshots` and `deal_workspace_runtime_transaction_attempts`;
+- all protected tables use `ENABLE ROW LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY`;
+- PostgreSQL 16 compatible idempotency uses `DROP POLICY IF EXISTS` followed by `CREATE POLICY`;
+- legacy three-argument `set_app_context` is removed;
+- SQL does not create session-level context setters;
+- role, user, organization, tenant and session settings are treated as mandatory trusted transaction context;
+- rehearsal scripts refuse production mode, require a dedicated rehearsal URL and always roll back;
+- static validation detects Prisma/RLS table drift and forbidden legacy constructs;
+- no production database is modified.
 
 DONE:
 - #2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation
@@ -35,6 +30,7 @@ DONE:
 - #2250 VP-3.41 Runtime Persistence Internal Service Wiring Implementation
 - #2252 VP-3.42 Runtime Persistence Authenticated Internal Command Boundary
 - #2254 VP-3.43 Transaction-Local Trusted RLS Context
+- #2256 VP-3.44 Runtime Persistence Trusted Transaction Binding
 
 LOCKED:
 - production migration execution;
@@ -45,23 +41,24 @@ LOCKED:
 - live bank/FGIS/EDO integrations.
 
 NEXT:
-- Layer: VP-3.45 Physical Table RLS Policy Alignment and Rehearsal.
+- Layer: VP-3.46 Ephemeral PostgreSQL RLS Integration Harness.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
-  - infra/sql/production-rls-policies.sql
-  - apps/api/prisma/migrations/**
-  - apps/api/src/common/prisma/rls-transaction.service.spec.ts
+  - apps/api/test/rls/**
   - scripts/platform-v7-rls-*.mjs
   - scripts/platform-v7-rls-*.sh
+  - .github/workflows/platform-v7-rls-integration.yml
 - Success criteria:
-  - RLS policies reference canonical physical PostgreSQL table names from Prisma mappings;
-  - tenant, organization, role and user policies are explicit per protected table;
-  - policy SQL is idempotent and fail-closed;
-  - non-production apply and rollback rehearsal scripts exist;
-  - no production database is modified by CI;
-  - migration and policy drift is detected automatically;
-  - production-enabled claims remain forbidden until controlled application evidence exists.
+  - CI starts an isolated PostgreSQL 16 service with no production credentials;
+  - schema and canonical RLS SQL are applied to the ephemeral database only;
+  - two tenants and two organizations are seeded;
+  - participant access succeeds only for its own deal;
+  - cross-tenant deal, audit, outbox and runtime snapshot reads are denied;
+  - incomplete trusted context is denied;
+  - transaction-local context does not leak to a reused pooled connection;
+  - test teardown destroys all data and credentials;
+  - production-enabled claims remain forbidden.
 - Readiness remains 85% honest architectural readiness.
 
 AFTER NEXT:

--- a/infra/sql/production-rls-policies.sql
+++ b/infra/sql/production-rls-policies.sql
@@ -1,141 +1,441 @@
--- GrainFlow — PostgreSQL Row Level Security (ТЗ 4.1)
--- Применяется поверх Prisma-миграций в production PostgreSQL.
--- SQLite не поддерживает RLS — этот файл исполняется только в production.
+-- platform-v7 PostgreSQL 16 Row Level Security policy set.
 --
--- Соглашение: current_setting('app.current_org_id', true) содержит orgId текущего пользователя,
--- current_setting('app.current_role', true) содержит роль (ADMIN/COMPLIANCE_OFFICER/etc.)
--- Устанавливается в начале транзакции через SET LOCAL.
+-- IMPORTANT:
+-- - This file is a deployment artifact, not proof that production RLS is enabled.
+-- - Apply only after the canonical Prisma schema exists.
+-- - The API must set all five app.current_* values with set_config(..., true)
+--   inside the same transaction that performs protected reads/writes.
+-- - No session-level context setter is created here.
 
--- ── 1. Deal ──────────────────────────────────────────────────────────────────
-ALTER TABLE "Deal" ENABLE ROW LEVEL SECURITY;
+BEGIN;
 
--- Admin и Compliance видят все сделки
-CREATE POLICY IF NOT EXISTS deal_admin_policy ON "Deal"
-  USING (
-    current_setting('app.current_role', true) IN ('ADMIN', 'COMPLIANCE_OFFICER', 'SUPPORT_MANAGER')
-  );
+-- Remove the legacy three-field, session-level helper. The API now sets the
+-- complete context directly and transaction-locally through RlsTransactionService.
+DROP FUNCTION IF EXISTS public.set_app_context(TEXT, TEXT, TEXT);
 
--- Участники сделки видят свою сделку
-CREATE POLICY IF NOT EXISTS deal_participant_policy ON "Deal"
-  USING (
-    "sellerOrgId" = current_setting('app.current_org_id', true)
-    OR "buyerOrgId" = current_setting('app.current_org_id', true)
-  );
-
--- Arbitrator видит только сделки с активными спорами, где назначен арбитром
-CREATE POLICY IF NOT EXISTS deal_arbitrator_policy ON "Deal"
-  USING (
-    current_setting('app.current_role', true) = 'ARBITRATOR'
-    AND EXISTS (
-      SELECT 1 FROM "Dispute" d
-      WHERE d."dealId" = "Deal"."id"
-        AND d."arbitratorId" = current_setting('app.current_user_id', true)
-    )
-  );
-
--- ── 2. Organization ───────────────────────────────────────────────────────────
-ALTER TABLE "organizations" ENABLE ROW LEVEL SECURITY;
-
--- ADMIN/COMPLIANCE/SUPPORT видят все организации
-CREATE POLICY IF NOT EXISTS org_admin_policy ON "organizations"
-  USING (
-    current_setting('app.current_role', true) IN ('ADMIN', 'COMPLIANCE_OFFICER', 'SUPPORT_MANAGER')
-  );
-
--- Пользователь видит свою организацию
-CREATE POLICY IF NOT EXISTS org_own_policy ON "organizations"
-  USING ("id" = current_setting('app.current_org_id', true));
-
--- ── 3. AuditEvent (append-only: DELETE запрещён для всех) ─────────────────────
-ALTER TABLE "AuditEvent" ENABLE ROW LEVEL SECURITY;
-
--- Только ADMIN и COMPLIANCE могут читать все записи
-CREATE POLICY IF NOT EXISTS audit_read_policy ON "AuditEvent" FOR SELECT
-  USING (
-    current_setting('app.current_role', true) IN ('ADMIN', 'COMPLIANCE_OFFICER')
-  );
-
--- Участники сделки видят только аудит своей сделки
-CREATE POLICY IF NOT EXISTS audit_deal_policy ON "AuditEvent" FOR SELECT
-  USING (
-    "dealId" IS NOT NULL
-    AND EXISTS (
-      SELECT 1 FROM "Deal" d
-      WHERE d."id" = "AuditEvent"."dealId"
-        AND (d."sellerOrgId" = current_setting('app.current_org_id', true)
-          OR d."buyerOrgId" = current_setting('app.current_org_id', true))
-    )
-  );
-
--- INSERT разрешён только через сервисный аккаунт (role: app_service)
-CREATE POLICY IF NOT EXISTS audit_insert_policy ON "AuditEvent" FOR INSERT
-  WITH CHECK (current_user = 'app_service');
-
--- DELETE и UPDATE запрещены всем (append-only enforcement)
-CREATE POLICY IF NOT EXISTS audit_no_delete_policy ON "AuditEvent" FOR DELETE
-  USING (false);
-
-CREATE POLICY IF NOT EXISTS audit_no_update_policy ON "AuditEvent" FOR UPDATE
-  USING (false);
-
--- ── 4. LedgerEntry (финансовые записи) ───────────────────────────────────────
-ALTER TABLE "LedgerEntry" ENABLE ROW LEVEL SECURITY;
-
-CREATE POLICY IF NOT EXISTS ledger_admin_policy ON "LedgerEntry"
-  USING (
-    current_setting('app.current_role', true) IN ('ADMIN', 'ACCOUNTING', 'COMPLIANCE_OFFICER')
-  );
-
-CREATE POLICY IF NOT EXISTS ledger_deal_policy ON "LedgerEntry"
-  USING (
-    EXISTS (
-      SELECT 1 FROM "Deal" d
-      WHERE d."id" = "LedgerEntry"."dealId"
-        AND (d."sellerOrgId" = current_setting('app.current_org_id', true)
-          OR d."buyerOrgId" = current_setting('app.current_org_id', true))
-    )
-  );
-
--- UPDATE/DELETE запрещены (immutable ledger)
-CREATE POLICY IF NOT EXISTS ledger_no_delete_policy ON "LedgerEntry" FOR DELETE
-  USING (false);
-
-CREATE POLICY IF NOT EXISTS ledger_no_update_policy ON "LedgerEntry" FOR UPDATE
-  USING (false);
-
--- ── 5. IntegrationEvent ───────────────────────────────────────────────────────
-ALTER TABLE "IntegrationEvent" ENABLE ROW LEVEL SECURITY;
-
-CREATE POLICY IF NOT EXISTS integration_event_policy ON "IntegrationEvent"
-  USING (
-    current_setting('app.current_role', true) IN ('ADMIN', 'COMPLIANCE_OFFICER', 'SUPPORT_MANAGER')
-  );
-
--- ── 6. OutboxEntry ────────────────────────────────────────────────────────────
-ALTER TABLE "OutboxEntry" ENABLE ROW LEVEL SECURITY;
-
--- Только сервисный аккаунт и ADMIN
-CREATE POLICY IF NOT EXISTS outbox_service_policy ON "OutboxEntry"
-  USING (
-    current_user = 'app_service'
-    OR current_setting('app.current_role', true) = 'ADMIN'
-  );
-
--- ── Вспомогательные функции ─────────────────────────────────────────────────
--- Функция для установки контекста пользователя в начале каждого запроса
-CREATE OR REPLACE FUNCTION set_app_context(
-  p_user_id TEXT,
-  p_org_id TEXT,
-  p_role TEXT
-) RETURNS void
-LANGUAGE plpgsql AS $$
-BEGIN
-  PERFORM set_config('app.current_user_id', COALESCE(p_user_id, ''), false);
-  PERFORM set_config('app.current_org_id', COALESCE(p_org_id, ''), false);
-  PERFORM set_config('app.current_role', COALESCE(p_role, ''), false);
-END;
+CREATE OR REPLACE FUNCTION public.app_rls_context_ready()
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+PARALLEL SAFE
+SET search_path = pg_catalog
+AS $$
+  SELECT
+    NULLIF(current_setting('app.current_user_id', true), '') IS NOT NULL
+    AND NULLIF(current_setting('app.current_org_id', true), '') IS NOT NULL
+    AND NULLIF(current_setting('app.current_tenant_id', true), '') IS NOT NULL
+    AND NULLIF(current_setting('app.current_role', true), '') IS NOT NULL
+    AND NULLIF(current_setting('app.current_session_id', true), '') IS NOT NULL
 $$;
 
-COMMENT ON FUNCTION set_app_context IS
-  'Вызывается API перед каждой транзакцией для RLS context. '
-  'Prisma middleware: $executeRaw`SELECT set_app_context($1, $2, $3)`';
+CREATE OR REPLACE FUNCTION public.app_rls_privileged()
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+PARALLEL SAFE
+SET search_path = pg_catalog
+AS $$
+  SELECT current_setting('app.current_role', true) IN (
+    'ADMIN',
+    'COMPLIANCE_OFFICER',
+    'SUPPORT_MANAGER'
+  )
+$$;
+
+COMMENT ON FUNCTION public.app_rls_context_ready() IS
+  'True only when the complete trusted transaction-local RLS context is present.';
+COMMENT ON FUNCTION public.app_rls_privileged() IS
+  'True for platform roles allowed to perform explicitly defined cross-organization reads.';
+
+-- ── deals ─────────────────────────────────────────────────────────────────────
+ALTER TABLE public."deals" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."deals" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS deals_select ON public."deals";
+DROP POLICY IF EXISTS deals_insert ON public."deals";
+DROP POLICY IF EXISTS deals_update ON public."deals";
+
+CREATE POLICY deals_select ON public."deals"
+FOR SELECT
+USING (
+  public.app_rls_context_ready()
+  AND (
+    public.app_rls_privileged()
+    OR (
+      "tenantId" = current_setting('app.current_tenant_id', true)
+      AND (
+        "sellerOrgId" = current_setting('app.current_org_id', true)
+        OR "buyerOrgId" = current_setting('app.current_org_id', true)
+      )
+    )
+    OR (
+      current_setting('app.current_role', true) = 'ARBITRATOR'
+      AND EXISTS (
+        SELECT 1
+        FROM public."disputes" d
+        WHERE d."dealId" = "deals"."id"
+          AND d."arbitratorId" = current_setting('app.current_user_id', true)
+          AND d."status" IN ('OPEN', 'ARBITRATION')
+      )
+    )
+  )
+);
+
+CREATE POLICY deals_insert ON public."deals"
+FOR INSERT
+WITH CHECK (
+  public.app_rls_context_ready()
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR "sellerOrgId" = current_setting('app.current_org_id', true)
+    OR "buyerOrgId" = current_setting('app.current_org_id', true)
+  )
+);
+
+CREATE POLICY deals_update ON public."deals"
+FOR UPDATE
+USING (
+  public.app_rls_context_ready()
+  AND (
+    public.app_rls_privileged()
+    OR (
+      "tenantId" = current_setting('app.current_tenant_id', true)
+      AND (
+        "sellerOrgId" = current_setting('app.current_org_id', true)
+        OR "buyerOrgId" = current_setting('app.current_org_id', true)
+      )
+    )
+  )
+)
+WITH CHECK (
+  public.app_rls_context_ready()
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR "sellerOrgId" = current_setting('app.current_org_id', true)
+    OR "buyerOrgId" = current_setting('app.current_org_id', true)
+  )
+);
+
+-- No DELETE policy: physical deal deletion is denied.
+
+-- ── organizations ─────────────────────────────────────────────────────────────
+ALTER TABLE public."organizations" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."organizations" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS organizations_select ON public."organizations";
+DROP POLICY IF EXISTS organizations_write_privileged ON public."organizations";
+
+CREATE POLICY organizations_select ON public."organizations"
+FOR SELECT
+USING (
+  public.app_rls_context_ready()
+  AND (
+    public.app_rls_privileged()
+    OR (
+      "id" = current_setting('app.current_org_id', true)
+      AND "tenantId" = current_setting('app.current_tenant_id', true)
+    )
+  )
+);
+
+CREATE POLICY organizations_write_privileged ON public."organizations"
+FOR ALL
+USING (public.app_rls_context_ready() AND public.app_rls_privileged())
+WITH CHECK (public.app_rls_context_ready() AND public.app_rls_privileged());
+
+-- ── audit_events: append-only ─────────────────────────────────────────────────
+ALTER TABLE public."audit_events" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."audit_events" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS audit_events_select ON public."audit_events";
+DROP POLICY IF EXISTS audit_events_insert ON public."audit_events";
+
+CREATE POLICY audit_events_select ON public."audit_events"
+FOR SELECT
+USING (
+  public.app_rls_context_ready()
+  AND (
+    public.app_rls_privileged()
+    OR (
+      "tenantId" = current_setting('app.current_tenant_id', true)
+      AND "orgId" = current_setting('app.current_org_id', true)
+    )
+    OR (
+      "dealId" IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM public."deals" d
+        WHERE d."id" = "audit_events"."dealId"
+          AND d."tenantId" = current_setting('app.current_tenant_id', true)
+          AND (
+            d."sellerOrgId" = current_setting('app.current_org_id', true)
+            OR d."buyerOrgId" = current_setting('app.current_org_id', true)
+          )
+      )
+    )
+  )
+);
+
+CREATE POLICY audit_events_insert ON public."audit_events"
+FOR INSERT
+WITH CHECK (
+  public.app_rls_context_ready()
+  AND "actorUserId" = current_setting('app.current_user_id', true)
+  AND "actorRole" = current_setting('app.current_role', true)
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND "orgId" = current_setting('app.current_org_id', true)
+  AND (
+    "dealId" IS NULL
+    OR public.app_rls_privileged()
+    OR EXISTS (
+      SELECT 1
+      FROM public."deals" d
+      WHERE d."id" = "audit_events"."dealId"
+        AND d."tenantId" = current_setting('app.current_tenant_id', true)
+        AND (
+          d."sellerOrgId" = current_setting('app.current_org_id', true)
+          OR d."buyerOrgId" = current_setting('app.current_org_id', true)
+        )
+    )
+  )
+);
+
+-- No UPDATE/DELETE policies: audit is append-only.
+
+-- ── ledger_entries: immutable financial journal ───────────────────────────────
+ALTER TABLE public."ledger_entries" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."ledger_entries" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS ledger_entries_select ON public."ledger_entries";
+DROP POLICY IF EXISTS ledger_entries_insert ON public."ledger_entries";
+
+CREATE POLICY ledger_entries_select ON public."ledger_entries"
+FOR SELECT
+USING (
+  public.app_rls_context_ready()
+  AND (
+    current_setting('app.current_role', true) IN (
+      'ADMIN', 'ACCOUNTING', 'COMPLIANCE_OFFICER', 'SUPPORT_MANAGER'
+    )
+    OR "debitAccount" = current_setting('app.current_org_id', true)
+    OR "creditAccount" = current_setting('app.current_org_id', true)
+    OR (
+      "dealId" IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM public."deals" d
+        WHERE d."id" = "ledger_entries"."dealId"
+          AND d."tenantId" = current_setting('app.current_tenant_id', true)
+          AND (
+            d."sellerOrgId" = current_setting('app.current_org_id', true)
+            OR d."buyerOrgId" = current_setting('app.current_org_id', true)
+          )
+      )
+    )
+  )
+);
+
+CREATE POLICY ledger_entries_insert ON public."ledger_entries"
+FOR INSERT
+WITH CHECK (
+  public.app_rls_context_ready()
+  AND current_setting('app.current_role', true) IN ('ADMIN', 'ACCOUNTING')
+  AND "createdByUserId" = current_setting('app.current_user_id', true)
+  AND (
+    "dealId" IS NULL
+    OR public.app_rls_privileged()
+    OR EXISTS (
+      SELECT 1
+      FROM public."deals" d
+      WHERE d."id" = "ledger_entries"."dealId"
+        AND d."tenantId" = current_setting('app.current_tenant_id', true)
+        AND (
+          d."sellerOrgId" = current_setting('app.current_org_id', true)
+          OR d."buyerOrgId" = current_setting('app.current_org_id', true)
+        )
+    )
+  )
+);
+
+-- No UPDATE/DELETE policies: ledger entries are immutable.
+
+-- ── integration_events ────────────────────────────────────────────────────────
+ALTER TABLE public."integration_events" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."integration_events" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
+DROP POLICY IF EXISTS integration_events_insert ON public."integration_events";
+
+CREATE POLICY integration_events_select ON public."integration_events"
+FOR SELECT
+USING (
+  public.app_rls_context_ready()
+  AND (
+    public.app_rls_privileged()
+    OR (
+      "dealId" IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM public."deals" d
+        WHERE d."id" = "integration_events"."dealId"
+          AND d."tenantId" = current_setting('app.current_tenant_id', true)
+          AND (
+            d."sellerOrgId" = current_setting('app.current_org_id', true)
+            OR d."buyerOrgId" = current_setting('app.current_org_id', true)
+          )
+      )
+    )
+  )
+);
+
+CREATE POLICY integration_events_insert ON public."integration_events"
+FOR INSERT
+WITH CHECK (
+  current_user IN ('app_service', 'app_integration_worker')
+  OR (public.app_rls_context_ready() AND public.app_rls_privileged())
+);
+
+-- ── outbox_entries ────────────────────────────────────────────────────────────
+ALTER TABLE public."outbox_entries" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."outbox_entries" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS outbox_entries_worker ON public."outbox_entries";
+DROP POLICY IF EXISTS outbox_entries_select ON public."outbox_entries";
+DROP POLICY IF EXISTS outbox_entries_insert ON public."outbox_entries";
+
+CREATE POLICY outbox_entries_worker ON public."outbox_entries"
+FOR ALL
+USING (current_user IN ('app_service', 'app_outbox_worker'))
+WITH CHECK (current_user IN ('app_service', 'app_outbox_worker'));
+
+CREATE POLICY outbox_entries_select ON public."outbox_entries"
+FOR SELECT
+USING (
+  public.app_rls_context_ready()
+  AND (
+    public.app_rls_privileged()
+    OR (
+      "dealId" IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM public."deals" d
+        WHERE d."id" = "outbox_entries"."dealId"
+          AND d."tenantId" = current_setting('app.current_tenant_id', true)
+          AND (
+            d."sellerOrgId" = current_setting('app.current_org_id', true)
+            OR d."buyerOrgId" = current_setting('app.current_org_id', true)
+          )
+      )
+    )
+  )
+);
+
+CREATE POLICY outbox_entries_insert ON public."outbox_entries"
+FOR INSERT
+WITH CHECK (
+  public.app_rls_context_ready()
+  AND (
+    public.app_rls_privileged()
+    OR (
+      "dealId" IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM public."deals" d
+        WHERE d."id" = "outbox_entries"."dealId"
+          AND d."tenantId" = current_setting('app.current_tenant_id', true)
+          AND (
+            d."sellerOrgId" = current_setting('app.current_org_id', true)
+            OR d."buyerOrgId" = current_setting('app.current_org_id', true)
+          )
+      )
+    )
+  )
+);
+
+-- ── deal_workspace_runtime_snapshots ─────────────────────────────────────────
+ALTER TABLE public."deal_workspace_runtime_snapshots" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."deal_workspace_runtime_snapshots" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS runtime_snapshots_select ON public."deal_workspace_runtime_snapshots";
+DROP POLICY IF EXISTS runtime_snapshots_insert ON public."deal_workspace_runtime_snapshots";
+
+CREATE POLICY runtime_snapshots_select ON public."deal_workspace_runtime_snapshots"
+FOR SELECT
+USING (
+  public.app_rls_context_ready()
+  AND (
+    public.app_rls_privileged()
+    OR EXISTS (
+      SELECT 1
+      FROM public."deals" d
+      WHERE d."id" = "deal_workspace_runtime_snapshots"."dealId"
+        AND d."tenantId" = current_setting('app.current_tenant_id', true)
+        AND (
+          d."sellerOrgId" = current_setting('app.current_org_id', true)
+          OR d."buyerOrgId" = current_setting('app.current_org_id', true)
+        )
+    )
+  )
+);
+
+CREATE POLICY runtime_snapshots_insert ON public."deal_workspace_runtime_snapshots"
+FOR INSERT
+WITH CHECK (
+  public.app_rls_context_ready()
+  AND "actorId" = current_setting('app.current_user_id', true)
+  AND "actorRole" = current_setting('app.current_role', true)
+  AND (
+    public.app_rls_privileged()
+    OR EXISTS (
+      SELECT 1
+      FROM public."deals" d
+      WHERE d."id" = "deal_workspace_runtime_snapshots"."dealId"
+        AND d."tenantId" = current_setting('app.current_tenant_id', true)
+        AND (
+          d."sellerOrgId" = current_setting('app.current_org_id', true)
+          OR d."buyerOrgId" = current_setting('app.current_org_id', true)
+        )
+    )
+  )
+);
+
+-- No UPDATE/DELETE policies: persisted runtime snapshots are immutable.
+
+-- ── deal_workspace_runtime_transaction_attempts ───────────────────────────────
+ALTER TABLE public."deal_workspace_runtime_transaction_attempts" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public."deal_workspace_runtime_transaction_attempts" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS runtime_attempts_select ON public."deal_workspace_runtime_transaction_attempts";
+DROP POLICY IF EXISTS runtime_attempts_insert ON public."deal_workspace_runtime_transaction_attempts";
+
+CREATE POLICY runtime_attempts_select ON public."deal_workspace_runtime_transaction_attempts"
+FOR SELECT
+USING (
+  public.app_rls_context_ready()
+  AND EXISTS (
+    SELECT 1
+    FROM public."deal_workspace_runtime_snapshots" s
+    WHERE s."id" = "deal_workspace_runtime_transaction_attempts"."snapshotId"
+  )
+);
+
+CREATE POLICY runtime_attempts_insert ON public."deal_workspace_runtime_transaction_attempts"
+FOR INSERT
+WITH CHECK (
+  public.app_rls_context_ready()
+  AND EXISTS (
+    SELECT 1
+    FROM public."deal_workspace_runtime_snapshots" s
+    WHERE s."id" = "deal_workspace_runtime_transaction_attempts"."snapshotId"
+      AND (
+        public.app_rls_privileged()
+        OR s."actorId" = current_setting('app.current_user_id', true)
+      )
+  )
+);
+
+-- No UPDATE/DELETE policies: transaction attempts are append-only.
+
+COMMIT;

--- a/infra/sql/production-rls-policies.sql
+++ b/infra/sql/production-rls-policies.sql
@@ -114,8 +114,10 @@ CREATE POLICY deals_update ON public."deals" FOR UPDATE USING (
 -- ── organizations ─────────────────────────────────────────────────────────────
 ALTER TABLE public."organizations" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."organizations" FORCE ROW LEVEL SECURITY;
-DROP POLICY IF EXISTS organizations_select ON public."organizations";
 DROP POLICY IF EXISTS organizations_write_privileged ON public."organizations";
+DROP POLICY IF EXISTS organizations_select ON public."organizations";
+DROP POLICY IF EXISTS organizations_insert_privileged ON public."organizations";
+DROP POLICY IF EXISTS organizations_update_privileged ON public."organizations";
 CREATE POLICY organizations_select ON public."organizations" FOR SELECT USING (
   public.app_rls_context_ready() AND (
     public.app_rls_privileged()
@@ -125,9 +127,12 @@ CREATE POLICY organizations_select ON public."organizations" FOR SELECT USING (
     )
   )
 );
-CREATE POLICY organizations_write_privileged ON public."organizations" FOR ALL
+CREATE POLICY organizations_insert_privileged ON public."organizations" FOR INSERT
+WITH CHECK (public.app_rls_context_ready() AND public.app_rls_privileged());
+CREATE POLICY organizations_update_privileged ON public."organizations" FOR UPDATE
 USING (public.app_rls_context_ready() AND public.app_rls_privileged())
 WITH CHECK (public.app_rls_context_ready() AND public.app_rls_privileged());
+-- No DELETE policy: organizations are lifecycle-managed, not physically deleted.
 
 -- ── audit_events: append-only ─────────────────────────────────────────────────
 ALTER TABLE public."audit_events" ENABLE ROW LEVEL SECURITY;
@@ -192,14 +197,22 @@ CREATE POLICY integration_events_insert ON public."integration_events" FOR INSER
   current_user IN ('app_service', 'app_integration_worker')
   OR (public.app_rls_context_ready() AND public.app_rls_privileged())
 );
+-- No UPDATE/DELETE policies.
 
 -- ── outbox_entries ────────────────────────────────────────────────────────────
 ALTER TABLE public."outbox_entries" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."outbox_entries" FORCE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS outbox_entries_worker ON public."outbox_entries";
+DROP POLICY IF EXISTS outbox_entries_worker_select ON public."outbox_entries";
+DROP POLICY IF EXISTS outbox_entries_worker_insert ON public."outbox_entries";
+DROP POLICY IF EXISTS outbox_entries_worker_update ON public."outbox_entries";
 DROP POLICY IF EXISTS outbox_entries_select ON public."outbox_entries";
 DROP POLICY IF EXISTS outbox_entries_insert ON public."outbox_entries";
-CREATE POLICY outbox_entries_worker ON public."outbox_entries" FOR ALL
+CREATE POLICY outbox_entries_worker_select ON public."outbox_entries" FOR SELECT
+USING (current_user IN ('app_service', 'app_outbox_worker'));
+CREATE POLICY outbox_entries_worker_insert ON public."outbox_entries" FOR INSERT
+WITH CHECK (current_user IN ('app_service', 'app_outbox_worker'));
+CREATE POLICY outbox_entries_worker_update ON public."outbox_entries" FOR UPDATE
 USING (current_user IN ('app_service', 'app_outbox_worker'))
 WITH CHECK (current_user IN ('app_service', 'app_outbox_worker'));
 CREATE POLICY outbox_entries_select ON public."outbox_entries" FOR SELECT USING (
@@ -215,6 +228,7 @@ CREATE POLICY outbox_entries_insert ON public."outbox_entries" FOR INSERT WITH C
     OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
   )
 );
+-- No DELETE policy: processed outbox records remain auditable.
 
 -- ── deal_workspace_runtime_snapshots ─────────────────────────────────────────
 ALTER TABLE public."deal_workspace_runtime_snapshots" ENABLE ROW LEVEL SECURITY;

--- a/infra/sql/production-rls-policies.sql
+++ b/infra/sql/production-rls-policies.sql
@@ -1,16 +1,9 @@
 -- platform-v7 PostgreSQL 16 Row Level Security policy set.
---
--- IMPORTANT:
--- - This file is a deployment artifact, not proof that production RLS is enabled.
--- - Apply only after the canonical Prisma schema exists.
--- - The API must set all five app.current_* values with set_config(..., true)
---   inside the same transaction that performs protected reads/writes.
--- - No session-level context setter is created here.
+-- Deployment artifact only: this file does not prove production RLS is enabled.
+-- The caller owns the transaction. Never add BEGIN/COMMIT here.
+-- The API sets all five app.current_* values with set_config(..., true)
+-- inside the same transaction as every protected read/write.
 
-BEGIN;
-
--- Remove the legacy three-field, session-level helper. The API now sets the
--- complete context directly and transaction-locally through RlsTransactionService.
 DROP FUNCTION IF EXISTS public.set_app_context(TEXT, TEXT, TEXT);
 
 CREATE OR REPLACE FUNCTION public.app_rls_context_ready()
@@ -36,30 +29,38 @@ PARALLEL SAFE
 SET search_path = pg_catalog
 AS $$
   SELECT current_setting('app.current_role', true) IN (
-    'ADMIN',
-    'COMPLIANCE_OFFICER',
-    'SUPPORT_MANAGER'
+    'ADMIN', 'COMPLIANCE_OFFICER', 'SUPPORT_MANAGER'
+  )
+$$;
+
+-- SECURITY INVOKER is intentional. The lookup remains constrained by deals RLS.
+CREATE OR REPLACE FUNCTION public.app_rls_deal_visible(p_deal_id TEXT)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public."deals" d WHERE d."id" = p_deal_id
   )
 $$;
 
 COMMENT ON FUNCTION public.app_rls_context_ready() IS
-  'True only when the complete trusted transaction-local RLS context is present.';
+  'Complete trusted transaction-local RLS context is present.';
 COMMENT ON FUNCTION public.app_rls_privileged() IS
-  'True for platform roles allowed to perform explicitly defined cross-organization reads.';
+  'Role has an explicitly defined cross-organization read path.';
+COMMENT ON FUNCTION public.app_rls_deal_visible(TEXT) IS
+  'SECURITY INVOKER deal visibility probe constrained by deals RLS.';
 
 -- ── deals ─────────────────────────────────────────────────────────────────────
 ALTER TABLE public."deals" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."deals" FORCE ROW LEVEL SECURITY;
-
 DROP POLICY IF EXISTS deals_select ON public."deals";
 DROP POLICY IF EXISTS deals_insert ON public."deals";
 DROP POLICY IF EXISTS deals_update ON public."deals";
-
-CREATE POLICY deals_select ON public."deals"
-FOR SELECT
-USING (
-  public.app_rls_context_ready()
-  AND (
+CREATE POLICY deals_select ON public."deals" FOR SELECT USING (
+  public.app_rls_context_ready() AND (
     public.app_rls_privileged()
     OR (
       "tenantId" = current_setting('app.current_tenant_id', true)
@@ -71,8 +72,7 @@ USING (
     OR (
       current_setting('app.current_role', true) = 'ARBITRATOR'
       AND EXISTS (
-        SELECT 1
-        FROM public."disputes" d
+        SELECT 1 FROM public."disputes" d
         WHERE d."dealId" = "deals"."id"
           AND d."arbitratorId" = current_setting('app.current_user_id', true)
           AND d."status" IN ('OPEN', 'ARBITRATION')
@@ -80,10 +80,7 @@ USING (
     )
   )
 );
-
-CREATE POLICY deals_insert ON public."deals"
-FOR INSERT
-WITH CHECK (
+CREATE POLICY deals_insert ON public."deals" FOR INSERT WITH CHECK (
   public.app_rls_context_ready()
   AND "tenantId" = current_setting('app.current_tenant_id', true)
   AND (
@@ -92,12 +89,8 @@ WITH CHECK (
     OR "buyerOrgId" = current_setting('app.current_org_id', true)
   )
 );
-
-CREATE POLICY deals_update ON public."deals"
-FOR UPDATE
-USING (
-  public.app_rls_context_ready()
-  AND (
+CREATE POLICY deals_update ON public."deals" FOR UPDATE USING (
+  public.app_rls_context_ready() AND (
     public.app_rls_privileged()
     OR (
       "tenantId" = current_setting('app.current_tenant_id', true)
@@ -107,8 +100,7 @@ USING (
       )
     )
   )
-)
-WITH CHECK (
+) WITH CHECK (
   public.app_rls_context_ready()
   AND "tenantId" = current_setting('app.current_tenant_id', true)
   AND (
@@ -117,21 +109,15 @@ WITH CHECK (
     OR "buyerOrgId" = current_setting('app.current_org_id', true)
   )
 );
-
 -- No DELETE policy: physical deal deletion is denied.
 
 -- ── organizations ─────────────────────────────────────────────────────────────
 ALTER TABLE public."organizations" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."organizations" FORCE ROW LEVEL SECURITY;
-
 DROP POLICY IF EXISTS organizations_select ON public."organizations";
 DROP POLICY IF EXISTS organizations_write_privileged ON public."organizations";
-
-CREATE POLICY organizations_select ON public."organizations"
-FOR SELECT
-USING (
-  public.app_rls_context_ready()
-  AND (
+CREATE POLICY organizations_select ON public."organizations" FOR SELECT USING (
+  public.app_rls_context_ready() AND (
     public.app_rls_privileged()
     OR (
       "id" = current_setting('app.current_org_id', true)
@@ -139,160 +125,70 @@ USING (
     )
   )
 );
-
-CREATE POLICY organizations_write_privileged ON public."organizations"
-FOR ALL
+CREATE POLICY organizations_write_privileged ON public."organizations" FOR ALL
 USING (public.app_rls_context_ready() AND public.app_rls_privileged())
 WITH CHECK (public.app_rls_context_ready() AND public.app_rls_privileged());
 
 -- ── audit_events: append-only ─────────────────────────────────────────────────
 ALTER TABLE public."audit_events" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."audit_events" FORCE ROW LEVEL SECURITY;
-
 DROP POLICY IF EXISTS audit_events_select ON public."audit_events";
 DROP POLICY IF EXISTS audit_events_insert ON public."audit_events";
-
-CREATE POLICY audit_events_select ON public."audit_events"
-FOR SELECT
-USING (
-  public.app_rls_context_ready()
-  AND (
+CREATE POLICY audit_events_select ON public."audit_events" FOR SELECT USING (
+  public.app_rls_context_ready() AND (
     public.app_rls_privileged()
     OR (
       "tenantId" = current_setting('app.current_tenant_id', true)
       AND "orgId" = current_setting('app.current_org_id', true)
     )
-    OR (
-      "dealId" IS NOT NULL
-      AND EXISTS (
-        SELECT 1
-        FROM public."deals" d
-        WHERE d."id" = "audit_events"."dealId"
-          AND d."tenantId" = current_setting('app.current_tenant_id', true)
-          AND (
-            d."sellerOrgId" = current_setting('app.current_org_id', true)
-            OR d."buyerOrgId" = current_setting('app.current_org_id', true)
-          )
-      )
-    )
+    OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
   )
 );
-
-CREATE POLICY audit_events_insert ON public."audit_events"
-FOR INSERT
-WITH CHECK (
+CREATE POLICY audit_events_insert ON public."audit_events" FOR INSERT WITH CHECK (
   public.app_rls_context_ready()
   AND "actorUserId" = current_setting('app.current_user_id', true)
   AND "actorRole" = current_setting('app.current_role', true)
   AND "tenantId" = current_setting('app.current_tenant_id', true)
   AND "orgId" = current_setting('app.current_org_id', true)
-  AND (
-    "dealId" IS NULL
-    OR public.app_rls_privileged()
-    OR EXISTS (
-      SELECT 1
-      FROM public."deals" d
-      WHERE d."id" = "audit_events"."dealId"
-        AND d."tenantId" = current_setting('app.current_tenant_id', true)
-        AND (
-          d."sellerOrgId" = current_setting('app.current_org_id', true)
-          OR d."buyerOrgId" = current_setting('app.current_org_id', true)
-        )
-    )
-  )
+  AND ("dealId" IS NULL OR public.app_rls_deal_visible("dealId"))
 );
-
--- No UPDATE/DELETE policies: audit is append-only.
+-- No UPDATE/DELETE policies.
 
 -- ── ledger_entries: immutable financial journal ───────────────────────────────
 ALTER TABLE public."ledger_entries" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."ledger_entries" FORCE ROW LEVEL SECURITY;
-
 DROP POLICY IF EXISTS ledger_entries_select ON public."ledger_entries";
 DROP POLICY IF EXISTS ledger_entries_insert ON public."ledger_entries";
-
-CREATE POLICY ledger_entries_select ON public."ledger_entries"
-FOR SELECT
-USING (
-  public.app_rls_context_ready()
-  AND (
+CREATE POLICY ledger_entries_select ON public."ledger_entries" FOR SELECT USING (
+  public.app_rls_context_ready() AND (
     current_setting('app.current_role', true) IN (
       'ADMIN', 'ACCOUNTING', 'COMPLIANCE_OFFICER', 'SUPPORT_MANAGER'
     )
     OR "debitAccount" = current_setting('app.current_org_id', true)
     OR "creditAccount" = current_setting('app.current_org_id', true)
-    OR (
-      "dealId" IS NOT NULL
-      AND EXISTS (
-        SELECT 1
-        FROM public."deals" d
-        WHERE d."id" = "ledger_entries"."dealId"
-          AND d."tenantId" = current_setting('app.current_tenant_id', true)
-          AND (
-            d."sellerOrgId" = current_setting('app.current_org_id', true)
-            OR d."buyerOrgId" = current_setting('app.current_org_id', true)
-          )
-      )
-    )
+    OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
   )
 );
-
-CREATE POLICY ledger_entries_insert ON public."ledger_entries"
-FOR INSERT
-WITH CHECK (
+CREATE POLICY ledger_entries_insert ON public."ledger_entries" FOR INSERT WITH CHECK (
   public.app_rls_context_ready()
   AND current_setting('app.current_role', true) IN ('ADMIN', 'ACCOUNTING')
   AND "createdByUserId" = current_setting('app.current_user_id', true)
-  AND (
-    "dealId" IS NULL
-    OR public.app_rls_privileged()
-    OR EXISTS (
-      SELECT 1
-      FROM public."deals" d
-      WHERE d."id" = "ledger_entries"."dealId"
-        AND d."tenantId" = current_setting('app.current_tenant_id', true)
-        AND (
-          d."sellerOrgId" = current_setting('app.current_org_id', true)
-          OR d."buyerOrgId" = current_setting('app.current_org_id', true)
-        )
-    )
-  )
+  AND ("dealId" IS NULL OR public.app_rls_deal_visible("dealId"))
 );
-
--- No UPDATE/DELETE policies: ledger entries are immutable.
+-- No UPDATE/DELETE policies.
 
 -- ── integration_events ────────────────────────────────────────────────────────
 ALTER TABLE public."integration_events" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."integration_events" FORCE ROW LEVEL SECURITY;
-
 DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
 DROP POLICY IF EXISTS integration_events_insert ON public."integration_events";
-
-CREATE POLICY integration_events_select ON public."integration_events"
-FOR SELECT
-USING (
-  public.app_rls_context_ready()
-  AND (
+CREATE POLICY integration_events_select ON public."integration_events" FOR SELECT USING (
+  public.app_rls_context_ready() AND (
     public.app_rls_privileged()
-    OR (
-      "dealId" IS NOT NULL
-      AND EXISTS (
-        SELECT 1
-        FROM public."deals" d
-        WHERE d."id" = "integration_events"."dealId"
-          AND d."tenantId" = current_setting('app.current_tenant_id', true)
-          AND (
-            d."sellerOrgId" = current_setting('app.current_org_id', true)
-            OR d."buyerOrgId" = current_setting('app.current_org_id', true)
-          )
-      )
-    )
+    OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
   )
 );
-
-CREATE POLICY integration_events_insert ON public."integration_events"
-FOR INSERT
-WITH CHECK (
+CREATE POLICY integration_events_insert ON public."integration_events" FOR INSERT WITH CHECK (
   current_user IN ('app_service', 'app_integration_worker')
   OR (public.app_rls_context_ready() AND public.app_rls_privileged())
 );
@@ -300,142 +196,61 @@ WITH CHECK (
 -- ── outbox_entries ────────────────────────────────────────────────────────────
 ALTER TABLE public."outbox_entries" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."outbox_entries" FORCE ROW LEVEL SECURITY;
-
 DROP POLICY IF EXISTS outbox_entries_worker ON public."outbox_entries";
 DROP POLICY IF EXISTS outbox_entries_select ON public."outbox_entries";
 DROP POLICY IF EXISTS outbox_entries_insert ON public."outbox_entries";
-
-CREATE POLICY outbox_entries_worker ON public."outbox_entries"
-FOR ALL
+CREATE POLICY outbox_entries_worker ON public."outbox_entries" FOR ALL
 USING (current_user IN ('app_service', 'app_outbox_worker'))
 WITH CHECK (current_user IN ('app_service', 'app_outbox_worker'));
-
-CREATE POLICY outbox_entries_select ON public."outbox_entries"
-FOR SELECT
-USING (
-  public.app_rls_context_ready()
-  AND (
+CREATE POLICY outbox_entries_select ON public."outbox_entries" FOR SELECT USING (
+  public.app_rls_context_ready() AND (
     public.app_rls_privileged()
-    OR (
-      "dealId" IS NOT NULL
-      AND EXISTS (
-        SELECT 1
-        FROM public."deals" d
-        WHERE d."id" = "outbox_entries"."dealId"
-          AND d."tenantId" = current_setting('app.current_tenant_id', true)
-          AND (
-            d."sellerOrgId" = current_setting('app.current_org_id', true)
-            OR d."buyerOrgId" = current_setting('app.current_org_id', true)
-          )
-      )
-    )
+    OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
   )
 );
-
-CREATE POLICY outbox_entries_insert ON public."outbox_entries"
-FOR INSERT
-WITH CHECK (
+CREATE POLICY outbox_entries_insert ON public."outbox_entries" FOR INSERT WITH CHECK (
   public.app_rls_context_ready()
   AND (
     public.app_rls_privileged()
-    OR (
-      "dealId" IS NOT NULL
-      AND EXISTS (
-        SELECT 1
-        FROM public."deals" d
-        WHERE d."id" = "outbox_entries"."dealId"
-          AND d."tenantId" = current_setting('app.current_tenant_id', true)
-          AND (
-            d."sellerOrgId" = current_setting('app.current_org_id', true)
-            OR d."buyerOrgId" = current_setting('app.current_org_id', true)
-          )
-      )
-    )
+    OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
   )
 );
 
 -- ── deal_workspace_runtime_snapshots ─────────────────────────────────────────
 ALTER TABLE public."deal_workspace_runtime_snapshots" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."deal_workspace_runtime_snapshots" FORCE ROW LEVEL SECURITY;
-
 DROP POLICY IF EXISTS runtime_snapshots_select ON public."deal_workspace_runtime_snapshots";
 DROP POLICY IF EXISTS runtime_snapshots_insert ON public."deal_workspace_runtime_snapshots";
-
-CREATE POLICY runtime_snapshots_select ON public."deal_workspace_runtime_snapshots"
-FOR SELECT
-USING (
+CREATE POLICY runtime_snapshots_select ON public."deal_workspace_runtime_snapshots" FOR SELECT USING (
   public.app_rls_context_ready()
-  AND (
-    public.app_rls_privileged()
-    OR EXISTS (
-      SELECT 1
-      FROM public."deals" d
-      WHERE d."id" = "deal_workspace_runtime_snapshots"."dealId"
-        AND d."tenantId" = current_setting('app.current_tenant_id', true)
-        AND (
-          d."sellerOrgId" = current_setting('app.current_org_id', true)
-          OR d."buyerOrgId" = current_setting('app.current_org_id', true)
-        )
-    )
-  )
+  AND (public.app_rls_privileged() OR public.app_rls_deal_visible("dealId"))
 );
-
-CREATE POLICY runtime_snapshots_insert ON public."deal_workspace_runtime_snapshots"
-FOR INSERT
-WITH CHECK (
+CREATE POLICY runtime_snapshots_insert ON public."deal_workspace_runtime_snapshots" FOR INSERT WITH CHECK (
   public.app_rls_context_ready()
   AND "actorId" = current_setting('app.current_user_id', true)
   AND "actorRole" = current_setting('app.current_role', true)
-  AND (
-    public.app_rls_privileged()
-    OR EXISTS (
-      SELECT 1
-      FROM public."deals" d
-      WHERE d."id" = "deal_workspace_runtime_snapshots"."dealId"
-        AND d."tenantId" = current_setting('app.current_tenant_id', true)
-        AND (
-          d."sellerOrgId" = current_setting('app.current_org_id', true)
-          OR d."buyerOrgId" = current_setting('app.current_org_id', true)
-        )
-    )
-  )
+  AND (public.app_rls_privileged() OR public.app_rls_deal_visible("dealId"))
 );
-
--- No UPDATE/DELETE policies: persisted runtime snapshots are immutable.
+-- No UPDATE/DELETE policies.
 
 -- ── deal_workspace_runtime_transaction_attempts ───────────────────────────────
 ALTER TABLE public."deal_workspace_runtime_transaction_attempts" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."deal_workspace_runtime_transaction_attempts" FORCE ROW LEVEL SECURITY;
-
 DROP POLICY IF EXISTS runtime_attempts_select ON public."deal_workspace_runtime_transaction_attempts";
 DROP POLICY IF EXISTS runtime_attempts_insert ON public."deal_workspace_runtime_transaction_attempts";
-
-CREATE POLICY runtime_attempts_select ON public."deal_workspace_runtime_transaction_attempts"
-FOR SELECT
-USING (
+CREATE POLICY runtime_attempts_select ON public."deal_workspace_runtime_transaction_attempts" FOR SELECT USING (
   public.app_rls_context_ready()
   AND EXISTS (
-    SELECT 1
-    FROM public."deal_workspace_runtime_snapshots" s
+    SELECT 1 FROM public."deal_workspace_runtime_snapshots" s
     WHERE s."id" = "deal_workspace_runtime_transaction_attempts"."snapshotId"
   )
 );
-
-CREATE POLICY runtime_attempts_insert ON public."deal_workspace_runtime_transaction_attempts"
-FOR INSERT
-WITH CHECK (
+CREATE POLICY runtime_attempts_insert ON public."deal_workspace_runtime_transaction_attempts" FOR INSERT WITH CHECK (
   public.app_rls_context_ready()
   AND EXISTS (
-    SELECT 1
-    FROM public."deal_workspace_runtime_snapshots" s
+    SELECT 1 FROM public."deal_workspace_runtime_snapshots" s
     WHERE s."id" = "deal_workspace_runtime_transaction_attempts"."snapshotId"
-      AND (
-        public.app_rls_privileged()
-        OR s."actorId" = current_setting('app.current_user_id', true)
-      )
+      AND (public.app_rls_privileged() OR s."actorId" = current_setting('app.current_user_id', true))
   )
 );
-
--- No UPDATE/DELETE policies: transaction attempts are append-only.
-
-COMMIT;
+-- No UPDATE/DELETE policies.

--- a/scripts/platform-v7-rls-apply-rehearsal.sh
+++ b/scripts/platform-v7-rls-apply-rehearsal.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POLICY_FILE="$ROOT_DIR/infra/sql/production-rls-policies.sql"
+VALIDATOR="$ROOT_DIR/scripts/platform-v7-rls-validate.mjs"
+PROTECTED_TABLES="deals organizations audit_events ledger_entries integration_events outbox_entries deal_workspace_runtime_snapshots deal_workspace_runtime_transaction_attempts"
+
+: "${RLS_REHEARSAL_DATABASE_URL:?Set RLS_REHEARSAL_DATABASE_URL to a dedicated non-production PostgreSQL database}"
+
+if [[ "${NODE_ENV:-}" == "production" ]]; then
+  echo "Refusing RLS rehearsal with NODE_ENV=production" >&2
+  exit 2
+fi
+if [[ -n "${DATABASE_URL:-}" && "$RLS_REHEARSAL_DATABASE_URL" == "$DATABASE_URL" ]]; then
+  echo "Refusing RLS rehearsal: rehearsal URL equals DATABASE_URL" >&2
+  exit 2
+fi
+if [[ "$RLS_REHEARSAL_DATABASE_URL" =~ (^|[^a-z])(prod|production)([^a-z]|$) ]]; then
+  echo "Refusing RLS rehearsal: URL appears production-like" >&2
+  exit 2
+fi
+
+command -v node >/dev/null || { echo "node is required" >&2; exit 2; }
+command -v psql >/dev/null || { echo "psql is required" >&2; exit 2; }
+node "$VALIDATOR"
+
+TABLE_ARRAY="$(printf "'%s'," $PROTECTED_TABLES | sed 's/,$//')"
+{
+  echo 'BEGIN;'
+  cat "$POLICY_FILE"
+  cat <<SQL
+DO \$rehearsal\$
+DECLARE
+  enabled_count INTEGER;
+  forced_count INTEGER;
+  policy_count INTEGER;
+BEGIN
+  SELECT count(*) INTO enabled_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relname IN ($TABLE_ARRAY) AND c.relrowsecurity;
+
+  SELECT count(*) INTO forced_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relname IN ($TABLE_ARRAY) AND c.relforcerowsecurity;
+
+  SELECT count(*) INTO policy_count
+  FROM pg_policies
+  WHERE schemaname = 'public' AND tablename IN ($TABLE_ARRAY);
+
+  IF enabled_count <> 8 THEN
+    RAISE EXCEPTION 'RLS rehearsal: expected 8 enabled tables, got %', enabled_count;
+  END IF;
+  IF forced_count <> 8 THEN
+    RAISE EXCEPTION 'RLS rehearsal: expected 8 forced tables, got %', forced_count;
+  END IF;
+  IF policy_count < 16 THEN
+    RAISE EXCEPTION 'RLS rehearsal: expected at least 16 policies, got %', policy_count;
+  END IF;
+END
+\$rehearsal\$;
+ROLLBACK;
+SQL
+} | psql "$RLS_REHEARSAL_DATABASE_URL" -X --set ON_ERROR_STOP=1 --quiet
+
+echo "RLS apply rehearsal passed and was rolled back."

--- a/scripts/platform-v7-rls-rollback-rehearsal.sh
+++ b/scripts/platform-v7-rls-rollback-rehearsal.sh
@@ -36,6 +36,9 @@ DROP POLICY IF EXISTS runtime_snapshots_insert ON public."deal_workspace_runtime
 DROP POLICY IF EXISTS runtime_snapshots_select ON public."deal_workspace_runtime_snapshots";
 DROP POLICY IF EXISTS outbox_entries_insert ON public."outbox_entries";
 DROP POLICY IF EXISTS outbox_entries_select ON public."outbox_entries";
+DROP POLICY IF EXISTS outbox_entries_worker_update ON public."outbox_entries";
+DROP POLICY IF EXISTS outbox_entries_worker_insert ON public."outbox_entries";
+DROP POLICY IF EXISTS outbox_entries_worker_select ON public."outbox_entries";
 DROP POLICY IF EXISTS outbox_entries_worker ON public."outbox_entries";
 DROP POLICY IF EXISTS integration_events_insert ON public."integration_events";
 DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
@@ -43,6 +46,8 @@ DROP POLICY IF EXISTS ledger_entries_insert ON public."ledger_entries";
 DROP POLICY IF EXISTS ledger_entries_select ON public."ledger_entries";
 DROP POLICY IF EXISTS audit_events_insert ON public."audit_events";
 DROP POLICY IF EXISTS audit_events_select ON public."audit_events";
+DROP POLICY IF EXISTS organizations_update_privileged ON public."organizations";
+DROP POLICY IF EXISTS organizations_insert_privileged ON public."organizations";
 DROP POLICY IF EXISTS organizations_write_privileged ON public."organizations";
 DROP POLICY IF EXISTS organizations_select ON public."organizations";
 DROP POLICY IF EXISTS deals_update ON public."deals";
@@ -74,11 +79,16 @@ SQL
 DO \$rollback_rehearsal\$
 DECLARE
   enabled_count INTEGER;
+  forced_count INTEGER;
   policy_count INTEGER;
 BEGIN
   SELECT count(*) INTO enabled_count
   FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
   WHERE n.nspname = 'public' AND c.relname IN ($TABLE_ARRAY) AND c.relrowsecurity;
+
+  SELECT count(*) INTO forced_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relname IN ($TABLE_ARRAY) AND c.relforcerowsecurity;
 
   SELECT count(*) INTO policy_count
   FROM pg_policies
@@ -86,6 +96,9 @@ BEGIN
 
   IF enabled_count <> 0 THEN
     RAISE EXCEPTION 'RLS rollback rehearsal: expected zero enabled tables, got %', enabled_count;
+  END IF;
+  IF forced_count <> 0 THEN
+    RAISE EXCEPTION 'RLS rollback rehearsal: expected zero forced tables, got %', forced_count;
   END IF;
   IF policy_count <> 0 THEN
     RAISE EXCEPTION 'RLS rollback rehearsal: expected zero policies, got %', policy_count;

--- a/scripts/platform-v7-rls-rollback-rehearsal.sh
+++ b/scripts/platform-v7-rls-rollback-rehearsal.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POLICY_FILE="$ROOT_DIR/infra/sql/production-rls-policies.sql"
+VALIDATOR="$ROOT_DIR/scripts/platform-v7-rls-validate.mjs"
+PROTECTED_TABLES="deals organizations audit_events ledger_entries integration_events outbox_entries deal_workspace_runtime_snapshots deal_workspace_runtime_transaction_attempts"
+
+: "${RLS_REHEARSAL_DATABASE_URL:?Set RLS_REHEARSAL_DATABASE_URL to a dedicated non-production PostgreSQL database}"
+
+if [[ "${NODE_ENV:-}" == "production" ]]; then
+  echo "Refusing RLS rollback rehearsal with NODE_ENV=production" >&2
+  exit 2
+fi
+if [[ -n "${DATABASE_URL:-}" && "$RLS_REHEARSAL_DATABASE_URL" == "$DATABASE_URL" ]]; then
+  echo "Refusing RLS rollback rehearsal: rehearsal URL equals DATABASE_URL" >&2
+  exit 2
+fi
+if [[ "$RLS_REHEARSAL_DATABASE_URL" =~ (^|[^a-z])(prod|production)([^a-z]|$) ]]; then
+  echo "Refusing RLS rollback rehearsal: URL appears production-like" >&2
+  exit 2
+fi
+
+command -v node >/dev/null || { echo "node is required" >&2; exit 2; }
+command -v psql >/dev/null || { echo "psql is required" >&2; exit 2; }
+node "$VALIDATOR"
+
+TABLE_ARRAY="$(printf "'%s'," $PROTECTED_TABLES | sed 's/,$//')"
+{
+  echo 'BEGIN;'
+  cat "$POLICY_FILE"
+  cat <<'SQL'
+DROP POLICY IF EXISTS runtime_attempts_insert ON public."deal_workspace_runtime_transaction_attempts";
+DROP POLICY IF EXISTS runtime_attempts_select ON public."deal_workspace_runtime_transaction_attempts";
+DROP POLICY IF EXISTS runtime_snapshots_insert ON public."deal_workspace_runtime_snapshots";
+DROP POLICY IF EXISTS runtime_snapshots_select ON public."deal_workspace_runtime_snapshots";
+DROP POLICY IF EXISTS outbox_entries_insert ON public."outbox_entries";
+DROP POLICY IF EXISTS outbox_entries_select ON public."outbox_entries";
+DROP POLICY IF EXISTS outbox_entries_worker ON public."outbox_entries";
+DROP POLICY IF EXISTS integration_events_insert ON public."integration_events";
+DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
+DROP POLICY IF EXISTS ledger_entries_insert ON public."ledger_entries";
+DROP POLICY IF EXISTS ledger_entries_select ON public."ledger_entries";
+DROP POLICY IF EXISTS audit_events_insert ON public."audit_events";
+DROP POLICY IF EXISTS audit_events_select ON public."audit_events";
+DROP POLICY IF EXISTS organizations_write_privileged ON public."organizations";
+DROP POLICY IF EXISTS organizations_select ON public."organizations";
+DROP POLICY IF EXISTS deals_update ON public."deals";
+DROP POLICY IF EXISTS deals_insert ON public."deals";
+DROP POLICY IF EXISTS deals_select ON public."deals";
+
+ALTER TABLE public."deal_workspace_runtime_transaction_attempts" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public."deal_workspace_runtime_transaction_attempts" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public."deal_workspace_runtime_snapshots" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public."deal_workspace_runtime_snapshots" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public."outbox_entries" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public."outbox_entries" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public."integration_events" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public."integration_events" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public."ledger_entries" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public."ledger_entries" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public."audit_events" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public."audit_events" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public."organizations" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public."organizations" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public."deals" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public."deals" DISABLE ROW LEVEL SECURITY;
+
+DROP FUNCTION IF EXISTS public.app_rls_deal_visible(TEXT);
+DROP FUNCTION IF EXISTS public.app_rls_privileged();
+DROP FUNCTION IF EXISTS public.app_rls_context_ready();
+SQL
+  cat <<SQL
+DO \$rollback_rehearsal\$
+DECLARE
+  enabled_count INTEGER;
+  policy_count INTEGER;
+BEGIN
+  SELECT count(*) INTO enabled_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relname IN ($TABLE_ARRAY) AND c.relrowsecurity;
+
+  SELECT count(*) INTO policy_count
+  FROM pg_policies
+  WHERE schemaname = 'public' AND tablename IN ($TABLE_ARRAY);
+
+  IF enabled_count <> 0 THEN
+    RAISE EXCEPTION 'RLS rollback rehearsal: expected zero enabled tables, got %', enabled_count;
+  END IF;
+  IF policy_count <> 0 THEN
+    RAISE EXCEPTION 'RLS rollback rehearsal: expected zero policies, got %', policy_count;
+  END IF;
+END
+\$rollback_rehearsal\$;
+ROLLBACK;
+SQL
+} | psql "$RLS_REHEARSAL_DATABASE_URL" -X --set ON_ERROR_STOP=1 --quiet
+
+echo "RLS rollback rehearsal passed and the rehearsal transaction was rolled back."

--- a/scripts/platform-v7-rls-validate.mjs
+++ b/scripts/platform-v7-rls-validate.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SCHEMA_PATH = path.join(ROOT, 'apps/api/prisma/schema.prisma');
 const POLICY_PATH = path.join(ROOT, 'infra/sql/production-rls-policies.sql');
 
@@ -33,11 +33,24 @@ const FORBIDDEN_PATTERNS = [
   ['Prisma model table IntegrationEvent', /(?:ALTER TABLE|ON)\s+(?:public\.)?"IntegrationEvent"/],
   ['Prisma model table OutboxEntry', /(?:ALTER TABLE|ON)\s+(?:public\.)?"OutboxEntry"/],
   ['unsupported CREATE POLICY IF NOT EXISTS', /CREATE\s+POLICY\s+IF\s+NOT\s+EXISTS/i],
+  ['broad FOR ALL policy', /CREATE\s+POLICY\s+[a-z0-9_]+\s+ON\s+[^;]+?\s+FOR\s+ALL\b/i],
   ['legacy set_app_context creation', /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:public\.)?set_app_context/i],
   ['session-level set_config', /set_config\([^;]+,\s*false\s*\)/is],
   ['embedded transaction BEGIN', /^\s*BEGIN\s*;/im],
   ['embedded transaction COMMIT', /^\s*COMMIT\s*;/im],
 ];
+
+const APPEND_ONLY_TABLES = [
+  'audit_events',
+  'ledger_entries',
+  'integration_events',
+  'deal_workspace_runtime_snapshots',
+  'deal_workspace_runtime_transaction_attempts',
+];
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 export function validateRlsArtifacts(schema, sql) {
   const errors = [];
@@ -47,9 +60,15 @@ export function validateRlsArtifacts(schema, sql) {
       errors.push(`Prisma schema is missing @@map(\"${table}\")`);
     }
 
-    const escaped = table.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const enable = new RegExp(`ALTER\\s+TABLE\\s+public\\.\"${escaped}\"\\s+ENABLE\\s+ROW\\s+LEVEL\\s+SECURITY`, 'i');
-    const force = new RegExp(`ALTER\\s+TABLE\\s+public\\.\"${escaped}\"\\s+FORCE\\s+ROW\\s+LEVEL\\s+SECURITY`, 'i');
+    const escaped = escapeRegExp(table);
+    const enable = new RegExp(
+      `ALTER\\s+TABLE\\s+public\\.\"${escaped}\"\\s+ENABLE\\s+ROW\\s+LEVEL\\s+SECURITY`,
+      'i',
+    );
+    const force = new RegExp(
+      `ALTER\\s+TABLE\\s+public\\.\"${escaped}\"\\s+FORCE\\s+ROW\\s+LEVEL\\s+SECURITY`,
+      'i',
+    );
     if (!enable.test(sql)) errors.push(`${table}: ENABLE ROW LEVEL SECURITY missing`);
     if (!force.test(sql)) errors.push(`${table}: FORCE ROW LEVEL SECURITY missing`);
   }
@@ -64,8 +83,23 @@ export function validateRlsArtifacts(schema, sql) {
     if (pattern.test(sql)) errors.push(`Forbidden construct: ${label}`);
   }
 
-  const createdPolicies = [...sql.matchAll(/CREATE\s+POLICY\s+([a-z0-9_]+)/gi)].map((match) => match[1]);
-  const duplicatePolicies = createdPolicies.filter((name, index) => createdPolicies.indexOf(name) !== index);
+  for (const table of APPEND_ONLY_TABLES) {
+    const escaped = escapeRegExp(table);
+    const destructivePolicy = new RegExp(
+      `CREATE\\s+POLICY\\s+[a-z0-9_]+\\s+ON\\s+public\\.\"${escaped}\"\\s+FOR\\s+(?:UPDATE|DELETE|ALL)\\b`,
+      'i',
+    );
+    if (destructivePolicy.test(sql)) {
+      errors.push(`${table}: append-only table has UPDATE, DELETE or ALL policy`);
+    }
+  }
+
+  const createdPolicies = [...sql.matchAll(/CREATE\s+POLICY\s+([a-z0-9_]+)/gi)].map(
+    (match) => match[1],
+  );
+  const duplicatePolicies = createdPolicies.filter(
+    (name, index) => createdPolicies.indexOf(name) !== index,
+  );
   if (duplicatePolicies.length > 0) {
     errors.push(`Duplicate policy names: ${[...new Set(duplicatePolicies)].join(', ')}`);
   }
@@ -75,8 +109,20 @@ export function validateRlsArtifacts(schema, sql) {
     if (!drop.test(sql)) errors.push(`${policy}: matching DROP POLICY IF EXISTS missing`);
   }
 
-  if (!/DROP\s+FUNCTION\s+IF\s+EXISTS\s+public\.set_app_context\s*\(TEXT,\s*TEXT,\s*TEXT\)/i.test(sql)) {
+  if (
+    !/DROP\s+FUNCTION\s+IF\s+EXISTS\s+public\.set_app_context\s*\(TEXT,\s*TEXT,\s*TEXT\)/i.test(
+      sql,
+    )
+  ) {
     errors.push('Legacy three-argument set_app_context is not explicitly removed');
+  }
+
+  if (!/CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.app_rls_context_ready\s*\(\s*\)/i.test(sql)) {
+    errors.push('Fail-closed app_rls_context_ready function is missing');
+  }
+
+  if (!/SECURITY\s+INVOKER/i.test(sql)) {
+    errors.push('Deal visibility helper must remain SECURITY INVOKER');
   }
 
   return { valid: errors.length === 0, errors, policies: createdPolicies.length };
@@ -96,7 +142,7 @@ async function cli() {
   if (!result.valid) process.exitCode = 1;
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   cli().catch((error) => {
     process.stderr.write(`${error.message}\n`);
     process.exitCode = 1;

--- a/scripts/platform-v7-rls-validate.mjs
+++ b/scripts/platform-v7-rls-validate.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const SCHEMA_PATH = path.join(ROOT, 'apps/api/prisma/schema.prisma');
+const POLICY_PATH = path.join(ROOT, 'infra/sql/production-rls-policies.sql');
+
+export const REQUIRED_TABLES = [
+  'deals',
+  'organizations',
+  'audit_events',
+  'ledger_entries',
+  'integration_events',
+  'outbox_entries',
+  'deal_workspace_runtime_snapshots',
+  'deal_workspace_runtime_transaction_attempts',
+];
+
+export const REQUIRED_CONTEXT_SETTINGS = [
+  'app.current_user_id',
+  'app.current_org_id',
+  'app.current_tenant_id',
+  'app.current_role',
+  'app.current_session_id',
+];
+
+const FORBIDDEN_PATTERNS = [
+  ['Prisma model table Deal', /(?:ALTER TABLE|ON)\s+(?:public\.)?"Deal"/],
+  ['Prisma model table AuditEvent', /(?:ALTER TABLE|ON)\s+(?:public\.)?"AuditEvent"/],
+  ['Prisma model table LedgerEntry', /(?:ALTER TABLE|ON)\s+(?:public\.)?"LedgerEntry"/],
+  ['Prisma model table IntegrationEvent', /(?:ALTER TABLE|ON)\s+(?:public\.)?"IntegrationEvent"/],
+  ['Prisma model table OutboxEntry', /(?:ALTER TABLE|ON)\s+(?:public\.)?"OutboxEntry"/],
+  ['unsupported CREATE POLICY IF NOT EXISTS', /CREATE\s+POLICY\s+IF\s+NOT\s+EXISTS/i],
+  ['legacy set_app_context creation', /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:public\.)?set_app_context/i],
+  ['session-level set_config', /set_config\([^;]+,\s*false\s*\)/is],
+  ['embedded transaction BEGIN', /^\s*BEGIN\s*;/im],
+  ['embedded transaction COMMIT', /^\s*COMMIT\s*;/im],
+];
+
+export function validateRlsArtifacts(schema, sql) {
+  const errors = [];
+
+  for (const table of REQUIRED_TABLES) {
+    if (!schema.includes(`@@map("${table}")`)) {
+      errors.push(`Prisma schema is missing @@map(\"${table}\")`);
+    }
+
+    const escaped = table.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const enable = new RegExp(`ALTER\\s+TABLE\\s+public\\.\"${escaped}\"\\s+ENABLE\\s+ROW\\s+LEVEL\\s+SECURITY`, 'i');
+    const force = new RegExp(`ALTER\\s+TABLE\\s+public\\.\"${escaped}\"\\s+FORCE\\s+ROW\\s+LEVEL\\s+SECURITY`, 'i');
+    if (!enable.test(sql)) errors.push(`${table}: ENABLE ROW LEVEL SECURITY missing`);
+    if (!force.test(sql)) errors.push(`${table}: FORCE ROW LEVEL SECURITY missing`);
+  }
+
+  for (const setting of REQUIRED_CONTEXT_SETTINGS) {
+    if (!sql.includes(`current_setting('${setting}', true)`)) {
+      errors.push(`RLS SQL is missing trusted context setting ${setting}`);
+    }
+  }
+
+  for (const [label, pattern] of FORBIDDEN_PATTERNS) {
+    if (pattern.test(sql)) errors.push(`Forbidden construct: ${label}`);
+  }
+
+  const createdPolicies = [...sql.matchAll(/CREATE\s+POLICY\s+([a-z0-9_]+)/gi)].map((match) => match[1]);
+  const duplicatePolicies = createdPolicies.filter((name, index) => createdPolicies.indexOf(name) !== index);
+  if (duplicatePolicies.length > 0) {
+    errors.push(`Duplicate policy names: ${[...new Set(duplicatePolicies)].join(', ')}`);
+  }
+
+  for (const policy of createdPolicies) {
+    const drop = new RegExp(`DROP\\s+POLICY\\s+IF\\s+EXISTS\\s+${policy}\\s+ON`, 'i');
+    if (!drop.test(sql)) errors.push(`${policy}: matching DROP POLICY IF EXISTS missing`);
+  }
+
+  if (!/DROP\s+FUNCTION\s+IF\s+EXISTS\s+public\.set_app_context\s*\(TEXT,\s*TEXT,\s*TEXT\)/i.test(sql)) {
+    errors.push('Legacy three-argument set_app_context is not explicitly removed');
+  }
+
+  return { valid: errors.length === 0, errors, policies: createdPolicies.length };
+}
+
+export async function validateRlsFiles() {
+  const [schema, sql] = await Promise.all([
+    readFile(SCHEMA_PATH, 'utf8'),
+    readFile(POLICY_PATH, 'utf8'),
+  ]);
+  return validateRlsArtifacts(schema, sql);
+}
+
+async function cli() {
+  const result = await validateRlsFiles();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!result.valid) process.exitCode = 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  cli().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Суть

Исправлен PostgreSQL RLS artifact: прежний файл ссылался на Prisma model names вместо реальных physical table names, использовал неподдерживаемый `CREATE POLICY IF NOT EXISTS` и создавал session-level context helper.

## Реализовано

- политики переведены на canonical physical tables: `deals`, `organizations`, `audit_events`, `ledger_entries`, `integration_events`, `outbox_entries`, runtime snapshots и attempts;
- на всех защищаемых таблицах включены `ENABLE` и `FORCE ROW LEVEL SECURITY`;
- policy deployment сделан идемпотентным через `DROP POLICY IF EXISTS` + `CREATE POLICY`;
- legacy `set_app_context(text,text,text)` удаляется и больше не создаётся;
- обязательны все пять trusted settings: user, organization, tenant, role, session;
- runtime snapshot/outbox/audit/attempt policies согласованы с transaction-local persistence path;
- append-only сущности не получают UPDATE/DELETE policies;
- SQL не содержит BEGIN/COMMIT: транзакцией управляет deployment/rehearsal caller;
- добавлен static Prisma/RLS drift validator;
- добавлены apply и rollback rehearsals, которые отказываются работать в production mode, требуют отдельный rehearsal URL и всегда заканчиваются `ROLLBACK`;
- API tests запускают validator и проверяют rollback-only safeguards.

## Граница зрелости

Production RLS не применялся. Скрипты являются проверяемым deployment artifact и non-production rehearsal, но не доказательством production enforcement.