### PR TITLE
Persistent identity, session rotation and MFA foundation

### DIFF
--- a/apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
+++ b/apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
@@ -1,0 +1,131 @@
+-- Persistent identity, session, refresh-family and MFA security layer.
+-- Forward-only. This migration does not drop legacy mfaSecret/mfaBackup columns;
+-- they remain deprecated until an explicit data migration proves safe removal.
+
+ALTER TABLE public."users"
+  ADD COLUMN IF NOT EXISTS "consentVersion" TEXT,
+  ADD COLUMN IF NOT EXISTS "consentAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "lastLoginAt" TIMESTAMP(3);
+
+CREATE TABLE IF NOT EXISTS public."auth_sessions" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "organizationId" TEXT NOT NULL,
+  "tenantId" TEXT NOT NULL,
+  "role" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'ACTIVE',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "mfaVerifiedAt" TIMESTAMP(3),
+  "revokedAt" TIMESTAMP(3),
+  "revokeReason" TEXT,
+  "userAgentHash" TEXT,
+  "ipHash" TEXT,
+  CONSTRAINT "auth_sessions_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "auth_sessions_user_fkey" FOREIGN KEY ("userId") REFERENCES public."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "auth_sessions_user_status_idx" ON public."auth_sessions"("userId", "status");
+CREATE INDEX IF NOT EXISTS "auth_sessions_tenant_org_idx" ON public."auth_sessions"("tenantId", "organizationId");
+CREATE INDEX IF NOT EXISTS "auth_sessions_expires_idx" ON public."auth_sessions"("expiresAt");
+
+CREATE TABLE IF NOT EXISTS public."auth_refresh_families" (
+  "id" TEXT NOT NULL,
+  "sessionId" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'ACTIVE',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "lastRotatedAt" TIMESTAMP(3),
+  "revokedAt" TIMESTAMP(3),
+  "revokeReason" TEXT,
+  CONSTRAINT "auth_refresh_families_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "auth_refresh_families_session_fkey" FOREIGN KEY ("sessionId") REFERENCES public."auth_sessions"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "auth_refresh_families_user_fkey" FOREIGN KEY ("userId") REFERENCES public."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "auth_refresh_families_session_key" ON public."auth_refresh_families"("sessionId");
+CREATE INDEX IF NOT EXISTS "auth_refresh_families_user_status_idx" ON public."auth_refresh_families"("userId", "status");
+CREATE INDEX IF NOT EXISTS "auth_refresh_families_expires_idx" ON public."auth_refresh_families"("expiresAt");
+
+CREATE TABLE IF NOT EXISTS public."auth_refresh_tokens" (
+  "id" TEXT NOT NULL,
+  "familyId" TEXT NOT NULL,
+  "tokenHash" TEXT NOT NULL,
+  "parentTokenId" TEXT,
+  "replacedByTokenId" TEXT,
+  "status" TEXT NOT NULL DEFAULT 'ACTIVE',
+  "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "usedAt" TIMESTAMP(3),
+  "revokedAt" TIMESTAMP(3),
+  "reuseDetectedAt" TIMESTAMP(3),
+  CONSTRAINT "auth_refresh_tokens_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "auth_refresh_tokens_family_fkey" FOREIGN KEY ("familyId") REFERENCES public."auth_refresh_families"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "auth_refresh_tokens_hash_key" ON public."auth_refresh_tokens"("tokenHash");
+CREATE INDEX IF NOT EXISTS "auth_refresh_tokens_family_status_idx" ON public."auth_refresh_tokens"("familyId", "status");
+CREATE INDEX IF NOT EXISTS "auth_refresh_tokens_expires_idx" ON public."auth_refresh_tokens"("expiresAt");
+
+CREATE TABLE IF NOT EXISTS public."auth_login_attempts" (
+  "accountKeyHash" TEXT NOT NULL,
+  "failures" INTEGER NOT NULL DEFAULT 0,
+  "lockedUntil" TIMESTAMP(3),
+  "lastFailureAt" TIMESTAMP(3),
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "auth_login_attempts_pkey" PRIMARY KEY ("accountKeyHash")
+);
+
+CREATE INDEX IF NOT EXISTS "auth_login_attempts_locked_idx" ON public."auth_login_attempts"("lockedUntil");
+
+CREATE TABLE IF NOT EXISTS public."mfa_factors" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "type" TEXT NOT NULL DEFAULT 'TOTP',
+  "status" TEXT NOT NULL DEFAULT 'PENDING',
+  "secretCiphertext" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "activatedAt" TIMESTAMP(3),
+  "revokedAt" TIMESTAMP(3),
+  "lastUsedAt" TIMESTAMP(3),
+  CONSTRAINT "mfa_factors_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "mfa_factors_user_fkey" FOREIGN KEY ("userId") REFERENCES public."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "mfa_factors_user_status_idx" ON public."mfa_factors"("userId", "status");
+
+CREATE TABLE IF NOT EXISTS public."mfa_backup_codes" (
+  "id" TEXT NOT NULL,
+  "factorId" TEXT NOT NULL,
+  "codeHash" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "usedAt" TIMESTAMP(3),
+  CONSTRAINT "mfa_backup_codes_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "mfa_backup_codes_factor_fkey" FOREIGN KEY ("factorId") REFERENCES public."mfa_factors"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "mfa_backup_codes_hash_key" ON public."mfa_backup_codes"("codeHash");
+CREATE INDEX IF NOT EXISTS "mfa_backup_codes_factor_used_idx" ON public."mfa_backup_codes"("factorId", "usedAt");
+
+CREATE TABLE IF NOT EXISTS public."mfa_challenges" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "sessionId" TEXT,
+  "factorId" TEXT,
+  "purpose" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'PENDING',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "verifiedAt" TIMESTAMP(3),
+  "consumedAt" TIMESTAMP(3),
+  CONSTRAINT "mfa_challenges_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "mfa_challenges_user_fkey" FOREIGN KEY ("userId") REFERENCES public."users"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "mfa_challenges_session_fkey" FOREIGN KEY ("sessionId") REFERENCES public."auth_sessions"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "mfa_challenges_factor_fkey" FOREIGN KEY ("factorId") REFERENCES public."mfa_factors"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "mfa_challenges_user_purpose_status_idx" ON public."mfa_challenges"("userId", "purpose", "status");
+CREATE INDEX IF NOT EXISTS "mfa_challenges_session_status_idx" ON public."mfa_challenges"("sessionId", "status");
+CREATE INDEX IF NOT EXISTS "mfa_challenges_expires_idx" ON public."mfa_challenges"("expiresAt");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -44,8 +44,11 @@ model User {
   fullName         String
   status           String   @default("ACTIVE")
   mfaEnabled       Boolean  @default(false)
-  mfaSecret        String?
-  mfaBackup        String?
+  mfaSecret        String?  // deprecated: encrypted factors live in mfa_factors
+  mfaBackup        String?  // deprecated: hashed codes live in mfa_backup_codes
+  consentVersion   String?
+  consentAt        DateTime?
+  lastLoginAt      DateTime?
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
   deletedAt        DateTime?
@@ -53,6 +56,10 @@ model User {
   orgs             UserOrg[]
   ukepCerts        UkepCertificate[]
   dealParticipants DealParticipant[]
+  authSessions     AuthSession[]
+  refreshFamilies  AuthRefreshFamily[]
+  mfaFactors       MfaFactor[]
+  mfaChallenges    MfaChallenge[]
 
   @@map("users")
 }
@@ -71,6 +78,139 @@ model UserOrg {
   @@unique([userId, organizationId])
   @@index([organizationId])
   @@map("user_orgs")
+}
+
+// ── Persistent Identity & Session Security ───────────────────────────────────
+
+model AuthSession {
+  id               String   @id
+  userId           String
+  organizationId   String
+  tenantId         String
+  role             String
+  status           String   @default("ACTIVE") // ACTIVE | REVOKED | EXPIRED
+  createdAt        DateTime @default(now())
+  expiresAt        DateTime
+  lastSeenAt       DateTime @default(now())
+  mfaVerifiedAt    DateTime?
+  revokedAt        DateTime?
+  revokeReason     String?
+  userAgentHash    String?
+  ipHash           String?
+
+  user             User              @relation(fields: [userId], references: [id], onDelete: Restrict)
+  refreshFamily    AuthRefreshFamily?
+  mfaChallenges    MfaChallenge[]
+
+  @@index([userId, status])
+  @@index([tenantId, organizationId])
+  @@index([expiresAt])
+  @@map("auth_sessions")
+}
+
+model AuthRefreshFamily {
+  id            String   @id
+  sessionId     String   @unique
+  userId        String
+  status        String   @default("ACTIVE") // ACTIVE | REVOKED | EXPIRED | REPLAYED
+  createdAt     DateTime @default(now())
+  expiresAt     DateTime
+  lastRotatedAt DateTime?
+  revokedAt     DateTime?
+  revokeReason  String?
+
+  session       AuthSession       @relation(fields: [sessionId], references: [id], onDelete: Restrict)
+  user          User              @relation(fields: [userId], references: [id], onDelete: Restrict)
+  tokens        AuthRefreshToken[]
+
+  @@index([userId, status])
+  @@index([expiresAt])
+  @@map("auth_refresh_families")
+}
+
+model AuthRefreshToken {
+  id                String   @id @default(cuid())
+  familyId          String
+  tokenHash         String   @unique
+  parentTokenId     String?
+  replacedByTokenId String?
+  status            String   @default("ACTIVE") // ACTIVE | ROTATED | REVOKED | EXPIRED | REPLAYED
+  issuedAt          DateTime @default(now())
+  expiresAt         DateTime
+  usedAt            DateTime?
+  revokedAt         DateTime?
+  reuseDetectedAt   DateTime?
+
+  family            AuthRefreshFamily @relation(fields: [familyId], references: [id], onDelete: Restrict)
+
+  @@index([familyId, status])
+  @@index([expiresAt])
+  @@map("auth_refresh_tokens")
+}
+
+model AuthLoginAttempt {
+  accountKeyHash String   @id
+  failures       Int      @default(0)
+  lockedUntil    DateTime?
+  lastFailureAt  DateTime?
+  updatedAt      DateTime @updatedAt
+
+  @@index([lockedUntil])
+  @@map("auth_login_attempts")
+}
+
+model MfaFactor {
+  id               String   @id @default(cuid())
+  userId           String
+  type             String   @default("TOTP")
+  status           String   @default("PENDING") // PENDING | ACTIVE | REVOKED
+  secretCiphertext String
+  createdAt        DateTime @default(now())
+  activatedAt      DateTime?
+  revokedAt        DateTime?
+  lastUsedAt       DateTime?
+
+  user             User            @relation(fields: [userId], references: [id], onDelete: Restrict)
+  backupCodes      MfaBackupCode[]
+  challenges       MfaChallenge[]
+
+  @@index([userId, status])
+  @@map("mfa_factors")
+}
+
+model MfaBackupCode {
+  id        String   @id @default(cuid())
+  factorId  String
+  codeHash  String   @unique
+  createdAt DateTime @default(now())
+  usedAt    DateTime?
+
+  factor    MfaFactor @relation(fields: [factorId], references: [id], onDelete: Restrict)
+
+  @@index([factorId, usedAt])
+  @@map("mfa_backup_codes")
+}
+
+model MfaChallenge {
+  id         String   @id @default(cuid())
+  userId     String
+  sessionId  String?
+  factorId   String?
+  purpose    String   // SETUP | STEP_UP
+  status     String   @default("PENDING") // PENDING | VERIFIED | CONSUMED | EXPIRED
+  createdAt  DateTime @default(now())
+  expiresAt  DateTime
+  verifiedAt DateTime?
+  consumedAt DateTime?
+
+  user       User         @relation(fields: [userId], references: [id], onDelete: Restrict)
+  session    AuthSession? @relation(fields: [sessionId], references: [id], onDelete: Restrict)
+  factor     MfaFactor?   @relation(fields: [factorId], references: [id], onDelete: Restrict)
+
+  @@index([userId, purpose, status])
+  @@index([sessionId, status])
+  @@index([expiresAt])
+  @@map("mfa_challenges")
 }
 
 model UkepCertificate {

--- a/apps/api/src/common/guards/mfa.guard.ts
+++ b/apps/api/src/common/guards/mfa.guard.ts
@@ -4,16 +4,10 @@ import { Reflector } from '@nestjs/core';
 export const SKIP_MFA_KEY = 'skipMfa';
 
 /**
- * Guard enforcing MFA verification per ТЗ 11.1.
+ * Critical-operation MFA guard.
  *
- * Applied to routes that require MFA:
- *  - Financial operations > 100 000 ₽
- *  - УКЭП signing
- *  - Changes to organization details
- *  - Admin / Compliance / Arbitrator role endpoints
- *
- * In production the JWT carries `mfaVerified: true` after the user completes TOTP.
- * In test environments the header `X-MFA-Verified: true` is accepted as a bypass.
+ * `request.user.mfaVerified` is not trusted from the JWT. It is computed by the
+ * durable session verifier from auth_sessions.mfaVerifiedAt and a bounded TTL.
  */
 @Injectable()
 export class RequiresMfaGuard implements CanActivate {
@@ -27,21 +21,13 @@ export class RequiresMfaGuard implements CanActivate {
     if (skip) return true;
 
     const request = context.switchToHttp().getRequest();
-    const user = request.user as { mfaVerified?: boolean; role?: string } | undefined;
-
-    // Test environment bypass via explicit header
-    const testBypass = request.headers?.['x-mfa-verified'] === 'true';
-    if (testBypass) return true;
-
-    // mfaVerified === false means user presented a valid JWT but hasn't completed MFA challenge.
-    // mfaVerified === undefined means the token was issued before MFA was introduced — allow through.
-    if (user?.mfaVerified === false) {
+    const user = request.user as { mfaVerified?: boolean; sessionId?: string } | undefined;
+    if (!user?.sessionId || user.mfaVerified !== true) {
       throw new UnauthorizedException({
         code: 'MFA_REQUIRED',
-        message: 'Двухфакторная аутентификация обязательна для этой операции. Пройдите MFA и повторите запрос.',
+        message: 'Для этой операции требуется актуальное подтверждение MFA.',
       });
     }
-
     return true;
   }
 }

--- a/apps/api/src/modules/auth/auth-crypto.ts
+++ b/apps/api/src/modules/auth/auth-crypto.ts
@@ -1,0 +1,92 @@
+import { createHash, createHmac, randomBytes, randomUUID } from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { requireSecret } from '../../common/config/secrets';
+import type { Role } from '../../common/types/request-user';
+
+const JWT_SECRET = requireSecret('JWT_SECRET');
+const AUTH_HASH_SECRET = requireSecret('AUTH_HASH_SECRET');
+
+export const ACCESS_TOKEN_TTL_SECONDS = 15 * 60;
+export const SESSION_IDLE_TTL_MS = 12 * 60 * 60 * 1000;
+export const REFRESH_FAMILY_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+export const SESSION_TTL_MS = REFRESH_FAMILY_TTL_MS;
+export const MFA_ELEVATION_TTL_MS = 10 * 60 * 1000;
+
+export type AccessTokenClaims = {
+  sub: string;
+  sid: string;
+  email: string;
+  role: Role;
+  orgId: string;
+  tenantId: string;
+  fullName?: string;
+};
+
+export function issueAccessToken(claims: AccessTokenClaims): string {
+  return jwt.sign(
+    {
+      sid: claims.sid,
+      email: claims.email,
+      role: claims.role,
+      orgId: claims.orgId,
+      tenantId: claims.tenantId,
+      fullName: claims.fullName,
+    },
+    JWT_SECRET,
+    {
+      subject: claims.sub,
+      issuer: 'transparent-price-api',
+      audience: 'platform-v7',
+      jwtid: randomUUID(),
+      expiresIn: ACCESS_TOKEN_TTL_SECONDS,
+    },
+  );
+}
+
+export function verifyAccessTokenSignature(token: string): AccessTokenClaims {
+  const payload = jwt.verify(token, JWT_SECRET, {
+    issuer: 'transparent-price-api',
+    audience: 'platform-v7',
+  }) as jwt.JwtPayload;
+
+  if (
+    typeof payload.sub !== 'string' ||
+    typeof payload.sid !== 'string' ||
+    typeof payload.email !== 'string' ||
+    typeof payload.role !== 'string' ||
+    typeof payload.orgId !== 'string' ||
+    typeof payload.tenantId !== 'string'
+  ) {
+    throw new Error('Incomplete access token claims');
+  }
+
+  return {
+    sub: payload.sub,
+    sid: payload.sid,
+    email: payload.email,
+    role: payload.role as Role,
+    orgId: payload.orgId,
+    tenantId: payload.tenantId,
+    fullName: typeof payload.fullName === 'string' ? payload.fullName : undefined,
+  };
+}
+
+export function createOpaqueRefreshToken(): string {
+  return randomBytes(48).toString('base64url');
+}
+
+export function hashOpaqueToken(token: string): string {
+  return createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+export function hmacFingerprint(value: string | undefined | null): string | null {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  if (!normalized) return null;
+  return createHmac('sha256', AUTH_HASH_SECRET).update(normalized, 'utf8').digest('hex');
+}
+
+export function accountKeyHash(email: string): string {
+  const value = hmacFingerprint(email);
+  if (!value) throw new Error('Email is required for account fingerprint');
+  return value;
+}

--- a/apps/api/src/modules/auth/auth-session.service.ts
+++ b/apps/api/src/modules/auth/auth-session.service.ts
@@ -1,0 +1,484 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { RequestUser, Role } from '../../common/types/request-user';
+import {
+  ACCESS_TOKEN_TTL_SECONDS,
+  MFA_ELEVATION_TTL_MS,
+  REFRESH_FAMILY_TTL_MS,
+  SESSION_IDLE_TTL_MS,
+  SESSION_TTL_MS,
+  createOpaqueRefreshToken,
+  hashOpaqueToken,
+  hmacFingerprint,
+  issueAccessToken,
+  verifyAccessTokenSignature,
+} from './auth-crypto';
+
+const LAST_SEEN_WRITE_INTERVAL_MS = 5 * 60 * 1000;
+
+type SessionIdentity = {
+  id: string;
+  email: string;
+  fullName: string;
+  status: string;
+  mfaEnabled: boolean;
+};
+
+type MembershipIdentity = {
+  organizationId: string;
+  role: string;
+  organization: { tenantId: string; status: string };
+};
+
+export type IssuedAuthSession = {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  user: RequestUser & { mfaEnabled: boolean };
+};
+
+@Injectable()
+export class AuthSessionService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createSession(
+    user: SessionIdentity,
+    membership: MembershipIdentity,
+    userAgent?: string,
+    ip?: string,
+  ): Promise<IssuedAuthSession> {
+    const now = new Date();
+    const sessionId = randomUUID();
+    const familyId = randomUUID();
+    const rawRefreshToken = createOpaqueRefreshToken();
+    const refreshTokenId = randomUUID();
+    const sessionExpiresAt = new Date(now.getTime() + SESSION_TTL_MS);
+    const refreshExpiresAt = new Date(now.getTime() + REFRESH_FAMILY_TTL_MS);
+
+    await this.prisma.$transaction(
+      async (tx) => {
+        await tx.authSession.create({
+          data: {
+            id: sessionId,
+            userId: user.id,
+            organizationId: membership.organizationId,
+            tenantId: membership.organization.tenantId,
+            role: membership.role,
+            status: 'ACTIVE',
+            expiresAt: sessionExpiresAt,
+            lastSeenAt: now,
+            userAgentHash: hmacFingerprint(userAgent),
+            ipHash: hmacFingerprint(ip),
+          },
+        });
+        await tx.authRefreshFamily.create({
+          data: {
+            id: familyId,
+            sessionId,
+            userId: user.id,
+            status: 'ACTIVE',
+            expiresAt: refreshExpiresAt,
+          },
+        });
+        await tx.authRefreshToken.create({
+          data: {
+            id: refreshTokenId,
+            familyId,
+            tokenHash: hashOpaqueToken(rawRefreshToken),
+            status: 'ACTIVE',
+            expiresAt: refreshExpiresAt,
+          },
+        });
+        await tx.user.update({
+          where: { id: user.id },
+          data: { lastLoginAt: now },
+        });
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+
+    const requestUser = this.toRequestUser({
+      sessionId,
+      user,
+      membership,
+      mfaVerifiedAt: null,
+    });
+    return this.issueSessionResponse(requestUser, user.mfaEnabled, rawRefreshToken);
+  }
+
+  async rotateRefreshToken(
+    rawRefreshToken: string,
+    userAgent?: string,
+    ip?: string,
+  ): Promise<IssuedAuthSession> {
+    const tokenHash = hashOpaqueToken(rawRefreshToken);
+    const now = new Date();
+    const idleCutoff = new Date(now.getTime() - SESSION_IDLE_TTL_MS);
+
+    const result = await this.prisma.$transaction(
+      async (tx) => {
+        const token = await tx.authRefreshToken.findUnique({
+          where: { tokenHash },
+          include: {
+            family: {
+              include: {
+                session: { include: { user: true } },
+              },
+            },
+          },
+        });
+
+        if (!token) return { kind: 'invalid' as const };
+
+        const family = token.family;
+        const session = family.session;
+        const expired =
+          token.expiresAt <= now ||
+          family.expiresAt <= now ||
+          session.expiresAt <= now;
+        const idleExpired = session.lastSeenAt <= idleCutoff;
+        const replayed =
+          token.status !== 'ACTIVE' ||
+          Boolean(token.usedAt) ||
+          Boolean(token.revokedAt);
+        const inactive = family.status !== 'ACTIVE' || session.status !== 'ACTIVE';
+
+        if (expired || idleExpired || replayed || inactive) {
+          const reason = replayed
+            ? 'refresh_token_replay'
+            : idleExpired
+              ? 'session_idle_timeout'
+              : expired
+                ? 'refresh_expired'
+                : 'session_inactive';
+          await this.revokeFamilyInTransaction(tx, family.id, session.id, reason, now, replayed);
+          return { kind: 'revoked' as const, reason };
+        }
+
+        const claimed = await tx.authRefreshToken.updateMany({
+          where: {
+            id: token.id,
+            status: 'ACTIVE',
+            usedAt: null,
+            revokedAt: null,
+            expiresAt: { gt: now },
+          },
+          data: { status: 'ROTATED', usedAt: now },
+        });
+        if (claimed.count !== 1) {
+          await this.revokeFamilyInTransaction(
+            tx,
+            family.id,
+            session.id,
+            'refresh_token_concurrent_replay',
+            now,
+            true,
+          );
+          return { kind: 'revoked' as const, reason: 'refresh_token_concurrent_replay' };
+        }
+
+        const membership = await tx.userOrg.findUnique({
+          where: {
+            userId_organizationId: {
+              userId: session.userId,
+              organizationId: session.organizationId,
+            },
+          },
+          include: { organization: true },
+        });
+
+        if (
+          !membership ||
+          membership.role !== session.role ||
+          membership.organization.tenantId !== session.tenantId ||
+          membership.organization.status === 'BLOCKED' ||
+          membership.organization.status === 'SUSPENDED' ||
+          session.user.status !== 'ACTIVE' ||
+          session.user.deletedAt
+        ) {
+          await this.revokeFamilyInTransaction(
+            tx,
+            family.id,
+            session.id,
+            'membership_or_account_changed',
+            now,
+            false,
+          );
+          return { kind: 'revoked' as const, reason: 'membership_or_account_changed' };
+        }
+
+        const nextRawToken = createOpaqueRefreshToken();
+        const nextTokenId = randomUUID();
+        await tx.authRefreshToken.create({
+          data: {
+            id: nextTokenId,
+            familyId: family.id,
+            tokenHash: hashOpaqueToken(nextRawToken),
+            parentTokenId: token.id,
+            status: 'ACTIVE',
+            expiresAt: family.expiresAt,
+          },
+        });
+        await tx.authRefreshToken.update({
+          where: { id: token.id },
+          data: { replacedByTokenId: nextTokenId },
+        });
+        await tx.authRefreshFamily.update({
+          where: { id: family.id },
+          data: { lastRotatedAt: now },
+        });
+        await tx.authSession.update({
+          where: { id: session.id },
+          data: {
+            lastSeenAt: now,
+            userAgentHash: hmacFingerprint(userAgent) ?? session.userAgentHash,
+            ipHash: hmacFingerprint(ip) ?? session.ipHash,
+          },
+        });
+
+        return {
+          kind: 'rotated' as const,
+          rawRefreshToken: nextRawToken,
+          session: {
+            id: session.id,
+            mfaVerifiedAt: session.mfaVerifiedAt,
+          },
+          user: session.user,
+          membership,
+        };
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+
+    if (result.kind !== 'rotated') {
+      throw new UnauthorizedException('Invalid, expired or replayed refresh token');
+    }
+
+    const requestUser = this.toRequestUser({
+      sessionId: result.session.id,
+      user: result.user,
+      membership: result.membership,
+      mfaVerifiedAt: result.session.mfaVerifiedAt,
+    });
+    return this.issueSessionResponse(
+      requestUser,
+      result.user.mfaEnabled,
+      result.rawRefreshToken,
+    );
+  }
+
+  async verifyAccessToken(token: string): Promise<RequestUser> {
+    let claims;
+    try {
+      claims = verifyAccessTokenSignature(token);
+    } catch {
+      throw new UnauthorizedException('Invalid or expired access token');
+    }
+
+    const now = new Date();
+    const idleCutoff = new Date(now.getTime() - SESSION_IDLE_TTL_MS);
+    const session = await this.prisma.authSession.findUnique({
+      where: { id: claims.sid },
+      include: { user: true },
+    });
+    if (
+      !session ||
+      session.userId !== claims.sub ||
+      session.status !== 'ACTIVE' ||
+      session.expiresAt <= now ||
+      session.lastSeenAt <= idleCutoff ||
+      session.user.status !== 'ACTIVE' ||
+      Boolean(session.user.deletedAt)
+    ) {
+      if (session?.status === 'ACTIVE') {
+        await this.revokeSession(
+          session.id,
+          session.lastSeenAt <= idleCutoff ? 'session_idle_timeout' : 'session_expired',
+        );
+      }
+      throw new UnauthorizedException('Session is inactive or expired');
+    }
+
+    const membership = await this.prisma.userOrg.findUnique({
+      where: {
+        userId_organizationId: {
+          userId: session.userId,
+          organizationId: session.organizationId,
+        },
+      },
+      include: { organization: true },
+    });
+    if (
+      !membership ||
+      membership.role !== session.role ||
+      membership.organization.tenantId !== session.tenantId ||
+      membership.organization.status === 'BLOCKED' ||
+      membership.organization.status === 'SUSPENDED'
+    ) {
+      await this.revokeSession(session.id, 'membership_or_scope_changed');
+      throw new UnauthorizedException('Session membership is no longer valid');
+    }
+
+    if (session.lastSeenAt.getTime() < now.getTime() - LAST_SEEN_WRITE_INTERVAL_MS) {
+      await this.prisma.authSession.updateMany({
+        where: { id: session.id, status: 'ACTIVE', lastSeenAt: session.lastSeenAt },
+        data: { lastSeenAt: now },
+      });
+    }
+
+    return this.toRequestUser({
+      sessionId: session.id,
+      user: session.user,
+      membership,
+      mfaVerifiedAt: session.mfaVerifiedAt,
+    });
+  }
+
+  async revokeSession(sessionId: string, reason = 'logout'): Promise<void> {
+    const now = new Date();
+    await this.prisma.$transaction(async (tx) => {
+      const family = await tx.authRefreshFamily.findUnique({ where: { sessionId } });
+      await tx.authSession.updateMany({
+        where: { id: sessionId, status: 'ACTIVE' },
+        data: { status: 'REVOKED', revokedAt: now, revokeReason: reason, mfaVerifiedAt: null },
+      });
+      if (family) {
+        await this.revokeFamilyInTransaction(tx, family.id, sessionId, reason, now, false);
+      }
+    });
+  }
+
+  async revokeByRefreshToken(rawRefreshToken: string, reason = 'logout'): Promise<void> {
+    const token = await this.prisma.authRefreshToken.findUnique({
+      where: { tokenHash: hashOpaqueToken(rawRefreshToken) },
+      include: { family: true },
+    });
+    if (token) await this.revokeSession(token.family.sessionId, reason);
+  }
+
+  async revokeAllUserSessions(userId: string, reason: string): Promise<void> {
+    const now = new Date();
+    await this.prisma.$transaction(async (tx) => {
+      const sessions = await tx.authSession.findMany({
+        where: { userId, status: 'ACTIVE' },
+        select: { id: true },
+      });
+      const sessionIds = sessions.map((item) => item.id);
+      if (!sessionIds.length) return;
+      const families = await tx.authRefreshFamily.findMany({
+        where: { sessionId: { in: sessionIds } },
+        select: { id: true },
+      });
+      const familyIds = families.map((item) => item.id);
+      await tx.authSession.updateMany({
+        where: { id: { in: sessionIds } },
+        data: { status: 'REVOKED', revokedAt: now, revokeReason: reason, mfaVerifiedAt: null },
+      });
+      if (familyIds.length) {
+        await tx.authRefreshFamily.updateMany({
+          where: { id: { in: familyIds } },
+          data: { status: 'REVOKED', revokedAt: now, revokeReason: reason },
+        });
+        await tx.authRefreshToken.updateMany({
+          where: { familyId: { in: familyIds }, status: 'ACTIVE' },
+          data: { status: 'REVOKED', revokedAt: now },
+        });
+      }
+    });
+  }
+
+  async markMfaVerified(sessionId: string): Promise<Date> {
+    const verifiedAt = new Date();
+    const updated = await this.prisma.authSession.updateMany({
+      where: {
+        id: sessionId,
+        status: 'ACTIVE',
+        expiresAt: { gt: verifiedAt },
+        lastSeenAt: { gt: new Date(verifiedAt.getTime() - SESSION_IDLE_TTL_MS) },
+      },
+      data: { mfaVerifiedAt: verifiedAt, lastSeenAt: verifiedAt },
+    });
+    if (updated.count !== 1) throw new UnauthorizedException('Active session required for MFA elevation');
+    return verifiedAt;
+  }
+
+  async clearMfaElevation(sessionId: string): Promise<void> {
+    await this.prisma.authSession.updateMany({
+      where: { id: sessionId },
+      data: { mfaVerifiedAt: null },
+    });
+  }
+
+  private async revokeFamilyInTransaction(
+    tx: Prisma.TransactionClient,
+    familyId: string,
+    sessionId: string,
+    reason: string,
+    now: Date,
+    replayed: boolean,
+  ): Promise<void> {
+    await tx.authRefreshFamily.updateMany({
+      where: { id: familyId },
+      data: {
+        status: replayed ? 'REPLAYED' : 'REVOKED',
+        revokedAt: now,
+        revokeReason: reason,
+      },
+    });
+    await tx.authRefreshToken.updateMany({
+      where: { familyId, status: 'ACTIVE' },
+      data: replayed
+        ? { status: 'REPLAYED', revokedAt: now, reuseDetectedAt: now }
+        : { status: 'REVOKED', revokedAt: now },
+    });
+    await tx.authSession.updateMany({
+      where: { id: sessionId },
+      data: { status: 'REVOKED', revokedAt: now, revokeReason: reason, mfaVerifiedAt: null },
+    });
+  }
+
+  private issueSessionResponse(
+    requestUser: RequestUser,
+    mfaEnabled: boolean,
+    refreshToken: string,
+  ): IssuedAuthSession {
+    return {
+      accessToken: issueAccessToken({
+        sub: requestUser.id,
+        sid: requestUser.sessionId!,
+        email: requestUser.email,
+        role: requestUser.role,
+        orgId: requestUser.orgId,
+        tenantId: requestUser.tenantId!,
+        fullName: requestUser.fullName,
+      }),
+      refreshToken,
+      expiresIn: ACCESS_TOKEN_TTL_SECONDS,
+      user: { ...requestUser, mfaEnabled },
+    };
+  }
+
+  private toRequestUser(input: {
+    sessionId: string;
+    user: SessionIdentity;
+    membership: MembershipIdentity;
+    mfaVerifiedAt: Date | null;
+  }): RequestUser {
+    const mfaVerified = Boolean(
+      input.mfaVerifiedAt &&
+        input.mfaVerifiedAt.getTime() >= Date.now() - MFA_ELEVATION_TTL_MS,
+    );
+    return {
+      id: input.user.id,
+      email: input.user.email,
+      fullName: input.user.fullName,
+      role: input.membership.role as Role,
+      orgId: input.membership.organizationId,
+      tenantId: input.membership.organization.tenantId,
+      sessionId: input.sessionId,
+      mfaVerified,
+    };
+  }
+}

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { BusinessReputationModule } from '../business-reputation/business-reputation.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { AuthSessionService } from './auth-session.service';
 
 @Module({
   imports: [BusinessReputationModule],
   controllers: [AuthController],
-  providers: [AuthService],
-  exports: [AuthService]
+  providers: [AuthService, AuthSessionService],
+  exports: [AuthService, AuthSessionService],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -1,48 +1,25 @@
-import { Injectable, UnauthorizedException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
-import * as jwt from 'jsonwebtoken';
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
 import { randomUUID } from 'crypto';
+import { PrismaService } from '../../common/prisma/prisma.service';
 import { RequestUser, Role } from '../../common/types/request-user';
 import { LoginDto } from './dto/login.dto';
-import { requireSecret } from '../../common/config/secrets';
-
-const JWT_SECRET = requireSecret('JWT_SECRET');
-const ACCESS_TOKEN_TTL = '8h';
-const REFRESH_TOKEN_TTL = '30d';
-const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+import { RegisterDto } from './dto/register.dto';
+import { accountKeyHash } from './auth-crypto';
+import { AuthSessionService } from './auth-session.service';
 
 const CURRENT_CONSENT_VERSION = '1.2';
+const MAX_FAILED_LOGINS = 5;
+const LOGIN_LOCKOUT_MS = 15 * 60 * 1000;
+const DUMMY_PASSWORD_HASH = bcrypt.hashSync('invalid-account-password-sentinel', 10);
 
-interface StoredUser {
-  id: string;
-  email: string;
-  passwordHash: string;
-  role: Role;
-  orgId: string;
-  fullName: string;
-  phone?: string;
-  consentVersion?: string;
-  consentAt?: string;
-  anonymized?: boolean;
-  createdAt?: string;
-}
-
-interface RefreshTokenRecord {
-  token: string;
-  userId: string;
-  expiresAt: number;
-}
-
-const DEMO_ORG_ID = 'org-demo-001';
-
-/**
- * Roles a user is permitted to grant themselves at self-service registration.
- * Privileged / oversight roles (ADMIN, SUPPORT_MANAGER, EXECUTIVE,
- * COMPLIANCE_OFFICER, ARBITRATOR) and GUEST must NEVER be self-assignable —
- * ADMIN/SUPPORT_MANAGER bypass all route + object guards, so accepting them
- * from an anonymous request body is a full authorization bypass. These roles
- * are provisioned only through an authenticated administrator flow.
- */
 const SELF_REGISTERABLE_ROLES: ReadonlySet<Role> = new Set<Role>([
   Role.FARMER,
   Role.BUYER,
@@ -53,252 +30,163 @@ const SELF_REGISTERABLE_ROLES: ReadonlySet<Role> = new Set<Role>([
   Role.ACCOUNTING,
 ]);
 
-// Brute-force / credential-stuffing protection on login (per-account).
-const MAX_FAILED_LOGINS = 5;
-const LOGIN_LOCKOUT_MS = 15 * 60 * 1000; // 15 minutes
-
-/**
- * Demo accounts are seeded ONLY when SEED_DEMO_USERS=true (never implicitly in
- * production). They carry a well-known password and must not exist in any
- * environment serving real users.
- */
-const SHOULD_SEED_DEMO_USERS = String(process.env.SEED_DEMO_USERS || '').toLowerCase() === 'true';
-
-const demoUsers: StoredUser[] = [
-  { id: 'user-farmer-001', email: 'farmer@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.FARMER, orgId: 'org-farmer-001', fullName: 'Demo Farmer' },
-  { id: 'user-buyer-001', email: 'buyer@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.BUYER, orgId: 'org-buyer-001', fullName: 'Demo Buyer' },
-  { id: 'user-logistician-001', email: 'logistician@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.LOGISTICIAN, orgId: 'org-logistics-001', fullName: 'Demo Logistician' },
-  { id: 'user-driver-001', email: 'driver@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.DRIVER, orgId: 'org-logistics-001', fullName: 'Demo Driver' },
-  { id: 'user-lab-001', email: 'lab@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.LAB, orgId: 'org-lab-001', fullName: 'Demo Lab' },
-  { id: 'user-elevator-001', email: 'elevator@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.ELEVATOR, orgId: 'org-elevator-001', fullName: 'Demo Elevator' },
-  { id: 'user-accounting-001', email: 'accounting@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.ACCOUNTING, orgId: 'org-farmer-001', fullName: 'Demo Accounting' },
-  { id: 'user-executive-001', email: 'executive@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.EXECUTIVE, orgId: DEMO_ORG_ID, fullName: 'Demo Executive' },
-  { id: 'user-operator-001', email: 'operator@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.SUPPORT_MANAGER, orgId: DEMO_ORG_ID, fullName: 'Demo Operator' },
-  { id: 'user-admin-001', email: 'admin@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.ADMIN, orgId: DEMO_ORG_ID, fullName: 'Demo Admin' },
-  { id: 'user-compliance-001', email: 'compliance@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.COMPLIANCE_OFFICER, orgId: DEMO_ORG_ID, fullName: 'Demo Compliance Officer' },
-  { id: 'user-arbitrator-001', email: 'arbitrator@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.ARBITRATOR, orgId: DEMO_ORG_ID, fullName: 'Demo Arbitrator' },
-];
-
-const usersStore: StoredUser[] = SHOULD_SEED_DEMO_USERS ? [...demoUsers] : [];
-const refreshTokensStore = new Map<string, RefreshTokenRecord>();
-
-interface LoginAttemptRecord {
-  failures: number;
-  lockedUntil: number;
-}
-const loginAttemptsStore = new Map<string, LoginAttemptRecord>();
-
-const ACCESS_TOKEN_TTL_MS = 8 * 60 * 60 * 1000; // must match ACCESS_TOKEN_TTL ('8h')
-
-// --- Session revocation (L2) ---
-// A stateless JWT cannot be un-issued, so we keep a server-side deny-list of
-// revoked session ids and the set of currently-active sessions per user. Every
-// authenticated request is checked against the deny-list (see
-// verifyAccessToken), which lets logout, account anonymization and role changes
-// invalidate live access tokens immediately instead of waiting 8h for expiry.
-//
-// NOTE (federal / multi-instance scale): these maps are in-process. For a fleet
-// of API instances they must be backed by a shared store (e.g. Redis) so a
-// revocation on one node is honoured by all. The logic below is written so only
-// the store implementation needs swapping.
-const activeUserSessions = new Map<string, Set<string>>();
-const revokedSessions = new Map<string, number>(); // sessionId -> expiry (ms epoch)
-
-function pruneRevokedSessions(now: number): void {
-  for (const [sessionId, expiresAt] of revokedSessions) {
-    if (expiresAt <= now) revokedSessions.delete(sessionId);
-  }
-}
-
-function trackSession(userId: string, sessionId: string): void {
-  let sessions = activeUserSessions.get(userId);
-  if (!sessions) {
-    sessions = new Set<string>();
-    activeUserSessions.set(userId, sessions);
-  }
-  sessions.add(sessionId);
-}
-
-function revokeSession(sessionId: string, now = Date.now()): void {
-  if (!sessionId) return;
-  revokedSessions.set(sessionId, now + ACCESS_TOKEN_TTL_MS);
-  for (const sessions of activeUserSessions.values()) sessions.delete(sessionId);
-}
-
-function revokeAllUserSessions(userId: string, now = Date.now()): void {
-  const sessions = activeUserSessions.get(userId);
-  if (!sessions) return;
-  for (const sessionId of sessions) revokedSessions.set(sessionId, now + ACCESS_TOKEN_TTL_MS);
-  activeUserSessions.delete(userId);
-}
-
-function isSessionRevoked(sessionId: string | undefined, now = Date.now()): boolean {
-  if (!sessionId) return false;
-  const expiresAt = revokedSessions.get(sessionId);
-  if (expiresAt === undefined) return false;
-  if (expiresAt <= now) {
-    revokedSessions.delete(sessionId);
-    return false;
-  }
-  return true;
-}
-
 @Injectable()
 export class AuthService {
-  private issueTokens(user: StoredUser) {
-    const payload: RequestUser = {
-      id: user.id,
-      email: user.email,
-      role: user.role,
-      orgId: user.orgId,
-      fullName: user.fullName,
-      sessionId: randomUUID(),
-    };
-    trackSession(user.id, payload.sessionId!);
-    const accessToken = jwt.sign(payload, JWT_SECRET, { expiresIn: ACCESS_TOKEN_TTL });
-    const refreshToken = randomUUID();
-    refreshTokensStore.set(refreshToken, {
-      token: refreshToken,
-      userId: user.id,
-      expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
-    });
-    return {
-      accessToken,
-      refreshToken,
-      user: {
-        id: user.id,
-        email: user.email,
-        role: user.role,
-        orgId: user.orgId,
-        fullName: user.fullName,
-      },
-    };
-  }
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly sessions: AuthSessionService,
+  ) {}
 
   async login(dto: LoginDto, userAgent?: string, ip?: string) {
-    const accountKey = dto.email.toLowerCase();
-    this.assertNotLockedOut(accountKey);
+    const email = dto.email.trim().toLowerCase();
+    const keyHash = accountKeyHash(email);
+    await this.assertNotLockedOut(keyHash);
 
-    const user = usersStore.find((u) => u.email.toLowerCase() === accountKey);
-    // Always run a bcrypt comparison (even for unknown users) to avoid leaking
-    // account existence via response timing, and to feed the lockout counter.
-    const passwordHash = user?.passwordHash || '';
-    const valid = passwordHash ? await bcrypt.compare(dto.password, passwordHash) : false;
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+      include: {
+        orgs: {
+          include: { organization: true },
+          orderBy: [{ isDefault: 'desc' }, { joinedAt: 'asc' }],
+        },
+      },
+    });
 
-    if (!user || !valid || user.anonymized) {
-      this.registerFailedLogin(accountKey);
+    const passwordHash = user?.passwordHash || DUMMY_PASSWORD_HASH;
+    const valid = await bcrypt.compare(dto.password, passwordHash);
+    const membership = user?.orgs.find(
+      (item) => item.organization.status !== 'BLOCKED' && item.organization.status !== 'SUSPENDED',
+    );
+
+    if (!user || !valid || user.status !== 'ACTIVE' || user.deletedAt || !membership) {
+      await this.registerFailedLogin(keyHash);
       throw new UnauthorizedException('Invalid credentials');
     }
 
-    this.clearFailedLogins(accountKey);
-    return this.issueTokens(user);
+    await this.clearFailedLogins(keyHash);
+    return this.sessions.createSession(user, membership, userAgent, ip);
   }
 
-  private assertNotLockedOut(accountKey: string): void {
-    const record = loginAttemptsStore.get(accountKey);
-    if (record && record.lockedUntil > Date.now()) {
-      const retryAfterSec = Math.ceil((record.lockedUntil - Date.now()) / 1000);
-      throw new UnauthorizedException(
-        `Account temporarily locked after too many failed attempts. Try again in ${retryAfterSec}s.`,
-      );
-    }
-  }
-
-  private registerFailedLogin(accountKey: string): void {
-    const record = loginAttemptsStore.get(accountKey) ?? { failures: 0, lockedUntil: 0 };
-    record.failures += 1;
-    if (record.failures >= MAX_FAILED_LOGINS) {
-      record.lockedUntil = Date.now() + LOGIN_LOCKOUT_MS;
-      record.failures = 0;
-    }
-    loginAttemptsStore.set(accountKey, record);
-  }
-
-  private clearFailedLogins(accountKey: string): void {
-    loginAttemptsStore.delete(accountKey);
-  }
-
-  async register(dto: any) {
-    const requestedRole = (dto.role as Role) || Role.GUEST;
+  async register(dto: RegisterDto) {
+    const requestedRole = dto.role || Role.GUEST;
     if (!SELF_REGISTERABLE_ROLES.has(requestedRole)) {
-      // Do not reveal which roles are privileged — a generic refusal is enough.
       throw new ForbiddenException(
         'The selected role cannot be self-registered. Contact an administrator for access.',
       );
     }
-    const existing = usersStore.find((u) => u.email.toLowerCase() === dto.email.toLowerCase());
-    if (existing) throw new ConflictException('Email already registered');
+    if (dto.orgId) {
+      throw new ForbiddenException({
+        code: 'ORG_INVITE_REQUIRED',
+        message: 'Joining an existing organization requires a server-issued invitation.',
+      });
+    }
+
+    const email = dto.email.trim().toLowerCase();
     const passwordHash = await bcrypt.hash(dto.password, 10);
-    const newUser: StoredUser = {
-      id: `user-${randomUUID()}`,
-      email: dto.email,
-      passwordHash,
-      role: requestedRole,
-      orgId: dto.orgId || `org-${randomUUID()}`,
-      fullName: dto.fullName || dto.email,
-      phone: dto.phone,
-      consentVersion: dto.consentVersion || CURRENT_CONSENT_VERSION,
-      consentAt: new Date().toISOString(),
-      createdAt: new Date().toISOString(),
-    };
-    usersStore.push(newUser);
-    return this.issueTokens(newUser);
+    const now = new Date();
+    const userId = `user-${randomUUID()}`;
+    const organizationId = `org-${randomUUID()}`;
+    const tenantId = `tenant-${randomUUID()}`;
+    const inn = dto.orgInn?.trim() || `PENDING-${randomUUID()}`;
+
+    let created;
+    try {
+      created = await this.prisma.$transaction(
+        async (tx) => {
+          const existing = await tx.user.findUnique({ where: { email }, select: { id: true } });
+          if (existing) throw new ConflictException('Email already registered');
+
+          const organization = await tx.organization.create({
+            data: {
+              id: organizationId,
+              inn,
+              name: dto.orgLegalName?.trim() || `Организация ${dto.fullName.trim()}`,
+              type: dto.orgType || 'LEGAL',
+              status: 'PENDING',
+              tenantId,
+              kycStatus: 'PENDING',
+              amlStatus: 'CLEAR',
+            },
+          });
+          const user = await tx.user.create({
+            data: {
+              id: userId,
+              email,
+              phone: dto.phone?.trim() || null,
+              passwordHash,
+              fullName: dto.fullName.trim(),
+              status: 'ACTIVE',
+              consentVersion: dto.consentVersion || CURRENT_CONSENT_VERSION,
+              consentAt: now,
+            },
+          });
+          const membership = await tx.userOrg.create({
+            data: {
+              userId,
+              organizationId,
+              role: requestedRole,
+              isDefault: true,
+            },
+            include: { organization: true },
+          });
+          return { user, membership, organization };
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+    } catch (error) {
+      if (error instanceof ConflictException) throw error;
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new ConflictException('Email or organization identifier is already registered');
+      }
+      throw error;
+    }
+
+    return this.sessions.createSession(created.user, created.membership);
   }
 
   async refresh(dto: { refreshToken: string }, userAgent?: string, ip?: string) {
-    const record = refreshTokensStore.get(dto.refreshToken);
-    if (!record) throw new UnauthorizedException('Invalid refresh token');
-    if (record.expiresAt < Date.now()) {
-      refreshTokensStore.delete(dto.refreshToken);
-      throw new UnauthorizedException('Refresh token expired');
-    }
-    refreshTokensStore.delete(dto.refreshToken);
-    const user = usersStore.find((u) => u.id === record.userId);
-    if (!user) throw new UnauthorizedException('User not found');
-    return this.issueTokens(user);
+    if (!dto?.refreshToken) throw new UnauthorizedException('Refresh token is required');
+    return this.sessions.rotateRefreshToken(dto.refreshToken, userAgent, ip);
   }
 
   async logout(dto: { refreshToken?: string }, sessionId?: string) {
-    if (dto?.refreshToken) refreshTokensStore.delete(dto.refreshToken);
-    // Immediately invalidate the caller's live access token, not just the refresh token.
-    if (sessionId) revokeSession(sessionId);
-    pruneRevokedSessions(Date.now());
+    if (dto?.refreshToken) await this.sessions.revokeByRefreshToken(dto.refreshToken, 'logout');
+    if (sessionId) await this.sessions.revokeSession(sessionId, 'logout');
     return { success: true };
   }
 
   async me(user: RequestUser) {
+    const record = await this.prisma.user.findUnique({
+      where: { id: user.id },
+      select: { mfaEnabled: true, status: true },
+    });
+    if (!record || record.status !== 'ACTIVE') throw new UnauthorizedException('Account is inactive');
     return {
       id: user.id,
       email: user.email,
       role: user.role,
       orgId: user.orgId,
+      tenantId: user.tenantId,
       fullName: user.fullName,
       surfaceRole: user.surfaceRole,
+      sessionId: user.sessionId,
+      mfaEnabled: record.mfaEnabled,
+      mfaVerified: Boolean(user.mfaVerified),
     };
   }
 
-  async verifyAccessToken(token: string): Promise<RequestUser> {
-    let payload: any;
-    try {
-      payload = jwt.verify(token, JWT_SECRET);
-    } catch {
-      throw new UnauthorizedException('Invalid or expired access token');
-    }
-    if (isSessionRevoked(payload.sessionId)) {
-      throw new UnauthorizedException('Session has been revoked');
-    }
-    return {
-      id: payload.id,
-      email: payload.email,
-      role: payload.role,
-      orgId: payload.orgId,
-      fullName: payload.fullName,
-      surfaceRole: payload.surfaceRole,
-      sessionId: payload.sessionId,
-    };
+  verifyAccessToken(token: string): Promise<RequestUser> {
+    return this.sessions.verifyAccessToken(token);
   }
 
-  sberBusinessStart(query: { returnPath?: string; orgType?: string; inn?: string; legalName?: string; fullName?: string; email?: string }) {
+  sberBusinessStart(query: {
+    returnPath?: string;
+    orgType?: string;
+    inn?: string;
+    legalName?: string;
+    fullName?: string;
+    email?: string;
+  }) {
     return {
       provider: 'sber-business',
       status: 'not_configured',
@@ -307,7 +195,7 @@ export class AuthService {
     };
   }
 
-  sberBusinessCallback(query: { code?: string; state?: string }, userAgent?: string, ip?: string) {
+  sberBusinessCallback(_query: { code?: string; state?: string }, _userAgent?: string, _ip?: string) {
     return {
       provider: 'sber-business',
       status: 'not_configured',
@@ -316,97 +204,166 @@ export class AuthService {
   }
 
   oidcProviders() {
-    return {
-      providers: [],
-      message: 'No OIDC providers configured',
-    };
+    return { providers: [], message: 'No OIDC providers configured' };
   }
 
   oidcAuthorizationUrl() {
-    return {
-      url: null,
-      message: 'No OIDC provider configured',
-    };
+    return { url: null, message: 'No OIDC provider configured' };
   }
 
-  listUsers() {
-    return usersStore.map((u) => ({
-      id: u.id,
-      email: u.email,
-      role: u.role,
-      orgId: u.orgId,
-      fullName: u.fullName,
-    }));
+  async listUsers() {
+    const users = await this.prisma.user.findMany({
+      where: { deletedAt: null },
+      include: {
+        orgs: {
+          include: { organization: true },
+          orderBy: [{ isDefault: 'desc' }, { joinedAt: 'asc' }],
+        },
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+    return users.map((user) => {
+      const membership = user.orgs[0];
+      return {
+        id: user.id,
+        email: user.email,
+        role: membership?.role ?? Role.GUEST,
+        orgId: membership?.organizationId ?? '',
+        tenantId: membership?.organization.tenantId ?? '',
+        fullName: user.fullName,
+      };
+    });
   }
 
-  updateUserRole(userId: string, role: Role): { id: string; role: Role } {
-    const user = usersStore.find((u) => u.id === userId);
-    if (!user) throw new Error(`User ${userId} not found`);
-    user.role = role;
-    // Invalidate live tokens so the privilege change takes effect immediately —
-    // a token minted with the old role must not keep the old access.
-    revokeAllUserSessions(userId);
-    return { id: user.id, role: user.role };
+  async updateUserRole(userId: string, role: Role): Promise<{ id: string; role: Role }> {
+    if (role === Role.BANK_CALLBACK || role === Role.GUEST) {
+      throw new ForbiddenException('System or guest role cannot be assigned to an active membership');
+    }
+    const membership = await this.prisma.userOrg.findFirst({
+      where: { userId },
+      orderBy: [{ isDefault: 'desc' }, { joinedAt: 'asc' }],
+    });
+    if (!membership) throw new NotFoundException(`User ${userId} has no organization membership`);
+    await this.prisma.userOrg.update({ where: { id: membership.id }, data: { role } });
+    await this.sessions.revokeAllUserSessions(userId, 'membership_role_changed');
+    return { id: userId, role };
   }
 
-  updateUserOrg(userId: string, orgId: string): { id: string; orgId: string } {
-    const user = usersStore.find((u) => u.id === userId);
-    if (!user) throw new Error(`User ${userId} not found`);
-    user.orgId = orgId;
-    // Org scope is security-relevant — invalidate live tokens carrying the old org.
-    revokeAllUserSessions(userId);
-    return { id: user.id, orgId: user.orgId };
+  async updateUserOrg(userId: string, orgId: string): Promise<{ id: string; orgId: string }> {
+    const membership = await this.prisma.userOrg.findUnique({
+      where: { userId_organizationId: { userId, organizationId: orgId } },
+    });
+    if (!membership) {
+      throw new ForbiddenException('Organization change requires an existing approved membership');
+    }
+    await this.prisma.$transaction(async (tx) => {
+      await tx.userOrg.updateMany({ where: { userId }, data: { isDefault: false } });
+      await tx.userOrg.update({ where: { id: membership.id }, data: { isDefault: true } });
+    });
+    await this.sessions.revokeAllUserSessions(userId, 'default_organization_changed');
+    return { id: userId, orgId };
   }
 
-  getUserData(requestingUserId: string) {
-    const user = usersStore.find((u) => u.id === requestingUserId);
+  async getUserData(requestingUserId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: requestingUserId },
+      include: {
+        orgs: { include: { organization: true }, orderBy: { joinedAt: 'asc' } },
+        authSessions: {
+          select: { id: true, status: true, createdAt: true, lastSeenAt: true, revokedAt: true },
+          orderBy: { createdAt: 'desc' },
+        },
+      },
+    });
     if (!user) throw new NotFoundException('User not found');
-    if (user.anonymized) throw new ForbiddenException('Account has been anonymized');
+    if (user.deletedAt) throw new ForbiddenException('Account has been anonymized');
     return {
       exportedAt: new Date().toISOString(),
-      exportVersion: '1.0',
+      exportVersion: '2.0',
       subject: '152-ФЗ Data Portability Export',
       profile: {
         id: user.id,
         email: user.email,
         fullName: user.fullName,
-        phone: user.phone ?? null,
-        role: user.role,
-        orgId: user.orgId,
-        createdAt: user.createdAt ?? null,
+        phone: user.phone,
+        createdAt: user.createdAt,
       },
+      memberships: user.orgs.map((membership) => ({
+        organizationId: membership.organizationId,
+        organizationName: membership.organization.name,
+        tenantId: membership.organization.tenantId,
+        role: membership.role,
+        isDefault: membership.isDefault,
+        joinedAt: membership.joinedAt,
+      })),
       consent: {
-        version: user.consentVersion ?? null,
-        recordedAt: user.consentAt ?? null,
+        version: user.consentVersion,
+        recordedAt: user.consentAt,
         currentPolicyVersion: CURRENT_CONSENT_VERSION,
       },
-      accountStatus: {
-        anonymized: user.anonymized ?? false,
-      },
+      sessions: user.authSessions,
+      accountStatus: { status: user.status, anonymized: false },
     };
   }
 
-  anonymizeUser(requestingUserId: string): { success: boolean; anonymizedAt: string } {
-    const user = usersStore.find((u) => u.id === requestingUserId);
+  async anonymizeUser(requestingUserId: string): Promise<{ success: boolean; anonymizedAt: string }> {
+    const user = await this.prisma.user.findUnique({ where: { id: requestingUserId } });
     if (!user) throw new NotFoundException('User not found');
-    if (user.anonymized) throw new ConflictException('Account already anonymized');
+    if (user.deletedAt) throw new ConflictException('Account already anonymized');
 
-    const anonymizedAt = new Date().toISOString();
-    user.email = `anon-${user.id}@deleted.invalid`;
-    user.fullName = 'Anonymized User';
-    user.phone = undefined;
-    user.passwordHash = '';
-    user.anonymized = true;
+    await this.sessions.revokeAllUserSessions(requestingUserId, 'account_anonymized');
+    const anonymizedAt = new Date();
+    await this.prisma.user.update({
+      where: { id: requestingUserId },
+      data: {
+        email: `anon-${requestingUserId}-${randomUUID()}@deleted.invalid`,
+        fullName: 'Anonymized User',
+        phone: null,
+        passwordHash: '',
+        status: 'ANONYMIZED',
+        deletedAt: anonymizedAt,
+        mfaEnabled: false,
+        mfaSecret: null,
+        mfaBackup: null,
+      },
+    });
+    return { success: true, anonymizedAt: anonymizedAt.toISOString() };
+  }
 
-    // Revoke all refresh tokens for this user
-    for (const [key, rec] of refreshTokensStore.entries()) {
-      if (rec.userId === requestingUserId) {
-        refreshTokensStore.delete(key);
-      }
+  private async assertNotLockedOut(keyHash: string): Promise<void> {
+    const record = await this.prisma.authLoginAttempt.findUnique({ where: { accountKeyHash: keyHash } });
+    if (record?.lockedUntil && record.lockedUntil > new Date()) {
+      const retryAfterSec = Math.ceil((record.lockedUntil.getTime() - Date.now()) / 1000);
+      throw new UnauthorizedException(
+        `Account temporarily locked after too many failed attempts. Try again in ${retryAfterSec}s.`,
+      );
     }
-    // Revoke all live access sessions for this user.
-    revokeAllUserSessions(requestingUserId);
+  }
 
-    return { success: true, anonymizedAt };
+  private async registerFailedLogin(keyHash: string): Promise<void> {
+    const now = new Date();
+    await this.prisma.$transaction(async (tx) => {
+      const record = await tx.authLoginAttempt.findUnique({ where: { accountKeyHash: keyHash } });
+      const failures = (record?.failures ?? 0) + 1;
+      const lock = failures >= MAX_FAILED_LOGINS;
+      await tx.authLoginAttempt.upsert({
+        where: { accountKeyHash: keyHash },
+        update: {
+          failures: lock ? 0 : failures,
+          lockedUntil: lock ? new Date(now.getTime() + LOGIN_LOCKOUT_MS) : record?.lockedUntil,
+          lastFailureAt: now,
+        },
+        create: {
+          accountKeyHash: keyHash,
+          failures: lock ? 0 : failures,
+          lockedUntil: lock ? new Date(now.getTime() + LOGIN_LOCKOUT_MS) : null,
+          lastFailureAt: now,
+        },
+      });
+    });
+  }
+
+  private async clearFailedLogins(keyHash: string): Promise<void> {
+    await this.prisma.authLoginAttempt.deleteMany({ where: { accountKeyHash: keyHash } });
   }
 }

--- a/apps/api/src/modules/auth/jwt-auth.guard.ts
+++ b/apps/api/src/modules/auth/jwt-auth.guard.ts
@@ -1,9 +1,6 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
-import * as jwt from 'jsonwebtoken';
 import type { RequestUser } from '../../common/types/request-user';
-import { requireSecret } from '../../common/config/secrets';
-
-const JWT_SECRET = requireSecret('JWT_SECRET');
+import { AuthService } from './auth.service';
 
 function extractBearerToken(authorization?: string): string | null {
   if (!authorization) return null;
@@ -14,30 +11,19 @@ function extractBearerToken(authorization?: string): string | null {
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
-  canActivate(context: ExecutionContext): boolean {
-    const request = context.switchToHttp().getRequest<{ headers: Record<string, string | string[] | undefined>; user?: RequestUser }>();
+  constructor(private readonly auth: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<{
+      headers: Record<string, string | string[] | undefined>;
+      user?: RequestUser;
+    }>();
     const rawAuthorization = request.headers.authorization;
     const authorization = Array.isArray(rawAuthorization) ? rawAuthorization[0] : rawAuthorization;
     const token = extractBearerToken(authorization);
+    if (!token) throw new UnauthorizedException('Missing bearer token');
 
-    if (!token) {
-      throw new UnauthorizedException('Missing bearer token');
-    }
-
-    try {
-      const payload = jwt.verify(token, JWT_SECRET) as RequestUser;
-      request.user = {
-        id: payload.id,
-        email: payload.email,
-        role: payload.role,
-        orgId: payload.orgId,
-        fullName: payload.fullName,
-        surfaceRole: payload.surfaceRole,
-        sessionId: payload.sessionId,
-      };
-      return true;
-    } catch {
-      throw new UnauthorizedException('Invalid or expired access token');
-    }
+    request.user = await this.auth.verifyAccessToken(token);
+    return true;
   }
 }

--- a/apps/api/src/modules/deals/canonical-test-deal.seed.ts
+++ b/apps/api/src/modules/deals/canonical-test-deal.seed.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import * as bcrypt from 'bcryptjs';
 import { PrismaService } from '../../common/prisma/prisma.service';
-import { AuthService } from '../auth/auth.service';
 import { Role } from '../../common/types/request-user';
 import { CANONICAL_TEST_DEAL_ID } from './deal-command.policy';
 
@@ -10,18 +9,18 @@ const TEST_PASSWORD = 'demo1234';
 const enabled = (name: string) => String(process.env[name] ?? '').toLowerCase() === 'true';
 
 const identities = [
-  { email: 'farmer@demo.ru', fullName: 'Тестовый продавец', role: Role.FARMER, orgId: 'org-canonical-seller' },
-  { email: 'buyer@demo.ru', fullName: 'Тестовый покупатель', role: Role.BUYER, orgId: 'org-canonical-buyer' },
-  { email: 'logistician@demo.ru', fullName: 'Тестовый логист', role: Role.LOGISTICIAN, orgId: 'org-canonical-logistics' },
-  { email: 'driver@demo.ru', fullName: 'Тестовый водитель', role: Role.DRIVER, orgId: 'org-canonical-logistics' },
-  { email: 'surveyor@demo.ru', fullName: 'Тестовый сюрвейер', role: Role.SURVEYOR, orgId: 'org-canonical-surveyor' },
-  { email: 'elevator@demo.ru', fullName: 'Тестовый элеватор', role: Role.ELEVATOR, orgId: 'org-canonical-elevator' },
-  { email: 'lab@demo.ru', fullName: 'Тестовая лаборатория', role: Role.LAB, orgId: 'org-canonical-lab' },
-  { email: 'accounting@demo.ru', fullName: 'Тестовый банковский сотрудник', role: Role.ACCOUNTING, orgId: 'org-canonical-bank' },
-  { email: 'compliance@demo.ru', fullName: 'Тестовый комплаенс', role: Role.COMPLIANCE_OFFICER, orgId: 'org-canonical-platform' },
-  { email: 'arbitrator@demo.ru', fullName: 'Тестовый арбитр', role: Role.ARBITRATOR, orgId: 'org-canonical-platform' },
-  { email: 'operator@demo.ru', fullName: 'Тестовый оператор', role: Role.SUPPORT_MANAGER, orgId: 'org-canonical-platform' },
-  { email: 'executive@demo.ru', fullName: 'Тестовый руководитель', role: Role.EXECUTIVE, orgId: 'org-canonical-platform' },
+  { userId: 'user-canonical-farmer', email: 'farmer@demo.ru', fullName: 'Тестовый продавец', role: Role.FARMER, orgId: 'org-canonical-seller' },
+  { userId: 'user-canonical-buyer', email: 'buyer@demo.ru', fullName: 'Тестовый покупатель', role: Role.BUYER, orgId: 'org-canonical-buyer' },
+  { userId: 'user-canonical-logistician', email: 'logistician@demo.ru', fullName: 'Тестовый логист', role: Role.LOGISTICIAN, orgId: 'org-canonical-logistics' },
+  { userId: 'user-canonical-driver', email: 'driver@demo.ru', fullName: 'Тестовый водитель', role: Role.DRIVER, orgId: 'org-canonical-logistics' },
+  { userId: 'user-canonical-surveyor', email: 'surveyor@demo.ru', fullName: 'Тестовый сюрвейер', role: Role.SURVEYOR, orgId: 'org-canonical-surveyor' },
+  { userId: 'user-canonical-elevator', email: 'elevator@demo.ru', fullName: 'Тестовый элеватор', role: Role.ELEVATOR, orgId: 'org-canonical-elevator' },
+  { userId: 'user-canonical-lab', email: 'lab@demo.ru', fullName: 'Тестовая лаборатория', role: Role.LAB, orgId: 'org-canonical-lab' },
+  { userId: 'user-canonical-accounting', email: 'accounting@demo.ru', fullName: 'Тестовый банковский сотрудник', role: Role.ACCOUNTING, orgId: 'org-canonical-bank' },
+  { userId: 'user-canonical-compliance', email: 'compliance@demo.ru', fullName: 'Тестовый комплаенс', role: Role.COMPLIANCE_OFFICER, orgId: 'org-canonical-platform' },
+  { userId: 'user-canonical-arbitrator', email: 'arbitrator@demo.ru', fullName: 'Тестовый арбитр', role: Role.ARBITRATOR, orgId: 'org-canonical-platform' },
+  { userId: 'user-canonical-operator', email: 'operator@demo.ru', fullName: 'Тестовый оператор', role: Role.SUPPORT_MANAGER, orgId: 'org-canonical-platform' },
+  { userId: 'user-canonical-executive', email: 'executive@demo.ru', fullName: 'Тестовый руководитель', role: Role.EXECUTIVE, orgId: 'org-canonical-platform' },
 ] as const;
 
 function participantAccess(role: Role): 'READ' | 'WORK' | 'APPROVE' {
@@ -38,10 +37,7 @@ function participantAccess(role: Role): 'READ' | 'WORK' | 'APPROVE' {
 export class CanonicalTestDealSeedService implements OnModuleInit {
   private readonly logger = new Logger(CanonicalTestDealSeedService.name);
 
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly auth: AuthService,
-  ) {}
+  constructor(private readonly prisma: PrismaService) {}
 
   async onModuleInit(): Promise<void> {
     if (!enabled('SEED_CANONICAL_TEST_DEAL')) return;
@@ -144,55 +140,42 @@ export class CanonicalTestDealSeedService implements OnModuleInit {
 
   private async seedIdentitiesMembershipsAndParticipants(): Promise<void> {
     const passwordHash = bcrypt.hashSync(TEST_PASSWORD, 10);
+    const consentAt = new Date();
 
     for (const identity of identities) {
-      let user = this.auth.listUsers().find((item) => item.email.toLowerCase() === identity.email);
-      if (!user) {
-        const registered = await this.auth.register({
-          email: identity.email,
-          password: TEST_PASSWORD,
-          role: Role.DRIVER,
-          orgId: identity.orgId,
-          fullName: identity.fullName,
-          consentVersion: '1.2',
-        });
-        user = registered.user;
-      }
-
-      this.auth.updateUserRole(user.id, identity.role);
-      this.auth.updateUserOrg(user.id, identity.orgId);
-
       await this.prisma.$transaction(async (tx) => {
         await tx.user.upsert({
-          where: { id: user.id },
+          where: { id: identity.userId },
           update: {
             email: identity.email,
             passwordHash,
             fullName: identity.fullName,
             status: 'ACTIVE',
+            deletedAt: null,
+            consentVersion: '1.2',
+            consentAt,
           },
           create: {
-            id: user.id,
+            id: identity.userId,
             email: identity.email,
             passwordHash,
             fullName: identity.fullName,
             status: 'ACTIVE',
+            consentVersion: '1.2',
+            consentAt,
           },
         });
 
         await tx.userOrg.upsert({
           where: {
             userId_organizationId: {
-              userId: user.id,
+              userId: identity.userId,
               organizationId: identity.orgId,
             },
           },
-          update: {
-            role: identity.role,
-            isDefault: true,
-          },
+          update: { role: identity.role, isDefault: true },
           create: {
-            userId: user.id,
+            userId: identity.userId,
             organizationId: identity.orgId,
             role: identity.role,
             isDefault: true,
@@ -203,7 +186,7 @@ export class CanonicalTestDealSeedService implements OnModuleInit {
           where: {
             dealId_userId_role: {
               dealId: CANONICAL_TEST_DEAL_ID,
-              userId: user.id,
+              userId: identity.userId,
               role: identity.role,
             },
           },
@@ -219,7 +202,7 @@ export class CanonicalTestDealSeedService implements OnModuleInit {
             dealId: CANONICAL_TEST_DEAL_ID,
             tenantId: CANONICAL_TENANT_ID,
             organizationId: identity.orgId,
-            userId: user.id,
+            userId: identity.userId,
             role: identity.role,
             accessLevel: participantAccess(identity.role),
             status: 'ACTIVE',

--- a/apps/api/src/modules/mfa/mfa.controller.ts
+++ b/apps/api/src/modules/mfa/mfa.controller.ts
@@ -1,40 +1,40 @@
-import { Controller, Post, Body, UseGuards, Get } from '@nestjs/common';
-import { MfaService } from './mfa.service';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
-import { RequestUser } from '../../common/types/request-user';
+import type { RequestUser } from '../../common/types/request-user';
+import { MfaService } from './mfa.service';
 
 @Controller('api/mfa')
-@UseGuards(JwtAuthGuard)
 export class MfaController {
   constructor(private readonly mfa: MfaService) {}
 
+  @Get('status')
+  status(@CurrentUser() user: RequestUser) {
+    return this.mfa.status(user);
+  }
+
   @Post('setup/init')
   initSetup(@CurrentUser() user: RequestUser) {
-    const { secret, otpauthUrl } = this.mfa.generateSecret();
-    const url = otpauthUrl('GrainFlow', user.email);
-    // In production: save secret to DB (encrypted), don't return plain secret
-    return { secret, otpauthUrl: url, message: 'Scan QR code and verify with a TOTP code' };
+    return this.mfa.beginSetup(user);
   }
 
   @Post('setup/verify')
   verifySetup(
     @CurrentUser() user: RequestUser,
-    @Body() body: { secret: string; code: string },
+    @Body() body: { challengeId: string; code: string },
   ) {
-    const valid = this.mfa.verifyTotp(body.secret, body.code);
-    if (!valid) return { success: false, message: 'Invalid code' };
-    const { plain, hashed } = this.mfa.generateBackupCodes();
-    // In production: save hashed codes and enable MFA for user in DB
-    return { success: true, backupCodes: plain, message: 'MFA enabled. Save backup codes securely.' };
+    return this.mfa.confirmSetup(user, body.challengeId, body.code);
+  }
+
+  @Post('verify/init')
+  initVerification(@CurrentUser() user: RequestUser) {
+    return this.mfa.beginStepUp(user);
   }
 
   @Post('verify')
   verify(
-    @CurrentUser() _user: RequestUser,
-    @Body() body: { secret: string; code: string },
+    @CurrentUser() user: RequestUser,
+    @Body() body: { challengeId: string; code?: string; backupCode?: string },
   ) {
-    const valid = this.mfa.verifyTotp(body.secret, body.code);
-    return { valid };
+    return this.mfa.verifyStepUp(user, body);
   }
 }

--- a/apps/api/src/modules/mfa/mfa.service.ts
+++ b/apps/api/src/modules/mfa/mfa.service.ts
@@ -1,31 +1,37 @@
-import { Injectable, BadRequestException, UnauthorizedException } from '@nestjs/common';
-import { createHmac, randomBytes, createHash } from 'crypto';
+import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from 'crypto';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { requireSecret } from '../../common/config/secrets';
+import type { RequestUser } from '../../common/types/request-user';
+import { MFA_ELEVATION_TTL_MS } from '../auth/auth-crypto';
 
-// RFC 6238 TOTP implementation (no external dependency)
+const MFA_CHALLENGE_TTL_MS = 5 * 60 * 1000;
+const MFA_KEY = createHash('sha256').update(requireSecret('MFA_ENCRYPTION_KEY')).digest();
+
 function hotp(secret: Buffer, counter: number, digits = 6): string {
   const buf = Buffer.alloc(8);
   let tmp = counter;
-  for (let i = 7; i >= 0; i--) {
+  for (let i = 7; i >= 0; i -= 1) {
     buf[i] = tmp & 0xff;
     tmp = Math.floor(tmp / 256);
   }
   const hmac = createHmac('sha1', secret).update(buf).digest();
   const offset = hmac[hmac.length - 1] & 0x0f;
-  const code = ((hmac[offset] & 0x7f) << 24) |
+  const code =
+    ((hmac[offset] & 0x7f) << 24) |
     ((hmac[offset + 1] & 0xff) << 16) |
     ((hmac[offset + 2] & 0xff) << 8) |
     (hmac[offset + 3] & 0xff);
-  return String(code % Math.pow(10, digits)).padStart(digits, '0');
-}
-
-function totp(secret: Buffer, window = 1): { code: string; validCodes: string[] } {
-  const step = 30;
-  const counter = Math.floor(Date.now() / 1000 / step);
-  const validCodes: string[] = [];
-  for (let i = -window; i <= window; i++) {
-    validCodes.push(hotp(secret, counter + i));
-  }
-  return { code: validCodes[window], validCodes };
+  return String(code % 10 ** digits).padStart(digits, '0');
 }
 
 function base32Decode(encoded: string): Buffer {
@@ -33,17 +39,18 @@ function base32Decode(encoded: string): Buffer {
   const clean = encoded.toUpperCase().replace(/=+$/, '');
   let bits = 0;
   let value = 0;
-  let index = 0;
-  const output = Buffer.alloc(Math.floor((clean.length * 5) / 8));
+  const bytes: number[] = [];
   for (const char of clean) {
-    value = (value << 5) | alphabet.indexOf(char);
+    const index = alphabet.indexOf(char);
+    if (index < 0) throw new Error('Invalid base32 secret');
+    value = (value << 5) | index;
     bits += 5;
     if (bits >= 8) {
-      output[index++] = (value >>> (bits - 8)) & 255;
+      bytes.push((value >>> (bits - 8)) & 255);
       bits -= 8;
     }
   }
-  return output.slice(0, index);
+  return Buffer.from(bytes);
 }
 
 function base32Encode(buf: Buffer): string {
@@ -63,49 +70,291 @@ function base32Encode(buf: Buffer): string {
   return output;
 }
 
+function verifyTotp(secret: string, code: string, now = Date.now()): boolean {
+  if (!/^\d{6}$/.test(code)) return false;
+  const secretBuffer = base32Decode(secret);
+  const counter = Math.floor(now / 1000 / 30);
+  const supplied = Buffer.from(code, 'utf8');
+  return [-1, 0, 1].some((window) => {
+    const expected = Buffer.from(hotp(secretBuffer, counter + window), 'utf8');
+    return expected.length === supplied.length && timingSafeEqual(expected, supplied);
+  });
+}
+
+function encryptSecret(secret: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', MFA_KEY, iv);
+  const encrypted = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return ['v1', iv.toString('base64url'), tag.toString('base64url'), encrypted.toString('base64url')].join(':');
+}
+
+function decryptSecret(value: string): string {
+  const [version, ivRaw, tagRaw, payloadRaw] = value.split(':');
+  if (version !== 'v1' || !ivRaw || !tagRaw || !payloadRaw) throw new Error('Invalid MFA ciphertext');
+  const decipher = createDecipheriv('aes-256-gcm', MFA_KEY, Buffer.from(ivRaw, 'base64url'));
+  decipher.setAuthTag(Buffer.from(tagRaw, 'base64url'));
+  return Buffer.concat([
+    decipher.update(Buffer.from(payloadRaw, 'base64url')),
+    decipher.final(),
+  ]).toString('utf8');
+}
+
+function generateBackupCodes(count = 8): { plain: string[]; hashed: string[] } {
+  const plain: string[] = [];
+  const hashed: string[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const normalized = randomBytes(6).toString('hex').toUpperCase();
+    plain.push(`${normalized.slice(0, 4)}-${normalized.slice(4, 8)}-${normalized.slice(8)}`);
+    hashed.push(createHash('sha256').update(normalized, 'utf8').digest('hex'));
+  }
+  return { plain, hashed };
+}
+
+function hashBackupCode(code: string): string {
+  return createHash('sha256')
+    .update(code.replace(/-/g, '').trim().toUpperCase(), 'utf8')
+    .digest('hex');
+}
+
 @Injectable()
 export class MfaService {
-  generateSecret(): { secret: string; otpauthUrl: (issuer: string, email: string) => string } {
-    const secret = base32Encode(randomBytes(20));
+  constructor(private readonly prisma: PrismaService) {}
+
+  async status(user: RequestUser) {
+    const activeFactor = await this.prisma.mfaFactor.findFirst({
+      where: { userId: user.id, status: 'ACTIVE' },
+      select: { id: true, type: true, activatedAt: true, lastUsedAt: true },
+    });
     return {
-      secret,
-      otpauthUrl: (issuer: string, email: string) =>
-        `otpauth://totp/${encodeURIComponent(issuer)}:${encodeURIComponent(email)}?secret=${secret}&issuer=${encodeURIComponent(issuer)}&algorithm=SHA1&digits=6&period=30`,
+      enabled: Boolean(activeFactor),
+      factor: activeFactor,
+      elevated: Boolean(user.mfaVerified),
+      elevationTtlSeconds: Math.floor(MFA_ELEVATION_TTL_MS / 1000),
     };
   }
 
-  verifyTotp(secret: string, code: string): boolean {
-    if (!/^\d{6}$/.test(code)) return false;
-    try {
-      const secretBuf = base32Decode(secret);
-      const { validCodes } = totp(secretBuf, 1);
-      return validCodes.includes(code);
-    } catch {
-      return false;
-    }
+  async beginSetup(user: RequestUser) {
+    this.requireSession(user);
+    const secret = base32Encode(randomBytes(20));
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + MFA_CHALLENGE_TTL_MS);
+
+    const result = await this.prisma.$transaction(
+      async (tx) => {
+        await tx.mfaChallenge.updateMany({
+          where: { userId: user.id, purpose: 'SETUP', status: 'PENDING' },
+          data: { status: 'EXPIRED', consumedAt: now },
+        });
+        await tx.mfaFactor.updateMany({
+          where: { userId: user.id, status: 'PENDING' },
+          data: { status: 'REVOKED', revokedAt: now },
+        });
+        const factor = await tx.mfaFactor.create({
+          data: {
+            userId: user.id,
+            type: 'TOTP',
+            status: 'PENDING',
+            secretCiphertext: encryptSecret(secret),
+          },
+        });
+        const challenge = await tx.mfaChallenge.create({
+          data: {
+            userId: user.id,
+            sessionId: user.sessionId,
+            factorId: factor.id,
+            purpose: 'SETUP',
+            status: 'PENDING',
+            expiresAt,
+          },
+        });
+        return { factorId: factor.id, challengeId: challenge.id };
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+
+    const issuer = 'Прозрачная Цена';
+    const otpauthUrl =
+      `otpauth://totp/${encodeURIComponent(issuer)}:${encodeURIComponent(user.email)}` +
+      `?secret=${secret}&issuer=${encodeURIComponent(issuer)}&algorithm=SHA1&digits=6&period=30`;
+    return {
+      challengeId: result.challengeId,
+      factorId: result.factorId,
+      otpauthUrl,
+      expiresAt: expiresAt.toISOString(),
+    };
   }
 
-  generateBackupCodes(count = 8): { plain: string[]; hashed: string[] } {
-    const plain: string[] = [];
-    const hashed: string[] = [];
-    for (let i = 0; i < count; i++) {
-      const code = randomBytes(4).toString('hex').toUpperCase();
-      plain.push(`${code.slice(0, 4)}-${code.slice(4)}`);
-      hashed.push(createHash('sha256').update(code).digest('hex'));
-    }
-    return { plain, hashed };
+  async confirmSetup(user: RequestUser, challengeId: string, code: string) {
+    this.requireSession(user);
+    const now = new Date();
+    const backup = generateBackupCodes();
+
+    const result = await this.prisma.$transaction(
+      async (tx) => {
+        const challenge = await tx.mfaChallenge.findUnique({
+          where: { id: challengeId },
+          include: { factor: true },
+        });
+        this.assertChallenge(challenge, user, 'SETUP', now);
+        if (!challenge?.factor || challenge.factor.status !== 'PENDING') {
+          throw new BadRequestException('Pending MFA factor not found');
+        }
+        const secret = decryptSecret(challenge.factor.secretCiphertext);
+        if (!verifyTotp(secret, code)) throw new UnauthorizedException('Invalid MFA code');
+
+        await tx.mfaFactor.updateMany({
+          where: { userId: user.id, status: 'ACTIVE', id: { not: challenge.factor.id } },
+          data: { status: 'REVOKED', revokedAt: now },
+        });
+        await tx.mfaBackupCode.createMany({
+          data: backup.hashed.map((codeHash) => ({
+            id: randomUUID(),
+            factorId: challenge.factor!.id,
+            codeHash,
+          })),
+        });
+        await tx.mfaFactor.update({
+          where: { id: challenge.factor.id },
+          data: { status: 'ACTIVE', activatedAt: now, lastUsedAt: now },
+        });
+        await tx.mfaChallenge.update({
+          where: { id: challenge.id },
+          data: { status: 'CONSUMED', verifiedAt: now, consumedAt: now },
+        });
+        await tx.user.update({ where: { id: user.id }, data: { mfaEnabled: true } });
+        const elevated = await tx.authSession.updateMany({
+          where: { id: user.sessionId, userId: user.id, status: 'ACTIVE', expiresAt: { gt: now } },
+          data: { mfaVerifiedAt: now },
+        });
+        if (elevated.count !== 1) throw new UnauthorizedException('Active session required');
+        return { factorId: challenge.factor.id };
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+
+    return {
+      success: true,
+      factorId: result.factorId,
+      backupCodes: backup.plain,
+      elevationExpiresAt: new Date(now.getTime() + MFA_ELEVATION_TTL_MS).toISOString(),
+    };
   }
 
-  verifyBackupCode(code: string, hashedCodes: string[]): { valid: boolean; usedIndex: number } {
-    const normalized = code.replace(/-/g, '').toUpperCase();
-    const hash = createHash('sha256').update(normalized).digest('hex');
-    const usedIndex = hashedCodes.indexOf(hash);
-    return { valid: usedIndex >= 0, usedIndex };
+  async beginStepUp(user: RequestUser) {
+    this.requireSession(user);
+    const factor = await this.prisma.mfaFactor.findFirst({
+      where: { userId: user.id, status: 'ACTIVE' },
+      orderBy: { activatedAt: 'desc' },
+    });
+    if (!factor) throw new BadRequestException('MFA is not configured');
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + MFA_CHALLENGE_TTL_MS);
+    const challenge = await this.prisma.mfaChallenge.create({
+      data: {
+        userId: user.id,
+        sessionId: user.sessionId,
+        factorId: factor.id,
+        purpose: 'STEP_UP',
+        status: 'PENDING',
+        expiresAt,
+      },
+    });
+    return { challengeId: challenge.id, expiresAt: expiresAt.toISOString() };
+  }
+
+  async verifyStepUp(
+    user: RequestUser,
+    input: { challengeId: string; code?: string; backupCode?: string },
+  ) {
+    this.requireSession(user);
+    if (!input.code && !input.backupCode) throw new BadRequestException('MFA code is required');
+    const now = new Date();
+
+    await this.prisma.$transaction(
+      async (tx) => {
+        const challenge = await tx.mfaChallenge.findUnique({
+          where: { id: input.challengeId },
+          include: { factor: true },
+        });
+        this.assertChallenge(challenge, user, 'STEP_UP', now);
+        if (!challenge?.factor || challenge.factor.status !== 'ACTIVE') {
+          throw new BadRequestException('Active MFA factor not found');
+        }
+
+        let valid = false;
+        if (input.code) {
+          valid = verifyTotp(decryptSecret(challenge.factor.secretCiphertext), input.code);
+        } else if (input.backupCode) {
+          const used = await tx.mfaBackupCode.updateMany({
+            where: {
+              factorId: challenge.factor.id,
+              codeHash: hashBackupCode(input.backupCode),
+              usedAt: null,
+            },
+            data: { usedAt: now },
+          });
+          valid = used.count === 1;
+        }
+        if (!valid) throw new UnauthorizedException('Invalid MFA code');
+
+        await tx.mfaFactor.update({
+          where: { id: challenge.factor.id },
+          data: { lastUsedAt: now },
+        });
+        await tx.mfaChallenge.update({
+          where: { id: challenge.id },
+          data: { status: 'CONSUMED', verifiedAt: now, consumedAt: now },
+        });
+        const elevated = await tx.authSession.updateMany({
+          where: { id: user.sessionId, userId: user.id, status: 'ACTIVE', expiresAt: { gt: now } },
+          data: { mfaVerifiedAt: now },
+        });
+        if (elevated.count !== 1) throw new UnauthorizedException('Active session required');
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+
+    return {
+      valid: true,
+      elevationExpiresAt: new Date(now.getTime() + MFA_ELEVATION_TTL_MS).toISOString(),
+    };
   }
 
   assertMfaVerified(mfaVerified: boolean | undefined, requireMfa: boolean): void {
     if (requireMfa && !mfaVerified) {
       throw new UnauthorizedException('MFA verification required for this operation');
+    }
+  }
+
+  private requireSession(user: RequestUser): asserts user is RequestUser & { sessionId: string } {
+    if (!user.sessionId) throw new UnauthorizedException('Active session is required');
+  }
+
+  private assertChallenge(
+    challenge:
+      | {
+          id: string;
+          userId: string;
+          sessionId: string | null;
+          purpose: string;
+          status: string;
+          expiresAt: Date;
+        }
+      | null,
+    user: RequestUser & { sessionId: string },
+    purpose: 'SETUP' | 'STEP_UP',
+    now: Date,
+  ): void {
+    if (
+      !challenge ||
+      challenge.userId !== user.id ||
+      challenge.sessionId !== user.sessionId ||
+      challenge.purpose !== purpose ||
+      challenge.status !== 'PENDING' ||
+      challenge.expiresAt <= now
+    ) {
+      throw new UnauthorizedException('MFA challenge is invalid or expired');
     }
   }
 }

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -1,109 +1,107 @@
 {
   "project": "platform-v7",
-  "mode": "industrial-one-deal-recovery",
+  "mode": "persistent-identity-session-mfa",
   "status": "active",
-  "currentStatus": "ready",
-  "current": "PostgreSQL One Deal Recovery Matrix.",
+  "currentStatus": "in_progress",
+  "current": "Persistent Identity, Session, Refresh-Family Revocation and MFA.",
   "fullTzReadinessPercent": 87,
-  "openPr": "#2274",
+  "openPr": "#2275",
   "lastClosed": [
+    "#2274 Industrial one-deal concurrency replay and recovery matrix",
     "#2270 Industrial one-deal PostgreSQL 16 E2E exploitation gate",
-    "#2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
-    "#2245 VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
-    "#2250 VP-3.41 Runtime Persistence Internal Service Wiring Implementation",
-    "#2252 VP-3.42 Runtime Persistence Authenticated Internal Command Boundary",
-    "#2254 VP-3.43 Transaction-Local Trusted RLS Context",
-    "#2256 VP-3.44 Runtime Persistence Trusted Transaction Binding",
-    "#2258 VP-3.45 Physical Table RLS Policy Alignment and Rehearsal",
+    "#2267 Canonical gateway consolidation",
     "#2260 Industrial one-deal foundation",
-    "#2267 Canonical gateway consolidation"
+    "#2258 VP-3.45 Physical Table RLS Policy Alignment and Rehearsal"
   ],
   "openBlockers": [
-    "#2113 repository settings cleanup",
-    "#2115 persistent auth write path",
+    "persistent identity session refresh and MFA implementation under CI verification",
+    "server-derived platform shell and design-system migration",
     "production migration and RLS execution evidence",
     "live bank FGIS EDO and signature evidence",
     "production load restore and DR acceptance"
   ],
-  "blockerNotes": "PR #2274 is green on isolated PostgreSQL 16. It proves one valid concurrent command winner, stable partner+event callback replay, material replay mismatch rejection, out-of-order callback rollback, fresh runtime continuation, atomic forced rollback, transaction-local RLS pool isolation and deterministic full replay after CLOSED. The next authorized scope is backend-only persistent identity/session/MFA; platform UI and client authority remain locked.",
+  "blockerNotes": "The isolated lifecycle and recovery matrix are proven. PR #2275 is the active backend-only P0 layer: durable PostgreSQL sessions, refresh-family rotation/replay revocation, current membership revalidation and server-side MFA challenges. UI remains locked until this security boundary is green.",
   "lockedUntilCurrentGreen": [
-    "persistent identity session MFA changes",
     "platform UI implementation",
+    "production identity migration execution",
     "live external integration activation",
-    "production migration execution",
     "production load and disaster-recovery claims"
   ],
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "apps/api/src/modules/deals/industrial-deal-command.gateway.ts",
-    "apps/api/src/modules/deals/industrial-deal-command.gateway.spec.ts",
-    "apps/api/test/one-deal/**",
-    "scripts/platform-v7-one-deal-*.mjs",
-    "scripts/platform-v7-one-deal-*.sh",
+    "apps/api/prisma/schema.prisma",
+    "apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql",
+    "apps/api/src/modules/auth/**",
+    "apps/api/src/modules/mfa/**",
+    "apps/api/src/modules/deals/canonical-test-deal.seed.ts",
+    "apps/api/src/common/guards/**",
+    "apps/api/src/common/types/request-user.ts",
+    "apps/api/test/auth/**",
     ".github/workflows/ci.yml"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "apps/api/src/modules/deals/industrial-deal-command.gateway.ts",
-    "apps/api/src/modules/deals/industrial-deal-command.gateway.spec.ts",
-    "apps/api/test/one-deal/**",
-    "scripts/platform-v7-one-deal-*.mjs",
-    "scripts/platform-v7-one-deal-*.sh",
+    "apps/api/prisma/schema.prisma",
+    "apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql",
+    "apps/api/src/modules/auth/**",
+    "apps/api/src/modules/mfa/**",
+    "apps/api/src/modules/deals/canonical-test-deal.seed.ts",
+    "apps/api/src/common/guards/**",
+    "apps/api/src/common/types/request-user.ts",
+    "apps/api/test/auth/**",
     ".github/workflows/ci.yml"
   ],
-  "industrialOneDealFoundation": {
-    "layer": "Canonical PostgreSQL deal command path and shared role workspace",
-    "implementationPr": "#2260",
-    "consolidationPr": "#2267",
-    "status": "merged_green",
-    "canonicalDealId": "DEAL-INDUSTRIAL-001"
-  },
   "industrialOneDealE2e": {
-    "layer": "Industrial One Deal Ephemeral PostgreSQL E2E Harness",
     "implementationPr": "#2270",
     "status": "merged_green",
     "mergeCommit": "45a7fd7826eade875b81c1c631eb3a049c3fba94",
     "canonicalDealId": "DEAL-INDUSTRIAL-001"
   },
   "industrialOneDealRecovery": {
-    "layer": "Concurrency Replay Restart Rollback and RLS Pool Isolation",
     "implementationPr": "#2274",
-    "status": "green_ready_for_merge",
-    "canonicalDealId": "DEAL-INDUSTRIAL-001",
-    "resolvedDefect": {
-      "code": "BANK_CALLBACK_RECEIPT_MISSED_AFTER_STATE_CHANGE",
-      "file": "apps/api/src/modules/deals/industrial-deal-command.gateway.ts",
-      "correction": "successful callbacks now use stable verified partner plus event identity while a material payload digest remains bound to commandId for replay mismatch rejection"
-    },
+    "status": "merged_green",
+    "mergeCommit": "cc10110293d9716c2f93790e7756589ead017afd",
     "provenEvidence": [
-      "exactly one concurrent command winner and one aggregate version",
-      "duplicate bank callbacks return the original receipt without duplicate transition event ledger or outbox evidence",
-      "same partner event ID with different material payload is rejected as BANK_EVENT_REPLAY_MISMATCH",
-      "out-of-order callbacks fail with no evidence mutation",
-      "fresh Prisma and service instances continue from persisted pending operations and receipts",
-      "forced transaction failure rolls back Deal event audit ledger and outbox atomically",
-      "transaction-local RLS context does not leak through sequential or parallel pooled connection reuse",
-      "full user command and bank callback replay is deterministic and idempotent after CLOSED",
-      "evidence snapshots remain stable after replay and restart"
+      "one concurrent winner and one aggregate version",
+      "stable callback replay receipt and material mismatch rejection",
+      "out-of-order callback rollback",
+      "fresh process continuation from persisted state",
+      "atomic forced rollback",
+      "transaction-local RLS pool isolation",
+      "deterministic replay after CLOSED"
+    ]
+  },
+  "persistentIdentity": {
+    "implementationPr": "#2275",
+    "status": "in_progress",
+    "requiredEvidence": [
+      "PostgreSQL users memberships sessions refresh families and login attempts",
+      "15-minute access token with DB session and membership revalidation",
+      "30-day absolute and 12-hour idle session limits",
+      "atomic refresh rotation and full-family replay revocation",
+      "cross-instance logout and security-scope revocation",
+      "AES-GCM MFA factors with server-side challenges",
+      "single-use hashed backup codes and ten-minute elevation",
+      "fail-closed MFA guard without header bypass",
+      "migration deploy zero drift unit integration restart and security gates"
     ]
   },
   "nextAfterCurrentGreen": [
-    "persistent identity session refresh-family revoke and MFA after blocker #2115",
-    "durable outbox worker and bank reconciliation",
+    "server-derived mobile-first shell and design-system migration",
+    "durable outbox worker bank reconciliation and partner-key rotation",
     "truthful driver offline acknowledgement",
     "server-rendered RU EN ZH i18n",
-    "complete mobile-first design-system and role-cabinet migration",
-    "load restore DR and accessibility acceptance"
+    "load restore DR accessibility and operational acceptance"
   ],
   "designContractReserved": {
-    "status": "queued_after_persistent_identity",
+    "status": "next_after_persistent_identity",
     "principles": [
       "verified server session is the only role tenant and shell projection source",
       "one primary action per state",
       "status blocker reason and next step are immediately visible",
-      "technical diagnostics are second-level information",
+      "one header one bottom navigation and one Deal work surface",
       "mobile first across RU EN ZH",
       "remove URL-derived role localStorage authority and CSS hotfix cascade",
       "visual regression accessibility and low-bandwidth states are mandatory"
@@ -116,7 +114,6 @@
     "apps/web/components/v7r",
     "apps/web/lib/platform-v7",
     "apps/web/app/api",
-    "apps/api/prisma/migrations/** except explicitly authorized current migration",
     "package.json",
     "package-lock.json",
     "pnpm-lock.yaml",
@@ -126,15 +123,16 @@
   "maturityLanguage": [
     "isolated-postgresql-e2e-proven",
     "isolated-recovery-matrix-proven",
-    "platform-temporarily-without-external-integrations"
+    "persistent-identity-under-verification",
+    "platform-temporarily-without-confirmed-live-integrations"
   ],
   "forbiddenClaims": [
     "full production readiness",
-    "production migration applied",
-    "persistent identity complete",
+    "production identity migration applied",
+    "persistent identity complete before CI proof",
     "external integration completion",
     "live bank money movement",
     "production scale proven"
   ],
-  "readiness": "87% honest architectural readiness. The isolated PostgreSQL lifecycle and recovery matrix are proven. Persistent identity, live integrations, production migration, load, restore and DR remain unproven. Production exploitation remains NO-GO."
+  "readiness": "87% honest architectural readiness. The isolated Deal lifecycle and recovery matrix are proven. Persistent identity/session/MFA is under verification. Production exploitation remains NO-GO."
 }

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,88 +1,67 @@
 # platform-v7 execution queue
 
-CURRENT: PostgreSQL One Deal Recovery Matrix.
+CURRENT: Persistent Identity, Session, Refresh-Family Revocation and MFA.
 
-STATUS: READY FOR MERGE.
+GOAL: Заменить process-local identity/session/MFA на единый PostgreSQL source of truth без ослабления доказанного Deal/RLS/recovery-контура.
 
 BASELINE PROVEN:
-- PR #2270 merged to `main` as `45a7fd7826eade875b81c1c631eb3a049c3fba94`;
-- eight forward-only migrations apply to clean PostgreSQL 16 with zero schema drift;
-- strict tenant/object RLS is enforced through a non-owner `NOSUPERUSER NOBYPASSRLS` application role;
-- one canonical Deal has 12 ACTIVE DealParticipant assignments;
-- all 19 commands execute to `CLOSED` with signed bank callbacks and full reconciliation.
+- PR #2270: восемь forward-only migrations, zero drift, strict tenant/object RLS, 12 DealParticipant и 19 команд до CLOSED;
+- PR #2274 / main `cc10110293d9716c2f93790e7756589ead017afd`: один concurrent winner, callback replay safety, restart continuation, atomic rollback и отсутствие RLS pool leakage;
+- production migration, live integrations, production load и DR по-прежнему не заявлены.
 
-RECOVERY EVIDENCE PROVEN IN PR #2274:
-- simultaneous commands preserve one aggregate version and exactly one valid winner;
-- successful bank callbacks use stable verified partner + event identity rather than mutable Deal version;
-- duplicate callback returns the original receipt without a second event, ledger entry, outbox write or transition;
-- same partner event ID with changed material payload fails as `BANK_EVENT_REPLAY_MISMATCH`;
-- out-of-order release callback fails before any mutation;
-- fresh Prisma/service/gateway instances continue from persisted Deal, pending BankOperation, outbox and receipt state;
-- forced failure rolls back Deal, DealEvent, AuditEvent, ledger and outbox atomically;
-- sequential and parallel transaction-local RLS contexts do not leak tenant, organization, role or session through the pool;
-- full command and callback rerun after `CLOSED` is deterministic and idempotent;
-- evidence snapshots remain byte-for-byte stable across replay and restart checks.
+CURRENT DEFECTS:
+- users, login attempts, refresh tokens, active sessions and revocation были process-local;
+- access token не подтверждал текущую DB-сессию и membership;
+- MFA setup возвращал secret, verify принимал secret от клиента, backup codes и elevation не были durable;
+- MFA guard допускал undefined state и header bypass.
 
-CORRECTED PRODUCT DEFECT:
-- previous generic callback fingerprint included mutable `expectedUpdatedAt`;
-- the same verified event therefore missed its original receipt after `RESERVE_REQUESTED → RESERVED`;
-- correction keeps event identity stable by verified partner + event ID and binds the material payload hash to commandId;
-- HMAC verification, exact pending operation binding and state-machine rules remain unchanged.
+CURRENT IMPLEMENTATION PR: #2275.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
-- apps/api/src/modules/deals/industrial-deal-command.gateway.ts
-- apps/api/src/modules/deals/industrial-deal-command.gateway.spec.ts
-- apps/api/test/one-deal/**
-- scripts/platform-v7-one-deal-*.mjs
-- scripts/platform-v7-one-deal-*.sh
+- apps/api/prisma/schema.prisma
+- apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
+- apps/api/src/modules/auth/**
+- apps/api/src/modules/mfa/**
+- apps/api/src/modules/deals/canonical-test-deal.seed.ts
+- apps/api/src/common/guards/**
+- apps/api/src/common/types/request-user.ts
+- apps/api/test/auth/**
 - .github/workflows/ci.yml
 
-LOCKED:
-- every production file outside the exact gateway and unit-spec listed above;
-- production migration or RLS execution;
-- persistent identity/session/revocation/MFA implementation until this PR merges;
-- live bank, ФГИС, ЭДО and signature activation;
-- platform UI implementation during this recovery proof;
-- apps/landing;
-- package and lockfiles;
-- production load, restore and disaster-recovery claims.
+CURRENT CRITERIA:
+- PostgreSQL User/UserOrg/Organization are the identity and membership truth;
+- AuthSession has 30-day absolute limit and 12-hour idle timeout;
+- access token TTL is 15 minutes and every request revalidates active DB session, user and membership;
+- refresh tokens are opaque, stored only as SHA-256, rotated atomically inside a family;
+- replay or concurrent reuse revokes the full refresh family and session;
+- logout, role change, default organization change and anonymization revoke all affected sessions across API instances;
+- login lockout is persistent and account identifiers/IP/user-agent are HMAC-fingerprinted;
+- MFA secret is AES-GCM encrypted server-side;
+- setup and step-up use short-lived server challenge IDs; verify never accepts a secret from the client;
+- backup codes are hashed and transactionally single-use;
+- MFA elevation is stored on the active session and expires after ten minutes;
+- MFA guard is fail-closed and has no header bypass;
+- canonical 12-role seed creates durable users/memberships directly through Prisma;
+- migration deploy, zero drift, auth unit/integration, one-deal E2E, restart/replay and security checks remain green.
+
+LOCKED UNTIL THIS LAYER IS GREEN:
+- platform UI and design-system implementation;
+- production identity migration execution;
+- live bank, ФГИС, ЭДО and КЭП activation;
+- production load, restore and DR claims;
+- apps/landing and package/lockfiles.
 
 NEXT:
-- Layer: Persistent Identity, Session, Refresh-Family Revocation and MFA.
-- Allowed files:
-  - docs/platform-v7/autopilot/autopilot-state.json
-  - docs/platform-v7/execution-queue.md
-  - apps/api/prisma/schema.prisma
-  - apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
-  - apps/api/src/modules/auth/**
-  - apps/api/src/common/guards/**
-  - apps/api/src/common/types/request-user.ts
-  - apps/api/test/auth/**
-  - .github/workflows/ci.yml
-- Success criteria:
-  - persistent PostgreSQL users, memberships, sessions and refresh-token families replace process memory as identity truth;
-  - access tokens carry only opaque session identity and are re-authorized against persistent session and membership state;
-  - refresh rotation invalidates the previous token and reuse revokes the complete token family;
-  - logout, password reset, organization suspension and administrator revoke invalidate affected sessions deterministically;
-  - privileged roles and threshold financial actions require verified MFA state from the persistent session;
-  - role, tenant and organization are derived from server-side membership, never URL, request DTO, localStorage or client cookies;
-  - login, refresh, MFA verify, logout, revoke, reuse detection and denied access produce immutable audit evidence;
-  - horizontal API instances share the same PostgreSQL session truth and survive process restart;
-  - migration deploy, zero drift, unit, integration, security and restart tests are mandatory;
-  - production readiness and live identity-provider integration remain unclaimed.
-- Readiness remains 87% honest architectural readiness until persistent identity, live integrations, production load, restore and DR are independently proven.
+- Server-Derived Mobile-First Shell and Design System:
+  - verified server session as the only role/tenant/shell projection source;
+  - one header, one bottom navigation, one Deal work surface;
+  - removal of pathname, pc-role, Zustand and sessionStorage authority;
+  - design tokens, WCAG 2.2 AA, visual regression and RU/EN/ZH-ready message keys;
+  - controlled deletion of the 26 CSS/hotfix layers only after coverage.
+- Durable outbox worker, bank reconciliation and partner-key rotation.
+- Truthful driver offline acknowledgement.
+- Load, restore, DR and operational acceptance.
 
-AFTER NEXT:
-- Durable outbox workers, bank reconciliation and partner-key rotation.
-- Truthful driver offline acknowledgement and conflict handling.
-- Server-rendered RU/EN/ZH i18n.
-- Complete mobile-first design-system and role-cabinet migration:
-  - one server-derived shell;
-  - one visual hierarchy;
-  - one primary action per state;
-  - status, blocker reason and next step visible without interpretation;
-  - removal of URL-derived role, client authority and CSS/hotfix cascade;
-  - accessibility and visual-regression acceptance.
-- Load, restore, DR and operational acceptance gates.
+MATURITY: isolated Deal lifecycle and recovery are proven. Persistent identity is under verification. Production exploitation remains NO-GO.


### PR DESCRIPTION
## Цель

Заменить process-local identity/session/MFA на PostgreSQL-backed security boundary, сохранив доказанный Deal/RLS/recovery-контур.

## Реализовано

- durable User/UserOrg/Organization identity truth;
- AuthSession с 30-дневным absolute limit и 12-часовым idle timeout;
- 15-минутные access tokens с обязательной DB session и membership revalidation;
- opaque refresh tokens, SHA-256 storage, Serializable rotation и full-family replay revocation;
- persistent login lockout и HMAC device/account fingerprints;
- logout/role/org/anonymization revoke across API instances;
- AES-GCM MFA factor storage;
- short-lived setup/step-up challenge IDs;
- hashed single-use backup codes;
- ten-minute session elevation;
- fail-closed MFA guard без header bypass;
- canonical 12-role seed переведён на durable Prisma identities.

## Не входит

UI/design migration выполняется следующим отдельным PR после зелёного security boundary. Не заявляются production migration, live bank/ФГИС/ЭДО, production load или DR acceptance.