### PR TITLE
Persistent auth sessions and industrial UX layer

### DIFF
--- a/apps/api/prisma/migrations/20260710220000_persistent_auth_sessions/migration.sql
+++ b/apps/api/prisma/migrations/20260710220000_persistent_auth_sessions/migration.sql
@@ -1,0 +1,61 @@
+-- Persistent authentication state for horizontally scaled API instances.
+-- Raw refresh tokens and MFA codes are never stored.
+
+CREATE TABLE IF NOT EXISTS "auth_sessions" (
+  "id" TEXT PRIMARY KEY,
+  "user_id" TEXT NOT NULL,
+  "refresh_token_hash" TEXT NOT NULL UNIQUE,
+  "refresh_family_id" TEXT NOT NULL,
+  "refresh_generation" INTEGER NOT NULL DEFAULT 0,
+  "user_agent" TEXT,
+  "ip_hash" TEXT,
+  "mfa_verified_at" TIMESTAMPTZ,
+  "last_seen_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expires_at" TIMESTAMPTZ NOT NULL,
+  "revoked_at" TIMESTAMPTZ,
+  "revoke_reason" TEXT,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "auth_sessions_user_fk"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "auth_sessions_user_active_idx"
+  ON "auth_sessions" ("user_id", "revoked_at", "expires_at");
+CREATE INDEX IF NOT EXISTS "auth_sessions_family_idx"
+  ON "auth_sessions" ("refresh_family_id");
+
+CREATE TABLE IF NOT EXISTS "auth_login_attempts" (
+  "account_key_hash" TEXT PRIMARY KEY,
+  "failure_count" INTEGER NOT NULL DEFAULT 0,
+  "first_failure_at" TIMESTAMPTZ,
+  "last_failure_at" TIMESTAMPTZ,
+  "locked_until" TIMESTAMPTZ,
+  "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS "auth_login_attempts_locked_idx"
+  ON "auth_login_attempts" ("locked_until");
+
+CREATE TABLE IF NOT EXISTS "auth_mfa_challenges" (
+  "id" TEXT PRIMARY KEY,
+  "user_id" TEXT NOT NULL,
+  "session_id" TEXT,
+  "purpose" TEXT NOT NULL,
+  "code_hash" TEXT NOT NULL,
+  "attempt_count" INTEGER NOT NULL DEFAULT 0,
+  "max_attempts" INTEGER NOT NULL DEFAULT 5,
+  "expires_at" TIMESTAMPTZ NOT NULL,
+  "consumed_at" TIMESTAMPTZ,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "auth_mfa_challenges_user_fk"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE,
+  CONSTRAINT "auth_mfa_challenges_session_fk"
+    FOREIGN KEY ("session_id") REFERENCES "auth_sessions"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "auth_mfa_challenges_user_idx"
+  ON "auth_mfa_challenges" ("user_id", "purpose", "expires_at");
+
+COMMENT ON TABLE "auth_sessions" IS 'Server-side session and refresh-token rotation ledger. Stores hashes only.';
+COMMENT ON TABLE "auth_login_attempts" IS 'Cluster-safe per-account credential-stuffing lockout ledger.';
+COMMENT ON TABLE "auth_mfa_challenges" IS 'Single-use hashed MFA challenge ledger.';

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { BusinessReputationModule } from '../business-reputation/business-reputation.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { PersistentAuthSessionService } from './persistent-auth-session.service';
 
 @Module({
   imports: [BusinessReputationModule],
   controllers: [AuthController],
-  providers: [AuthService],
-  exports: [AuthService]
+  providers: [AuthService, PersistentAuthSessionService],
+  exports: [AuthService, PersistentAuthSessionService],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -2,12 +2,17 @@ import { Module } from '@nestjs/common';
 import { BusinessReputationModule } from '../business-reputation/business-reputation.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { IndustrialAuthService } from './industrial-auth.service';
 import { PersistentAuthSessionService } from './persistent-auth-session.service';
 
 @Module({
   imports: [BusinessReputationModule],
   controllers: [AuthController],
-  providers: [AuthService, PersistentAuthSessionService],
+  providers: [
+    PersistentAuthSessionService,
+    IndustrialAuthService,
+    { provide: AuthService, useExisting: IndustrialAuthService },
+  ],
   exports: [AuthService, PersistentAuthSessionService],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/industrial-auth.service.ts
+++ b/apps/api/src/modules/auth/industrial-auth.service.ts
@@ -1,0 +1,299 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import * as bcrypt from 'bcryptjs';
+import * as jwt from 'jsonwebtoken';
+import { randomUUID } from 'crypto';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { requireSecret } from '../../common/config/secrets';
+import { RequestUser, Role } from '../../common/types/request-user';
+import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
+import { RefreshDto } from './dto/refresh.dto';
+import { AuthService } from './auth.service';
+import { PersistentAuthSessionService } from './persistent-auth-session.service';
+
+const JWT_SECRET = requireSecret('JWT_SECRET');
+const ACCESS_TOKEN_TTL = '15m';
+const CURRENT_CONSENT_VERSION = '1.2';
+
+const SELF_REGISTERABLE_ROLES: ReadonlySet<Role> = new Set<Role>([
+  Role.FARMER,
+  Role.BUYER,
+  Role.LOGISTICIAN,
+  Role.DRIVER,
+  Role.SURVEYOR,
+  Role.LAB,
+  Role.ELEVATOR,
+  Role.ACCOUNTING,
+]);
+
+type PersistentIdentity = {
+  id: string;
+  email: string;
+  passwordHash: string;
+  fullName: string;
+  phone: string | null;
+  status: string;
+  mfaEnabled: boolean;
+  deletedAt: Date | null;
+  orgId: string;
+  tenantId: string;
+  role: Role;
+};
+
+@Injectable()
+export class IndustrialAuthService extends AuthService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly sessions: PersistentAuthSessionService,
+  ) {
+    super();
+  }
+
+  private async findIdentityByEmail(email: string): Promise<PersistentIdentity | null> {
+    const user = await this.prisma.user.findUnique({
+      where: { email: email.trim().toLowerCase() },
+      include: {
+        orgs: {
+          include: { organization: true },
+          orderBy: [{ isDefault: 'desc' }, { joinedAt: 'asc' }],
+          take: 1,
+        },
+      },
+    });
+    const membership = user?.orgs[0];
+    if (!user || !membership) return null;
+    return {
+      id: user.id,
+      email: user.email,
+      passwordHash: user.passwordHash,
+      fullName: user.fullName,
+      phone: user.phone,
+      status: user.status,
+      mfaEnabled: user.mfaEnabled,
+      deletedAt: user.deletedAt,
+      orgId: membership.organizationId,
+      tenantId: membership.organization.tenantId,
+      role: membership.role as Role,
+    };
+  }
+
+  private async findIdentityById(userId: string): Promise<PersistentIdentity | null> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: {
+        orgs: {
+          include: { organization: true },
+          orderBy: [{ isDefault: 'desc' }, { joinedAt: 'asc' }],
+          take: 1,
+        },
+      },
+    });
+    const membership = user?.orgs[0];
+    if (!user || !membership) return null;
+    return {
+      id: user.id,
+      email: user.email,
+      passwordHash: user.passwordHash,
+      fullName: user.fullName,
+      phone: user.phone,
+      status: user.status,
+      mfaEnabled: user.mfaEnabled,
+      deletedAt: user.deletedAt,
+      orgId: membership.organizationId,
+      tenantId: membership.organization.tenantId,
+      role: membership.role as Role,
+    };
+  }
+
+  private accessToken(identity: PersistentIdentity, sessionId: string, mfaVerified = false): string {
+    const payload: RequestUser = {
+      id: identity.id,
+      email: identity.email,
+      fullName: identity.fullName,
+      role: identity.role,
+      orgId: identity.orgId,
+      tenantId: identity.tenantId,
+      sessionId,
+      mfaVerified,
+    };
+    return jwt.sign(payload, JWT_SECRET, {
+      expiresIn: ACCESS_TOKEN_TTL,
+      issuer: 'prozrachnaya-cena-api',
+      audience: 'prozrachnaya-cena-platform-v7',
+      subject: identity.id,
+      jwtid: randomUUID(),
+    });
+  }
+
+  private publicIdentity(identity: PersistentIdentity) {
+    return {
+      id: identity.id,
+      email: identity.email,
+      fullName: identity.fullName,
+      role: identity.role,
+      orgId: identity.orgId,
+      tenantId: identity.tenantId,
+      mfaEnabled: identity.mfaEnabled,
+    };
+  }
+
+  override async login(dto: LoginDto, userAgent?: string, ip?: string) {
+    const identity = await this.findIdentityByEmail(dto.email);
+    const fallbackHash = '$2a$10$7EqJtq98hPqEX7fNZaFWoO5bsNq8YxF7p7N0e1mGZy5VQx3xJ8K5K';
+    const valid = await bcrypt.compare(dto.password, identity?.passwordHash || fallbackHash);
+
+    if (!identity || !valid || identity.status !== 'ACTIVE' || identity.deletedAt) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const issued = await this.sessions.issue(identity.id, userAgent, ip);
+    return {
+      accessToken: this.accessToken(identity, issued.sessionId, false),
+      refreshToken: issued.refreshToken,
+      expiresInSeconds: 15 * 60,
+      user: this.publicIdentity(identity),
+    };
+  }
+
+  override async refresh(dto: RefreshDto, userAgent?: string, ip?: string) {
+    const rotated = await this.sessions.rotate(dto.refreshToken, userAgent, ip);
+    const identity = await this.findIdentityById(rotated.userId);
+    if (!identity || identity.status !== 'ACTIVE' || identity.deletedAt) {
+      await this.sessions.revoke(rotated.sessionId, 'identity_unavailable');
+      throw new UnauthorizedException('User is unavailable');
+    }
+    return {
+      accessToken: this.accessToken(identity, rotated.sessionId, false),
+      refreshToken: rotated.refreshToken,
+      expiresInSeconds: 15 * 60,
+      user: this.publicIdentity(identity),
+    };
+  }
+
+  override async logout(_dto: RefreshDto, sessionId?: string) {
+    if (sessionId) await this.sessions.revoke(sessionId, 'logout');
+    return { success: true };
+  }
+
+  async logoutAll(userId: string) {
+    const revoked = await this.sessions.revokeAllForUser(userId, 'logout_all');
+    return { success: true, revoked };
+  }
+
+  override async verifyAccessToken(token: string): Promise<RequestUser> {
+    let payload: RequestUser;
+    try {
+      payload = jwt.verify(token, JWT_SECRET, {
+        issuer: 'prozrachnaya-cena-api',
+        audience: 'prozrachnaya-cena-platform-v7',
+      }) as RequestUser;
+    } catch {
+      throw new UnauthorizedException('Invalid or expired access token');
+    }
+    if (!payload.sessionId) throw new UnauthorizedException('Session is missing');
+    await this.sessions.assertActive(payload.sessionId);
+
+    const identity = await this.findIdentityById(payload.id);
+    if (!identity || identity.status !== 'ACTIVE' || identity.deletedAt) {
+      throw new UnauthorizedException('Identity is unavailable');
+    }
+
+    if (
+      payload.role !== identity.role ||
+      payload.orgId !== identity.orgId ||
+      payload.tenantId !== identity.tenantId
+    ) {
+      await this.sessions.revoke(payload.sessionId, 'membership_changed');
+      throw new UnauthorizedException('Session membership is stale');
+    }
+
+    return {
+      ...payload,
+      email: identity.email,
+      fullName: identity.fullName,
+      role: identity.role,
+      orgId: identity.orgId,
+      tenantId: identity.tenantId,
+    };
+  }
+
+  override async register(dto: RegisterDto) {
+    if (!SELF_REGISTERABLE_ROLES.has(dto.role)) {
+      throw new ForbiddenException('The selected role cannot be self-registered.');
+    }
+    if (!dto.orgInn || !dto.orgLegalName) {
+      throw new BadRequestException('Organization INN and legal name are required.');
+    }
+
+    const email = dto.email.trim().toLowerCase();
+    const passwordHash = await bcrypt.hash(dto.password, 12);
+
+    const identity = await this.prisma.$transaction(async (tx) => {
+      const existing = await tx.user.findUnique({ where: { email } });
+      if (existing) throw new ConflictException('Email already registered');
+
+      const organization = await tx.organization.upsert({
+        where: { inn: dto.orgInn! },
+        update: { name: dto.orgLegalName!, type: dto.orgType || 'LEGAL' },
+        create: {
+          inn: dto.orgInn!,
+          name: dto.orgLegalName!,
+          type: dto.orgType || 'LEGAL',
+          status: 'PENDING',
+          kycStatus: 'PENDING',
+        },
+      });
+      const user = await tx.user.create({
+        data: {
+          email,
+          phone: dto.phone,
+          passwordHash,
+          fullName: dto.fullName,
+          status: 'ACTIVE',
+          orgs: {
+            create: {
+              organizationId: organization.id,
+              role: dto.role,
+              isDefault: true,
+            },
+          },
+        },
+      });
+      return {
+        id: user.id,
+        email: user.email,
+        passwordHash: user.passwordHash,
+        fullName: user.fullName,
+        phone: user.phone,
+        status: user.status,
+        mfaEnabled: user.mfaEnabled,
+        deletedAt: user.deletedAt,
+        orgId: organization.id,
+        tenantId: organization.tenantId,
+        role: dto.role,
+      } satisfies PersistentIdentity;
+    }, { isolationLevel: 'Serializable' });
+
+    const issued = await this.sessions.issue(identity.id);
+    return {
+      accessToken: this.accessToken(identity, issued.sessionId, false),
+      refreshToken: issued.refreshToken,
+      expiresInSeconds: 15 * 60,
+      consentVersion: dto.consentVersion || CURRENT_CONSENT_VERSION,
+      user: this.publicIdentity(identity),
+    };
+  }
+
+  override async me(user: RequestUser) {
+    const identity = await this.findIdentityById(user.id);
+    if (!identity) throw new NotFoundException('User not found');
+    return this.publicIdentity(identity);
+  }
+}

--- a/apps/api/src/modules/auth/persistent-auth-session.service.spec.ts
+++ b/apps/api/src/modules/auth/persistent-auth-session.service.spec.ts
@@ -1,0 +1,75 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { PersistentAuthSessionService } from './persistent-auth-session.service';
+
+describe('PersistentAuthSessionService', () => {
+  function createService() {
+    const tx = {
+      $queryRaw: jest.fn(),
+      $executeRaw: jest.fn().mockResolvedValue(1),
+    };
+    const prisma = {
+      $executeRaw: jest.fn().mockResolvedValue(1),
+      $queryRaw: jest.fn(),
+      $transaction: jest.fn(async (work: (client: typeof tx) => Promise<unknown>) => work(tx)),
+    };
+    return { service: new PersistentAuthSessionService(prisma as any), prisma, tx };
+  }
+
+  it('stores only token and IP hashes when issuing a session', async () => {
+    const { service, prisma } = createService();
+    const result = await service.issue('user-one', 'Mobile Safari', '203.0.113.10');
+
+    expect(result.refreshToken).toBeTruthy();
+    expect(result.sessionId).toBeTruthy();
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+
+    const serializedCall = JSON.stringify(prisma.$executeRaw.mock.calls[0]);
+    expect(serializedCall).not.toContain(result.refreshToken);
+    expect(serializedCall).not.toContain('203.0.113.10');
+  });
+
+  it('rotates refresh token in a serializable transaction', async () => {
+    const { service, prisma, tx } = createService();
+    tx.$queryRaw.mockResolvedValue([{
+      id: 'session-one',
+      user_id: 'user-one',
+      refresh_token_hash: 'hash',
+      refresh_family_id: 'family-one',
+      refresh_generation: 0,
+      expires_at: new Date(Date.now() + 60_000),
+      revoked_at: null,
+    }]);
+
+    const result = await service.rotate('refresh-token-one', 'Mobile Safari', '203.0.113.10');
+
+    expect(result.userId).toBe('user-one');
+    expect(result.generation).toBe(1);
+    expect(result.refreshToken).not.toBe('refresh-token-one');
+    expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), { isolationLevel: 'Serializable' });
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(2);
+  });
+
+  it('revokes the complete token family when a rotated token is reused', async () => {
+    const { service, tx } = createService();
+    tx.$queryRaw.mockResolvedValue([{
+      id: 'session-old',
+      user_id: 'user-one',
+      refresh_token_hash: 'hash',
+      refresh_family_id: 'family-one',
+      refresh_generation: 0,
+      expires_at: new Date(Date.now() + 60_000),
+      revoked_at: new Date(),
+    }]);
+
+    await expect(service.rotate('reused-token')).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an absent or expired server-side session', async () => {
+    const { service, prisma } = createService();
+    prisma.$queryRaw.mockResolvedValue([{ active: false }]);
+
+    await expect(service.assertActive('missing-session')).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(prisma.$executeRaw).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/auth/persistent-auth-session.service.ts
+++ b/apps/api/src/modules/auth/persistent-auth-session.service.ts
@@ -3,6 +3,9 @@ import { createHash, randomUUID } from 'crypto';
 import { PrismaService } from '../../common/prisma/prisma.service';
 
 const REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const LOGIN_LOCKOUT_MS = 15 * 60 * 1000;
+const MAX_FAILED_LOGINS = 5;
+const SESSION_TOUCH_INTERVAL_MS = 5 * 60 * 1000;
 
 interface SessionRow {
   id: string;
@@ -12,6 +15,11 @@ interface SessionRow {
   refresh_generation: number;
   expires_at: Date;
   revoked_at: Date | null;
+}
+
+interface LoginAttemptRow {
+  failure_count: number;
+  locked_until: Date | null;
 }
 
 export interface IssuedPersistentSession {
@@ -28,6 +36,10 @@ function sha256(value: string): string {
 
 function hashIp(ip?: string): string | null {
   return ip ? sha256(ip.trim().toLowerCase()) : null;
+}
+
+function accountKey(email: string): string {
+  return sha256(email.trim().toLowerCase());
 }
 
 @Injectable()
@@ -93,11 +105,14 @@ export class PersistentAuthSessionService {
       const nextGeneration = current.refresh_generation + 1;
       const replacementSessionId = randomUUID();
 
-      await tx.$executeRaw`
+      const revokedCount = await tx.$executeRaw`
         UPDATE "auth_sessions"
         SET "revoked_at" = ${now}, "revoke_reason" = 'rotated', "last_seen_at" = ${now}
         WHERE "id" = ${current.id} AND "revoked_at" IS NULL
       `;
+      if (Number(revokedCount) !== 1) {
+        throw new UnauthorizedException('Refresh token was already consumed');
+      }
 
       await tx.$executeRaw`
         INSERT INTO "auth_sessions" (
@@ -120,20 +135,36 @@ export class PersistentAuthSessionService {
     }, { isolationLevel: 'Serializable' });
   }
 
-  async assertActive(sessionId: string): Promise<void> {
-    const rows = await this.prisma.$queryRaw<Array<{ active: boolean }>>`
-      SELECT EXISTS (
-        SELECT 1 FROM "auth_sessions"
-        WHERE "id" = ${sessionId}
-          AND "revoked_at" IS NULL
-          AND "expires_at" > CURRENT_TIMESTAMP
-      ) AS "active"
+  async assertActive(sessionId: string): Promise<{ mfaVerified: boolean }> {
+    const rows = await this.prisma.$queryRaw<Array<{ active: boolean; mfa_verified_at: Date | null }>>`
+      SELECT
+        ("revoked_at" IS NULL AND "expires_at" > CURRENT_TIMESTAMP) AS "active",
+        "mfa_verified_at"
+      FROM "auth_sessions"
+      WHERE "id" = ${sessionId}
+      LIMIT 1
     `;
     if (!rows[0]?.active) throw new UnauthorizedException('Session has been revoked or expired');
 
+    const touchBefore = new Date(Date.now() - SESSION_TOUCH_INTERVAL_MS);
     await this.prisma.$executeRaw`
-      UPDATE "auth_sessions" SET "last_seen_at" = CURRENT_TIMESTAMP WHERE "id" = ${sessionId}
+      UPDATE "auth_sessions"
+      SET "last_seen_at" = CURRENT_TIMESTAMP
+      WHERE "id" = ${sessionId} AND "last_seen_at" < ${touchBefore}
     `;
+
+    return { mfaVerified: Boolean(rows[0].mfa_verified_at) };
+  }
+
+  async markMfaVerified(sessionId: string): Promise<void> {
+    const updated = await this.prisma.$executeRaw`
+      UPDATE "auth_sessions"
+      SET "mfa_verified_at" = CURRENT_TIMESTAMP, "last_seen_at" = CURRENT_TIMESTAMP
+      WHERE "id" = ${sessionId}
+        AND "revoked_at" IS NULL
+        AND "expires_at" > CURRENT_TIMESTAMP
+    `;
+    if (Number(updated) !== 1) throw new UnauthorizedException('Session has been revoked or expired');
   }
 
   async revoke(sessionId: string, reason = 'logout'): Promise<void> {
@@ -145,11 +176,74 @@ export class PersistentAuthSessionService {
     `;
   }
 
+  async revokeByRefreshToken(refreshToken: string, reason = 'logout'): Promise<void> {
+    await this.prisma.$executeRaw`
+      UPDATE "auth_sessions"
+      SET "revoked_at" = COALESCE("revoked_at", CURRENT_TIMESTAMP),
+          "revoke_reason" = COALESCE("revoke_reason", ${reason})
+      WHERE "refresh_token_hash" = ${sha256(refreshToken)}
+    `;
+  }
+
   async revokeAllForUser(userId: string, reason = 'logout_all'): Promise<number> {
-    return this.prisma.$executeRaw`
+    const count = await this.prisma.$executeRaw`
       UPDATE "auth_sessions"
       SET "revoked_at" = CURRENT_TIMESTAMP, "revoke_reason" = ${reason}
       WHERE "user_id" = ${userId} AND "revoked_at" IS NULL
+    `;
+    return Number(count);
+  }
+
+  async assertLoginAllowed(email: string): Promise<void> {
+    const rows = await this.prisma.$queryRaw<Array<{ locked_until: Date | null }>>`
+      SELECT "locked_until"
+      FROM "auth_login_attempts"
+      WHERE "account_key_hash" = ${accountKey(email)}
+      LIMIT 1
+    `;
+    const lockedUntil = rows[0]?.locked_until ? new Date(rows[0].locked_until) : null;
+    if (lockedUntil && lockedUntil.getTime() > Date.now()) {
+      const retryAfterSec = Math.ceil((lockedUntil.getTime() - Date.now()) / 1000);
+      throw new UnauthorizedException(`Account temporarily locked. Try again in ${retryAfterSec}s.`);
+    }
+  }
+
+  async recordLoginFailure(email: string): Promise<void> {
+    const key = accountKey(email);
+    const now = new Date();
+
+    await this.prisma.$transaction(async (tx) => {
+      const rows = await tx.$queryRaw<LoginAttemptRow[]>`
+        SELECT "failure_count", "locked_until"
+        FROM "auth_login_attempts"
+        WHERE "account_key_hash" = ${key}
+        FOR UPDATE
+      `;
+      const current = rows[0];
+      const activeLock = current?.locked_until && new Date(current.locked_until).getTime() > now.getTime();
+      const nextCount = activeLock ? current.failure_count : (current?.failure_count ?? 0) + 1;
+      const lockedUntil = nextCount >= MAX_FAILED_LOGINS
+        ? new Date(now.getTime() + LOGIN_LOCKOUT_MS)
+        : (activeLock ? current.locked_until : null);
+
+      await tx.$executeRaw`
+        INSERT INTO "auth_login_attempts" (
+          "account_key_hash", "failure_count", "first_failure_at", "last_failure_at", "locked_until", "updated_at"
+        ) VALUES (
+          ${key}, ${nextCount}, ${now}, ${now}, ${lockedUntil}, ${now}
+        )
+        ON CONFLICT ("account_key_hash") DO UPDATE SET
+          "failure_count" = EXCLUDED."failure_count",
+          "last_failure_at" = EXCLUDED."last_failure_at",
+          "locked_until" = EXCLUDED."locked_until",
+          "updated_at" = EXCLUDED."updated_at"
+      `;
+    }, { isolationLevel: 'Serializable' });
+  }
+
+  async clearLoginFailures(email: string): Promise<void> {
+    await this.prisma.$executeRaw`
+      DELETE FROM "auth_login_attempts" WHERE "account_key_hash" = ${accountKey(email)}
     `;
   }
 }

--- a/apps/api/src/modules/auth/persistent-auth-session.service.ts
+++ b/apps/api/src/modules/auth/persistent-auth-session.service.ts
@@ -1,0 +1,155 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { createHash, randomUUID } from 'crypto';
+import { PrismaService } from '../../common/prisma/prisma.service';
+
+const REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface SessionRow {
+  id: string;
+  user_id: string;
+  refresh_token_hash: string;
+  refresh_family_id: string;
+  refresh_generation: number;
+  expires_at: Date;
+  revoked_at: Date | null;
+}
+
+export interface IssuedPersistentSession {
+  sessionId: string;
+  refreshToken: string;
+  familyId: string;
+  generation: number;
+  expiresAt: Date;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function hashIp(ip?: string): string | null {
+  return ip ? sha256(ip.trim().toLowerCase()) : null;
+}
+
+@Injectable()
+export class PersistentAuthSessionService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async issue(userId: string, userAgent?: string, ip?: string): Promise<IssuedPersistentSession> {
+    const sessionId = randomUUID();
+    const refreshToken = `${randomUUID()}${randomUUID()}`;
+    const familyId = randomUUID();
+    const expiresAt = new Date(Date.now() + REFRESH_TTL_MS);
+
+    await this.prisma.$executeRaw`
+      INSERT INTO "auth_sessions" (
+        "id", "user_id", "refresh_token_hash", "refresh_family_id",
+        "refresh_generation", "user_agent", "ip_hash", "expires_at"
+      ) VALUES (
+        ${sessionId}, ${userId}, ${sha256(refreshToken)}, ${familyId},
+        0, ${userAgent ?? null}, ${hashIp(ip)}, ${expiresAt}
+      )
+    `;
+
+    return { sessionId, refreshToken, familyId, generation: 0, expiresAt };
+  }
+
+  async rotate(refreshToken: string, userAgent?: string, ip?: string): Promise<IssuedPersistentSession & { userId: string }> {
+    const tokenHash = sha256(refreshToken);
+    const replacementToken = `${randomUUID()}${randomUUID()}`;
+    const replacementHash = sha256(replacementToken);
+    const now = new Date();
+    const expiresAt = new Date(Date.now() + REFRESH_TTL_MS);
+
+    return this.prisma.$transaction(async (tx) => {
+      const rows = await tx.$queryRaw<SessionRow[]>`
+        SELECT "id", "user_id", "refresh_token_hash", "refresh_family_id",
+               "refresh_generation", "expires_at", "revoked_at"
+        FROM "auth_sessions"
+        WHERE "refresh_token_hash" = ${tokenHash}
+        FOR UPDATE
+      `;
+      const current = rows[0];
+      if (!current) throw new UnauthorizedException('Invalid refresh token');
+
+      if (current.revoked_at) {
+        await tx.$executeRaw`
+          UPDATE "auth_sessions"
+          SET "revoked_at" = COALESCE("revoked_at", ${now}),
+              "revoke_reason" = COALESCE("revoke_reason", 'refresh_token_reuse')
+          WHERE "refresh_family_id" = ${current.refresh_family_id}
+        `;
+        throw new UnauthorizedException('Refresh token reuse detected');
+      }
+
+      if (new Date(current.expires_at).getTime() <= now.getTime()) {
+        await tx.$executeRaw`
+          UPDATE "auth_sessions"
+          SET "revoked_at" = ${now}, "revoke_reason" = 'expired'
+          WHERE "id" = ${current.id} AND "revoked_at" IS NULL
+        `;
+        throw new UnauthorizedException('Refresh token expired');
+      }
+
+      const nextGeneration = current.refresh_generation + 1;
+      const replacementSessionId = randomUUID();
+
+      await tx.$executeRaw`
+        UPDATE "auth_sessions"
+        SET "revoked_at" = ${now}, "revoke_reason" = 'rotated', "last_seen_at" = ${now}
+        WHERE "id" = ${current.id} AND "revoked_at" IS NULL
+      `;
+
+      await tx.$executeRaw`
+        INSERT INTO "auth_sessions" (
+          "id", "user_id", "refresh_token_hash", "refresh_family_id",
+          "refresh_generation", "user_agent", "ip_hash", "expires_at"
+        ) VALUES (
+          ${replacementSessionId}, ${current.user_id}, ${replacementHash}, ${current.refresh_family_id},
+          ${nextGeneration}, ${userAgent ?? null}, ${hashIp(ip)}, ${expiresAt}
+        )
+      `;
+
+      return {
+        userId: current.user_id,
+        sessionId: replacementSessionId,
+        refreshToken: replacementToken,
+        familyId: current.refresh_family_id,
+        generation: nextGeneration,
+        expiresAt,
+      };
+    }, { isolationLevel: 'Serializable' });
+  }
+
+  async assertActive(sessionId: string): Promise<void> {
+    const rows = await this.prisma.$queryRaw<Array<{ active: boolean }>>`
+      SELECT EXISTS (
+        SELECT 1 FROM "auth_sessions"
+        WHERE "id" = ${sessionId}
+          AND "revoked_at" IS NULL
+          AND "expires_at" > CURRENT_TIMESTAMP
+      ) AS "active"
+    `;
+    if (!rows[0]?.active) throw new UnauthorizedException('Session has been revoked or expired');
+
+    await this.prisma.$executeRaw`
+      UPDATE "auth_sessions" SET "last_seen_at" = CURRENT_TIMESTAMP WHERE "id" = ${sessionId}
+    `;
+  }
+
+  async revoke(sessionId: string, reason = 'logout'): Promise<void> {
+    await this.prisma.$executeRaw`
+      UPDATE "auth_sessions"
+      SET "revoked_at" = COALESCE("revoked_at", CURRENT_TIMESTAMP),
+          "revoke_reason" = COALESCE("revoke_reason", ${reason})
+      WHERE "id" = ${sessionId}
+    `;
+  }
+
+  async revokeAllForUser(userId: string, reason = 'logout_all'): Promise<number> {
+    return this.prisma.$executeRaw`
+      UPDATE "auth_sessions"
+      SET "revoked_at" = CURRENT_TIMESTAMP, "revoke_reason" = ${reason}
+      WHERE "user_id" = ${userId} AND "revoked_at" IS NULL
+    `;
+  }
+}

--- a/apps/web/app/platform-v7/layout.tsx
+++ b/apps/web/app/platform-v7/layout.tsx
@@ -29,6 +29,7 @@ import '@/styles/platform-v7-public-mobile-safe-area.css';
 import '@/styles/platform-v7-seller-mobile-usability.css';
 import '@/styles/platform-v7-mobile-bottom-tools.css';
 import '@/styles/platform-v7-seller-workspace-v2.css';
+import '@/styles/platform-v7-industrial-design-system.css';
 
 export const metadata: Metadata = {
   title: { default: 'Прозрачная Цена', template: '%s · Прозрачная Цена' },

--- a/apps/web/styles/platform-v7-industrial-design-system.css
+++ b/apps/web/styles/platform-v7-industrial-design-system.css
@@ -1,0 +1,186 @@
+:root {
+  --pc-industrial-max: 1440px;
+  --pc-industrial-radius-xs: 10px;
+  --pc-industrial-radius-sm: 14px;
+  --pc-industrial-radius-md: 18px;
+  --pc-industrial-radius-lg: 24px;
+  --pc-industrial-touch: 48px;
+  --pc-industrial-gap: clamp(12px, 2vw, 20px);
+  --pc-industrial-focus: 0 0 0 3px color-mix(in srgb, var(--pc-accent) 28%, transparent);
+}
+
+/* Shared production workspace: one visual language across every role. */
+.platform-v7-shell main,
+[data-platform-v7-main] {
+  width: min(100%, var(--pc-industrial-max));
+  margin-inline: auto;
+}
+
+.deal-workspace {
+  gap: var(--pc-industrial-gap) !important;
+  padding-bottom: max(24px, env(safe-area-inset-bottom));
+}
+
+.deal-hero,
+.deal-attention,
+.deal-spine-card,
+.deal-action-card,
+.deal-facts-card,
+.deal-metrics article {
+  border-radius: var(--pc-industrial-radius-lg) !important;
+}
+
+.deal-hero h1 {
+  max-width: 18ch;
+  overflow-wrap: anywhere;
+}
+
+.deal-role-strip,
+.deal-attention,
+.deal-metrics article,
+.deal-spine-card,
+.deal-action-card,
+.deal-facts-card {
+  box-shadow: 0 1px 2px rgba(12, 35, 25, .04), 0 10px 30px rgba(12, 35, 25, .05) !important;
+}
+
+.deal-action-card {
+  position: sticky;
+  top: calc(var(--platform-v7-header-height, 64px) + 12px);
+}
+
+.deal-action-card button,
+.deal-error button,
+.section-heading button,
+.platform-v7-shell button,
+.platform-v7-shell a[role='button'] {
+  min-height: var(--pc-industrial-touch);
+  touch-action: manipulation;
+}
+
+.deal-action-card button:not(:disabled) {
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--pc-accent) 24%, transparent);
+}
+
+.deal-action-card button:not(:disabled):active {
+  transform: translateY(1px);
+  box-shadow: none;
+}
+
+.deal-action-card button:focus-visible,
+.deal-error button:focus-visible,
+.section-heading button:focus-visible,
+.platform-v7-shell button:focus-visible,
+.platform-v7-shell a:focus-visible,
+.platform-v7-shell input:focus-visible,
+.platform-v7-shell select:focus-visible,
+.platform-v7-shell textarea:focus-visible {
+  outline: none;
+  box-shadow: var(--pc-industrial-focus) !important;
+}
+
+.deal-message,
+.deal-attention {
+  overflow-wrap: anywhere;
+}
+
+.deal-spine li {
+  min-height: 68px !important;
+}
+
+.deal-spine strong,
+.deal-action-card p,
+.deal-attention p {
+  line-height: 1.5 !important;
+}
+
+/* Statuses must never be communicated by colour alone. */
+.deal-spine li.done strong::after {
+  content: ' · завершено';
+  color: var(--pc-text-muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.deal-spine li.active strong::after {
+  content: ' · требует внимания';
+  color: var(--pc-accent);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+@media (max-width: 920px) {
+  .deal-action-card {
+    position: static;
+  }
+}
+
+@media (max-width: 640px) {
+  .deal-workspace {
+    gap: 12px !important;
+  }
+
+  .deal-hero,
+  .deal-attention,
+  .deal-spine-card,
+  .deal-action-card,
+  .deal-facts-card {
+    border-radius: var(--pc-industrial-radius-md) !important;
+  }
+
+  .deal-hero {
+    padding: 20px !important;
+  }
+
+  .deal-hero h1 {
+    font-size: clamp(30px, 10vw, 42px) !important;
+    line-height: 1.02 !important;
+  }
+
+  .deal-role-strip {
+    align-items: flex-start !important;
+    flex-direction: column;
+    gap: 6px !important;
+  }
+
+  .deal-attention {
+    grid-template-columns: 40px minmax(0, 1fr) !important;
+    padding: 15px !important;
+  }
+
+  .attention-icon {
+    width: 40px !important;
+    height: 40px !important;
+  }
+
+  .deal-metrics {
+    grid-template-columns: 1fr 1fr !important;
+  }
+
+  .deal-metrics article {
+    min-height: 76px;
+    align-items: flex-start !important;
+  }
+
+  .deal-action-card button {
+    position: sticky;
+    bottom: max(10px, env(safe-area-inset-bottom));
+    z-index: 4;
+  }
+}
+
+@media (max-width: 390px) {
+  .deal-metrics {
+    grid-template-columns: 1fr !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .deal-workspace *,
+  .platform-v7-shell * {
+    scroll-behavior: auto !important;
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .01ms !important;
+  }
+}


### PR DESCRIPTION
## Статус: закрыт без merge

Изменения сохранены в ветке `industrial-persistent-auth-ux`, но текущий truth-source разрешает только Industrial One Deal Ephemeral PostgreSQL E2E scope. Auth и platform-v7 UI находятся в forbidden zone до зелёного E2E.

Причина закрытия — соблюдение последовательности industrial gates, а не отказ от работ.

После подтверждённого PostgreSQL one-deal E2E изменения будут перенесены на свежую ветку поверх актуального `main`, повторно проверены и разделены на безопасные PR: persistent auth/session/MFA и industrial design system.