### PR TITLE
VP-3.46 Ephemeral PostgreSQL RLS Integration Harness

### DIFF
--- a/apps/api/test/rls/README.md
+++ b/apps/api/test/rls/README.md
@@ -1,0 +1,13 @@
+# platform-v7 PostgreSQL RLS integration
+
+This fixture is CI-only and must run against a fresh local PostgreSQL 16 service.
+
+It intentionally:
+
+- applies only the canonical initial schema and runtime-persistence migration;
+- removes permissive legacy policies before assertions;
+- executes reads as `app_rls_test`, a `NOSUPERUSER NOBYPASSRLS` role;
+- verifies own-tenant visibility, cross-tenant denial, mandatory five-field context and transaction-local context cleanup;
+- contains no production credentials, hosts or deployment commands.
+
+`setup.sql` seeds two tenants. `assert.sql` is fail-fast. The owning entry point is `scripts/platform-v7-rls-integration.sh`, executed by the required `API Tests` workflow.

--- a/apps/api/test/rls/assert.sql
+++ b/apps/api/test/rls/assert.sql
@@ -1,0 +1,100 @@
+\set ON_ERROR_STOP on
+
+DO $catalog$
+DECLARE
+  legacy_count INTEGER;
+  enabled_count INTEGER;
+  forced_count INTEGER;
+BEGIN
+  SELECT count(*) INTO legacy_count FROM pg_policies
+  WHERE schemaname = 'public'
+    AND policyname IN ('deals_app_access','audit_insert_only','audit_select_all','ledger_insert_only','ledger_select_all');
+  IF legacy_count <> 0 THEN RAISE EXCEPTION 'Legacy permissive policies remain active: %', legacy_count; END IF;
+
+  SELECT count(*) INTO enabled_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname IN ('deals','organizations','audit_events','ledger_entries','integration_events','outbox_entries','deal_workspace_runtime_snapshots','deal_workspace_runtime_transaction_attempts')
+    AND c.relrowsecurity;
+
+  SELECT count(*) INTO forced_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname IN ('deals','organizations','audit_events','ledger_entries','integration_events','outbox_entries','deal_workspace_runtime_snapshots','deal_workspace_runtime_transaction_attempts')
+    AND c.relforcerowsecurity;
+
+  IF enabled_count <> 8 OR forced_count <> 8 THEN
+    RAISE EXCEPTION 'Expected 8 enabled and forced RLS tables, got enabled %, forced %', enabled_count, forced_count;
+  END IF;
+END
+$catalog$;
+
+SET ROLE app_rls_test;
+SET row_security = on;
+
+BEGIN;
+SELECT
+  set_config('app.current_user_id', 'user-a', true),
+  set_config('app.current_org_id', 'org-a-seller', true),
+  set_config('app.current_tenant_id', 'tenant-a', true),
+  set_config('app.current_role', 'FARMER', true),
+  set_config('app.current_session_id', 'session-a', true);
+DO $own_graph$
+DECLARE c INTEGER;
+BEGIN
+  SELECT count(*) INTO c FROM public."organizations"; IF c <> 1 THEN RAISE EXCEPTION 'Expected 1 visible organization, got %', c; END IF;
+  SELECT count(*) INTO c FROM public."deals"; IF c <> 1 THEN RAISE EXCEPTION 'Expected 1 visible deal, got %', c; END IF;
+  SELECT count(*) INTO c FROM public."deals" WHERE "id"='deal-a'; IF c <> 1 THEN RAISE EXCEPTION 'Own deal is not visible'; END IF;
+  SELECT count(*) INTO c FROM public."deals" WHERE "id"='deal-b'; IF c <> 0 THEN RAISE EXCEPTION 'Cross-tenant deal is visible'; END IF;
+  SELECT count(*) INTO c FROM public."audit_events"; IF c <> 1 THEN RAISE EXCEPTION 'Expected 1 visible audit event, got %', c; END IF;
+  SELECT count(*) INTO c FROM public."audit_events" WHERE "id"='audit-b'; IF c <> 0 THEN RAISE EXCEPTION 'Cross-tenant audit event is visible'; END IF;
+  SELECT count(*) INTO c FROM public."outbox_entries"; IF c <> 1 THEN RAISE EXCEPTION 'Expected 1 visible outbox entry, got %', c; END IF;
+  SELECT count(*) INTO c FROM public."outbox_entries" WHERE "id"='outbox-b'; IF c <> 0 THEN RAISE EXCEPTION 'Cross-tenant outbox entry is visible'; END IF;
+  SELECT count(*) INTO c FROM public."deal_workspace_runtime_snapshots"; IF c <> 1 THEN RAISE EXCEPTION 'Expected 1 visible runtime snapshot, got %', c; END IF;
+  SELECT count(*) INTO c FROM public."deal_workspace_runtime_snapshots" WHERE "id"='snapshot-record-b'; IF c <> 0 THEN RAISE EXCEPTION 'Cross-tenant runtime snapshot is visible'; END IF;
+  SELECT count(*) INTO c FROM public."deal_workspace_runtime_transaction_attempts"; IF c <> 1 THEN RAISE EXCEPTION 'Expected 1 visible runtime attempt, got %', c; END IF;
+  SELECT count(*) INTO c FROM public."deal_workspace_runtime_transaction_attempts" WHERE "id"='attempt-b'; IF c <> 0 THEN RAISE EXCEPTION 'Cross-tenant runtime attempt is visible'; END IF;
+END
+$own_graph$;
+COMMIT;
+
+BEGIN;
+DO $no_leak$
+DECLARE c INTEGER;
+BEGIN
+  IF NULLIF(current_setting('app.current_user_id', true), '') IS NOT NULL
+    OR NULLIF(current_setting('app.current_org_id', true), '') IS NOT NULL
+    OR NULLIF(current_setting('app.current_tenant_id', true), '') IS NOT NULL
+    OR NULLIF(current_setting('app.current_role', true), '') IS NOT NULL
+    OR NULLIF(current_setting('app.current_session_id', true), '') IS NOT NULL THEN
+    RAISE EXCEPTION 'Transaction-local RLS context leaked after COMMIT';
+  END IF;
+  SELECT count(*) INTO c FROM public."deals"; IF c <> 0 THEN RAISE EXCEPTION 'Deal visible without context after COMMIT'; END IF;
+  SELECT count(*) INTO c FROM public."audit_events"; IF c <> 0 THEN RAISE EXCEPTION 'Audit visible without context after COMMIT'; END IF;
+  SELECT count(*) INTO c FROM public."outbox_entries"; IF c <> 0 THEN RAISE EXCEPTION 'Outbox visible without context after COMMIT'; END IF;
+  SELECT count(*) INTO c FROM public."deal_workspace_runtime_snapshots"; IF c <> 0 THEN RAISE EXCEPTION 'Runtime snapshot visible without context after COMMIT'; END IF;
+END
+$no_leak$;
+COMMIT;
+
+BEGIN;
+SELECT set_config('app.current_org_id','org-a-seller',true), set_config('app.current_tenant_id','tenant-a',true), set_config('app.current_role','FARMER',true), set_config('app.current_session_id','session-a',true);
+DO $missing_user$ DECLARE c INTEGER; BEGIN SELECT count(*) INTO c FROM public."deals"; IF c<>0 THEN RAISE EXCEPTION 'Missing user context allowed rows'; END IF; END $missing_user$;
+COMMIT;
+BEGIN;
+SELECT set_config('app.current_user_id','user-a',true), set_config('app.current_tenant_id','tenant-a',true), set_config('app.current_role','FARMER',true), set_config('app.current_session_id','session-a',true);
+DO $missing_org$ DECLARE c INTEGER; BEGIN SELECT count(*) INTO c FROM public."deals"; IF c<>0 THEN RAISE EXCEPTION 'Missing organization context allowed rows'; END IF; END $missing_org$;
+COMMIT;
+BEGIN;
+SELECT set_config('app.current_user_id','user-a',true), set_config('app.current_org_id','org-a-seller',true), set_config('app.current_role','FARMER',true), set_config('app.current_session_id','session-a',true);
+DO $missing_tenant$ DECLARE c INTEGER; BEGIN SELECT count(*) INTO c FROM public."deals"; IF c<>0 THEN RAISE EXCEPTION 'Missing tenant context allowed rows'; END IF; END $missing_tenant$;
+COMMIT;
+BEGIN;
+SELECT set_config('app.current_user_id','user-a',true), set_config('app.current_org_id','org-a-seller',true), set_config('app.current_tenant_id','tenant-a',true), set_config('app.current_session_id','session-a',true);
+DO $missing_role$ DECLARE c INTEGER; BEGIN SELECT count(*) INTO c FROM public."deals"; IF c<>0 THEN RAISE EXCEPTION 'Missing role context allowed rows'; END IF; END $missing_role$;
+COMMIT;
+BEGIN;
+SELECT set_config('app.current_user_id','user-a',true), set_config('app.current_org_id','org-a-seller',true), set_config('app.current_tenant_id','tenant-a',true), set_config('app.current_role','FARMER',true);
+DO $missing_session$ DECLARE c INTEGER; BEGIN SELECT count(*) INTO c FROM public."deals"; IF c<>0 THEN RAISE EXCEPTION 'Missing session context allowed rows'; END IF; END $missing_session$;
+COMMIT;
+RESET ROLE;

--- a/apps/api/test/rls/setup.sql
+++ b/apps/api/test/rls/setup.sql
@@ -1,0 +1,70 @@
+\set ON_ERROR_STOP on
+
+DO $role$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_rls_test') THEN
+    CREATE ROLE app_rls_test NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOBYPASSRLS;
+  END IF;
+END
+$role$;
+
+GRANT USAGE ON SCHEMA public TO app_rls_test;
+GRANT SELECT ON TABLE
+  public."organizations",
+  public."deals",
+  public."disputes",
+  public."audit_events",
+  public."outbox_entries",
+  public."deal_workspace_runtime_snapshots",
+  public."deal_workspace_runtime_transaction_attempts"
+TO app_rls_test;
+
+INSERT INTO public."organizations" ("id", "inn", "name", "status", "tenantId") VALUES
+  ('org-a-seller', '7700000001', 'Tenant A Seller', 'VERIFIED', 'tenant-a'),
+  ('org-a-buyer',  '7700000002', 'Tenant A Buyer',  'VERIFIED', 'tenant-a'),
+  ('org-b-seller', '7700000003', 'Tenant B Seller', 'VERIFIED', 'tenant-b'),
+  ('org-b-buyer',  '7700000004', 'Tenant B Buyer',  'VERIFIED', 'tenant-b')
+ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO public."deals" (
+  "id", "dealNumber", "status", "tenantId", "sellerOrgId", "buyerOrgId",
+  "totalKopecks", "currency", "createdAt", "updatedAt"
+) VALUES
+  ('deal-a', 'RLS-A-001', 'EXECUTION', 'tenant-a', 'org-a-seller', 'org-a-buyer', 10000000, 'RUB', NOW(), NOW()),
+  ('deal-b', 'RLS-B-001', 'EXECUTION', 'tenant-b', 'org-b-seller', 'org-b-buyer', 20000000, 'RUB', NOW(), NOW())
+ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO public."outbox_entries" (
+  "id", "type", "dealId", "payload", "status", "idempotencyKey",
+  "correlationId", "auditId", "runtimeSnapshotId", "runtimeIdempotencyKey"
+) VALUES
+  ('outbox-a', 'runtime.persisted', 'deal-a', '{"tenant":"a"}', 'PENDING', 'outbox-idem-a', 'corr-a', 'audit-business-a', 'runtime-a', 'runtime-idem-a'),
+  ('outbox-b', 'runtime.persisted', 'deal-b', '{"tenant":"b"}', 'PENDING', 'outbox-idem-b', 'corr-b', 'audit-business-b', 'runtime-b', 'runtime-idem-b')
+ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO public."audit_events" (
+  "id", "action", "actorUserId", "actorRole", "tenantId", "orgId", "dealId",
+  "objectType", "objectId", "afterState", "outcome", "hash",
+  "correlationId", "runtimeSnapshotId", "runtimeIdempotencyKey"
+) VALUES
+  ('audit-a', 'runtime.persisted', 'user-a', 'FARMER', 'tenant-a', 'org-a-seller', 'deal-a', 'runtime_snapshot', 'runtime-a', '{"tenant":"a"}', 'SUCCESS', 'hash-a', 'corr-a', 'runtime-a', 'runtime-idem-a'),
+  ('audit-b', 'runtime.persisted', 'user-b', 'FARMER', 'tenant-b', 'org-b-seller', 'deal-b', 'runtime_snapshot', 'runtime-b', '{"tenant":"b"}', 'SUCCESS', 'hash-b', 'corr-b', 'runtime-b', 'runtime-idem-b')
+ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO public."deal_workspace_runtime_snapshots" (
+  "id", "runtimeSnapshotId", "idempotencyKey", "dealId", "intentId", "state",
+  "snapshotState", "statusLabel", "runtimeStoreRecordId", "runtimeStoreVersion",
+  "actorId", "actorRole", "correlationId", "auditId", "contractHash", "payload",
+  "outboxEntryId", "auditEventId", "version", "createdAt", "updatedAt"
+) VALUES
+  ('snapshot-record-a', 'runtime-a', 'runtime-idem-a', 'deal-a', 'start_document_review', 'fully_linked', 'updated', 'started', 'store-a', 'v1', 'user-a', 'FARMER', 'corr-a', 'audit-business-a', 'contract-a', '{"tenant":"a"}', 'outbox-a', 'audit-a', 1, NOW(), NOW()),
+  ('snapshot-record-b', 'runtime-b', 'runtime-idem-b', 'deal-b', 'start_document_review', 'fully_linked', 'updated', 'started', 'store-b', 'v1', 'user-b', 'FARMER', 'corr-b', 'audit-business-b', 'contract-b', '{"tenant":"b"}', 'outbox-b', 'audit-b', 1, NOW(), NOW())
+ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO public."deal_workspace_runtime_transaction_attempts" (
+  "id", "transactionId", "snapshotId", "idempotencyKey", "correlationId", "auditId",
+  "stage", "outcome", "isReplay", "startedAt", "completedAt", "metadata"
+) VALUES
+  ('attempt-a', 'tx-a', 'snapshot-record-a', 'runtime-idem-a', 'corr-a', 'audit-business-a', 'committed', 'persisted', FALSE, NOW(), NOW(), '{"tenant":"a"}'),
+  ('attempt-b', 'tx-b', 'snapshot-record-b', 'runtime-idem-b', 'corr-b', 'audit-business-b', 'committed', 'persisted', FALSE, NOW(), NOW(), '{"tenant":"b"}')
+ON CONFLICT ("id") DO NOTHING;

--- a/infra/sql/production-rls-policies.sql
+++ b/infra/sql/production-rls-policies.sql
@@ -7,14 +7,8 @@
 DROP FUNCTION IF EXISTS public.set_app_context(TEXT, TEXT, TEXT);
 
 CREATE OR REPLACE FUNCTION public.app_rls_context_ready()
-RETURNS BOOLEAN
-LANGUAGE sql
-STABLE
-PARALLEL SAFE
-SET search_path = pg_catalog
-AS $$
-  SELECT
-    NULLIF(current_setting('app.current_user_id', true), '') IS NOT NULL
+RETURNS BOOLEAN LANGUAGE sql STABLE PARALLEL SAFE SET search_path = pg_catalog AS $$
+  SELECT NULLIF(current_setting('app.current_user_id', true), '') IS NOT NULL
     AND NULLIF(current_setting('app.current_org_id', true), '') IS NOT NULL
     AND NULLIF(current_setting('app.current_tenant_id', true), '') IS NOT NULL
     AND NULLIF(current_setting('app.current_role', true), '') IS NOT NULL
@@ -22,96 +16,43 @@ AS $$
 $$;
 
 CREATE OR REPLACE FUNCTION public.app_rls_privileged()
-RETURNS BOOLEAN
-LANGUAGE sql
-STABLE
-PARALLEL SAFE
-SET search_path = pg_catalog
-AS $$
-  SELECT current_setting('app.current_role', true) IN (
-    'ADMIN', 'COMPLIANCE_OFFICER', 'SUPPORT_MANAGER'
-  )
+RETURNS BOOLEAN LANGUAGE sql STABLE PARALLEL SAFE SET search_path = pg_catalog AS $$
+  SELECT current_setting('app.current_role', true) IN ('ADMIN', 'COMPLIANCE_OFFICER', 'SUPPORT_MANAGER')
 $$;
 
--- SECURITY INVOKER is intentional. The lookup remains constrained by deals RLS.
 CREATE OR REPLACE FUNCTION public.app_rls_deal_visible(p_deal_id TEXT)
-RETURNS BOOLEAN
-LANGUAGE sql
-STABLE
-SECURITY INVOKER
-SET search_path = pg_catalog, public
-AS $$
-  SELECT EXISTS (
-    SELECT 1 FROM public."deals" d WHERE d."id" = p_deal_id
-  )
+RETURNS BOOLEAN LANGUAGE sql STABLE SECURITY INVOKER SET search_path = pg_catalog, public AS $$
+  SELECT EXISTS (SELECT 1 FROM public."deals" d WHERE d."id" = p_deal_id)
 $$;
 
-COMMENT ON FUNCTION public.app_rls_context_ready() IS
-  'Complete trusted transaction-local RLS context is present.';
-COMMENT ON FUNCTION public.app_rls_privileged() IS
-  'Role has an explicitly defined cross-organization read path.';
-COMMENT ON FUNCTION public.app_rls_deal_visible(TEXT) IS
-  'SECURITY INVOKER deal visibility probe constrained by deals RLS.';
+COMMENT ON FUNCTION public.app_rls_context_ready() IS 'Complete trusted transaction-local RLS context is present.';
+COMMENT ON FUNCTION public.app_rls_privileged() IS 'Role has an explicitly defined cross-organization read path.';
+COMMENT ON FUNCTION public.app_rls_deal_visible(TEXT) IS 'SECURITY INVOKER deal visibility probe constrained by deals RLS.';
 
--- ── deals ─────────────────────────────────────────────────────────────────────
 ALTER TABLE public."deals" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."deals" FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS deals_app_access ON public."deals";
 DROP POLICY IF EXISTS deals_select ON public."deals";
 DROP POLICY IF EXISTS deals_insert ON public."deals";
 DROP POLICY IF EXISTS deals_update ON public."deals";
 CREATE POLICY deals_select ON public."deals" FOR SELECT USING (
   public.app_rls_context_ready() AND (
     public.app_rls_privileged()
-    OR (
-      "tenantId" = current_setting('app.current_tenant_id', true)
-      AND (
-        "sellerOrgId" = current_setting('app.current_org_id', true)
-        OR "buyerOrgId" = current_setting('app.current_org_id', true)
-      )
-    )
-    OR (
-      current_setting('app.current_role', true) = 'ARBITRATOR'
-      AND EXISTS (
-        SELECT 1 FROM public."disputes" d
-        WHERE d."dealId" = "deals"."id"
-          AND d."arbitratorId" = current_setting('app.current_user_id', true)
-          AND d."status" IN ('OPEN', 'ARBITRATION')
-      )
-    )
+    OR ("tenantId" = current_setting('app.current_tenant_id', true) AND ("sellerOrgId" = current_setting('app.current_org_id', true) OR "buyerOrgId" = current_setting('app.current_org_id', true)))
+    OR (current_setting('app.current_role', true) = 'ARBITRATOR' AND EXISTS (SELECT 1 FROM public."disputes" d WHERE d."dealId" = "deals"."id" AND d."arbitratorId" = current_setting('app.current_user_id', true) AND d."status" IN ('OPEN','ARBITRATION')))
   )
 );
 CREATE POLICY deals_insert ON public."deals" FOR INSERT WITH CHECK (
-  public.app_rls_context_ready()
-  AND "tenantId" = current_setting('app.current_tenant_id', true)
-  AND (
-    public.app_rls_privileged()
-    OR "sellerOrgId" = current_setting('app.current_org_id', true)
-    OR "buyerOrgId" = current_setting('app.current_org_id', true)
-  )
+  public.app_rls_context_ready() AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND (public.app_rls_privileged() OR "sellerOrgId" = current_setting('app.current_org_id', true) OR "buyerOrgId" = current_setting('app.current_org_id', true))
 );
 CREATE POLICY deals_update ON public."deals" FOR UPDATE USING (
-  public.app_rls_context_ready() AND (
-    public.app_rls_privileged()
-    OR (
-      "tenantId" = current_setting('app.current_tenant_id', true)
-      AND (
-        "sellerOrgId" = current_setting('app.current_org_id', true)
-        OR "buyerOrgId" = current_setting('app.current_org_id', true)
-      )
-    )
-  )
+  public.app_rls_context_ready() AND (public.app_rls_privileged() OR ("tenantId" = current_setting('app.current_tenant_id', true) AND ("sellerOrgId" = current_setting('app.current_org_id', true) OR "buyerOrgId" = current_setting('app.current_org_id', true))))
 ) WITH CHECK (
-  public.app_rls_context_ready()
-  AND "tenantId" = current_setting('app.current_tenant_id', true)
-  AND (
-    public.app_rls_privileged()
-    OR "sellerOrgId" = current_setting('app.current_org_id', true)
-    OR "buyerOrgId" = current_setting('app.current_org_id', true)
-  )
+  public.app_rls_context_ready() AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND (public.app_rls_privileged() OR "sellerOrgId" = current_setting('app.current_org_id', true) OR "buyerOrgId" = current_setting('app.current_org_id', true))
 );
--- No DELETE policy: physical deal deletion is denied.
 
--- ── organizations ─────────────────────────────────────────────────────────────
 ALTER TABLE public."organizations" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."organizations" FORCE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS organizations_write_privileged ON public."organizations";
@@ -119,87 +60,50 @@ DROP POLICY IF EXISTS organizations_select ON public."organizations";
 DROP POLICY IF EXISTS organizations_insert_privileged ON public."organizations";
 DROP POLICY IF EXISTS organizations_update_privileged ON public."organizations";
 CREATE POLICY organizations_select ON public."organizations" FOR SELECT USING (
-  public.app_rls_context_ready() AND (
-    public.app_rls_privileged()
-    OR (
-      "id" = current_setting('app.current_org_id', true)
-      AND "tenantId" = current_setting('app.current_tenant_id', true)
-    )
-  )
+  public.app_rls_context_ready() AND (public.app_rls_privileged() OR ("id" = current_setting('app.current_org_id', true) AND "tenantId" = current_setting('app.current_tenant_id', true)))
 );
-CREATE POLICY organizations_insert_privileged ON public."organizations" FOR INSERT
-WITH CHECK (public.app_rls_context_ready() AND public.app_rls_privileged());
-CREATE POLICY organizations_update_privileged ON public."organizations" FOR UPDATE
-USING (public.app_rls_context_ready() AND public.app_rls_privileged())
-WITH CHECK (public.app_rls_context_ready() AND public.app_rls_privileged());
--- No DELETE policy: organizations are lifecycle-managed, not physically deleted.
+CREATE POLICY organizations_insert_privileged ON public."organizations" FOR INSERT WITH CHECK (public.app_rls_context_ready() AND public.app_rls_privileged());
+CREATE POLICY organizations_update_privileged ON public."organizations" FOR UPDATE USING (public.app_rls_context_ready() AND public.app_rls_privileged()) WITH CHECK (public.app_rls_context_ready() AND public.app_rls_privileged());
 
--- ── audit_events: append-only ─────────────────────────────────────────────────
 ALTER TABLE public."audit_events" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."audit_events" FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS audit_insert_only ON public."audit_events";
+DROP POLICY IF EXISTS audit_select_all ON public."audit_events";
 DROP POLICY IF EXISTS audit_events_select ON public."audit_events";
 DROP POLICY IF EXISTS audit_events_insert ON public."audit_events";
 CREATE POLICY audit_events_select ON public."audit_events" FOR SELECT USING (
-  public.app_rls_context_ready() AND (
-    public.app_rls_privileged()
-    OR (
-      "tenantId" = current_setting('app.current_tenant_id', true)
-      AND "orgId" = current_setting('app.current_org_id', true)
-    )
-    OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
-  )
+  public.app_rls_context_ready() AND (public.app_rls_privileged() OR ("tenantId" = current_setting('app.current_tenant_id', true) AND "orgId" = current_setting('app.current_org_id', true)) OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId")))
 );
 CREATE POLICY audit_events_insert ON public."audit_events" FOR INSERT WITH CHECK (
-  public.app_rls_context_ready()
-  AND "actorUserId" = current_setting('app.current_user_id', true)
-  AND "actorRole" = current_setting('app.current_role', true)
-  AND "tenantId" = current_setting('app.current_tenant_id', true)
-  AND "orgId" = current_setting('app.current_org_id', true)
+  public.app_rls_context_ready() AND "actorUserId" = current_setting('app.current_user_id', true) AND "actorRole" = current_setting('app.current_role', true)
+  AND "tenantId" = current_setting('app.current_tenant_id', true) AND "orgId" = current_setting('app.current_org_id', true)
   AND ("dealId" IS NULL OR public.app_rls_deal_visible("dealId"))
 );
--- No UPDATE/DELETE policies.
 
--- ── ledger_entries: immutable financial journal ───────────────────────────────
 ALTER TABLE public."ledger_entries" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."ledger_entries" FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS ledger_insert_only ON public."ledger_entries";
+DROP POLICY IF EXISTS ledger_select_all ON public."ledger_entries";
 DROP POLICY IF EXISTS ledger_entries_select ON public."ledger_entries";
 DROP POLICY IF EXISTS ledger_entries_insert ON public."ledger_entries";
 CREATE POLICY ledger_entries_select ON public."ledger_entries" FOR SELECT USING (
-  public.app_rls_context_ready() AND (
-    current_setting('app.current_role', true) IN (
-      'ADMIN', 'ACCOUNTING', 'COMPLIANCE_OFFICER', 'SUPPORT_MANAGER'
-    )
-    OR "debitAccount" = current_setting('app.current_org_id', true)
-    OR "creditAccount" = current_setting('app.current_org_id', true)
-    OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
-  )
+  public.app_rls_context_ready() AND (current_setting('app.current_role', true) IN ('ADMIN','ACCOUNTING','COMPLIANCE_OFFICER','SUPPORT_MANAGER') OR "debitAccount" = current_setting('app.current_org_id', true) OR "creditAccount" = current_setting('app.current_org_id', true) OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId")))
 );
 CREATE POLICY ledger_entries_insert ON public."ledger_entries" FOR INSERT WITH CHECK (
-  public.app_rls_context_ready()
-  AND current_setting('app.current_role', true) IN ('ADMIN', 'ACCOUNTING')
-  AND "createdByUserId" = current_setting('app.current_user_id', true)
-  AND ("dealId" IS NULL OR public.app_rls_deal_visible("dealId"))
+  public.app_rls_context_ready() AND current_setting('app.current_role', true) IN ('ADMIN','ACCOUNTING') AND "createdByUserId" = current_setting('app.current_user_id', true) AND ("dealId" IS NULL OR public.app_rls_deal_visible("dealId"))
 );
--- No UPDATE/DELETE policies.
 
--- ── integration_events ────────────────────────────────────────────────────────
 ALTER TABLE public."integration_events" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."integration_events" FORCE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
 DROP POLICY IF EXISTS integration_events_insert ON public."integration_events";
 CREATE POLICY integration_events_select ON public."integration_events" FOR SELECT USING (
-  public.app_rls_context_ready() AND (
-    public.app_rls_privileged()
-    OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
-  )
+  public.app_rls_context_ready() AND (public.app_rls_privileged() OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId")))
 );
 CREATE POLICY integration_events_insert ON public."integration_events" FOR INSERT WITH CHECK (
-  current_user IN ('app_service', 'app_integration_worker')
-  OR (public.app_rls_context_ready() AND public.app_rls_privileged())
+  current_user IN ('app_service','app_integration_worker') OR (public.app_rls_context_ready() AND public.app_rls_privileged())
 );
--- No UPDATE/DELETE policies.
 
--- ── outbox_entries ────────────────────────────────────────────────────────────
 ALTER TABLE public."outbox_entries" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."outbox_entries" FORCE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS outbox_entries_worker ON public."outbox_entries";
@@ -208,63 +112,35 @@ DROP POLICY IF EXISTS outbox_entries_worker_insert ON public."outbox_entries";
 DROP POLICY IF EXISTS outbox_entries_worker_update ON public."outbox_entries";
 DROP POLICY IF EXISTS outbox_entries_select ON public."outbox_entries";
 DROP POLICY IF EXISTS outbox_entries_insert ON public."outbox_entries";
-CREATE POLICY outbox_entries_worker_select ON public."outbox_entries" FOR SELECT
-USING (current_user IN ('app_service', 'app_outbox_worker'));
-CREATE POLICY outbox_entries_worker_insert ON public."outbox_entries" FOR INSERT
-WITH CHECK (current_user IN ('app_service', 'app_outbox_worker'));
-CREATE POLICY outbox_entries_worker_update ON public."outbox_entries" FOR UPDATE
-USING (current_user IN ('app_service', 'app_outbox_worker'))
-WITH CHECK (current_user IN ('app_service', 'app_outbox_worker'));
+CREATE POLICY outbox_entries_worker_select ON public."outbox_entries" FOR SELECT USING (current_user IN ('app_service','app_outbox_worker'));
+CREATE POLICY outbox_entries_worker_insert ON public."outbox_entries" FOR INSERT WITH CHECK (current_user IN ('app_service','app_outbox_worker'));
+CREATE POLICY outbox_entries_worker_update ON public."outbox_entries" FOR UPDATE USING (current_user IN ('app_service','app_outbox_worker')) WITH CHECK (current_user IN ('app_service','app_outbox_worker'));
 CREATE POLICY outbox_entries_select ON public."outbox_entries" FOR SELECT USING (
-  public.app_rls_context_ready() AND (
-    public.app_rls_privileged()
-    OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
-  )
+  public.app_rls_context_ready() AND (public.app_rls_privileged() OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId")))
 );
 CREATE POLICY outbox_entries_insert ON public."outbox_entries" FOR INSERT WITH CHECK (
-  public.app_rls_context_ready()
-  AND (
-    public.app_rls_privileged()
-    OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
-  )
+  public.app_rls_context_ready() AND (public.app_rls_privileged() OR ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId")))
 );
--- No DELETE policy: processed outbox records remain auditable.
 
--- ── deal_workspace_runtime_snapshots ─────────────────────────────────────────
 ALTER TABLE public."deal_workspace_runtime_snapshots" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."deal_workspace_runtime_snapshots" FORCE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS runtime_snapshots_select ON public."deal_workspace_runtime_snapshots";
 DROP POLICY IF EXISTS runtime_snapshots_insert ON public."deal_workspace_runtime_snapshots";
 CREATE POLICY runtime_snapshots_select ON public."deal_workspace_runtime_snapshots" FOR SELECT USING (
-  public.app_rls_context_ready()
-  AND (public.app_rls_privileged() OR public.app_rls_deal_visible("dealId"))
+  public.app_rls_context_ready() AND (public.app_rls_privileged() OR public.app_rls_deal_visible("dealId"))
 );
 CREATE POLICY runtime_snapshots_insert ON public."deal_workspace_runtime_snapshots" FOR INSERT WITH CHECK (
-  public.app_rls_context_ready()
-  AND "actorId" = current_setting('app.current_user_id', true)
-  AND "actorRole" = current_setting('app.current_role', true)
+  public.app_rls_context_ready() AND "actorId" = current_setting('app.current_user_id', true) AND "actorRole" = current_setting('app.current_role', true)
   AND (public.app_rls_privileged() OR public.app_rls_deal_visible("dealId"))
 );
--- No UPDATE/DELETE policies.
 
--- ── deal_workspace_runtime_transaction_attempts ───────────────────────────────
 ALTER TABLE public."deal_workspace_runtime_transaction_attempts" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public."deal_workspace_runtime_transaction_attempts" FORCE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS runtime_attempts_select ON public."deal_workspace_runtime_transaction_attempts";
 DROP POLICY IF EXISTS runtime_attempts_insert ON public."deal_workspace_runtime_transaction_attempts";
 CREATE POLICY runtime_attempts_select ON public."deal_workspace_runtime_transaction_attempts" FOR SELECT USING (
-  public.app_rls_context_ready()
-  AND EXISTS (
-    SELECT 1 FROM public."deal_workspace_runtime_snapshots" s
-    WHERE s."id" = "deal_workspace_runtime_transaction_attempts"."snapshotId"
-  )
+  public.app_rls_context_ready() AND EXISTS (SELECT 1 FROM public."deal_workspace_runtime_snapshots" s WHERE s."id" = "deal_workspace_runtime_transaction_attempts"."snapshotId")
 );
 CREATE POLICY runtime_attempts_insert ON public."deal_workspace_runtime_transaction_attempts" FOR INSERT WITH CHECK (
-  public.app_rls_context_ready()
-  AND EXISTS (
-    SELECT 1 FROM public."deal_workspace_runtime_snapshots" s
-    WHERE s."id" = "deal_workspace_runtime_transaction_attempts"."snapshotId"
-      AND (public.app_rls_privileged() OR s."actorId" = current_setting('app.current_user_id', true))
-  )
+  public.app_rls_context_ready() AND EXISTS (SELECT 1 FROM public."deal_workspace_runtime_snapshots" s WHERE s."id" = "deal_workspace_runtime_transaction_attempts"."snapshotId" AND (public.app_rls_privileged() OR s."actorId" = current_setting('app.current_user_id', true)))
 );
--- No UPDATE/DELETE policies.

--- a/scripts/platform-v7-rls-integration.sh
+++ b/scripts/platform-v7-rls-integration.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INITIAL_MIGRATION="$ROOT_DIR/apps/api/prisma/migrations/0001_postgresql_initial/migration.sql"
+RUNTIME_MIGRATION="$ROOT_DIR/apps/api/prisma/migrations/20260710060000_deal_workspace_runtime_persistence/migration.sql"
+POLICY_FILE="$ROOT_DIR/infra/sql/production-rls-policies.sql"
+SETUP_FILE="$ROOT_DIR/apps/api/test/rls/setup.sql"
+ASSERT_FILE="$ROOT_DIR/apps/api/test/rls/assert.sql"
+VALIDATOR="$ROOT_DIR/scripts/platform-v7-rls-validate.mjs"
+
+: "${RLS_INTEGRATION_ADMIN_URL:?Set RLS_INTEGRATION_ADMIN_URL to the ephemeral local PostgreSQL 16 database}"
+
+if [[ "${NODE_ENV:-test}" == "production" ]]; then
+  echo "Refusing RLS integration test with NODE_ENV=production" >&2
+  exit 2
+fi
+if [[ -n "${DATABASE_URL:-}" && "$RLS_INTEGRATION_ADMIN_URL" == "$DATABASE_URL" ]]; then
+  echo "Refusing RLS integration test: integration URL equals DATABASE_URL" >&2
+  exit 2
+fi
+case "$RLS_INTEGRATION_ADMIN_URL" in
+  postgresql://*@127.0.0.1:*/*|postgresql://*@localhost:*/*|postgres://*@127.0.0.1:*/*|postgres://*@localhost:*/*) ;;
+  *) echo "Refusing RLS integration test: database host must be localhost or 127.0.0.1" >&2; exit 2 ;;
+esac
+
+command -v node >/dev/null || { echo "node is required" >&2; exit 2; }
+command -v psql >/dev/null || { echo "psql is required" >&2; exit 2; }
+for file in "$INITIAL_MIGRATION" "$RUNTIME_MIGRATION" "$POLICY_FILE" "$SETUP_FILE" "$ASSERT_FILE" "$VALIDATOR"; do
+  [[ -f "$file" ]] || { echo "Required RLS integration artifact is missing: $file" >&2; exit 2; }
+done
+
+node "$VALIDATOR"
+SERVER_VERSION_NUM="$(psql "$RLS_INTEGRATION_ADMIN_URL" -XAtqc "SHOW server_version_num")"
+if (( SERVER_VERSION_NUM < 160000 || SERVER_VERSION_NUM >= 170000 )); then
+  echo "RLS integration requires PostgreSQL 16, got server_version_num=$SERVER_VERSION_NUM" >&2
+  exit 2
+fi
+TABLE_COUNT="$(psql "$RLS_INTEGRATION_ADMIN_URL" -XAtqc "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='public' AND c.relkind='r'")"
+if [[ "$TABLE_COUNT" != "0" ]]; then
+  echo "Refusing RLS integration test: ephemeral database is not clean ($TABLE_COUNT public tables)" >&2
+  exit 2
+fi
+
+INITIAL_SCHEMA_ONLY="$(mktemp)"
+trap 'rm -f "$INITIAL_SCHEMA_ONLY"' EXIT
+sed '/INSERT INTO "_prisma_migrations"/,$d' "$INITIAL_MIGRATION" > "$INITIAL_SCHEMA_ONLY"
+if grep -q '_prisma_migrations' "$INITIAL_SCHEMA_ONLY"; then
+  echo "RLS integration failed to remove Prisma metadata bookkeeping" >&2
+  exit 2
+fi
+if ! grep -q 'CREATE TABLE IF NOT EXISTS "deals"' "$INITIAL_SCHEMA_ONLY"; then
+  echo "RLS integration schema-only migration is missing the deals table" >&2
+  exit 2
+fi
+
+psql "$RLS_INTEGRATION_ADMIN_URL" -X --set ON_ERROR_STOP=1 --single-transaction --file "$INITIAL_SCHEMA_ONLY"
+psql "$RLS_INTEGRATION_ADMIN_URL" -X --set ON_ERROR_STOP=1 --single-transaction --file "$RUNTIME_MIGRATION"
+SCHEMA_READY="$(psql "$RLS_INTEGRATION_ADMIN_URL" -XAtqc "SELECT count(*) FROM (VALUES (to_regclass('public.deals')), (to_regclass('public.audit_events')), (to_regclass('public.outbox_entries')), (to_regclass('public.deal_workspace_runtime_snapshots')), (to_regclass('public.deal_workspace_runtime_transaction_attempts'))) AS required_table(name) WHERE name IS NOT NULL")"
+if [[ "$SCHEMA_READY" != "5" ]]; then
+  echo "RLS integration schema is incomplete: expected 5 required tables, got $SCHEMA_READY" >&2
+  exit 1
+fi
+
+psql "$RLS_INTEGRATION_ADMIN_URL" -X --set ON_ERROR_STOP=1 --single-transaction --file "$POLICY_FILE"
+psql "$RLS_INTEGRATION_ADMIN_URL" -X --set ON_ERROR_STOP=1 --file "$SETUP_FILE"
+psql "$RLS_INTEGRATION_ADMIN_URL" -X --set ON_ERROR_STOP=1 --file "$ASSERT_FILE"
+echo "Ephemeral PostgreSQL 16 RLS integration assertions passed."

--- a/scripts/platform-v7-rls-validate.mjs
+++ b/scripts/platform-v7-rls-validate.mjs
@@ -6,24 +6,16 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SCHEMA_PATH = path.join(ROOT, 'apps/api/prisma/schema.prisma');
 const POLICY_PATH = path.join(ROOT, 'infra/sql/production-rls-policies.sql');
+const INITIAL_MIGRATION_PATH = path.join(ROOT, 'apps/api/prisma/migrations/0001_postgresql_initial/migration.sql');
 
-export const REQUIRED_TABLES = [
-  'deals',
-  'organizations',
-  'audit_events',
-  'ledger_entries',
-  'integration_events',
-  'outbox_entries',
-  'deal_workspace_runtime_snapshots',
-  'deal_workspace_runtime_transaction_attempts',
-];
-
-export const REQUIRED_CONTEXT_SETTINGS = [
-  'app.current_user_id',
-  'app.current_org_id',
-  'app.current_tenant_id',
-  'app.current_role',
-  'app.current_session_id',
+export const REQUIRED_TABLES = ['deals','organizations','audit_events','ledger_entries','integration_events','outbox_entries','deal_workspace_runtime_snapshots','deal_workspace_runtime_transaction_attempts'];
+export const REQUIRED_CONTEXT_SETTINGS = ['app.current_user_id','app.current_org_id','app.current_tenant_id','app.current_role','app.current_session_id'];
+export const LEGACY_PERMISSIVE_POLICIES = [
+  ['deals_app_access','deals'],
+  ['audit_insert_only','audit_events'],
+  ['audit_select_all','audit_events'],
+  ['ledger_insert_only','ledger_entries'],
+  ['ledger_select_all','ledger_entries'],
 ];
 
 const FORBIDDEN_PATTERNS = [
@@ -39,112 +31,42 @@ const FORBIDDEN_PATTERNS = [
   ['embedded transaction BEGIN', /^\s*BEGIN\s*;/im],
   ['embedded transaction COMMIT', /^\s*COMMIT\s*;/im],
 ];
+const APPEND_ONLY_TABLES = ['audit_events','ledger_entries','integration_events','deal_workspace_runtime_snapshots','deal_workspace_runtime_transaction_attempts'];
 
-const APPEND_ONLY_TABLES = [
-  'audit_events',
-  'ledger_entries',
-  'integration_events',
-  'deal_workspace_runtime_snapshots',
-  'deal_workspace_runtime_transaction_attempts',
-];
+function escapeRegExp(value) { return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
 
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-export function validateRlsArtifacts(schema, sql) {
+export function validateRlsArtifacts(schema, sql, initialMigration = '') {
   const errors = [];
-
   for (const table of REQUIRED_TABLES) {
-    if (!schema.includes(`@@map("${table}")`)) {
-      errors.push(`Prisma schema is missing @@map(\"${table}\")`);
-    }
-
+    if (!schema.includes(`@@map("${table}")`)) errors.push(`Prisma schema is missing @@map("${table}")`);
     const escaped = escapeRegExp(table);
-    const enable = new RegExp(
-      `ALTER\\s+TABLE\\s+public\\.\"${escaped}\"\\s+ENABLE\\s+ROW\\s+LEVEL\\s+SECURITY`,
-      'i',
-    );
-    const force = new RegExp(
-      `ALTER\\s+TABLE\\s+public\\.\"${escaped}\"\\s+FORCE\\s+ROW\\s+LEVEL\\s+SECURITY`,
-      'i',
-    );
-    if (!enable.test(sql)) errors.push(`${table}: ENABLE ROW LEVEL SECURITY missing`);
-    if (!force.test(sql)) errors.push(`${table}: FORCE ROW LEVEL SECURITY missing`);
+    if (!new RegExp(`ALTER\\s+TABLE\\s+public\\."${escaped}"\\s+ENABLE\\s+ROW\\s+LEVEL\\s+SECURITY`, 'i').test(sql)) errors.push(`${table}: ENABLE ROW LEVEL SECURITY missing`);
+    if (!new RegExp(`ALTER\\s+TABLE\\s+public\\."${escaped}"\\s+FORCE\\s+ROW\\s+LEVEL\\s+SECURITY`, 'i').test(sql)) errors.push(`${table}: FORCE ROW LEVEL SECURITY missing`);
   }
-
-  for (const setting of REQUIRED_CONTEXT_SETTINGS) {
-    if (!sql.includes(`current_setting('${setting}', true)`)) {
-      errors.push(`RLS SQL is missing trusted context setting ${setting}`);
-    }
-  }
-
-  for (const [label, pattern] of FORBIDDEN_PATTERNS) {
-    if (pattern.test(sql)) errors.push(`Forbidden construct: ${label}`);
-  }
-
+  for (const setting of REQUIRED_CONTEXT_SETTINGS) if (!sql.includes(`current_setting('${setting}', true)`)) errors.push(`RLS SQL is missing trusted context setting ${setting}`);
+  for (const [label, pattern] of FORBIDDEN_PATTERNS) if (pattern.test(sql)) errors.push(`Forbidden construct: ${label}`);
   for (const table of APPEND_ONLY_TABLES) {
     const escaped = escapeRegExp(table);
-    const destructivePolicy = new RegExp(
-      `CREATE\\s+POLICY\\s+[a-z0-9_]+\\s+ON\\s+public\\.\"${escaped}\"\\s+FOR\\s+(?:UPDATE|DELETE|ALL)\\b`,
-      'i',
-    );
-    if (destructivePolicy.test(sql)) {
-      errors.push(`${table}: append-only table has UPDATE, DELETE or ALL policy`);
-    }
+    if (new RegExp(`CREATE\\s+POLICY\\s+[a-z0-9_]+\\s+ON\\s+public\\."${escaped}"\\s+FOR\\s+(?:UPDATE|DELETE|ALL)\\b`, 'i').test(sql)) errors.push(`${table}: append-only table has UPDATE, DELETE or ALL policy`);
   }
-
-  const createdPolicies = [...sql.matchAll(/CREATE\s+POLICY\s+([a-z0-9_]+)/gi)].map(
-    (match) => match[1],
-  );
-  const duplicatePolicies = createdPolicies.filter(
-    (name, index) => createdPolicies.indexOf(name) !== index,
-  );
-  if (duplicatePolicies.length > 0) {
-    errors.push(`Duplicate policy names: ${[...new Set(duplicatePolicies)].join(', ')}`);
+  for (const [policy, table] of LEGACY_PERMISSIVE_POLICIES) {
+    const p = escapeRegExp(policy); const t = escapeRegExp(table);
+    if (initialMigration && !new RegExp(`CREATE\\s+POLICY\\s+\"?${p}\"?\\s+ON\\s+\"?${t}\"?`, 'i').test(initialMigration)) errors.push(`Expected legacy migration policy not found: ${policy} on ${table}`);
+    if (!new RegExp(`DROP\\s+POLICY\\s+IF\\s+EXISTS\\s+\"?${p}\"?\\s+ON\\s+public\\.\"${t}\"`, 'i').test(sql)) errors.push(`Legacy permissive policy is not removed: ${policy} on ${table}`);
   }
-
-  for (const policy of createdPolicies) {
-    const drop = new RegExp(`DROP\\s+POLICY\\s+IF\\s+EXISTS\\s+${policy}\\s+ON`, 'i');
-    if (!drop.test(sql)) errors.push(`${policy}: matching DROP POLICY IF EXISTS missing`);
-  }
-
-  if (
-    !/DROP\s+FUNCTION\s+IF\s+EXISTS\s+public\.set_app_context\s*\(TEXT,\s*TEXT,\s*TEXT\)/i.test(
-      sql,
-    )
-  ) {
-    errors.push('Legacy three-argument set_app_context is not explicitly removed');
-  }
-
-  if (!/CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.app_rls_context_ready\s*\(\s*\)/i.test(sql)) {
-    errors.push('Fail-closed app_rls_context_ready function is missing');
-  }
-
-  if (!/SECURITY\s+INVOKER/i.test(sql)) {
-    errors.push('Deal visibility helper must remain SECURITY INVOKER');
-  }
-
+  const createdPolicies = [...sql.matchAll(/CREATE\s+POLICY\s+([a-z0-9_]+)/gi)].map((match) => match[1]);
+  const duplicates = createdPolicies.filter((name, index) => createdPolicies.indexOf(name) !== index);
+  if (duplicates.length) errors.push(`Duplicate policy names: ${[...new Set(duplicates)].join(', ')}`);
+  for (const policy of createdPolicies) if (!new RegExp(`DROP\\s+POLICY\\s+IF\\s+EXISTS\\s+${policy}\\s+ON`, 'i').test(sql)) errors.push(`${policy}: matching DROP POLICY IF EXISTS missing`);
+  if (!/DROP\s+FUNCTION\s+IF\s+EXISTS\s+public\.set_app_context\s*\(TEXT,\s*TEXT,\s*TEXT\)/i.test(sql)) errors.push('Legacy three-argument set_app_context is not explicitly removed');
+  if (!/CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.app_rls_context_ready\s*\(\s*\)/i.test(sql)) errors.push('Fail-closed app_rls_context_ready function is missing');
+  if (!/SECURITY\s+INVOKER/i.test(sql)) errors.push('Deal visibility helper must remain SECURITY INVOKER');
   return { valid: errors.length === 0, errors, policies: createdPolicies.length };
 }
 
 export async function validateRlsFiles() {
-  const [schema, sql] = await Promise.all([
-    readFile(SCHEMA_PATH, 'utf8'),
-    readFile(POLICY_PATH, 'utf8'),
-  ]);
-  return validateRlsArtifacts(schema, sql);
+  const [schema, sql, initialMigration] = await Promise.all([readFile(SCHEMA_PATH,'utf8'), readFile(POLICY_PATH,'utf8'), readFile(INITIAL_MIGRATION_PATH,'utf8')]);
+  return validateRlsArtifacts(schema, sql, initialMigration);
 }
-
-async function cli() {
-  const result = await validateRlsFiles();
-  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-  if (!result.valid) process.exitCode = 1;
-}
-
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  cli().catch((error) => {
-    process.stderr.write(`${error.message}\n`);
-    process.exitCode = 1;
-  });
-}
+async function cli() { const result = await validateRlsFiles(); process.stdout.write(`${JSON.stringify(result,null,2)}\n`); if (!result.valid) process.exitCode = 1; }
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) cli().catch((error) => { process.stderr.write(`${error.message}\n`); process.exitCode = 1; });


### PR DESCRIPTION
Закрыто как дубликат #2265.

#2265 сохраняет canonical RLS policy с минимальным точечным diff и добавляет тот же PostgreSQL 16 tenant-isolation harness. Ветка #2269 содержала избыточное переформатирование policy/validator и поэтому несла больший риск semantic drift.

Канонический RLS integration gate продолжается в #2265.