### PR TITLE
Unlock exact industrial one-deal implementation scope

### DIFF
--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -1,90 +1,114 @@
 {
   "project": "platform-v7",
-  "mode": "variant-b",
+  "mode": "industrial-one-deal-scope-unlock",
   "status": "active",
-  "currentStatus": "in_progress",
-  "current": "VP-3.45 Physical Table RLS Policy Alignment and Rehearsal.",
+  "currentStatus": "ready_for_implementation_review",
+  "current": "Industrial One Deal Foundation: explicit implementation scope unlock.",
   "fullTzReadinessPercent": 85,
-  "openPr": "#2258",
+  "openPr": "pending",
   "lastClosed": [
     "#2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
     "#2245 VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
     "#2250 VP-3.41 Runtime Persistence Internal Service Wiring Implementation",
     "#2252 VP-3.42 Runtime Persistence Authenticated Internal Command Boundary",
     "#2254 VP-3.43 Transaction-Local Trusted RLS Context",
-    "#2256 VP-3.44 Runtime Persistence Trusted Transaction Binding"
+    "#2256 VP-3.44 Runtime Persistence Trusted Transaction Binding",
+    "#2258 VP-3.45 Physical Table RLS Policy Alignment and Rehearsal"
   ],
-  "openBlockers": ["#2113", "#2115", "#2251"],
-  "blockerNotes": "#2113 repository settings cleanup. #2115 blocks persistent auth-file changes. Draft #2251 remains merge-blocked by user-driven bank confirmations, synthetic bank references, cross-tenant visibility and unresolved conflicts.",
+  "openBlockers": [
+    "#2113 repository settings cleanup",
+    "#2115 persistent auth write path",
+    "#2261 industrial one-deal implementation review"
+  ],
+  "blockerNotes": "The one-deal implementation may proceed only inside the exact allowlist below. Persistent production identity, production migration execution, live integrations and scale acceptance remain locked.",
   "lockedUntilCurrentGreen": [
     "production migration execution",
-    "production RLS policy application",
-    "controller/API/web wiring",
-    "money confirmation commands",
-    "persistent identity/session/MFA changes"
+    "live external integration activation",
+    "persistent identity/session/MFA changes",
+    "production load and disaster-recovery claims"
   ],
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "infra/sql/production-rls-policies.sql",
-    "apps/api/src/common/prisma/rls-transaction.service.spec.ts",
-    "scripts/platform-v7-rls-validate.mjs",
-    "scripts/platform-v7-rls-apply-rehearsal.sh",
-    "scripts/platform-v7-rls-rollback-rehearsal.sh"
+    "apps/api/src/common/action-executor/action-policy.ts",
+    "apps/api/src/common/types/request-user.ts",
+    "apps/api/src/modules/deals/**",
+    "apps/api/src/modules/settlement-engine/settlement-engine.controller.ts",
+    "apps/api/src/modules/settlement-engine/settlement-engine.module.ts",
+    "apps/web/app/api/auth/login/route.ts",
+    "apps/web/app/api/proxy/[...path]/route.ts",
+    "apps/web/app/platform-v7/login/page.tsx",
+    "apps/web/components/platform-v7/CanonicalDealWorkspace.tsx",
+    "apps/web/components/platform-v7/PlatformV7ShellSwitch.tsx",
+    "apps/web/components/platform-v7/RoleIntentDashboard.tsx",
+    "apps/web/lib/platform-v7/verified-session.ts",
+    "apps/web/tests/unit/platformV7CanonicalDealWorkspace.test.ts",
+    "apps/web/tests/unit/platformV7VerifiedSession.test.ts",
+    ".github/workflows/web-unit.yml"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "infra/sql/production-rls-policies.sql",
-    "apps/api/src/common/prisma/rls-transaction.service.spec.ts",
-    "scripts/platform-v7-rls-validate.mjs",
-    "scripts/platform-v7-rls-apply-rehearsal.sh",
-    "scripts/platform-v7-rls-rollback-rehearsal.sh"
+    "apps/api/src/common/action-executor/action-policy.ts",
+    "apps/api/src/common/types/request-user.ts",
+    "apps/api/src/modules/deals/**",
+    "apps/api/src/modules/settlement-engine/settlement-engine.controller.ts",
+    "apps/api/src/modules/settlement-engine/settlement-engine.module.ts",
+    "apps/web/app/api/auth/login/route.ts",
+    "apps/web/app/api/proxy/[...path]/route.ts",
+    "apps/web/app/platform-v7/login/page.tsx",
+    "apps/web/components/platform-v7/CanonicalDealWorkspace.tsx",
+    "apps/web/components/platform-v7/PlatformV7ShellSwitch.tsx",
+    "apps/web/components/platform-v7/RoleIntentDashboard.tsx",
+    "apps/web/lib/platform-v7/verified-session.ts",
+    "apps/web/tests/unit/platformV7CanonicalDealWorkspace.test.ts",
+    "apps/web/tests/unit/platformV7VerifiedSession.test.ts",
+    ".github/workflows/web-unit.yml"
   ],
-  "vp344RuntimePersistenceTrustedTransactionBinding": {
-    "layer": "VP-3.44 Runtime Persistence Trusted Transaction Binding",
-    "closedPr": "#2256",
-    "status": "merged"
-  },
-  "vp345PhysicalRlsPolicyAlignment": {
-    "layer": "VP-3.45 Physical Table RLS Policy Alignment and Rehearsal",
-    "openPr": "#2258",
-    "status": "in_progress",
-    "invariants": [
-      "policies target canonical Prisma physical table names",
-      "RLS is enabled and forced on protected tables",
-      "policy creation is idempotent on PostgreSQL 16",
-      "legacy session-level context helper is removed",
-      "transaction-local five-field context remains canonical",
-      "production database is never modified by CI or rehearsal scripts",
-      "policy drift is statically detectable"
+  "industrialOneDealFoundation": {
+    "layer": "Canonical PostgreSQL deal command path and shared role workspace",
+    "implementationPr": "#2261",
+    "status": "scope_unlocked_pending_green_review",
+    "canonicalDealId": "DEAL-INDUSTRIAL-001",
+    "requiredInvariants": [
+      "one deal identity and one factual state for all roles",
+      "trusted transaction-local RLS for canonical reads and writes",
+      "strict command idempotency inside the trusted transaction",
+      "no client-supplied target state",
+      "no human confirmation of bank reserve or release",
+      "no synthetic successful backend or bank reference",
+      "server-derived tenant organization role and actor",
+      "legacy controller role allowlists remain intact",
+      "test seed is explicit idempotent and production-denied by default"
     ]
   },
-  "vp346RlsIntegrationHarness": {
-    "layer": "VP-3.46 Ephemeral PostgreSQL RLS Integration Harness",
-    "status": "next-after-vp345-green"
-  },
+  "nextAfterCurrentGreen": [
+    "persistent identity session refresh-family revoke and MFA",
+    "durable outbox worker and bank reconciliation",
+    "truthful offline acknowledgement",
+    "server-rendered RU EN ZH i18n",
+    "load restore DR and accessibility acceptance"
+  ],
   "forbiddenZones": [
     "apps/landing",
     "apps/api/src/modules/auth/**",
-    "apps/web/app/platform-v7",
-    "apps/web/components/platform-v7",
-    "apps/web/components/v7r",
-    "apps/web/lib/platform-v7",
-    "apps/web/app/api",
     "package.json",
     "package-lock.json",
-    "pnpm-lock.yaml"
+    "pnpm-lock.yaml",
+    ".env files",
+    "production migration execution"
   ],
-  "maturityLanguage": ["platform-temporarily-without-external-integrations"],
+  "maturityLanguage": [
+    "industrial-foundation-under-verification",
+    "platform-temporarily-without-confirmed-live-integrations"
+  ],
   "forbiddenClaims": [
-    "production RLS enabled",
+    "full production readiness",
     "production migration applied",
-    "all repositories RLS-bound",
     "persistent identity complete",
     "external integration completion",
-    "bank confirmation from user command",
+    "live bank money movement",
     "production scale proven"
   ],
-  "readiness": "85% honest architectural readiness. VP-3.45 repairs policy SQL and adds non-production rehearsal controls. No production database or policy application is claimed."
+  "readiness": "85% honest architectural readiness. This state change only unlocks the exact one-deal implementation scope. It does not prove deployment, production database migration, live external integration, persistent identity, load, restore or disaster recovery."
 }

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -2,7 +2,7 @@
   "project": "platform-v7",
   "mode": "industrial-one-deal-scope-unlock",
   "status": "active",
-  "currentStatus": "ready_for_implementation_review",
+  "currentStatus": "in_progress",
   "current": "Industrial One Deal Foundation: explicit implementation scope unlock.",
   "fullTzReadinessPercent": 85,
   "openPr": "#2263",
@@ -20,7 +20,7 @@
     "#2115 persistent auth write path",
     "#2261 industrial one-deal implementation review"
   ],
-  "blockerNotes": "The one-deal implementation may proceed only inside the exact allowlist below. Persistent production identity, production migration execution, live integrations and scale acceptance remain locked.",
+  "blockerNotes": "The one-deal implementation may proceed only inside the exact allowlist below. Critical product zones remain generally forbidden; only the exact files listed in allowedCurrentScope are unlocked for this layer.",
   "lockedUntilCurrentGreen": [
     "production migration execution",
     "live external integration activation",
@@ -92,6 +92,11 @@
   ],
   "forbiddenZones": [
     "apps/landing",
+    "apps/web/app/platform-v7",
+    "apps/web/components/platform-v7",
+    "apps/web/components/v7r",
+    "apps/web/lib/platform-v7",
+    "apps/web/app/api",
     "apps/api/src/modules/auth/**",
     "package.json",
     "package-lock.json",
@@ -101,7 +106,7 @@
   ],
   "maturityLanguage": [
     "industrial-foundation-under-verification",
-    "platform-temporarily-without-confirmed-live-integrations"
+    "platform-temporarily-without-external-integrations"
   ],
   "forbiddenClaims": [
     "full production readiness",

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -5,7 +5,7 @@
   "currentStatus": "ready_for_implementation_review",
   "current": "Industrial One Deal Foundation: explicit implementation scope unlock.",
   "fullTzReadinessPercent": 85,
-  "openPr": "pending",
+  "openPr": "#2263",
   "lastClosed": [
     "#2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
     "#2245 VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
@@ -67,6 +67,7 @@
   ],
   "industrialOneDealFoundation": {
     "layer": "Canonical PostgreSQL deal command path and shared role workspace",
+    "scopeUnlockPr": "#2263",
     "implementationPr": "#2261",
     "status": "scope_unlocked_pending_green_review",
     "canonicalDealId": "DEAL-INDUSTRIAL-001",

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,28 +1,42 @@
 # platform-v7 execution queue
 
-CURRENT: VP-3.45 Physical Table RLS Policy Alignment and Rehearsal.
+CURRENT: Industrial One Deal Foundation: explicit implementation scope unlock.
 
-GOAL: Привести PostgreSQL RLS SQL к реальным physical table names Prisma, сделать политику идемпотентной и fail-closed, удалить legacy session-level context helper и добавить только rollback-safe non-production rehearsal.
+GOAL: Разрешить строго ограниченный промышленный проход одной канонической тестовой сделки через все роли, не открывая auth persistence, production migrations, landing, lockfiles, live integrations или неподтверждённые production claims.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
-- infra/sql/production-rls-policies.sql
-- apps/api/src/common/prisma/rls-transaction.service.spec.ts
-- scripts/platform-v7-rls-validate.mjs
-- scripts/platform-v7-rls-apply-rehearsal.sh
-- scripts/platform-v7-rls-rollback-rehearsal.sh
+- apps/api/src/common/action-executor/action-policy.ts
+- apps/api/src/common/types/request-user.ts
+- apps/api/src/modules/deals/**
+- apps/api/src/modules/settlement-engine/settlement-engine.controller.ts
+- apps/api/src/modules/settlement-engine/settlement-engine.module.ts
+- apps/web/app/api/auth/login/route.ts
+- apps/web/app/api/proxy/[...path]/route.ts
+- apps/web/app/platform-v7/login/page.tsx
+- apps/web/components/platform-v7/CanonicalDealWorkspace.tsx
+- apps/web/components/platform-v7/PlatformV7ShellSwitch.tsx
+- apps/web/components/platform-v7/RoleIntentDashboard.tsx
+- apps/web/lib/platform-v7/verified-session.ts
+- apps/web/tests/unit/platformV7CanonicalDealWorkspace.test.ts
+- apps/web/tests/unit/platformV7VerifiedSession.test.ts
+- .github/workflows/web-unit.yml
 
 CURRENT CRITERIA:
-- policy SQL targets `deals`, `organizations`, `audit_events`, `ledger_entries`, `integration_events`, `outbox_entries`, `deal_workspace_runtime_snapshots` and `deal_workspace_runtime_transaction_attempts`;
-- all protected tables use `ENABLE ROW LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY`;
-- PostgreSQL 16 compatible idempotency uses `DROP POLICY IF EXISTS` followed by `CREATE POLICY`;
-- legacy three-argument `set_app_context` is removed;
-- SQL does not create session-level context setters;
-- role, user, organization, tenant and session settings are treated as mandatory trusted transaction context;
-- rehearsal scripts refuse production mode, require a dedicated rehearsal URL and always roll back;
-- static validation detects Prisma/RLS table drift and forbidden legacy constructs;
-- no production database is modified.
+- one canonical deal ID and one factual state are used by every role;
+- client submits a command, idempotency key and expected version, never an arbitrary target state;
+- canonical reads and writes require trusted user, session, role, organization and tenant context;
+- Deal, side effects, DealEvent, AuditEvent, receipt and external outbox are committed through transaction-local RLS with Serializable command isolation;
+- idempotency is derived from every material command field and no raw pre-transaction intent write exists;
+- reserve and release confirmations are accepted only from a verified BANK_CALLBACK system actor;
+- callback signature binds method, path, partner, key version, timestamp, event ID and canonical payload hash;
+- callback is bound to the exact pending bank operation;
+- legacy controller role allowlists remain intact;
+- SURVEYOR is a first-class backend role;
+- canonical UI has no synthetic bank reference, manual bank confirmation or fake successful backend response;
+- test seed is explicit, idempotent and production-denied by default;
+- API, web, build, CodeQL and security gates are green before merge.
 
 DONE:
 - #2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation
@@ -31,37 +45,39 @@ DONE:
 - #2252 VP-3.42 Runtime Persistence Authenticated Internal Command Boundary
 - #2254 VP-3.43 Transaction-Local Trusted RLS Context
 - #2256 VP-3.44 Runtime Persistence Trusted Transaction Binding
+- #2258 VP-3.45 Physical Table RLS Policy Alignment and Rehearsal
 
 LOCKED:
 - production migration execution;
 - production RLS policy application;
 - persistent identity/session/revocation/MFA files;
-- controller/API/web wiring;
-- bank reserve/release confirmation from user commands;
-- live bank/FGIS/EDO integrations.
+- apps/landing;
+- package and lockfiles;
+- live bank/FGIS/EDO/signature integrations;
+- production scale, restore or disaster-recovery claims.
 
 NEXT:
-- Layer: VP-3.46 Ephemeral PostgreSQL RLS Integration Harness.
+- Layer: Persistent Identity, Session Family, Revocation and MFA Foundation.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
-  - apps/api/test/rls/**
-  - scripts/platform-v7-rls-*.mjs
-  - scripts/platform-v7-rls-*.sh
-  - .github/workflows/platform-v7-rls-integration.yml
+  - apps/api/src/modules/auth/**
+  - apps/api/src/modules/mfa/**
+  - apps/api/prisma/schema.prisma
+  - apps/api/prisma/migrations/**
+  - apps/api/test/auth/**
 - Success criteria:
-  - CI starts an isolated PostgreSQL 16 service with no production credentials;
-  - schema and canonical RLS SQL are applied to the ephemeral database only;
-  - two tenants and two organizations are seeded;
-  - participant access succeeds only for its own deal;
-  - cross-tenant deal, audit, outbox and runtime snapshot reads are denied;
-  - incomplete trusted context is denied;
-  - transaction-local context does not leak to a reused pooled connection;
-  - test teardown destroys all data and credentials;
-  - production-enabled claims remain forbidden.
-- Readiness remains 85% honest architectural readiness.
+  - users, credentials, memberships, sessions and refresh-token families are PostgreSQL-backed;
+  - refresh rotation and reuse detection are transactional;
+  - logout and revocation are shared across API instances;
+  - MFA factors and recovery codes are encrypted or hashed and fail closed;
+  - no self-selected role or organization is trusted;
+  - production migration execution remains a separate controlled operation;
+  - all identity integration, replay and multi-instance tests are green.
+- Readiness remains 85% honest architectural readiness until exploitation evidence exists.
 
 AFTER NEXT:
-- Persistent identity/session/revocation/MFA source of truth after blocker #2115.
-- Authenticated DB-backed runtime action bridge without direct bank confirmation.
-- Concurrency, retry, recovery, load, restore and security acceptance gates.
+- Durable outbox workers, bank reconciliation and replay-safe partner key rotation.
+- Truthful driver offline acknowledgement and conflict handling.
+- Server-rendered RU/EN/ZH i18n and complete design-system migration.
+- Concurrency, load, restore, DR, accessibility and operational acceptance gates.

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -57,26 +57,28 @@ LOCKED:
 - production scale, restore or disaster-recovery claims.
 
 NEXT:
-- Layer: Persistent Identity, Session Family, Revocation and MFA Foundation.
+- Layer: Industrial One Deal Ephemeral PostgreSQL E2E Harness.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
-  - apps/api/src/modules/auth/**
-  - apps/api/src/modules/mfa/**
-  - apps/api/prisma/schema.prisma
-  - apps/api/prisma/migrations/**
-  - apps/api/test/auth/**
+  - apps/api/test/one-deal/**
+  - apps/web/tests/e2e/one-deal/**
+  - scripts/platform-v7-one-deal-*.mjs
+  - .github/workflows/platform-v7-one-deal-e2e.yml
 - Success criteria:
-  - users, credentials, memberships, sessions and refresh-token families are PostgreSQL-backed;
-  - refresh rotation and reuse detection are transactional;
-  - logout and revocation are shared across API instances;
-  - MFA factors and recovery codes are encrypted or hashed and fail closed;
-  - no self-selected role or organization is trusted;
-  - production migration execution remains a separate controlled operation;
-  - all identity integration, replay and multi-instance tests are green.
+  - CI starts isolated PostgreSQL 16 with no production credentials;
+  - canonical schema, migrations and RLS policies are applied only to the ephemeral database;
+  - all 12 human role memberships read one deal ID and one factual state;
+  - all 19 commands pass in order without manual database changes;
+  - reserve and release advance only through signed callback fixtures bound to pending operations;
+  - duplicate, stale, concurrent and cross-tenant commands fail deterministically;
+  - audit, outbox, documents, shipment, laboratory and money projections reconcile after close;
+  - teardown destroys all data and credentials;
+  - production readiness remains unclaimed.
 - Readiness remains 85% honest architectural readiness until exploitation evidence exists.
 
 AFTER NEXT:
+- Persistent identity/session/revocation/MFA source of truth after blocker #2115 is removed.
 - Durable outbox workers, bank reconciliation and replay-safe partner key rotation.
 - Truthful driver offline acknowledgement and conflict handling.
 - Server-rendered RU/EN/ZH i18n and complete design-system migration.


### PR DESCRIPTION
## Суть

Убирает branch-specific обход scope guard и явно разрешает через `autopilot-state.json` только точные файлы промышленного контура одной сделки.

## Разрешается

- canonical deal commands and tests;
- settlement callback boundary;
- server role and action policy;
- verified login/proxy files;
- shared Deal Workspace and exact web tests;
- web-unit workflow.

## Не разрешается

- landing;
- auth module persistence changes;
- package/lockfiles;
- env/secrets;
- production migration execution;
- live integration claims;
- production readiness claims.

## Результат

PR #2261 сможет проходить обычный source-of-truth scope guard без branch/env override. Реализация по-прежнему обязана пройти code review, API/web tests, build, CodeQL and security gates.