### PR TITLE
Persistent identity, session rotation, revocation and MFA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate Prisma client
+        run: pnpm --filter @pc/api exec prisma generate --schema prisma/schema.prisma
+
       - name: Generate ephemeral auth secrets
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,83 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  persistent-auth-e2e:
+    name: "Persistent sessions · rotation · MFA · revoke"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: auth_admin
+          POSTGRES_PASSWORD: ephemeral_auth_admin_only
+          POSTGRES_DB: auth_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U auth_admin -d auth_e2e"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+    env:
+      NODE_ENV: test
+      DATABASE_URL: postgresql://auth_admin:ephemeral_auth_admin_only@127.0.0.1:5432/auth_e2e
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.2.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate ephemeral auth secrets
+        shell: bash
+        run: |
+          echo "JWT_SECRET=$(openssl rand -hex 48)" >> "$GITHUB_ENV"
+          echo "AUTH_TOKEN_PEPPER=$(openssl rand -hex 48)" >> "$GITHUB_ENV"
+          echo "MFA_ENCRYPTION_KEY=$(openssl rand -hex 48)" >> "$GITHUB_ENV"
+
+      - name: Apply forward-only migrations
+        run: pnpm --filter @pc/api exec prisma migrate deploy --schema prisma/schema.prisma
+
+      - name: Prove public Prisma schema remains drift-free
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm --filter @pc/api exec prisma migrate diff \
+            --from-url "$DATABASE_URL" \
+            --to-schema-datamodel prisma/schema.prisma \
+            --script \
+            --exit-code 2>&1 | tee /tmp/persistent-auth-drift.log
+
+      - name: Run persistent auth exploitation gate
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm --filter @pc/api exec jest --runInBand --config test/auth/jest.config.json 2>&1 | tee /tmp/persistent-auth-e2e.log
+
+      - name: Upload persistent auth evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: platform-v7-persistent-auth-evidence
+          path: |
+            /tmp/persistent-auth-drift.log
+            /tmp/persistent-auth-e2e.log
+          if-no-files-found: error
+          retention-days: 14
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
+++ b/apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
@@ -1,0 +1,166 @@
+-- Persistent identity/session/MFA substrate for platform-v7.
+-- Forward-only migration. Production execution is a separate operational gate.
+
+CREATE SCHEMA IF NOT EXISTS auth;
+REVOKE ALL ON SCHEMA auth FROM PUBLIC;
+
+CREATE TABLE auth.credential_states (
+  user_id TEXT PRIMARY KEY,
+  credential_version INTEGER NOT NULL DEFAULT 1,
+  failed_login_count INTEGER NOT NULL DEFAULT 0,
+  locked_until TIMESTAMPTZ,
+  password_changed_at TIMESTAMPTZ,
+  last_login_at TIMESTAMPTZ,
+  mfa_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  mfa_secret_ciphertext TEXT,
+  mfa_key_version TEXT,
+  mfa_backup_hashes JSONB,
+  consent_version TEXT,
+  consent_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT auth_credential_states_user_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT auth_credential_version_positive CHECK (credential_version > 0),
+  CONSTRAINT auth_failed_login_count_nonnegative CHECK (failed_login_count >= 0)
+);
+
+CREATE TABLE auth.sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  membership_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'ACTIVE',
+  refresh_family_id TEXT NOT NULL,
+  credential_version INTEGER NOT NULL,
+  mfa_level TEXT NOT NULL DEFAULT 'NONE',
+  mfa_verified_at TIMESTAMPTZ,
+  mfa_verified_method TEXT,
+  user_agent_hash TEXT,
+  ip_hash TEXT,
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ,
+  revocation_reason TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT auth_sessions_user_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT auth_sessions_membership_fkey
+    FOREIGN KEY (membership_id) REFERENCES public.user_orgs(id) ON DELETE RESTRICT,
+  CONSTRAINT auth_sessions_organization_fkey
+    FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT,
+  CONSTRAINT auth_sessions_status_check
+    CHECK (status IN ('MFA_PENDING', 'ACTIVE', 'REVOKED', 'EXPIRED')),
+  CONSTRAINT auth_sessions_mfa_level_check
+    CHECK (mfa_level IN ('NONE', 'TOTP', 'BACKUP'))
+);
+
+CREATE TABLE auth.refresh_tokens (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  family_id TEXT NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  parent_token_id TEXT,
+  replaced_by_token_id TEXT,
+  status TEXT NOT NULL DEFAULT 'ACTIVE',
+  issued_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ,
+  revocation_reason TEXT,
+  user_agent_hash TEXT,
+  ip_hash TEXT,
+  CONSTRAINT auth_refresh_tokens_session_fkey
+    FOREIGN KEY (session_id) REFERENCES auth.sessions(id) ON DELETE RESTRICT,
+  CONSTRAINT auth_refresh_tokens_parent_fkey
+    FOREIGN KEY (parent_token_id) REFERENCES auth.refresh_tokens(id) ON DELETE RESTRICT,
+  CONSTRAINT auth_refresh_tokens_replacement_fkey
+    FOREIGN KEY (replaced_by_token_id) REFERENCES auth.refresh_tokens(id) ON DELETE RESTRICT,
+  CONSTRAINT auth_refresh_tokens_status_check
+    CHECK (status IN ('ACTIVE', 'ROTATED', 'REVOKED', 'REUSED', 'EXPIRED'))
+);
+
+CREATE TABLE auth.mfa_challenges (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  challenge_token_hash TEXT NOT NULL UNIQUE,
+  type TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  max_attempts INTEGER NOT NULL DEFAULT 5,
+  expires_at TIMESTAMPTZ NOT NULL,
+  verified_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT auth_mfa_challenges_session_fkey
+    FOREIGN KEY (session_id) REFERENCES auth.sessions(id) ON DELETE RESTRICT,
+  CONSTRAINT auth_mfa_challenges_user_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT auth_mfa_challenges_type_check
+    CHECK (type IN ('TOTP_ENROLL', 'TOTP_VERIFY', 'BACKUP_VERIFY')),
+  CONSTRAINT auth_mfa_challenges_status_check
+    CHECK (status IN ('PENDING', 'VERIFIED', 'FAILED', 'EXPIRED')),
+  CONSTRAINT auth_mfa_challenges_attempts_check
+    CHECK (attempts >= 0 AND max_attempts > 0)
+);
+
+CREATE TABLE auth.audit_events (
+  id TEXT PRIMARY KEY,
+  user_id TEXT,
+  session_id TEXT,
+  membership_id TEXT,
+  organization_id TEXT,
+  tenant_id TEXT,
+  action TEXT NOT NULL,
+  outcome TEXT NOT NULL,
+  reason TEXT,
+  metadata JSONB,
+  hash TEXT NOT NULL,
+  prev_hash TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT auth_audit_events_outcome_check
+    CHECK (outcome IN ('SUCCESS', 'FAILURE', 'DENIED'))
+);
+
+CREATE INDEX auth_sessions_user_status_idx
+  ON auth.sessions(user_id, status);
+CREATE INDEX auth_sessions_family_status_idx
+  ON auth.sessions(refresh_family_id, status);
+CREATE INDEX auth_sessions_membership_status_idx
+  ON auth.sessions(membership_id, status);
+CREATE INDEX auth_sessions_expires_idx
+  ON auth.sessions(expires_at);
+CREATE INDEX auth_refresh_tokens_session_status_idx
+  ON auth.refresh_tokens(session_id, status);
+CREATE INDEX auth_refresh_tokens_family_status_idx
+  ON auth.refresh_tokens(family_id, status);
+CREATE INDEX auth_refresh_tokens_expires_idx
+  ON auth.refresh_tokens(expires_at);
+CREATE INDEX auth_mfa_challenges_session_status_idx
+  ON auth.mfa_challenges(session_id, status);
+CREATE INDEX auth_mfa_challenges_expires_idx
+  ON auth.mfa_challenges(expires_at);
+CREATE INDEX auth_audit_events_user_created_idx
+  ON auth.audit_events(user_id, created_at);
+CREATE INDEX auth_audit_events_session_created_idx
+  ON auth.audit_events(session_id, created_at);
+CREATE INDEX auth_audit_events_action_created_idx
+  ON auth.audit_events(action, created_at);
+CREATE INDEX auth_audit_events_tenant_created_idx
+  ON auth.audit_events(tenant_id, created_at);
+
+REVOKE ALL ON ALL TABLES IN SCHEMA auth FROM PUBLIC;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA auth FROM PUBLIC;
+
+DO $grant_auth_schema$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_service') THEN
+    GRANT USAGE ON SCHEMA auth TO app_service;
+    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA auth TO app_service;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA auth
+      GRANT SELECT, INSERT, UPDATE ON TABLES TO app_service;
+  END IF;
+END
+$grant_auth_schema$;

--- a/apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
+++ b/apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
@@ -4,6 +4,14 @@
 CREATE SCHEMA IF NOT EXISTS auth;
 REVOKE ALL ON SCHEMA auth FROM PUBLIC;
 
+CREATE TABLE auth.login_throttles (
+  account_hash TEXT PRIMARY KEY,
+  failures INTEGER NOT NULL DEFAULT 0,
+  locked_until TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT auth_login_throttles_failures_nonnegative CHECK (failures >= 0)
+);
+
 CREATE TABLE auth.credential_states (
   user_id TEXT PRIMARY KEY,
   credential_version INTEGER NOT NULL DEFAULT 1,
@@ -124,6 +132,8 @@ CREATE TABLE auth.audit_events (
     CHECK (outcome IN ('SUCCESS', 'FAILURE', 'DENIED'))
 );
 
+CREATE INDEX auth_login_throttles_locked_idx
+  ON auth.login_throttles(locked_until);
 CREATE INDEX auth_sessions_user_status_idx
   ON auth.sessions(user_id, status);
 CREATE INDEX auth_sessions_family_status_idx

--- a/apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
+++ b/apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
@@ -132,6 +132,20 @@ CREATE TABLE auth.audit_events (
     CHECK (outcome IN ('SUCCESS', 'FAILURE', 'DENIED'))
 );
 
+CREATE OR REPLACE FUNCTION auth.reject_audit_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  RAISE EXCEPTION 'auth.audit_events is append-only';
+END;
+$$;
+
+CREATE TRIGGER auth_audit_events_append_only
+BEFORE UPDATE OR DELETE ON auth.audit_events
+FOR EACH ROW EXECUTE FUNCTION auth.reject_audit_mutation();
+
 CREATE INDEX auth_login_throttles_locked_idx
   ON auth.login_throttles(locked_until);
 CREATE INDEX auth_sessions_user_status_idx
@@ -163,14 +177,19 @@ CREATE INDEX auth_audit_events_tenant_created_idx
 
 REVOKE ALL ON ALL TABLES IN SCHEMA auth FROM PUBLIC;
 REVOKE ALL ON ALL SEQUENCES IN SCHEMA auth FROM PUBLIC;
+REVOKE ALL ON FUNCTION auth.reject_audit_mutation() FROM PUBLIC;
 
 DO $grant_auth_schema$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_service') THEN
     GRANT USAGE ON SCHEMA auth TO app_service;
-    GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA auth TO app_service;
-    ALTER DEFAULT PRIVILEGES IN SCHEMA auth
-      GRANT SELECT, INSERT, UPDATE ON TABLES TO app_service;
+    GRANT SELECT, INSERT, UPDATE ON auth.login_throttles TO app_service;
+    GRANT SELECT, INSERT, UPDATE ON auth.credential_states TO app_service;
+    GRANT SELECT, INSERT, UPDATE ON auth.sessions TO app_service;
+    GRANT SELECT, INSERT, UPDATE ON auth.refresh_tokens TO app_service;
+    GRANT SELECT, INSERT, UPDATE ON auth.mfa_challenges TO app_service;
+    GRANT SELECT, INSERT ON auth.audit_events TO app_service;
+    REVOKE UPDATE, DELETE ON auth.audit_events FROM app_service;
   END IF;
 END
 $grant_auth_schema$;

--- a/apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
+++ b/apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
@@ -146,6 +146,113 @@ CREATE TRIGGER auth_audit_events_append_only
 BEFORE UPDATE OR DELETE ON auth.audit_events
 FOR EACH ROW EXECUTE FUNCTION auth.reject_audit_mutation();
 
+CREATE TRIGGER auth_audit_events_no_truncate
+BEFORE TRUNCATE ON auth.audit_events
+FOR EACH STATEMENT EXECUTE FUNCTION auth.reject_audit_mutation();
+
+CREATE OR REPLACE FUNCTION auth.revoke_sessions_for_membership_change()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  UPDATE auth.sessions
+  SET status = 'REVOKED',
+      revoked_at = NOW(),
+      revocation_reason = 'MEMBERSHIP_CHANGED',
+      updated_at = NOW()
+  WHERE membership_id = OLD.id
+    AND status IN ('ACTIVE', 'MFA_PENDING');
+
+  UPDATE auth.refresh_tokens rt
+  SET status = 'REVOKED',
+      revoked_at = NOW(),
+      revocation_reason = 'MEMBERSHIP_CHANGED'
+  FROM auth.sessions s
+  WHERE s.id = rt.session_id
+    AND s.membership_id = OLD.id
+    AND rt.status IN ('ACTIVE', 'ROTATED');
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER auth_revoke_on_membership_change
+AFTER UPDATE OF "userId", "organizationId", role ON public.user_orgs
+FOR EACH ROW
+WHEN (
+  OLD."userId" IS DISTINCT FROM NEW."userId"
+  OR OLD."organizationId" IS DISTINCT FROM NEW."organizationId"
+  OR OLD.role IS DISTINCT FROM NEW.role
+)
+EXECUTE FUNCTION auth.revoke_sessions_for_membership_change();
+
+CREATE OR REPLACE FUNCTION auth.revoke_sessions_for_organization_block()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  UPDATE auth.sessions
+  SET status = 'REVOKED',
+      revoked_at = NOW(),
+      revocation_reason = 'ORGANIZATION_NOT_VERIFIED',
+      updated_at = NOW()
+  WHERE organization_id = NEW.id
+    AND status IN ('ACTIVE', 'MFA_PENDING');
+
+  UPDATE auth.refresh_tokens rt
+  SET status = 'REVOKED',
+      revoked_at = NOW(),
+      revocation_reason = 'ORGANIZATION_NOT_VERIFIED'
+  FROM auth.sessions s
+  WHERE s.id = rt.session_id
+    AND s.organization_id = NEW.id
+    AND rt.status IN ('ACTIVE', 'ROTATED');
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER auth_revoke_on_organization_block
+AFTER UPDATE OF status ON public.organizations
+FOR EACH ROW
+WHEN (OLD.status IS DISTINCT FROM NEW.status AND NEW.status <> 'VERIFIED')
+EXECUTE FUNCTION auth.revoke_sessions_for_organization_block();
+
+CREATE OR REPLACE FUNCTION auth.revoke_sessions_for_user_block()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+  UPDATE auth.sessions
+  SET status = 'REVOKED',
+      revoked_at = NOW(),
+      revocation_reason = 'USER_NOT_ACTIVE',
+      updated_at = NOW()
+  WHERE user_id = NEW.id
+    AND status IN ('ACTIVE', 'MFA_PENDING');
+
+  UPDATE auth.refresh_tokens rt
+  SET status = 'REVOKED',
+      revoked_at = NOW(),
+      revocation_reason = 'USER_NOT_ACTIVE'
+  FROM auth.sessions s
+  WHERE s.id = rt.session_id
+    AND s.user_id = NEW.id
+    AND rt.status IN ('ACTIVE', 'ROTATED');
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER auth_revoke_on_user_block
+AFTER UPDATE OF status ON public.users
+FOR EACH ROW
+WHEN (OLD.status IS DISTINCT FROM NEW.status AND NEW.status <> 'ACTIVE')
+EXECUTE FUNCTION auth.revoke_sessions_for_user_block();
+
 CREATE INDEX auth_login_throttles_locked_idx
   ON auth.login_throttles(locked_until);
 CREATE INDEX auth_sessions_user_status_idx
@@ -178,6 +285,9 @@ CREATE INDEX auth_audit_events_tenant_created_idx
 REVOKE ALL ON ALL TABLES IN SCHEMA auth FROM PUBLIC;
 REVOKE ALL ON ALL SEQUENCES IN SCHEMA auth FROM PUBLIC;
 REVOKE ALL ON FUNCTION auth.reject_audit_mutation() FROM PUBLIC;
+REVOKE ALL ON FUNCTION auth.revoke_sessions_for_membership_change() FROM PUBLIC;
+REVOKE ALL ON FUNCTION auth.revoke_sessions_for_organization_block() FROM PUBLIC;
+REVOKE ALL ON FUNCTION auth.revoke_sessions_for_user_block() FROM PUBLIC;
 
 DO $grant_auth_schema$
 BEGIN

--- a/apps/api/src/common/guards/auth.guard.ts
+++ b/apps/api/src/common/guards/auth.guard.ts
@@ -1,7 +1,13 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { AuthService } from '../../modules/auth/auth.service';
+import { FINANCIAL_MFA_THRESHOLD_KOPECKS } from '../types/request-user';
 import { PUBLIC_ROUTE, PUBLIC_ROUTE_OPTIONS, PublicRouteOptions } from '../decorators/public.decorator';
+
+const FINANCIAL_COMMANDS_REQUIRING_RECENT_MFA = new Set([
+  'request_reserve',
+  'request_release',
+]);
 
 function enabled(flagName?: string) {
   if (!flagName) return true;
@@ -22,11 +28,11 @@ export class AppAuthGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const isPublic = this.reflector.getAllAndOverride<boolean>(PUBLIC_ROUTE, [
       context.getHandler(),
-      context.getClass()
+      context.getClass(),
     ]);
     const options = this.reflector.getAllAndOverride<PublicRouteOptions>(PUBLIC_ROUTE_OPTIONS, [
       context.getHandler(),
-      context.getClass()
+      context.getClass(),
     ]);
     if (isPublic && enabled(options?.envFlag)) return true;
 
@@ -35,6 +41,14 @@ export class AppAuthGuard implements CanActivate {
     if (!raw?.startsWith('Bearer ')) throw new UnauthorizedException('Missing bearer token');
     const token = raw.slice('Bearer '.length);
     req.user = await this.authService.verifyAccessToken(token);
+
+    const actionId = String(req.params?.actionId ?? '');
+    const bodyAmount = Number(req.body?.amountKopecks ?? req.body?.payload?.amountKopecks);
+    if (FINANCIAL_COMMANDS_REQUIRING_RECENT_MFA.has(actionId)) {
+      this.authService.assertRecentFinancialMfa(req.user, FINANCIAL_MFA_THRESHOLD_KOPECKS);
+    } else if (Number.isFinite(bodyAmount)) {
+      this.authService.assertRecentFinancialMfa(req.user, bodyAmount);
+    }
     return true;
   }
 }

--- a/apps/api/src/common/types/request-user.ts
+++ b/apps/api/src/common/types/request-user.ts
@@ -28,7 +28,10 @@ export type RequestUser = {
   surfaceRole?: string;
   sessionId?: string;
   tenantId?: string;
+  membershipId?: string;
+  credentialVersion?: number;
   mfaVerified?: boolean;
+  mfaVerifiedAt?: string;
 };
 
 export const ROLES_REQUIRING_MFA: Role[] = [

--- a/apps/api/src/modules/auth/auth-crypto.ts
+++ b/apps/api/src/modules/auth/auth-crypto.ts
@@ -1,0 +1,184 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from 'crypto';
+import { requireSecret } from '../../common/config/secrets';
+
+const JWT_SECRET = requireSecret('JWT_SECRET');
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const MFA_KEY_VERSION = 'v1';
+
+function production(): boolean {
+  return String(process.env.NODE_ENV ?? '').toLowerCase() === 'production';
+}
+
+function secretOrFallback(name: string): string {
+  const configured = String(process.env[name] ?? '').trim();
+  if (configured) return configured;
+  if (production()) {
+    throw new Error(`${name} is required in production`);
+  }
+  return JWT_SECRET;
+}
+
+function keyFrom(name: string): Buffer {
+  return createHash('sha256').update(secretOrFallback(name), 'utf8').digest();
+}
+
+export function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+export function stableJson(value: unknown): string {
+  const normalize = (item: unknown): unknown => {
+    if (Array.isArray(item)) return item.map(normalize);
+    if (item && typeof item === 'object') {
+      return Object.fromEntries(
+        Object.entries(item as Record<string, unknown>)
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([key, entry]) => [key, normalize(entry)]),
+      );
+    }
+    return item;
+  };
+  return JSON.stringify(normalize(value));
+}
+
+export function hashAuthMaterial(value: string): string {
+  return createHmac('sha256', keyFrom('AUTH_TOKEN_PEPPER')).update(value, 'utf8').digest('hex');
+}
+
+export function hashClientValue(value?: string | null): string | null {
+  const normalized = String(value ?? '').trim();
+  return normalized ? hashAuthMaterial(normalized) : null;
+}
+
+export function makeOpaqueToken(prefix: 'rt' | 'mc'): {
+  id: string;
+  secret: string;
+  token: string;
+  hash: string;
+} {
+  const id = `${prefix}_${randomBytes(18).toString('base64url')}`;
+  const secret = randomBytes(32).toString('base64url');
+  const token = `${id}.${secret}`;
+  return { id, secret, token, hash: hashAuthMaterial(token) };
+}
+
+export function parseOpaqueToken(token: string, prefix: 'rt' | 'mc'): {
+  id: string;
+  hash: string;
+} | null {
+  const [id, secret, extra] = String(token ?? '').split('.');
+  if (extra || !id || !secret || !id.startsWith(`${prefix}_`) || secret.length < 32) return null;
+  return { id, hash: hashAuthMaterial(`${id}.${secret}`) };
+}
+
+export function secureEqual(left: string, right: string): boolean {
+  const a = Buffer.from(left, 'utf8');
+  const b = Buffer.from(right, 'utf8');
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export function encryptMfaSecret(secret: string): { ciphertext: string; keyVersion: string } {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', keyFrom('MFA_ENCRYPTION_KEY'), iv);
+  const encrypted = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    keyVersion: MFA_KEY_VERSION,
+    ciphertext: [MFA_KEY_VERSION, iv.toString('base64url'), tag.toString('base64url'), encrypted.toString('base64url')].join(':'),
+  };
+}
+
+export function decryptMfaSecret(ciphertext: string): string {
+  const [version, ivRaw, tagRaw, encryptedRaw] = String(ciphertext ?? '').split(':');
+  if (version !== MFA_KEY_VERSION || !ivRaw || !tagRaw || !encryptedRaw) {
+    throw new Error('Unsupported MFA ciphertext');
+  }
+  const decipher = createDecipheriv(
+    'aes-256-gcm',
+    keyFrom('MFA_ENCRYPTION_KEY'),
+    Buffer.from(ivRaw, 'base64url'),
+  );
+  decipher.setAuthTag(Buffer.from(tagRaw, 'base64url'));
+  return Buffer.concat([
+    decipher.update(Buffer.from(encryptedRaw, 'base64url')),
+    decipher.final(),
+  ]).toString('utf8');
+}
+
+export function base32Encode(input: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let output = '';
+  for (const byte of input) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      output += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) output += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  return output;
+}
+
+function base32Decode(input: string): Buffer {
+  const normalized = input.toUpperCase().replace(/[^A-Z2-7]/g, '');
+  let bits = 0;
+  let value = 0;
+  const bytes: number[] = [];
+  for (const char of normalized) {
+    const index = BASE32_ALPHABET.indexOf(char);
+    if (index < 0) continue;
+    value = (value << 5) | index;
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 255);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(bytes);
+}
+
+export function generateTotpSecret(): string {
+  return base32Encode(randomBytes(20));
+}
+
+function totpAt(secret: string, unixMs: number): string {
+  const counter = BigInt(Math.floor(unixMs / 30_000));
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64BE(counter);
+  const hmac = createHmac('sha1', base32Decode(secret)).update(buffer).digest();
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const binary = ((hmac[offset] & 0x7f) << 24)
+    | ((hmac[offset + 1] & 0xff) << 16)
+    | ((hmac[offset + 2] & 0xff) << 8)
+    | (hmac[offset + 3] & 0xff);
+  return String(binary % 1_000_000).padStart(6, '0');
+}
+
+export function verifyTotp(secret: string, code: string, unixMs = Date.now()): boolean {
+  const normalized = String(code ?? '').replace(/\s+/g, '');
+  if (!/^\d{6}$/.test(normalized)) return false;
+  return [-1, 0, 1].some((offset) => secureEqual(totpAt(secret, unixMs + offset * 30_000), normalized));
+}
+
+export function buildOtpAuthUri(email: string, secret: string): string {
+  const issuer = 'Transparent Price';
+  const label = `${issuer}:${email}`;
+  return `otpauth://totp/${encodeURIComponent(label)}?secret=${secret}&issuer=${encodeURIComponent(issuer)}&algorithm=SHA1&digits=6&period=30`;
+}
+
+export function generateBackupCodes(count = 8): { codes: string[]; hashes: string[] } {
+  const codes = Array.from({ length: count }, () => {
+    const raw = randomBytes(6).toString('hex').toUpperCase();
+    return `${raw.slice(0, 4)}-${raw.slice(4, 8)}-${raw.slice(8, 12)}`;
+  });
+  return { codes, hashes: codes.map(hashAuthMaterial) };
+}

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,15 +1,17 @@
+import { Body, Controller, Get, Headers, HttpCode, Ip, Post, Query, UseGuards } from '@nestjs/common';
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { Roles } from '../../common/decorators/roles.decorator';
-import { UseGuards } from '@nestjs/common';
-import { Body, Controller, Get, Headers, Ip, Post, Query, HttpCode } from '@nestjs/common';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { RateLimit } from '../../common/decorators/rate-limit.decorator';
 import { Public } from '../../common/decorators/public.decorator';
-import { RequestUser } from '../../common/types/request-user';
+import { RequestUser, Role } from '../../common/types/request-user';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { RefreshDto } from './dto/refresh.dto';
+import { LogoutDto } from './dto/logout.dto';
+import { MfaVerifyDto } from './dto/mfa-verify.dto';
+import { RevokeUserSessionsDto } from './dto/revoke-user-sessions.dto';
 
 @UseGuards(RolesGuard)
 @Roles('ANY_AUTHENTICATED')
@@ -38,9 +40,22 @@ export class AuthController {
     return this.authService.refresh(dto, userAgent, ip);
   }
 
+  @Public()
+  @RateLimit({ name: 'auth_mfa_verify', scope: 'ip', limit: 10, windowSeconds: 60, limitEnv: 'RATE_LIMIT_AUTH_MFA_VERIFY', windowEnv: 'RATE_LIMIT_WINDOW_SECONDS' })
+  @Post('mfa/verify')
+  verifyMfa(@Body() dto: MfaVerifyDto, @Headers('user-agent') userAgent?: string, @Ip() ip?: string) {
+    return this.authService.verifyMfa(dto, userAgent, ip);
+  }
+
   @Post('logout')
-  logout(@Body() dto: RefreshDto, @CurrentUser() user: RequestUser) {
+  logout(@Body() dto: LogoutDto, @CurrentUser() user: RequestUser) {
     return this.authService.logout(dto, user?.sessionId);
+  }
+
+  @Post('sessions/revoke-user')
+  @Roles(Role.ADMIN)
+  revokeUserSessions(@Body() dto: RevokeUserSessionsDto) {
+    return this.authService.revokeUserSessions(dto.userId, dto.reason || 'ADMIN_REVOKE');
   }
 
   @Get('me')
@@ -59,7 +74,7 @@ export class AuthController {
   sberBusinessCallback(
     @Query() query: { code?: string; state?: string },
     @Headers('user-agent') userAgent?: string,
-    @Ip() ip?: string
+    @Ip() ip?: string,
   ) {
     return this.authService.sberBusinessCallback(query, userAgent, ip);
   }

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { BusinessReputationModule } from '../business-reputation/business-reputation.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { PersistentAuthRepository } from './persistent-auth.repository';
 
 @Module({
   imports: [BusinessReputationModule],
   controllers: [AuthController],
-  providers: [AuthService],
-  exports: [AuthService]
+  providers: [PersistentAuthRepository, AuthService],
+  exports: [AuthService, PersistentAuthRepository],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/auth.service.spec.ts
+++ b/apps/api/src/modules/auth/auth.service.spec.ts
@@ -1,57 +1,49 @@
-import { AuthService } from './auth.service';
-import { Role } from '../../common/types/request-user';
+import {
+  canSelfRegisterRole,
+  requiresRecentFinancialMfa,
+  requiresRoleMfa,
+} from './auth.service';
+import {
+  FINANCIAL_MFA_THRESHOLD_KOPECKS,
+  Role,
+} from '../../common/types/request-user';
 
-describe('AuthService security', () => {
-  describe('register() role allowlist (C1 — privilege escalation)', () => {
-    it.each([Role.ADMIN, Role.SUPPORT_MANAGER, Role.EXECUTIVE, Role.COMPLIANCE_OFFICER, Role.ARBITRATOR, Role.GUEST])(
-      'refuses self-registration as privileged role %s',
-      async (role) => {
-        const svc = new AuthService();
-        await expect(
-          svc.register({ email: `esc-${role}@x.ru`, fullName: 'E', role, password: 'Str0ng-Passw0rd!' }),
-        ).rejects.toThrow(/cannot be self-registered/i);
-      },
-    );
-
-    it('allows self-registration as an operational role (FARMER)', async () => {
-      const svc = new AuthService();
-      const res = await svc.register({ email: 'farmer-new@x.ru', fullName: 'F', role: Role.FARMER, password: 'Str0ng-Passw0rd!' });
-      expect(res.user.role).toBe(Role.FARMER);
-    });
+describe('persistent auth policy', () => {
+  it.each([
+    Role.ADMIN,
+    Role.SUPPORT_MANAGER,
+    Role.EXECUTIVE,
+    Role.COMPLIANCE_OFFICER,
+    Role.ARBITRATOR,
+    Role.GUEST,
+    Role.BANK_CALLBACK,
+  ])('refuses self-registration as privileged/system role %s', (role) => {
+    expect(canSelfRegisterRole(role)).toBe(false);
   });
 
-  describe('login() lockout (M2 — brute force)', () => {
-    it('locks the account after repeated failures, even for the correct password', async () => {
-      const svc = new AuthService();
-      const email = 'lock-me@x.ru';
-      await svc.register({ email, fullName: 'L', role: Role.BUYER, password: 'Correct-Horse-9!' });
-
-      for (let i = 0; i < 5; i += 1) {
-        await expect(svc.login({ email, password: 'wrong-password' } as any)).rejects.toThrow(/Invalid credentials/);
-      }
-      // Now locked — even the correct password is refused with a lockout message.
-      await expect(svc.login({ email, password: 'Correct-Horse-9!' } as any)).rejects.toThrow(/temporarily locked/i);
-    });
+  it.each([
+    Role.FARMER,
+    Role.BUYER,
+    Role.LOGISTICIAN,
+    Role.DRIVER,
+    Role.LAB,
+    Role.ELEVATOR,
+    Role.ACCOUNTING,
+  ])('allows self-registration request for operational role %s', (role) => {
+    expect(canSelfRegisterRole(role)).toBe(true);
   });
 
-  describe('session revocation (L2 — token revoke)', () => {
-    it('rejects a token after logout revokes its session', async () => {
-      const svc = new AuthService();
-      const { accessToken } = await svc.register({ email: 'logout@x.ru', fullName: 'L', role: Role.FARMER, password: 'Str0ng-Passw0rd!' });
-      const verified = await svc.verifyAccessToken(accessToken);
-      expect(verified.id).toBeTruthy();
+  it.each([
+    Role.ADMIN,
+    Role.COMPLIANCE_OFFICER,
+    Role.ARBITRATOR,
+  ])('requires MFA before activating privileged role %s', (role) => {
+    expect(requiresRoleMfa(role)).toBe(true);
+  });
 
-      await svc.logout({}, verified.sessionId);
-      await expect(svc.verifyAccessToken(accessToken)).rejects.toThrow(/revoked/i);
-    });
-
-    it('revokes all live tokens when a user role changes', async () => {
-      const svc = new AuthService();
-      const { accessToken, user } = await svc.register({ email: 'roled@x.ru', fullName: 'R', role: Role.BUYER, password: 'Str0ng-Passw0rd!' });
-      await expect(svc.verifyAccessToken(accessToken)).resolves.toBeTruthy();
-
-      svc.updateUserRole(user.id, Role.LOGISTICIAN);
-      await expect(svc.verifyAccessToken(accessToken)).rejects.toThrow(/revoked/i);
-    });
+  it('requires recent MFA at the exact financial threshold', () => {
+    expect(requiresRecentFinancialMfa(FINANCIAL_MFA_THRESHOLD_KOPECKS - 1)).toBe(false);
+    expect(requiresRecentFinancialMfa(FINANCIAL_MFA_THRESHOLD_KOPECKS)).toBe(true);
+    expect(requiresRecentFinancialMfa(FINANCIAL_MFA_THRESHOLD_KOPECKS + 1)).toBe(true);
   });
 });

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -1,48 +1,61 @@
-import { Injectable, UnauthorizedException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
-import * as jwt from 'jsonwebtoken';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
+import * as jwt from 'jsonwebtoken';
 import { randomUUID } from 'crypto';
-import { RequestUser, Role } from '../../common/types/request-user';
-import { LoginDto } from './dto/login.dto';
+import {
+  FINANCIAL_MFA_THRESHOLD_KOPECKS,
+  RequestUser,
+  Role,
+  ROLES_REQUIRING_MFA,
+} from '../../common/types/request-user';
 import { requireSecret } from '../../common/config/secrets';
+import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
+import {
+  buildOtpAuthUri,
+  decryptMfaSecret,
+  encryptMfaSecret,
+  generateBackupCodes,
+  generateTotpSecret,
+  hashAuthMaterial,
+  hashClientValue,
+  makeOpaqueToken,
+  parseOpaqueToken,
+  secureEqual,
+  sha256,
+  stableJson,
+  verifyTotp,
+} from './auth-crypto';
+import {
+  AuthSqlClient,
+  CredentialStateRow,
+  IdentityRow,
+  MfaChallengeRow,
+  PersistentAuthRepository,
+  SessionContextRow,
+} from './persistent-auth.repository';
 
 const JWT_SECRET = requireSecret('JWT_SECRET');
-const ACCESS_TOKEN_TTL = '8h';
-const REFRESH_TOKEN_TTL = '30d';
+const ACCESS_TOKEN_TTL = '15m';
+const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-
+const MFA_CHALLENGE_TTL_MS = 10 * 60 * 1000;
+const MFA_FRESHNESS_MS = 15 * 60 * 1000;
 const CURRENT_CONSENT_VERSION = '1.2';
+const MAX_FAILED_LOGINS = 5;
+const LOGIN_LOCKOUT_MS = 15 * 60 * 1000;
+const DUMMY_PASSWORD_HASH = bcrypt.hashSync('invalid-password-sentinel', 10);
+const ACCESS_ISSUER = 'transparent-price-api';
+const ACCESS_AUDIENCE = 'transparent-price-platform';
 
-interface StoredUser {
-  id: string;
-  email: string;
-  passwordHash: string;
-  role: Role;
-  orgId: string;
-  fullName: string;
-  phone?: string;
-  consentVersion?: string;
-  consentAt?: string;
-  anonymized?: boolean;
-  createdAt?: string;
-}
-
-interface RefreshTokenRecord {
-  token: string;
-  userId: string;
-  expiresAt: number;
-}
-
-const DEMO_ORG_ID = 'org-demo-001';
-
-/**
- * Roles a user is permitted to grant themselves at self-service registration.
- * Privileged / oversight roles (ADMIN, SUPPORT_MANAGER, EXECUTIVE,
- * COMPLIANCE_OFFICER, ARBITRATOR) and GUEST must NEVER be self-assignable —
- * ADMIN/SUPPORT_MANAGER bypass all route + object guards, so accepting them
- * from an anonymous request body is a full authorization bypass. These roles
- * are provisioned only through an authenticated administrator flow.
- */
 const SELF_REGISTERABLE_ROLES: ReadonlySet<Role> = new Set<Role>([
   Role.FARMER,
   Role.BUYER,
@@ -52,217 +65,505 @@ const SELF_REGISTERABLE_ROLES: ReadonlySet<Role> = new Set<Role>([
   Role.ELEVATOR,
   Role.ACCOUNTING,
 ]);
+const KNOWN_ROLES = new Set<string>(Object.values(Role));
+const PRIVILEGED_MFA_ROLES = new Set<string>(ROLES_REQUIRING_MFA);
+const SYNTHETIC_SEED_ENABLED = String(process.env.SEED_CANONICAL_TEST_DEAL ?? '').toLowerCase() === 'true';
 
-// Brute-force / credential-stuffing protection on login (per-account).
-const MAX_FAILED_LOGINS = 5;
-const LOGIN_LOCKOUT_MS = 15 * 60 * 1000; // 15 minutes
-
-/**
- * Demo accounts are seeded ONLY when SEED_DEMO_USERS=true (never implicitly in
- * production). They carry a well-known password and must not exist in any
- * environment serving real users.
- */
-const SHOULD_SEED_DEMO_USERS = String(process.env.SEED_DEMO_USERS || '').toLowerCase() === 'true';
-
-const demoUsers: StoredUser[] = [
-  { id: 'user-farmer-001', email: 'farmer@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.FARMER, orgId: 'org-farmer-001', fullName: 'Demo Farmer' },
-  { id: 'user-buyer-001', email: 'buyer@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.BUYER, orgId: 'org-buyer-001', fullName: 'Demo Buyer' },
-  { id: 'user-logistician-001', email: 'logistician@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.LOGISTICIAN, orgId: 'org-logistics-001', fullName: 'Demo Logistician' },
-  { id: 'user-driver-001', email: 'driver@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.DRIVER, orgId: 'org-logistics-001', fullName: 'Demo Driver' },
-  { id: 'user-lab-001', email: 'lab@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.LAB, orgId: 'org-lab-001', fullName: 'Demo Lab' },
-  { id: 'user-elevator-001', email: 'elevator@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.ELEVATOR, orgId: 'org-elevator-001', fullName: 'Demo Elevator' },
-  { id: 'user-accounting-001', email: 'accounting@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.ACCOUNTING, orgId: 'org-farmer-001', fullName: 'Demo Accounting' },
-  { id: 'user-executive-001', email: 'executive@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.EXECUTIVE, orgId: DEMO_ORG_ID, fullName: 'Demo Executive' },
-  { id: 'user-operator-001', email: 'operator@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.SUPPORT_MANAGER, orgId: DEMO_ORG_ID, fullName: 'Demo Operator' },
-  { id: 'user-admin-001', email: 'admin@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.ADMIN, orgId: DEMO_ORG_ID, fullName: 'Demo Admin' },
-  { id: 'user-compliance-001', email: 'compliance@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.COMPLIANCE_OFFICER, orgId: DEMO_ORG_ID, fullName: 'Demo Compliance Officer' },
-  { id: 'user-arbitrator-001', email: 'arbitrator@demo.ru', passwordHash: bcrypt.hashSync('demo1234', 10), role: Role.ARBITRATOR, orgId: DEMO_ORG_ID, fullName: 'Demo Arbitrator' },
-];
-
-const usersStore: StoredUser[] = SHOULD_SEED_DEMO_USERS ? [...demoUsers] : [];
-const refreshTokensStore = new Map<string, RefreshTokenRecord>();
-
-interface LoginAttemptRecord {
-  failures: number;
-  lockedUntil: number;
-}
-const loginAttemptsStore = new Map<string, LoginAttemptRecord>();
-
-const ACCESS_TOKEN_TTL_MS = 8 * 60 * 60 * 1000; // must match ACCESS_TOKEN_TTL ('8h')
-
-// --- Session revocation (L2) ---
-// A stateless JWT cannot be un-issued, so we keep a server-side deny-list of
-// revoked session ids and the set of currently-active sessions per user. Every
-// authenticated request is checked against the deny-list (see
-// verifyAccessToken), which lets logout, account anonymization and role changes
-// invalidate live access tokens immediately instead of waiting 8h for expiry.
-//
-// NOTE (federal / multi-instance scale): these maps are in-process. For a fleet
-// of API instances they must be backed by a shared store (e.g. Redis) so a
-// revocation on one node is honoured by all. The logic below is written so only
-// the store implementation needs swapping.
-const activeUserSessions = new Map<string, Set<string>>();
-const revokedSessions = new Map<string, number>(); // sessionId -> expiry (ms epoch)
-
-function pruneRevokedSessions(now: number): void {
-  for (const [sessionId, expiresAt] of revokedSessions) {
-    if (expiresAt <= now) revokedSessions.delete(sessionId);
-  }
+export function canSelfRegisterRole(role: Role): boolean {
+  return SELF_REGISTERABLE_ROLES.has(role);
 }
 
-function trackSession(userId: string, sessionId: string): void {
-  let sessions = activeUserSessions.get(userId);
-  if (!sessions) {
-    sessions = new Set<string>();
-    activeUserSessions.set(userId, sessions);
-  }
-  sessions.add(sessionId);
+export function requiresRoleMfa(role: Role): boolean {
+  return PRIVILEGED_MFA_ROLES.has(role);
 }
 
-function revokeSession(sessionId: string, now = Date.now()): void {
-  if (!sessionId) return;
-  revokedSessions.set(sessionId, now + ACCESS_TOKEN_TTL_MS);
-  for (const sessions of activeUserSessions.values()) sessions.delete(sessionId);
+export function requiresRecentFinancialMfa(amountKopecks: number): boolean {
+  return Number.isFinite(amountKopecks) && amountKopecks >= FINANCIAL_MFA_THRESHOLD_KOPECKS;
 }
 
-function revokeAllUserSessions(userId: string, now = Date.now()): void {
-  const sessions = activeUserSessions.get(userId);
-  if (!sessions) return;
-  for (const sessionId of sessions) revokedSessions.set(sessionId, now + ACCESS_TOKEN_TTL_MS);
-  activeUserSessions.delete(userId);
-}
+type SeedCompatibilityUser = {
+  id: string;
+  email: string;
+  role: Role;
+  orgId: string;
+  fullName: string;
+};
 
-function isSessionRevoked(sessionId: string | undefined, now = Date.now()): boolean {
-  if (!sessionId) return false;
-  const expiresAt = revokedSessions.get(sessionId);
-  if (expiresAt === undefined) return false;
-  if (expiresAt <= now) {
-    revokedSessions.delete(sessionId);
-    return false;
-  }
-  return true;
-}
+type AuthUserProjection = {
+  id: string;
+  email: string;
+  fullName: string;
+  role: Role;
+  orgId: string;
+  tenantId: string;
+  membershipId: string;
+  mfaVerified: boolean;
+};
+
+type AccessClaims = jwt.JwtPayload & {
+  sub: string;
+  sid: string;
+  typ: 'access';
+};
+
+type MfaVerifyInput = {
+  challengeToken: string;
+  code: string;
+};
 
 @Injectable()
 export class AuthService {
-  private issueTokens(user: StoredUser) {
-    const payload: RequestUser = {
-      id: user.id,
-      email: user.email,
-      role: user.role,
-      orgId: user.orgId,
-      fullName: user.fullName,
-      sessionId: randomUUID(),
-    };
-    trackSession(user.id, payload.sessionId!);
-    const accessToken = jwt.sign(payload, JWT_SECRET, { expiresIn: ACCESS_TOKEN_TTL });
-    const refreshToken = randomUUID();
-    refreshTokensStore.set(refreshToken, {
-      token: refreshToken,
-      userId: user.id,
-      expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
-    });
-    return {
-      accessToken,
-      refreshToken,
-      user: {
-        id: user.id,
-        email: user.email,
-        role: user.role,
-        orgId: user.orgId,
-        fullName: user.fullName,
-      },
-    };
-  }
+  private readonly seedCompatibilityUsers: SeedCompatibilityUser[] = [];
+
+  constructor(private readonly repository: PersistentAuthRepository) {}
 
   async login(dto: LoginDto, userAgent?: string, ip?: string) {
-    const accountKey = dto.email.toLowerCase();
-    this.assertNotLockedOut(accountKey);
+    const email = dto.email.trim().toLowerCase();
+    const accountHash = hashAuthMaterial(`account:${email}`);
+    const identity = await this.repository.findIdentityByEmail(this.repository.prisma, email);
+    const validPassword = await bcrypt.compare(dto.password, identity?.password_hash ?? DUMMY_PASSWORD_HASH);
 
-    const user = usersStore.find((u) => u.email.toLowerCase() === accountKey);
-    // Always run a bcrypt comparison (even for unknown users) to avoid leaking
-    // account existence via response timing, and to feed the lockout counter.
-    const passwordHash = user?.passwordHash || '';
-    const valid = passwordHash ? await bcrypt.compare(dto.password, passwordHash) : false;
+    const result = await this.repository.transaction(async (tx) => {
+      await this.repository.ensureLoginThrottle(tx, accountHash);
+      const throttle = await this.repository.getLoginThrottle(tx, accountHash, true);
+      const now = new Date();
+      if (throttle?.locked_until && throttle.locked_until > now) {
+        await this.audit(tx, {
+          userId: identity?.user_id,
+          membershipId: identity?.membership_id,
+          organizationId: identity?.organization_id,
+          tenantId: identity?.tenant_id,
+          action: 'auth.login',
+          outcome: 'DENIED',
+          reason: 'ACCOUNT_TEMPORARILY_LOCKED',
+          metadata: this.clientMetadata(userAgent, ip, { accountHash }),
+        });
+        return { kind: 'locked' as const, lockedUntil: throttle.locked_until };
+      }
 
-    if (!user || !valid || user.anonymized) {
-      this.registerFailedLogin(accountKey);
-      throw new UnauthorizedException('Invalid credentials');
+      if (!identity || !validPassword) {
+        const failures = (throttle?.failures ?? 0) + 1;
+        const lockedUntil = failures >= MAX_FAILED_LOGINS
+          ? new Date(Date.now() + LOGIN_LOCKOUT_MS)
+          : null;
+        await this.repository.setLoginThrottle(tx, accountHash, lockedUntil ? 0 : failures, lockedUntil);
+        await this.audit(tx, {
+          userId: identity?.user_id,
+          membershipId: identity?.membership_id,
+          organizationId: identity?.organization_id,
+          tenantId: identity?.tenant_id,
+          action: 'auth.login',
+          outcome: 'FAILURE',
+          reason: 'INVALID_CREDENTIALS',
+          metadata: this.clientMetadata(userAgent, ip, { accountHash, locked: Boolean(lockedUntil) }),
+        });
+        return { kind: 'invalid' as const };
+      }
+
+      await this.assertIdentityUsable(tx, identity, 'auth.login');
+      await this.repository.ensureCredentialState(tx, identity.user_id);
+      const credential = await this.requireCredentialState(tx, identity.user_id, true);
+      await this.repository.clearLoginThrottle(tx, accountHash);
+      await this.repository.markLoginSuccess(tx, identity.user_id);
+
+      const sessionId = `ses_${randomUUID()}`;
+      const familyId = `rf_${randomUUID()}`;
+      const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
+      const mfaRequired = requiresRoleMfa(this.role(identity.role)) || credential.mfa_enabled;
+      await this.repository.createSession(tx, {
+        id: sessionId,
+        userId: identity.user_id,
+        membershipId: identity.membership_id,
+        organizationId: identity.organization_id,
+        tenantId: identity.tenant_id,
+        status: mfaRequired ? 'MFA_PENDING' : 'ACTIVE',
+        refreshFamilyId: familyId,
+        credentialVersion: credential.credential_version,
+        userAgentHash: hashClientValue(userAgent),
+        ipHash: hashClientValue(ip),
+        expiresAt,
+      });
+
+      if (mfaRequired) {
+        const enrollment = !credential.mfa_enabled || !credential.mfa_secret_ciphertext;
+        let setupSecret: string | undefined;
+        if (enrollment) {
+          setupSecret = generateTotpSecret();
+          const encrypted = encryptMfaSecret(setupSecret);
+          await this.repository.setMfaSecret(tx, identity.user_id, encrypted.ciphertext, encrypted.keyVersion);
+        }
+        const challenge = makeOpaqueToken('mc');
+        await this.repository.createMfaChallenge(tx, {
+          id: challenge.id,
+          sessionId,
+          userId: identity.user_id,
+          challengeTokenHash: challenge.hash,
+          type: enrollment ? 'TOTP_ENROLL' : 'TOTP_VERIFY',
+          expiresAt: new Date(Date.now() + MFA_CHALLENGE_TTL_MS),
+        });
+        await this.audit(tx, {
+          userId: identity.user_id,
+          sessionId,
+          membershipId: identity.membership_id,
+          organizationId: identity.organization_id,
+          tenantId: identity.tenant_id,
+          action: 'auth.login.mfa_required',
+          outcome: 'SUCCESS',
+          metadata: this.clientMetadata(userAgent, ip, { enrollment }),
+        });
+        return {
+          kind: 'mfa' as const,
+          challengeToken: challenge.token,
+          expiresAt: new Date(Date.now() + MFA_CHALLENGE_TTL_MS).toISOString(),
+          setupSecret,
+          otpAuthUri: setupSecret ? buildOtpAuthUri(identity.email, setupSecret) : undefined,
+          user: this.userProjection(identity, false),
+        };
+      }
+
+      const tokens = await this.issueActiveTokens(tx, identity, {
+        id: sessionId,
+        familyId,
+        credentialVersion: credential.credential_version,
+        userAgent,
+        ip,
+      });
+      await this.audit(tx, {
+        userId: identity.user_id,
+        sessionId,
+        membershipId: identity.membership_id,
+        organizationId: identity.organization_id,
+        tenantId: identity.tenant_id,
+        action: 'auth.login',
+        outcome: 'SUCCESS',
+        metadata: this.clientMetadata(userAgent, ip),
+      });
+      return { kind: 'active' as const, ...tokens };
+    });
+
+    if (result.kind === 'locked') {
+      const retryAfterSec = Math.max(1, Math.ceil((result.lockedUntil.getTime() - Date.now()) / 1000));
+      throw new UnauthorizedException(`Account temporarily locked. Try again in ${retryAfterSec}s.`);
     }
-
-    this.clearFailedLogins(accountKey);
-    return this.issueTokens(user);
-  }
-
-  private assertNotLockedOut(accountKey: string): void {
-    const record = loginAttemptsStore.get(accountKey);
-    if (record && record.lockedUntil > Date.now()) {
-      const retryAfterSec = Math.ceil((record.lockedUntil - Date.now()) / 1000);
-      throw new UnauthorizedException(
-        `Account temporarily locked after too many failed attempts. Try again in ${retryAfterSec}s.`,
-      );
+    if (result.kind === 'invalid') throw new UnauthorizedException('Invalid credentials');
+    if (result.kind === 'mfa') {
+      return {
+        mfaRequired: true,
+        challengeToken: result.challengeToken,
+        challengeExpiresAt: result.expiresAt,
+        setupSecret: result.setupSecret,
+        otpAuthUri: result.otpAuthUri,
+        user: result.user,
+      };
     }
+    return { mfaRequired: false, ...result };
   }
 
-  private registerFailedLogin(accountKey: string): void {
-    const record = loginAttemptsStore.get(accountKey) ?? { failures: 0, lockedUntil: 0 };
-    record.failures += 1;
-    if (record.failures >= MAX_FAILED_LOGINS) {
-      record.lockedUntil = Date.now() + LOGIN_LOCKOUT_MS;
-      record.failures = 0;
-    }
-    loginAttemptsStore.set(accountKey, record);
-  }
-
-  private clearFailedLogins(accountKey: string): void {
-    loginAttemptsStore.delete(accountKey);
-  }
-
-  async register(dto: any) {
+  async register(dto: RegisterDto | any) {
     const requestedRole = (dto.role as Role) || Role.GUEST;
-    if (!SELF_REGISTERABLE_ROLES.has(requestedRole)) {
-      // Do not reveal which roles are privileged — a generic refusal is enough.
+    if (!canSelfRegisterRole(requestedRole)) {
       throw new ForbiddenException(
         'The selected role cannot be self-registered. Contact an administrator for access.',
       );
     }
-    const existing = usersStore.find((u) => u.email.toLowerCase() === dto.email.toLowerCase());
-    if (existing) throw new ConflictException('Email already registered');
-    const passwordHash = await bcrypt.hash(dto.password, 10);
-    const newUser: StoredUser = {
-      id: `user-${randomUUID()}`,
-      email: dto.email,
-      passwordHash,
-      role: requestedRole,
-      orgId: dto.orgId || `org-${randomUUID()}`,
-      fullName: dto.fullName || dto.email,
-      phone: dto.phone,
-      consentVersion: dto.consentVersion || CURRENT_CONSENT_VERSION,
-      consentAt: new Date().toISOString(),
-      createdAt: new Date().toISOString(),
-    };
-    usersStore.push(newUser);
-    return this.issueTokens(newUser);
+
+    if (SYNTHETIC_SEED_ENABLED && dto.orgId && String(dto.email).endsWith('@demo.ru')) {
+      return this.registerSyntheticSeedUser(dto, requestedRole);
+    }
+
+    const email = String(dto.email ?? '').trim().toLowerCase();
+    const fullName = String(dto.fullName ?? '').trim();
+    const orgInn = String(dto.orgInn ?? '').trim();
+    const orgLegalName = String(dto.orgLegalName ?? '').trim();
+    if (!email || !fullName || !orgInn || !orgLegalName) {
+      throw new BadRequestException('Email, full name, organization name and INN are required.');
+    }
+
+    return this.repository.transaction(async (tx) => {
+      const existing = await tx.user.findUnique({ where: { email } });
+      if (existing) throw new ConflictException('Email already registered');
+      const existingOrganization = await tx.organization.findUnique({ where: { inn: orgInn } });
+      if (existingOrganization) {
+        throw new ConflictException('Organization already exists. Request an administrator invitation.');
+      }
+
+      const organization = await tx.organization.create({
+        data: {
+          id: `org_${randomUUID()}`,
+          inn: orgInn,
+          name: orgLegalName,
+          type: String(dto.orgType ?? 'LEGAL'),
+          status: 'PENDING',
+          tenantId: `tenant_${randomUUID()}`,
+          kycStatus: 'PENDING',
+          amlStatus: 'CLEAR',
+        },
+      });
+      const user = await tx.user.create({
+        data: {
+          id: `user_${randomUUID()}`,
+          email,
+          phone: dto.phone ? String(dto.phone) : null,
+          passwordHash: await bcrypt.hash(String(dto.password), 12),
+          fullName,
+          status: 'ACTIVE',
+        },
+      });
+      const membership = await tx.userOrg.create({
+        data: {
+          userId: user.id,
+          organizationId: organization.id,
+          role: requestedRole,
+          isDefault: true,
+        },
+      });
+      await this.repository.ensureCredentialState(
+        tx,
+        user.id,
+        dto.consentVersion || CURRENT_CONSENT_VERSION,
+        new Date(),
+      );
+      await this.audit(tx, {
+        userId: user.id,
+        membershipId: membership.id,
+        organizationId: organization.id,
+        tenantId: organization.tenantId,
+        action: 'auth.register',
+        outcome: 'SUCCESS',
+        reason: 'ORGANIZATION_VERIFICATION_REQUIRED',
+        metadata: { requestedRole },
+      });
+      return {
+        status: 'PENDING_ORGANIZATION_VERIFICATION',
+        user: {
+          id: user.id,
+          email: user.email,
+          fullName: user.fullName,
+          role: requestedRole,
+          orgId: organization.id,
+          tenantId: organization.tenantId,
+          membershipId: membership.id,
+        },
+      };
+    });
   }
 
   async refresh(dto: { refreshToken: string }, userAgent?: string, ip?: string) {
-    const record = refreshTokensStore.get(dto.refreshToken);
-    if (!record) throw new UnauthorizedException('Invalid refresh token');
-    if (record.expiresAt < Date.now()) {
-      refreshTokensStore.delete(dto.refreshToken);
-      throw new UnauthorizedException('Refresh token expired');
+    const parsed = parseOpaqueToken(dto.refreshToken, 'rt');
+    if (!parsed) throw new UnauthorizedException('Invalid refresh token');
+
+    const result = await this.repository.transaction(async (tx) => {
+      const context = await this.repository.getRefreshContextForUpdate(tx, parsed.id);
+      if (!context || !secureEqual(context.refresh_token_hash, parsed.hash)) {
+        await this.audit(tx, {
+          action: 'auth.refresh',
+          outcome: 'DENIED',
+          reason: 'REFRESH_TOKEN_NOT_FOUND',
+          metadata: this.clientMetadata(userAgent, ip, { tokenId: parsed.id }),
+        });
+        return { kind: 'invalid' as const };
+      }
+
+      if (context.refresh_token_status !== 'ACTIVE' || context.refresh_token_consumed_at) {
+        await this.repository.revokeFamily(
+          tx,
+          context.refresh_token_family_id,
+          'REFRESH_TOKEN_REUSE_DETECTED',
+          context.refresh_token_id,
+        );
+        await this.audit(tx, {
+          userId: context.user_id,
+          sessionId: context.session_id,
+          membershipId: context.membership_id,
+          organizationId: context.organization_id,
+          tenantId: context.tenant_id,
+          action: 'auth.refresh.reuse',
+          outcome: 'DENIED',
+          reason: 'REFRESH_TOKEN_REUSE_DETECTED',
+          metadata: this.clientMetadata(userAgent, ip, { tokenId: parsed.id }),
+        });
+        return { kind: 'reuse' as const };
+      }
+
+      const invalidReason = this.sessionInvalidReason(context);
+      if (invalidReason || context.refresh_token_expires_at <= new Date()) {
+        await this.repository.revokeFamily(
+          tx,
+          context.refresh_token_family_id,
+          invalidReason ?? 'REFRESH_TOKEN_EXPIRED',
+        );
+        await this.audit(tx, {
+          userId: context.user_id,
+          sessionId: context.session_id,
+          membershipId: context.membership_id,
+          organizationId: context.organization_id,
+          tenantId: context.tenant_id,
+          action: 'auth.refresh',
+          outcome: 'DENIED',
+          reason: invalidReason ?? 'REFRESH_TOKEN_EXPIRED',
+          metadata: this.clientMetadata(userAgent, ip),
+        });
+        return { kind: 'invalid' as const };
+      }
+
+      const replacement = makeOpaqueToken('rt');
+      await this.repository.rotateRefreshToken(tx, {
+        currentTokenId: context.refresh_token_id,
+        replacementTokenId: replacement.id,
+        replacementTokenHash: replacement.hash,
+        sessionId: context.session_id,
+        familyId: context.refresh_token_family_id,
+        replacementExpiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
+        userAgentHash: hashClientValue(userAgent),
+        ipHash: hashClientValue(ip),
+      });
+      await this.audit(tx, {
+        userId: context.user_id,
+        sessionId: context.session_id,
+        membershipId: context.membership_id,
+        organizationId: context.organization_id,
+        tenantId: context.tenant_id,
+        action: 'auth.refresh',
+        outcome: 'SUCCESS',
+        metadata: this.clientMetadata(userAgent, ip, {
+          rotatedFrom: context.refresh_token_id,
+          rotatedTo: replacement.id,
+        }),
+      });
+      return {
+        kind: 'success' as const,
+        accessToken: this.signAccessToken(
+          context.user_id,
+          context.session_id,
+          context.current_credential_version,
+        ),
+        refreshToken: replacement.token,
+        user: this.userProjection(context, Boolean(context.mfa_verified_at)),
+      };
+    });
+
+    if (result.kind === 'reuse') {
+      throw new UnauthorizedException('Refresh token reuse detected; session family revoked.');
     }
-    refreshTokensStore.delete(dto.refreshToken);
-    const user = usersStore.find((u) => u.id === record.userId);
-    if (!user) throw new UnauthorizedException('User not found');
-    return this.issueTokens(user);
+    if (result.kind === 'invalid') throw new UnauthorizedException('Invalid or expired refresh token');
+    return result;
+  }
+
+  async verifyMfa(dto: MfaVerifyInput, userAgent?: string, ip?: string) {
+    const parsed = parseOpaqueToken(dto.challengeToken, 'mc');
+    if (!parsed) throw new UnauthorizedException('Invalid MFA challenge');
+
+    const result = await this.repository.transaction(async (tx) => {
+      const challenge = await this.repository.getMfaChallengeForUpdate(tx, parsed.id);
+      if (!challenge || !secureEqual(challenge.challenge_token_hash, parsed.hash)) {
+        return { kind: 'invalid' as const };
+      }
+      const invalidReason = this.sessionInvalidReason(challenge, true);
+      if (
+        invalidReason
+        || challenge.challenge_status !== 'PENDING'
+        || challenge.challenge_expires_at <= new Date()
+        || challenge.session_status !== 'MFA_PENDING'
+      ) {
+        await this.repository.revokeSession(tx, challenge.session_id, invalidReason ?? 'MFA_CHALLENGE_INVALID');
+        await this.audit(tx, {
+          userId: challenge.user_id,
+          sessionId: challenge.session_id,
+          membershipId: challenge.membership_id,
+          organizationId: challenge.organization_id,
+          tenantId: challenge.tenant_id,
+          action: 'auth.mfa.verify',
+          outcome: 'DENIED',
+          reason: invalidReason ?? 'MFA_CHALLENGE_INVALID',
+          metadata: this.clientMetadata(userAgent, ip),
+        });
+        return { kind: 'invalid' as const };
+      }
+
+      const credential = await this.requireCredentialState(tx, challenge.user_id, true);
+      if (!credential.mfa_secret_ciphertext) return { kind: 'invalid' as const };
+      const method = this.verifyMfaCode(credential, dto.code);
+      if (!method) {
+        const terminal = challenge.challenge_attempts + 1 >= challenge.challenge_max_attempts;
+        await this.repository.recordMfaFailure(tx, challenge.challenge_id, terminal);
+        if (terminal) await this.repository.revokeSession(tx, challenge.session_id, 'MFA_ATTEMPTS_EXHAUSTED');
+        await this.audit(tx, {
+          userId: challenge.user_id,
+          sessionId: challenge.session_id,
+          membershipId: challenge.membership_id,
+          organizationId: challenge.organization_id,
+          tenantId: challenge.tenant_id,
+          action: 'auth.mfa.verify',
+          outcome: 'FAILURE',
+          reason: terminal ? 'MFA_ATTEMPTS_EXHAUSTED' : 'MFA_CODE_INVALID',
+          metadata: this.clientMetadata(userAgent, ip, { attempts: challenge.challenge_attempts + 1 }),
+        });
+        return { kind: 'invalid' as const };
+      }
+
+      const enrollment = challenge.challenge_type === 'TOTP_ENROLL';
+      const backup = enrollment ? generateBackupCodes() : null;
+      await this.repository.activateMfaSession(tx, {
+        challengeId: challenge.challenge_id,
+        sessionId: challenge.session_id,
+        userId: challenge.user_id,
+        method,
+        enableMfa: enrollment,
+        backupHashes: backup?.hashes,
+      });
+      const refresh = makeOpaqueToken('rt');
+      await this.repository.createRefreshToken(tx, {
+        id: refresh.id,
+        sessionId: challenge.session_id,
+        familyId: challenge.refresh_family_id,
+        tokenHash: refresh.hash,
+        expiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
+        userAgentHash: hashClientValue(userAgent),
+        ipHash: hashClientValue(ip),
+      });
+      await this.audit(tx, {
+        userId: challenge.user_id,
+        sessionId: challenge.session_id,
+        membershipId: challenge.membership_id,
+        organizationId: challenge.organization_id,
+        tenantId: challenge.tenant_id,
+        action: 'auth.mfa.verify',
+        outcome: 'SUCCESS',
+        metadata: this.clientMetadata(userAgent, ip, { method, enrollment }),
+      });
+      return {
+        kind: 'success' as const,
+        accessToken: this.signAccessToken(
+          challenge.user_id,
+          challenge.session_id,
+          challenge.current_credential_version,
+        ),
+        refreshToken: refresh.token,
+        backupCodes: backup?.codes,
+        user: this.userProjection(challenge, true),
+      };
+    });
+
+    if (result.kind === 'invalid') throw new UnauthorizedException('Invalid or expired MFA challenge');
+    return result;
   }
 
   async logout(dto: { refreshToken?: string }, sessionId?: string) {
-    if (dto?.refreshToken) refreshTokensStore.delete(dto.refreshToken);
-    // Immediately invalidate the caller's live access token, not just the refresh token.
-    if (sessionId) revokeSession(sessionId);
-    pruneRevokedSessions(Date.now());
+    if (!sessionId) return { success: true };
+    await this.repository.transaction(async (tx) => {
+      const context = await this.repository.getSessionContext(tx, sessionId, '', false);
+      await this.repository.revokeSession(tx, sessionId, 'USER_LOGOUT');
+      await this.audit(tx, {
+        userId: context?.user_id,
+        sessionId,
+        membershipId: context?.membership_id,
+        organizationId: context?.organization_id,
+        tenantId: context?.tenant_id,
+        action: 'auth.logout',
+        outcome: 'SUCCESS',
+        metadata: { refreshTokenPresented: Boolean(dto?.refreshToken) },
+      });
+    });
     return { success: true };
   }
 
@@ -272,33 +573,180 @@ export class AuthService {
       email: user.email,
       role: user.role,
       orgId: user.orgId,
+      tenantId: user.tenantId,
+      membershipId: user.membershipId,
       fullName: user.fullName,
       surfaceRole: user.surfaceRole,
+      mfaVerified: user.mfaVerified,
+      mfaVerifiedAt: user.mfaVerifiedAt,
     };
   }
 
   async verifyAccessToken(token: string): Promise<RequestUser> {
-    let payload: any;
+    let claims: AccessClaims;
     try {
-      payload = jwt.verify(token, JWT_SECRET);
+      const raw = jwt.verify(token, JWT_SECRET, {
+        issuer: ACCESS_ISSUER,
+        audience: ACCESS_AUDIENCE,
+      });
+      if (
+        typeof raw === 'string'
+        || raw.typ !== 'access'
+        || typeof raw.sub !== 'string'
+        || typeof raw.sid !== 'string'
+      ) {
+        throw new Error('Invalid access claims');
+      }
+      claims = raw as AccessClaims;
     } catch {
       throw new UnauthorizedException('Invalid or expired access token');
     }
-    if (isSessionRevoked(payload.sessionId)) {
-      throw new UnauthorizedException('Session has been revoked');
+
+    const context = await this.repository.getSessionContext(
+      this.repository.prisma,
+      claims.sid,
+      claims.sub,
+    );
+    const reason = context ? this.sessionInvalidReason(context) : 'SESSION_NOT_FOUND';
+    if (!context || reason) {
+      if (context) {
+        await this.repository.transaction(async (tx) => {
+          await this.repository.revokeSession(tx, context.session_id, reason ?? 'SESSION_INVALID');
+          await this.audit(tx, {
+            userId: context.user_id,
+            sessionId: context.session_id,
+            membershipId: context.membership_id,
+            organizationId: context.organization_id,
+            tenantId: context.tenant_id,
+            action: 'auth.access',
+            outcome: 'DENIED',
+            reason,
+          });
+        });
+      }
+      throw new UnauthorizedException(reason === 'SESSION_REVOKED' ? 'Session has been revoked' : 'Session is not active');
     }
+
+    const role = this.role(context.role);
+    if (requiresRoleMfa(role) && !context.mfa_verified_at) {
+      throw new UnauthorizedException('MFA verification is required for this role');
+    }
+    await this.repository.touchSession(this.repository.prisma, context.session_id);
     return {
-      id: payload.id,
-      email: payload.email,
-      role: payload.role,
-      orgId: payload.orgId,
-      fullName: payload.fullName,
-      surfaceRole: payload.surfaceRole,
-      sessionId: payload.sessionId,
+      id: context.user_id,
+      email: context.email,
+      fullName: context.full_name,
+      role,
+      orgId: context.organization_id,
+      tenantId: context.tenant_id,
+      membershipId: context.membership_id,
+      sessionId: context.session_id,
+      credentialVersion: context.current_credential_version,
+      mfaVerified: Boolean(context.mfa_verified_at),
+      mfaVerifiedAt: context.mfa_verified_at?.toISOString(),
     };
   }
 
-  sberBusinessStart(query: { returnPath?: string; orgType?: string; inn?: string; legalName?: string; fullName?: string; email?: string }) {
+  async revokeUserSessions(userId: string, reason = 'ADMIN_REVOKE') {
+    await this.repository.transaction(async (tx) => {
+      await this.repository.revokeAllUserSessions(tx, userId, reason);
+      await this.audit(tx, {
+        userId,
+        action: 'auth.sessions.revoke_all',
+        outcome: 'SUCCESS',
+        reason,
+      });
+    });
+    return { success: true, userId, reason };
+  }
+
+  assertRecentFinancialMfa(user: RequestUser, amountKopecks: number): void {
+    if (!requiresRecentFinancialMfa(amountKopecks)) return;
+    if (!user.mfaVerified || !user.mfaVerifiedAt) {
+      throw new ForbiddenException('Recent MFA verification is required for this financial action.');
+    }
+    const age = Date.now() - new Date(user.mfaVerifiedAt).getTime();
+    if (!Number.isFinite(age) || age < 0 || age > MFA_FRESHNESS_MS) {
+      throw new ForbiddenException('MFA verification is too old for this financial action.');
+    }
+  }
+
+  async getUserData(requestingUserId: string) {
+    const user = await this.repository.prisma.user.findUnique({
+      where: { id: requestingUserId },
+      include: { orgs: { include: { organization: true } } },
+    });
+    if (!user) throw new NotFoundException('User not found');
+    if (user.deletedAt) throw new ForbiddenException('Account has been anonymized');
+    const credential = await this.repository.getCredentialState(this.repository.prisma, user.id);
+    return {
+      exportedAt: new Date().toISOString(),
+      exportVersion: '2.0',
+      subject: '152-ФЗ Data Portability Export',
+      profile: {
+        id: user.id,
+        email: user.email,
+        fullName: user.fullName,
+        phone: user.phone,
+        createdAt: user.createdAt.toISOString(),
+      },
+      memberships: user.orgs.map((membership) => ({
+        membershipId: membership.id,
+        role: membership.role,
+        organizationId: membership.organizationId,
+        organizationName: membership.organization.name,
+        tenantId: membership.organization.tenantId,
+        organizationStatus: membership.organization.status,
+      })),
+      consent: {
+        version: credential?.consent_version ?? null,
+        recordedAt: credential?.consent_at?.toISOString() ?? null,
+        currentPolicyVersion: CURRENT_CONSENT_VERSION,
+      },
+      security: {
+        mfaEnabled: credential?.mfa_enabled ?? false,
+        credentialVersion: credential?.credential_version ?? 1,
+      },
+    };
+  }
+
+  async anonymizeUser(requestingUserId: string) {
+    return this.repository.transaction(async (tx) => {
+      const user = await tx.user.findUnique({ where: { id: requestingUserId } });
+      if (!user) throw new NotFoundException('User not found');
+      if (user.deletedAt) throw new ConflictException('Account already anonymized');
+      const anonymizedAt = new Date();
+      await this.repository.revokeAllUserSessions(tx, user.id, 'ACCOUNT_ANONYMIZED');
+      await tx.user.update({
+        where: { id: user.id },
+        data: {
+          email: `anon-${user.id}@deleted.invalid`,
+          fullName: 'Anonymized User',
+          phone: null,
+          passwordHash: '',
+          status: 'BLOCKED',
+          deletedAt: anonymizedAt,
+        },
+      });
+      await tx.$executeRaw(Prisma.sql`
+        UPDATE auth.credential_states
+        SET credential_version = credential_version + 1,
+            mfa_secret_ciphertext = NULL,
+            mfa_backup_hashes = NULL,
+            updated_at = NOW()
+        WHERE user_id = ${user.id}
+      `);
+      await this.audit(tx, {
+        userId: user.id,
+        action: 'auth.account.anonymize',
+        outcome: 'SUCCESS',
+        reason: 'USER_REQUEST',
+      });
+      return { success: true, anonymizedAt: anonymizedAt.toISOString() };
+    });
+  }
+
+  sberBusinessStart(query: Record<string, string | undefined>) {
     return {
       provider: 'sber-business',
       status: 'not_configured',
@@ -307,7 +755,7 @@ export class AuthService {
     };
   }
 
-  sberBusinessCallback(query: { code?: string; state?: string }, userAgent?: string, ip?: string) {
+  sberBusinessCallback(_query: Record<string, string | undefined>, _userAgent?: string, _ip?: string) {
     return {
       provider: 'sber-business',
       status: 'not_configured',
@@ -316,97 +764,227 @@ export class AuthService {
   }
 
   oidcProviders() {
-    return {
-      providers: [],
-      message: 'No OIDC providers configured',
-    };
+    return { providers: [], message: 'No OIDC providers configured' };
   }
 
   oidcAuthorizationUrl() {
-    return {
-      url: null,
-      message: 'No OIDC provider configured',
-    };
+    return { url: null, message: 'No OIDC provider configured' };
   }
 
+  /** Synthetic E2E compatibility only. Runtime authorization never reads this cache. */
   listUsers() {
-    return usersStore.map((u) => ({
-      id: u.id,
-      email: u.email,
-      role: u.role,
-      orgId: u.orgId,
-      fullName: u.fullName,
-    }));
+    return [...this.seedCompatibilityUsers];
   }
 
-  updateUserRole(userId: string, role: Role): { id: string; role: Role } {
-    const user = usersStore.find((u) => u.id === userId);
-    if (!user) throw new Error(`User ${userId} not found`);
+  /** Synthetic E2E compatibility only. Membership authority remains PostgreSQL UserOrg. */
+  updateUserRole(userId: string, role: Role) {
+    this.assertSyntheticSeedCompatibility();
+    const user = this.seedCompatibilityUsers.find((item) => item.id === userId);
+    if (!user) throw new Error(`Synthetic seed user ${userId} not found`);
     user.role = role;
-    // Invalidate live tokens so the privilege change takes effect immediately —
-    // a token minted with the old role must not keep the old access.
-    revokeAllUserSessions(userId);
-    return { id: user.id, role: user.role };
+    return { id: user.id, role };
   }
 
-  updateUserOrg(userId: string, orgId: string): { id: string; orgId: string } {
-    const user = usersStore.find((u) => u.id === userId);
-    if (!user) throw new Error(`User ${userId} not found`);
+  /** Synthetic E2E compatibility only. Organization authority remains PostgreSQL UserOrg. */
+  updateUserOrg(userId: string, orgId: string) {
+    this.assertSyntheticSeedCompatibility();
+    const user = this.seedCompatibilityUsers.find((item) => item.id === userId);
+    if (!user) throw new Error(`Synthetic seed user ${userId} not found`);
     user.orgId = orgId;
-    // Org scope is security-relevant — invalidate live tokens carrying the old org.
-    revokeAllUserSessions(userId);
-    return { id: user.id, orgId: user.orgId };
+    return { id: user.id, orgId };
   }
 
-  getUserData(requestingUserId: string) {
-    const user = usersStore.find((u) => u.id === requestingUserId);
-    if (!user) throw new NotFoundException('User not found');
-    if (user.anonymized) throw new ForbiddenException('Account has been anonymized');
+  private async registerSyntheticSeedUser(dto: any, role: Role) {
+    this.assertSyntheticSeedCompatibility();
+    const email = String(dto.email).trim().toLowerCase();
+    const user = await this.repository.prisma.user.upsert({
+      where: { email },
+      update: {
+        passwordHash: await bcrypt.hash(String(dto.password), 10),
+        fullName: String(dto.fullName ?? email),
+        status: 'ACTIVE',
+      },
+      create: {
+        id: `user_${randomUUID()}`,
+        email,
+        passwordHash: await bcrypt.hash(String(dto.password), 10),
+        fullName: String(dto.fullName ?? email),
+        status: 'ACTIVE',
+      },
+    });
+    const projection: SeedCompatibilityUser = {
+      id: user.id,
+      email: user.email,
+      fullName: user.fullName,
+      role,
+      orgId: String(dto.orgId),
+    };
+    const index = this.seedCompatibilityUsers.findIndex((item) => item.id === user.id);
+    if (index >= 0) this.seedCompatibilityUsers[index] = projection;
+    else this.seedCompatibilityUsers.push(projection);
+    return { user: projection };
+  }
+
+  private assertSyntheticSeedCompatibility(): void {
+    if (!SYNTHETIC_SEED_ENABLED || String(process.env.NODE_ENV).toLowerCase() === 'production') {
+      throw new ForbiddenException('Synthetic identity compatibility is disabled.');
+    }
+  }
+
+  private async issueActiveTokens(
+    tx: AuthSqlClient,
+    identity: IdentityRow,
+    input: {
+      id: string;
+      familyId: string;
+      credentialVersion: number;
+      userAgent?: string;
+      ip?: string;
+    },
+  ) {
+    const refresh = makeOpaqueToken('rt');
+    await this.repository.createRefreshToken(tx, {
+      id: refresh.id,
+      sessionId: input.id,
+      familyId: input.familyId,
+      tokenHash: refresh.hash,
+      expiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
+      userAgentHash: hashClientValue(input.userAgent),
+      ipHash: hashClientValue(input.ip),
+    });
     return {
-      exportedAt: new Date().toISOString(),
-      exportVersion: '1.0',
-      subject: '152-ФЗ Data Portability Export',
-      profile: {
-        id: user.id,
-        email: user.email,
-        fullName: user.fullName,
-        phone: user.phone ?? null,
-        role: user.role,
-        orgId: user.orgId,
-        createdAt: user.createdAt ?? null,
-      },
-      consent: {
-        version: user.consentVersion ?? null,
-        recordedAt: user.consentAt ?? null,
-        currentPolicyVersion: CURRENT_CONSENT_VERSION,
-      },
-      accountStatus: {
-        anonymized: user.anonymized ?? false,
-      },
+      accessToken: this.signAccessToken(identity.user_id, input.id, input.credentialVersion),
+      refreshToken: refresh.token,
+      user: this.userProjection(identity, false),
     };
   }
 
-  anonymizeUser(requestingUserId: string): { success: boolean; anonymizedAt: string } {
-    const user = usersStore.find((u) => u.id === requestingUserId);
-    if (!user) throw new NotFoundException('User not found');
-    if (user.anonymized) throw new ConflictException('Account already anonymized');
+  private signAccessToken(userId: string, sessionId: string, credentialVersion: number): string {
+    return jwt.sign(
+      {
+        typ: 'access',
+        sid: sessionId,
+        cv: credentialVersion,
+      },
+      JWT_SECRET,
+      {
+        subject: userId,
+        issuer: ACCESS_ISSUER,
+        audience: ACCESS_AUDIENCE,
+        expiresIn: ACCESS_TOKEN_TTL,
+        jwtid: randomUUID(),
+      },
+    );
+  }
 
-    const anonymizedAt = new Date().toISOString();
-    user.email = `anon-${user.id}@deleted.invalid`;
-    user.fullName = 'Anonymized User';
-    user.phone = undefined;
-    user.passwordHash = '';
-    user.anonymized = true;
+  private userProjection(identity: IdentityRow | SessionContextRow | MfaChallengeRow, mfaVerified: boolean): AuthUserProjection {
+    return {
+      id: identity.user_id,
+      email: identity.email,
+      fullName: identity.full_name,
+      role: this.role(identity.role),
+      orgId: identity.organization_id,
+      tenantId: identity.tenant_id,
+      membershipId: identity.membership_id,
+      mfaVerified,
+    };
+  }
 
-    // Revoke all refresh tokens for this user
-    for (const [key, rec] of refreshTokensStore.entries()) {
-      if (rec.userId === requestingUserId) {
-        refreshTokensStore.delete(key);
-      }
+  private role(value: string): Role {
+    if (!KNOWN_ROLES.has(value) || value === Role.BANK_CALLBACK) {
+      throw new ForbiddenException('Membership role is not authorized for a human session.');
     }
-    // Revoke all live access sessions for this user.
-    revokeAllUserSessions(requestingUserId);
+    return value as Role;
+  }
 
-    return { success: true, anonymizedAt };
+  private async assertIdentityUsable(
+    tx: AuthSqlClient,
+    identity: IdentityRow,
+    action: string,
+  ): Promise<void> {
+    let reason: string | null = null;
+    if (identity.user_status !== 'ACTIVE') reason = 'USER_NOT_ACTIVE';
+    else if (identity.organization_status !== 'VERIFIED') reason = 'ORGANIZATION_NOT_VERIFIED';
+    else if (!KNOWN_ROLES.has(identity.role) || identity.role === Role.BANK_CALLBACK) reason = 'MEMBERSHIP_ROLE_INVALID';
+    if (!reason) return;
+    await this.audit(tx, {
+      userId: identity.user_id,
+      membershipId: identity.membership_id,
+      organizationId: identity.organization_id,
+      tenantId: identity.tenant_id,
+      action,
+      outcome: 'DENIED',
+      reason,
+    });
+    throw new ForbiddenException(reason);
+  }
+
+  private sessionInvalidReason(context: SessionContextRow, allowMfaPending = false): string | null {
+    if (context.session_status === 'REVOKED') return 'SESSION_REVOKED';
+    if (context.session_status === 'EXPIRED' || context.session_expires_at <= new Date()) return 'SESSION_EXPIRED';
+    if (context.session_status !== 'ACTIVE' && !(allowMfaPending && context.session_status === 'MFA_PENDING')) {
+      return 'SESSION_NOT_ACTIVE';
+    }
+    if (context.user_status !== 'ACTIVE') return 'USER_NOT_ACTIVE';
+    if (context.organization_status !== 'VERIFIED') return 'ORGANIZATION_NOT_VERIFIED';
+    if (context.session_credential_version !== context.current_credential_version) return 'CREDENTIAL_VERSION_CHANGED';
+    if (!KNOWN_ROLES.has(context.role) || context.role === Role.BANK_CALLBACK) return 'MEMBERSHIP_ROLE_INVALID';
+    return null;
+  }
+
+  private verifyMfaCode(credential: CredentialStateRow, code: string): 'TOTP' | 'BACKUP' | null {
+    const secret = credential.mfa_secret_ciphertext
+      ? decryptMfaSecret(credential.mfa_secret_ciphertext)
+      : null;
+    if (secret && verifyTotp(secret, code)) return 'TOTP';
+    const hashes = Array.isArray(credential.mfa_backup_hashes)
+      ? credential.mfa_backup_hashes.filter((item): item is string => typeof item === 'string')
+      : [];
+    const candidate = hashAuthMaterial(String(code).trim().toUpperCase());
+    if (hashes.some((item) => secureEqual(item, candidate))) return 'BACKUP';
+    return null;
+  }
+
+  private async requireCredentialState(
+    tx: AuthSqlClient,
+    userId: string,
+    forUpdate = false,
+  ): Promise<CredentialStateRow> {
+    await this.repository.ensureCredentialState(tx, userId);
+    const state = await this.repository.getCredentialState(tx, userId, forUpdate);
+    if (!state) throw new Error(`Credential state for ${userId} was not created`);
+    return state;
+  }
+
+  private clientMetadata(
+    userAgent?: string,
+    ip?: string,
+    extra: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return {
+      userAgentHash: hashClientValue(userAgent),
+      ipHash: hashClientValue(ip),
+      ...extra,
+    };
+  }
+
+  private async audit(
+    tx: AuthSqlClient,
+    input: {
+      userId?: string | null;
+      sessionId?: string | null;
+      membershipId?: string | null;
+      organizationId?: string | null;
+      tenantId?: string | null;
+      action: string;
+      outcome: 'SUCCESS' | 'FAILURE' | 'DENIED';
+      reason?: string | null;
+      metadata?: Record<string, unknown> | null;
+    },
+  ): Promise<void> {
+    const id = `auth_evt_${randomUUID()}`;
+    const prevHash = await this.repository.latestAuditHash(tx, input.userId, input.sessionId);
+    const hash = sha256(stableJson({ id, ...input, prevHash }));
+    await this.repository.insertAudit(tx, { id, ...input, hash, prevHash });
   }
 }

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -551,7 +551,7 @@ export class AuthService {
   async logout(dto: { refreshToken?: string }, sessionId?: string) {
     if (!sessionId) return { success: true };
     await this.repository.transaction(async (tx) => {
-      const context = await this.repository.getSessionContext(tx, sessionId, '', false);
+      const context = await this.repository.getSessionContext(tx, sessionId, undefined, true);
       await this.repository.revokeSession(tx, sessionId, 'USER_LOGOUT');
       await this.audit(tx, {
         userId: context?.user_id,

--- a/apps/api/src/modules/auth/dto/logout.dto.ts
+++ b/apps/api/src/modules/auth/dto/logout.dto.ts
@@ -1,0 +1,7 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class LogoutDto {
+  @IsOptional()
+  @IsString()
+  refreshToken?: string;
+}

--- a/apps/api/src/modules/auth/dto/mfa-verify.dto.ts
+++ b/apps/api/src/modules/auth/dto/mfa-verify.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, Matches, MinLength } from 'class-validator';
+
+export class MfaVerifyDto {
+  @IsString()
+  @MinLength(40)
+  challengeToken!: string;
+
+  @IsString()
+  @Matches(/^(?:\d{6}|[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4})$/)
+  code!: string;
+}

--- a/apps/api/src/modules/auth/dto/revoke-user-sessions.dto.ts
+++ b/apps/api/src/modules/auth/dto/revoke-user-sessions.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString, MinLength } from 'class-validator';
+
+export class RevokeUserSessionsDto {
+  @IsString()
+  @MinLength(3)
+  userId!: string;
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/apps/api/src/modules/auth/persistent-auth.repository.ts
+++ b/apps/api/src/modules/auth/persistent-auth.repository.ts
@@ -81,6 +81,8 @@ export type AuthAuditInput = {
   prevHash?: string | null;
 };
 
+const MAX_SERIALIZABLE_TRANSACTION_ATTEMPTS = 3;
+
 @Injectable()
 export class PersistentAuthRepository {
   constructor(readonly prisma: PrismaService) {}
@@ -89,7 +91,28 @@ export class PersistentAuthRepository {
     work: (tx: Prisma.TransactionClient) => Promise<T>,
     isolationLevel = Prisma.TransactionIsolationLevel.Serializable,
   ): Promise<T> {
-    return this.prisma.$transaction(work, { isolationLevel, timeout: 15_000, maxWait: 5_000 });
+    for (let attempt = 1; attempt <= MAX_SERIALIZABLE_TRANSACTION_ATTEMPTS; attempt += 1) {
+      try {
+        return await this.prisma.$transaction(work, { isolationLevel, timeout: 15_000, maxWait: 5_000 });
+      } catch (error) {
+        if (attempt >= MAX_SERIALIZABLE_TRANSACTION_ATTEMPTS || !this.isSerializationFailure(error)) {
+          throw error;
+        }
+      }
+    }
+    throw new Error('Auth transaction retry budget exhausted');
+  }
+
+  private isSerializationFailure(error: unknown): boolean {
+    const candidate = error as {
+      code?: unknown;
+      message?: unknown;
+      meta?: { code?: unknown; database_error?: unknown };
+    };
+    return candidate?.code === 'P2034'
+      || candidate?.meta?.code === '40001'
+      || String(candidate?.meta?.database_error ?? '').includes('40001')
+      || /could not serialize access|write conflict|deadlock detected/i.test(String(candidate?.message ?? ''));
   }
 
   async findIdentityByEmail(client: AuthSqlClient, email: string): Promise<IdentityRow | null> {

--- a/apps/api/src/modules/auth/persistent-auth.repository.ts
+++ b/apps/api/src/modules/auth/persistent-auth.repository.ts
@@ -709,8 +709,11 @@ export class PersistentAuthRepository {
     sessionId?: string | null,
   ): Promise<string | null> {
     const chainKey = sessionId ?? userId ?? 'auth-global';
-    await client.$queryRaw(Prisma.sql`
-      SELECT pg_advisory_xact_lock(hashtextextended(${chainKey}, 0))
+    await client.$queryRaw<Array<{ acquired: number }>>(Prisma.sql`
+      SELECT 1::int AS acquired
+      FROM (
+        SELECT pg_advisory_xact_lock(hashtextextended(${chainKey}, 0))
+      ) AS auth_audit_lock
     `);
     const rows = await client.$queryRaw<Array<{ hash: string }>>(Prisma.sql`
       SELECT hash

--- a/apps/api/src/modules/auth/persistent-auth.repository.ts
+++ b/apps/api/src/modules/auth/persistent-auth.repository.ts
@@ -1,0 +1,755 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../common/prisma/prisma.service';
+
+export type AuthSqlClient = Pick<Prisma.TransactionClient, '$queryRaw' | '$executeRaw'>;
+
+export type IdentityRow = {
+  user_id: string;
+  email: string;
+  password_hash: string;
+  full_name: string;
+  phone: string | null;
+  user_status: string;
+  membership_id: string;
+  role: string;
+  organization_id: string;
+  organization_status: string;
+  tenant_id: string;
+};
+
+export type CredentialStateRow = {
+  user_id: string;
+  credential_version: number;
+  failed_login_count: number;
+  locked_until: Date | null;
+  password_changed_at: Date | null;
+  last_login_at: Date | null;
+  mfa_enabled: boolean;
+  mfa_secret_ciphertext: string | null;
+  mfa_key_version: string | null;
+  mfa_backup_hashes: unknown;
+  consent_version: string | null;
+  consent_at: Date | null;
+};
+
+export type SessionContextRow = IdentityRow & {
+  session_id: string;
+  session_status: string;
+  refresh_family_id: string;
+  session_credential_version: number;
+  mfa_level: string;
+  mfa_verified_at: Date | null;
+  session_expires_at: Date;
+  revoked_at: Date | null;
+  revocation_reason: string | null;
+  current_credential_version: number;
+  current_mfa_enabled: boolean;
+};
+
+export type RefreshContextRow = SessionContextRow & {
+  refresh_token_id: string;
+  refresh_token_hash: string;
+  refresh_token_status: string;
+  refresh_token_expires_at: Date;
+  refresh_token_consumed_at: Date | null;
+  refresh_token_family_id: string;
+};
+
+export type MfaChallengeRow = SessionContextRow & {
+  challenge_id: string;
+  challenge_token_hash: string;
+  challenge_type: string;
+  challenge_status: string;
+  challenge_attempts: number;
+  challenge_max_attempts: number;
+  challenge_expires_at: Date;
+};
+
+export type AuthAuditInput = {
+  id: string;
+  userId?: string | null;
+  sessionId?: string | null;
+  membershipId?: string | null;
+  organizationId?: string | null;
+  tenantId?: string | null;
+  action: string;
+  outcome: 'SUCCESS' | 'FAILURE' | 'DENIED';
+  reason?: string | null;
+  metadata?: Record<string, unknown> | null;
+  hash: string;
+  prevHash?: string | null;
+};
+
+@Injectable()
+export class PersistentAuthRepository {
+  constructor(readonly prisma: PrismaService) {}
+
+  async transaction<T>(
+    work: (tx: Prisma.TransactionClient) => Promise<T>,
+    isolationLevel = Prisma.TransactionIsolationLevel.Serializable,
+  ): Promise<T> {
+    return this.prisma.$transaction(work, { isolationLevel, timeout: 15_000, maxWait: 5_000 });
+  }
+
+  async findIdentityByEmail(client: AuthSqlClient, email: string): Promise<IdentityRow | null> {
+    const rows = await client.$queryRaw<IdentityRow[]>(Prisma.sql`
+      SELECT
+        u.id AS user_id,
+        u.email,
+        u."passwordHash" AS password_hash,
+        u."fullName" AS full_name,
+        u.phone,
+        u.status AS user_status,
+        uo.id AS membership_id,
+        uo.role,
+        o.id AS organization_id,
+        o.status AS organization_status,
+        o."tenantId" AS tenant_id
+      FROM public.users u
+      JOIN public.user_orgs uo ON uo."userId" = u.id
+      JOIN public.organizations o ON o.id = uo."organizationId"
+      WHERE LOWER(u.email) = LOWER(${email})
+      ORDER BY uo."isDefault" DESC, uo."joinedAt" ASC, uo.id ASC
+      LIMIT 1
+    `);
+    return rows[0] ?? null;
+  }
+
+  async findIdentityByUserAndMembership(
+    client: AuthSqlClient,
+    userId: string,
+    membershipId: string,
+  ): Promise<IdentityRow | null> {
+    const rows = await client.$queryRaw<IdentityRow[]>(Prisma.sql`
+      SELECT
+        u.id AS user_id,
+        u.email,
+        u."passwordHash" AS password_hash,
+        u."fullName" AS full_name,
+        u.phone,
+        u.status AS user_status,
+        uo.id AS membership_id,
+        uo.role,
+        o.id AS organization_id,
+        o.status AS organization_status,
+        o."tenantId" AS tenant_id
+      FROM public.users u
+      JOIN public.user_orgs uo ON uo."userId" = u.id
+      JOIN public.organizations o ON o.id = uo."organizationId"
+      WHERE u.id = ${userId}
+        AND uo.id = ${membershipId}
+      LIMIT 1
+    `);
+    return rows[0] ?? null;
+  }
+
+  async ensureCredentialState(
+    client: AuthSqlClient,
+    userId: string,
+    consentVersion?: string | null,
+    consentAt?: Date | null,
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      INSERT INTO auth.credential_states (
+        user_id,
+        consent_version,
+        consent_at
+      ) VALUES (
+        ${userId},
+        ${consentVersion ?? null},
+        ${consentAt ?? null}
+      )
+      ON CONFLICT (user_id) DO NOTHING
+    `);
+  }
+
+  async getCredentialState(
+    client: AuthSqlClient,
+    userId: string,
+    forUpdate = false,
+  ): Promise<CredentialStateRow | null> {
+    const lock = forUpdate ? Prisma.sql` FOR UPDATE` : Prisma.empty;
+    const rows = await client.$queryRaw<CredentialStateRow[]>(Prisma.sql`
+      SELECT
+        user_id,
+        credential_version,
+        failed_login_count,
+        locked_until,
+        password_changed_at,
+        last_login_at,
+        mfa_enabled,
+        mfa_secret_ciphertext,
+        mfa_key_version,
+        mfa_backup_hashes,
+        consent_version,
+        consent_at
+      FROM auth.credential_states
+      WHERE user_id = ${userId}${lock}
+    `);
+    return rows[0] ?? null;
+  }
+
+  async getLoginThrottle(
+    client: AuthSqlClient,
+    accountHash: string,
+    forUpdate = false,
+  ): Promise<{ failures: number; locked_until: Date | null } | null> {
+    const lock = forUpdate ? Prisma.sql` FOR UPDATE` : Prisma.empty;
+    const rows = await client.$queryRaw<Array<{ failures: number; locked_until: Date | null }>>(Prisma.sql`
+      SELECT failures, locked_until
+      FROM auth.login_throttles
+      WHERE account_hash = ${accountHash}${lock}
+    `);
+    return rows[0] ?? null;
+  }
+
+  async ensureLoginThrottle(client: AuthSqlClient, accountHash: string): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      INSERT INTO auth.login_throttles (account_hash)
+      VALUES (${accountHash})
+      ON CONFLICT (account_hash) DO NOTHING
+    `);
+  }
+
+  async setLoginThrottle(
+    client: AuthSqlClient,
+    accountHash: string,
+    failures: number,
+    lockedUntil: Date | null,
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.login_throttles
+      SET failures = ${failures},
+          locked_until = ${lockedUntil},
+          updated_at = NOW()
+      WHERE account_hash = ${accountHash}
+    `);
+  }
+
+  async clearLoginThrottle(client: AuthSqlClient, accountHash: string): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.login_throttles
+      SET failures = 0,
+          locked_until = NULL,
+          updated_at = NOW()
+      WHERE account_hash = ${accountHash}
+    `);
+  }
+
+  async createSession(
+    client: AuthSqlClient,
+    input: {
+      id: string;
+      userId: string;
+      membershipId: string;
+      organizationId: string;
+      tenantId: string;
+      status: 'MFA_PENDING' | 'ACTIVE';
+      refreshFamilyId: string;
+      credentialVersion: number;
+      userAgentHash?: string | null;
+      ipHash?: string | null;
+      expiresAt: Date;
+    },
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      INSERT INTO auth.sessions (
+        id,
+        user_id,
+        membership_id,
+        organization_id,
+        tenant_id,
+        status,
+        refresh_family_id,
+        credential_version,
+        user_agent_hash,
+        ip_hash,
+        expires_at
+      ) VALUES (
+        ${input.id},
+        ${input.userId},
+        ${input.membershipId},
+        ${input.organizationId},
+        ${input.tenantId},
+        ${input.status},
+        ${input.refreshFamilyId},
+        ${input.credentialVersion},
+        ${input.userAgentHash ?? null},
+        ${input.ipHash ?? null},
+        ${input.expiresAt}
+      )
+    `);
+  }
+
+  async createRefreshToken(
+    client: AuthSqlClient,
+    input: {
+      id: string;
+      sessionId: string;
+      familyId: string;
+      tokenHash: string;
+      parentTokenId?: string | null;
+      expiresAt: Date;
+      userAgentHash?: string | null;
+      ipHash?: string | null;
+    },
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      INSERT INTO auth.refresh_tokens (
+        id,
+        session_id,
+        family_id,
+        token_hash,
+        parent_token_id,
+        expires_at,
+        user_agent_hash,
+        ip_hash
+      ) VALUES (
+        ${input.id},
+        ${input.sessionId},
+        ${input.familyId},
+        ${input.tokenHash},
+        ${input.parentTokenId ?? null},
+        ${input.expiresAt},
+        ${input.userAgentHash ?? null},
+        ${input.ipHash ?? null}
+      )
+    `);
+  }
+
+  async createMfaChallenge(
+    client: AuthSqlClient,
+    input: {
+      id: string;
+      sessionId: string;
+      userId: string;
+      challengeTokenHash: string;
+      type: 'TOTP_ENROLL' | 'TOTP_VERIFY';
+      expiresAt: Date;
+    },
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      INSERT INTO auth.mfa_challenges (
+        id,
+        session_id,
+        user_id,
+        challenge_token_hash,
+        type,
+        expires_at
+      ) VALUES (
+        ${input.id},
+        ${input.sessionId},
+        ${input.userId},
+        ${input.challengeTokenHash},
+        ${input.type},
+        ${input.expiresAt}
+      )
+    `);
+  }
+
+  async getSessionContext(
+    client: AuthSqlClient,
+    sessionId: string,
+    userId: string,
+    forUpdate = false,
+  ): Promise<SessionContextRow | null> {
+    const lock = forUpdate ? Prisma.sql` FOR UPDATE OF s` : Prisma.empty;
+    const rows = await client.$queryRaw<SessionContextRow[]>(Prisma.sql`
+      SELECT
+        u.id AS user_id,
+        u.email,
+        u."passwordHash" AS password_hash,
+        u."fullName" AS full_name,
+        u.phone,
+        u.status AS user_status,
+        uo.id AS membership_id,
+        uo.role,
+        o.id AS organization_id,
+        o.status AS organization_status,
+        o."tenantId" AS tenant_id,
+        s.id AS session_id,
+        s.status AS session_status,
+        s.refresh_family_id,
+        s.credential_version AS session_credential_version,
+        s.mfa_level,
+        s.mfa_verified_at,
+        s.expires_at AS session_expires_at,
+        s.revoked_at,
+        s.revocation_reason,
+        cs.credential_version AS current_credential_version,
+        cs.mfa_enabled AS current_mfa_enabled
+      FROM auth.sessions s
+      JOIN public.users u ON u.id = s.user_id
+      JOIN public.user_orgs uo ON uo.id = s.membership_id
+        AND uo."userId" = s.user_id
+        AND uo."organizationId" = s.organization_id
+      JOIN public.organizations o ON o.id = s.organization_id
+        AND o."tenantId" = s.tenant_id
+      JOIN auth.credential_states cs ON cs.user_id = s.user_id
+      WHERE s.id = ${sessionId}
+        AND s.user_id = ${userId}${lock}
+    `);
+    return rows[0] ?? null;
+  }
+
+  async getRefreshContextForUpdate(
+    client: AuthSqlClient,
+    refreshTokenId: string,
+  ): Promise<RefreshContextRow | null> {
+    const rows = await client.$queryRaw<RefreshContextRow[]>(Prisma.sql`
+      SELECT
+        u.id AS user_id,
+        u.email,
+        u."passwordHash" AS password_hash,
+        u."fullName" AS full_name,
+        u.phone,
+        u.status AS user_status,
+        uo.id AS membership_id,
+        uo.role,
+        o.id AS organization_id,
+        o.status AS organization_status,
+        o."tenantId" AS tenant_id,
+        s.id AS session_id,
+        s.status AS session_status,
+        s.refresh_family_id,
+        s.credential_version AS session_credential_version,
+        s.mfa_level,
+        s.mfa_verified_at,
+        s.expires_at AS session_expires_at,
+        s.revoked_at,
+        s.revocation_reason,
+        cs.credential_version AS current_credential_version,
+        cs.mfa_enabled AS current_mfa_enabled,
+        rt.id AS refresh_token_id,
+        rt.token_hash AS refresh_token_hash,
+        rt.status AS refresh_token_status,
+        rt.expires_at AS refresh_token_expires_at,
+        rt.consumed_at AS refresh_token_consumed_at,
+        rt.family_id AS refresh_token_family_id
+      FROM auth.refresh_tokens rt
+      JOIN auth.sessions s ON s.id = rt.session_id
+      JOIN public.users u ON u.id = s.user_id
+      JOIN public.user_orgs uo ON uo.id = s.membership_id
+        AND uo."userId" = s.user_id
+        AND uo."organizationId" = s.organization_id
+      JOIN public.organizations o ON o.id = s.organization_id
+        AND o."tenantId" = s.tenant_id
+      JOIN auth.credential_states cs ON cs.user_id = s.user_id
+      WHERE rt.id = ${refreshTokenId}
+      FOR UPDATE OF rt, s
+    `);
+    return rows[0] ?? null;
+  }
+
+  async getMfaChallengeForUpdate(
+    client: AuthSqlClient,
+    challengeId: string,
+  ): Promise<MfaChallengeRow | null> {
+    const rows = await client.$queryRaw<MfaChallengeRow[]>(Prisma.sql`
+      SELECT
+        u.id AS user_id,
+        u.email,
+        u."passwordHash" AS password_hash,
+        u."fullName" AS full_name,
+        u.phone,
+        u.status AS user_status,
+        uo.id AS membership_id,
+        uo.role,
+        o.id AS organization_id,
+        o.status AS organization_status,
+        o."tenantId" AS tenant_id,
+        s.id AS session_id,
+        s.status AS session_status,
+        s.refresh_family_id,
+        s.credential_version AS session_credential_version,
+        s.mfa_level,
+        s.mfa_verified_at,
+        s.expires_at AS session_expires_at,
+        s.revoked_at,
+        s.revocation_reason,
+        cs.credential_version AS current_credential_version,
+        cs.mfa_enabled AS current_mfa_enabled,
+        c.id AS challenge_id,
+        c.challenge_token_hash,
+        c.type AS challenge_type,
+        c.status AS challenge_status,
+        c.attempts AS challenge_attempts,
+        c.max_attempts AS challenge_max_attempts,
+        c.expires_at AS challenge_expires_at
+      FROM auth.mfa_challenges c
+      JOIN auth.sessions s ON s.id = c.session_id
+      JOIN public.users u ON u.id = s.user_id
+      JOIN public.user_orgs uo ON uo.id = s.membership_id
+        AND uo."userId" = s.user_id
+        AND uo."organizationId" = s.organization_id
+      JOIN public.organizations o ON o.id = s.organization_id
+        AND o."tenantId" = s.tenant_id
+      JOIN auth.credential_states cs ON cs.user_id = s.user_id
+      WHERE c.id = ${challengeId}
+      FOR UPDATE OF c, s, cs
+    `);
+    return rows[0] ?? null;
+  }
+
+  async rotateRefreshToken(
+    client: AuthSqlClient,
+    input: {
+      currentTokenId: string;
+      replacementTokenId: string;
+      replacementTokenHash: string;
+      sessionId: string;
+      familyId: string;
+      replacementExpiresAt: Date;
+      userAgentHash?: string | null;
+      ipHash?: string | null;
+    },
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.refresh_tokens
+      SET status = 'ROTATED',
+          consumed_at = NOW(),
+          replaced_by_token_id = ${input.replacementTokenId}
+      WHERE id = ${input.currentTokenId}
+        AND status = 'ACTIVE'
+    `);
+    await this.createRefreshToken(client, {
+      id: input.replacementTokenId,
+      sessionId: input.sessionId,
+      familyId: input.familyId,
+      tokenHash: input.replacementTokenHash,
+      parentTokenId: input.currentTokenId,
+      expiresAt: input.replacementExpiresAt,
+      userAgentHash: input.userAgentHash,
+      ipHash: input.ipHash,
+    });
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.sessions
+      SET last_seen_at = NOW(), updated_at = NOW()
+      WHERE id = ${input.sessionId}
+    `);
+  }
+
+  async revokeFamily(
+    client: AuthSqlClient,
+    familyId: string,
+    reason: string,
+    reusedTokenId?: string | null,
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.refresh_tokens
+      SET status = CASE WHEN id = ${reusedTokenId ?? null} THEN 'REUSED' ELSE 'REVOKED' END,
+          revoked_at = NOW(),
+          revocation_reason = ${reason}
+      WHERE family_id = ${familyId}
+        AND status IN ('ACTIVE', 'ROTATED')
+    `);
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.sessions
+      SET status = 'REVOKED',
+          revoked_at = NOW(),
+          revocation_reason = ${reason},
+          updated_at = NOW()
+      WHERE refresh_family_id = ${familyId}
+        AND status IN ('ACTIVE', 'MFA_PENDING')
+    `);
+  }
+
+  async revokeSession(
+    client: AuthSqlClient,
+    sessionId: string,
+    reason: string,
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.sessions
+      SET status = 'REVOKED',
+          revoked_at = NOW(),
+          revocation_reason = ${reason},
+          updated_at = NOW()
+      WHERE id = ${sessionId}
+        AND status IN ('ACTIVE', 'MFA_PENDING')
+    `);
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.refresh_tokens
+      SET status = 'REVOKED',
+          revoked_at = NOW(),
+          revocation_reason = ${reason}
+      WHERE session_id = ${sessionId}
+        AND status IN ('ACTIVE', 'ROTATED')
+    `);
+  }
+
+  async revokeAllUserSessions(
+    client: AuthSqlClient,
+    userId: string,
+    reason: string,
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.sessions
+      SET status = 'REVOKED',
+          revoked_at = NOW(),
+          revocation_reason = ${reason},
+          updated_at = NOW()
+      WHERE user_id = ${userId}
+        AND status IN ('ACTIVE', 'MFA_PENDING')
+    `);
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.refresh_tokens rt
+      SET status = 'REVOKED',
+          revoked_at = NOW(),
+          revocation_reason = ${reason}
+      FROM auth.sessions s
+      WHERE s.id = rt.session_id
+        AND s.user_id = ${userId}
+        AND rt.status IN ('ACTIVE', 'ROTATED')
+    `);
+  }
+
+  async activateMfaSession(
+    client: AuthSqlClient,
+    input: {
+      challengeId: string;
+      sessionId: string;
+      userId: string;
+      method: 'TOTP' | 'BACKUP';
+      enableMfa: boolean;
+      backupHashes?: string[] | null;
+    },
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.mfa_challenges
+      SET status = 'VERIFIED', verified_at = NOW()
+      WHERE id = ${input.challengeId}
+    `);
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.sessions
+      SET status = 'ACTIVE',
+          mfa_level = ${input.method},
+          mfa_verified_at = NOW(),
+          mfa_verified_method = ${input.method},
+          last_seen_at = NOW(),
+          updated_at = NOW()
+      WHERE id = ${input.sessionId}
+        AND status = 'MFA_PENDING'
+    `);
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.credential_states
+      SET mfa_enabled = CASE WHEN ${input.enableMfa} THEN TRUE ELSE mfa_enabled END,
+          mfa_backup_hashes = CASE
+            WHEN ${JSON.stringify(input.backupHashes ?? null)}::jsonb IS NULL THEN mfa_backup_hashes
+            ELSE ${JSON.stringify(input.backupHashes ?? null)}::jsonb
+          END,
+          last_login_at = NOW(),
+          failed_login_count = 0,
+          locked_until = NULL,
+          updated_at = NOW()
+      WHERE user_id = ${input.userId}
+    `);
+    if (input.enableMfa) {
+      await client.$executeRaw(Prisma.sql`
+        UPDATE public.users SET "mfaEnabled" = TRUE WHERE id = ${input.userId}
+      `);
+    }
+  }
+
+  async recordMfaFailure(
+    client: AuthSqlClient,
+    challengeId: string,
+    terminal: boolean,
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.mfa_challenges
+      SET attempts = attempts + 1,
+          status = CASE WHEN ${terminal} THEN 'FAILED' ELSE status END
+      WHERE id = ${challengeId}
+    `);
+  }
+
+  async setMfaSecret(
+    client: AuthSqlClient,
+    userId: string,
+    ciphertext: string,
+    keyVersion: string,
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.credential_states
+      SET mfa_secret_ciphertext = ${ciphertext},
+          mfa_key_version = ${keyVersion},
+          updated_at = NOW()
+      WHERE user_id = ${userId}
+    `);
+  }
+
+  async markLoginSuccess(client: AuthSqlClient, userId: string): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.credential_states
+      SET failed_login_count = 0,
+          locked_until = NULL,
+          last_login_at = NOW(),
+          updated_at = NOW()
+      WHERE user_id = ${userId}
+    `);
+  }
+
+  async touchSession(client: AuthSqlClient, sessionId: string): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.sessions
+      SET last_seen_at = NOW(), updated_at = NOW()
+      WHERE id = ${sessionId}
+        AND last_seen_at < NOW() - INTERVAL '60 seconds'
+    `);
+  }
+
+  async latestAuditHash(
+    client: AuthSqlClient,
+    userId?: string | null,
+    sessionId?: string | null,
+  ): Promise<string | null> {
+    const chainKey = sessionId ?? userId ?? 'auth-global';
+    await client.$queryRaw(Prisma.sql`
+      SELECT pg_advisory_xact_lock(hashtextextended(${chainKey}, 0))
+    `);
+    const rows = await client.$queryRaw<Array<{ hash: string }>>(Prisma.sql`
+      SELECT hash
+      FROM auth.audit_events
+      WHERE (${sessionId ?? null}::text IS NOT NULL AND session_id = ${sessionId ?? null})
+         OR (${sessionId ?? null}::text IS NULL AND ${userId ?? null}::text IS NOT NULL AND user_id = ${userId ?? null})
+         OR (${sessionId ?? null}::text IS NULL AND ${userId ?? null}::text IS NULL AND user_id IS NULL AND session_id IS NULL)
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1
+    `);
+    return rows[0]?.hash ?? null;
+  }
+
+  async insertAudit(client: AuthSqlClient, input: AuthAuditInput): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      INSERT INTO auth.audit_events (
+        id,
+        user_id,
+        session_id,
+        membership_id,
+        organization_id,
+        tenant_id,
+        action,
+        outcome,
+        reason,
+        metadata,
+        hash,
+        prev_hash
+      ) VALUES (
+        ${input.id},
+        ${input.userId ?? null},
+        ${input.sessionId ?? null},
+        ${input.membershipId ?? null},
+        ${input.organizationId ?? null},
+        ${input.tenantId ?? null},
+        ${input.action},
+        ${input.outcome},
+        ${input.reason ?? null},
+        ${JSON.stringify(input.metadata ?? {})}::jsonb,
+        ${input.hash},
+        ${input.prevHash ?? null}
+      )
+    `);
+  }
+}

--- a/apps/api/src/modules/auth/persistent-auth.repository.ts
+++ b/apps/api/src/modules/auth/persistent-auth.repository.ts
@@ -351,10 +351,11 @@ export class PersistentAuthRepository {
   async getSessionContext(
     client: AuthSqlClient,
     sessionId: string,
-    userId: string,
+    userId?: string,
     forUpdate = false,
   ): Promise<SessionContextRow | null> {
     const lock = forUpdate ? Prisma.sql` FOR UPDATE OF s` : Prisma.empty;
+    const userFilter = userId ? Prisma.sql` AND s.user_id = ${userId}` : Prisma.empty;
     const rows = await client.$queryRaw<SessionContextRow[]>(Prisma.sql`
       SELECT
         u.id AS user_id,
@@ -387,8 +388,7 @@ export class PersistentAuthRepository {
       JOIN public.organizations o ON o.id = s.organization_id
         AND o."tenantId" = s.tenant_id
       JOIN auth.credential_states cs ON cs.user_id = s.user_id
-      WHERE s.id = ${sessionId}
-        AND s.user_id = ${userId}${lock}
+      WHERE s.id = ${sessionId}${userFilter}${lock}
     `);
     return rows[0] ?? null;
   }
@@ -505,14 +505,6 @@ export class PersistentAuthRepository {
       ipHash?: string | null;
     },
   ): Promise<void> {
-    await client.$executeRaw(Prisma.sql`
-      UPDATE auth.refresh_tokens
-      SET status = 'ROTATED',
-          consumed_at = NOW(),
-          replaced_by_token_id = ${input.replacementTokenId}
-      WHERE id = ${input.currentTokenId}
-        AND status = 'ACTIVE'
-    `);
     await this.createRefreshToken(client, {
       id: input.replacementTokenId,
       sessionId: input.sessionId,
@@ -523,6 +515,17 @@ export class PersistentAuthRepository {
       userAgentHash: input.userAgentHash,
       ipHash: input.ipHash,
     });
+    const rotated = await client.$executeRaw(Prisma.sql`
+      UPDATE auth.refresh_tokens
+      SET status = 'ROTATED',
+          consumed_at = NOW(),
+          replaced_by_token_id = ${input.replacementTokenId}
+      WHERE id = ${input.currentTokenId}
+        AND status = 'ACTIVE'
+    `);
+    if (rotated !== 1) {
+      throw new Error('Refresh token rotation conflict');
+    }
     await client.$executeRaw(Prisma.sql`
       UPDATE auth.sessions
       SET last_seen_at = NOW(), updated_at = NOW()

--- a/apps/api/test/auth/jest.config.json
+++ b/apps/api/test/auth/jest.config.json
@@ -1,0 +1,12 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "../..",
+  "testRegex": "test/auth/.*\\.e2e-spec\\.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "collectCoverage": false,
+  "testEnvironment": "node",
+  "testTimeout": 60000,
+  "maxWorkers": 1
+}

--- a/apps/api/test/auth/persistent-auth.e2e-spec.ts
+++ b/apps/api/test/auth/persistent-auth.e2e-spec.ts
@@ -1,0 +1,288 @@
+import { createHmac } from 'crypto';
+import * as bcrypt from 'bcryptjs';
+import * as jwt from 'jsonwebtoken';
+import { PrismaService } from '../../src/common/prisma/prisma.service';
+import { Role } from '../../src/common/types/request-user';
+import { AuthService } from '../../src/modules/auth/auth.service';
+import { PersistentAuthRepository } from '../../src/modules/auth/persistent-auth.repository';
+
+const PASSWORD = 'Correct-Horse-9!';
+
+type Runtime = {
+  prisma: PrismaService;
+  repository: PersistentAuthRepository;
+  auth: AuthService;
+};
+
+function runtime(): Runtime {
+  const prisma = new PrismaService();
+  const repository = new PersistentAuthRepository(prisma);
+  return { prisma, repository, auth: new AuthService(repository) };
+}
+
+function base32Decode(input: string): Buffer {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const normalized = input.toUpperCase().replace(/[^A-Z2-7]/g, '');
+  let bits = 0;
+  let value = 0;
+  const bytes: number[] = [];
+  for (const char of normalized) {
+    value = (value << 5) | alphabet.indexOf(char);
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 255);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(bytes);
+}
+
+function totp(secret: string, unixMs = Date.now()): string {
+  const counter = BigInt(Math.floor(unixMs / 30_000));
+  const counterBuffer = Buffer.alloc(8);
+  counterBuffer.writeBigUInt64BE(counter);
+  const digest = createHmac('sha1', base32Decode(secret)).update(counterBuffer).digest();
+  const offset = digest[digest.length - 1] & 0x0f;
+  const binary = ((digest[offset] & 0x7f) << 24)
+    | ((digest[offset + 1] & 0xff) << 16)
+    | ((digest[offset + 2] & 0xff) << 8)
+    | (digest[offset + 3] & 0xff);
+  return String(binary % 1_000_000).padStart(6, '0');
+}
+
+describe('persistent PostgreSQL identity, session rotation, revocation and MFA', () => {
+  const first = runtime();
+  const second = runtime();
+
+  beforeAll(async () => {
+    await Promise.all([first.prisma.$connect(), second.prisma.$connect()]);
+  });
+
+  afterAll(async () => {
+    await Promise.all([first.prisma.$disconnect(), second.prisma.$disconnect()]);
+  });
+
+  async function seedIdentity(
+    key: string,
+    role: Role,
+    options: { organizationStatus?: string; mfaEnabled?: boolean } = {},
+  ) {
+    const userId = `auth-user-${key}`;
+    const organizationId = `auth-org-${key}`;
+    const tenantId = `auth-tenant-${key}`;
+    const email = `${key}@auth.test`;
+    const organization = await first.prisma.organization.upsert({
+      where: { id: organizationId },
+      update: {
+        status: options.organizationStatus ?? 'VERIFIED',
+        tenantId,
+        kycStatus: 'APPROVED',
+        amlStatus: 'CLEAR',
+      },
+      create: {
+        id: organizationId,
+        inn: `77${String(Math.abs(hashCode(key))).padStart(10, '0').slice(0, 10)}`,
+        name: `Auth Test ${key}`,
+        status: options.organizationStatus ?? 'VERIFIED',
+        tenantId,
+        kycStatus: 'APPROVED',
+        amlStatus: 'CLEAR',
+        verifiedAt: new Date(),
+      },
+    });
+    const user = await first.prisma.user.upsert({
+      where: { id: userId },
+      update: {
+        email,
+        passwordHash: await bcrypt.hash(PASSWORD, 10),
+        fullName: `Auth ${key}`,
+        status: 'ACTIVE',
+        mfaEnabled: options.mfaEnabled ?? false,
+        deletedAt: null,
+      },
+      create: {
+        id: userId,
+        email,
+        passwordHash: await bcrypt.hash(PASSWORD, 10),
+        fullName: `Auth ${key}`,
+        status: 'ACTIVE',
+        mfaEnabled: options.mfaEnabled ?? false,
+      },
+    });
+    const membership = await first.prisma.userOrg.upsert({
+      where: {
+        userId_organizationId: {
+          userId,
+          organizationId,
+        },
+      },
+      update: { role, isDefault: true },
+      create: { userId, organizationId, role, isDefault: true },
+    });
+    return { user, organization, membership, email, userId, organizationId, tenantId };
+  }
+
+  it('keeps role, tenant and organization out of JWT and re-authorizes through PostgreSQL', async () => {
+    const identity = await seedIdentity('buyer', Role.BUYER);
+    const login = await first.auth.login({ email: identity.email, password: PASSWORD }, 'auth-e2e-1', '127.0.0.1') as any;
+
+    expect(login.mfaRequired).toBe(false);
+    expect(login.accessToken).toEqual(expect.any(String));
+    expect(login.refreshToken).toMatch(/^rt_/);
+    const decoded = jwt.decode(login.accessToken) as Record<string, unknown>;
+    expect(decoded).toMatchObject({ sub: identity.userId, typ: 'access' });
+    expect(decoded.sid).toEqual(expect.any(String));
+    expect(decoded).not.toHaveProperty('role');
+    expect(decoded).not.toHaveProperty('orgId');
+    expect(decoded).not.toHaveProperty('tenantId');
+
+    await expect(second.auth.verifyAccessToken(login.accessToken)).resolves.toMatchObject({
+      id: identity.userId,
+      role: Role.BUYER,
+      orgId: identity.organizationId,
+      tenantId: identity.tenantId,
+      membershipId: identity.membership.id,
+      mfaVerified: false,
+    });
+  });
+
+  it('rotates refresh once and revokes the complete family on old-token reuse across instances', async () => {
+    const identity = await seedIdentity('refresh', Role.FARMER);
+    const login = await first.auth.login({ email: identity.email, password: PASSWORD }) as any;
+    const rotated = await second.auth.refresh({ refreshToken: login.refreshToken }, 'auth-e2e-2', '127.0.0.2') as any;
+
+    expect(rotated.refreshToken).not.toBe(login.refreshToken);
+    await expect(first.auth.verifyAccessToken(rotated.accessToken)).resolves.toMatchObject({ id: identity.userId });
+
+    await expect(
+      first.auth.refresh({ refreshToken: login.refreshToken }, 'auth-e2e-reuse', '127.0.0.3'),
+    ).rejects.toThrow(/reuse detected/i);
+    await expect(second.auth.verifyAccessToken(rotated.accessToken)).rejects.toThrow(/revoked|not active/i);
+    await expect(second.auth.refresh({ refreshToken: rotated.refreshToken })).rejects.toThrow(/reuse|invalid|expired/i);
+
+    const sessions = await first.prisma.$queryRaw<Array<{ status: string; revocation_reason: string | null }>>`
+      SELECT status, revocation_reason
+      FROM auth.sessions
+      WHERE user_id = ${identity.userId}
+    `;
+    expect(sessions).toEqual([
+      expect.objectContaining({ status: 'REVOKED', revocation_reason: 'REFRESH_TOKEN_REUSE_DETECTED' }),
+    ]);
+  });
+
+  it('persists brute-force lockout across a fresh AuthService instance', async () => {
+    const identity = await seedIdentity('lockout', Role.DRIVER);
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const service = attempt % 2 === 0 ? first.auth : second.auth;
+      await expect(service.login({ email: identity.email, password: 'wrong-password' } as any)).rejects.toThrow(/Invalid credentials/i);
+    }
+    await expect(
+      second.auth.login({ email: identity.email, password: PASSWORD }),
+    ).rejects.toThrow(/temporarily locked/i);
+  });
+
+  it('requires TOTP before activating a privileged compliance session', async () => {
+    const identity = await seedIdentity('compliance', Role.COMPLIANCE_OFFICER);
+    const pending = await first.auth.login({ email: identity.email, password: PASSWORD }) as any;
+
+    expect(pending.mfaRequired).toBe(true);
+    expect(pending).not.toHaveProperty('accessToken');
+    expect(pending.challengeToken).toMatch(/^mc_/);
+    expect(pending.setupSecret).toEqual(expect.any(String));
+    expect(pending.otpAuthUri).toMatch(/^otpauth:\/\/totp\//);
+
+    const verified = await second.auth.verifyMfa({
+      challengeToken: pending.challengeToken,
+      code: totp(pending.setupSecret),
+    }, 'auth-e2e-mfa', '127.0.0.4') as any;
+    expect(verified.accessToken).toEqual(expect.any(String));
+    expect(verified.refreshToken).toMatch(/^rt_/);
+    expect(verified.backupCodes).toHaveLength(8);
+
+    const user = await first.auth.verifyAccessToken(verified.accessToken);
+    expect(user).toMatchObject({
+      id: identity.userId,
+      role: Role.COMPLIANCE_OFFICER,
+      mfaVerified: true,
+      mfaVerifiedAt: expect.any(String),
+    });
+
+    await first.auth.logout({}, user.sessionId);
+    await expect(second.auth.verifyAccessToken(verified.accessToken)).rejects.toThrow(/revoked|not active/i);
+  });
+
+  it('applies administrator revocation and organization suspension across API instances', async () => {
+    const revokedIdentity = await seedIdentity('admin-revoke-target', Role.LOGISTICIAN);
+    const revokedLogin = await first.auth.login({ email: revokedIdentity.email, password: PASSWORD }) as any;
+    const verified = await second.auth.verifyAccessToken(revokedLogin.accessToken);
+    expect(verified.id).toBe(revokedIdentity.userId);
+
+    await first.auth.revokeUserSessions(revokedIdentity.userId, 'SECURITY_REVIEW');
+    await expect(second.auth.verifyAccessToken(revokedLogin.accessToken)).rejects.toThrow(/revoked|not active/i);
+
+    const suspendedIdentity = await seedIdentity('suspended-org', Role.ELEVATOR);
+    const suspendedLogin = await first.auth.login({ email: suspendedIdentity.email, password: PASSWORD }) as any;
+    await first.prisma.organization.update({
+      where: { id: suspendedIdentity.organizationId },
+      data: { status: 'SUSPENDED' },
+    });
+    await expect(second.auth.verifyAccessToken(suspendedLogin.accessToken)).rejects.toThrow(/not active/i);
+  });
+
+  it('ignores client orgId during self-registration and creates a pending organization', async () => {
+    const result = await first.auth.register({
+      email: 'pending-registration@auth.test',
+      fullName: 'Pending Registration',
+      role: Role.BUYER,
+      password: PASSWORD,
+      orgId: 'org-attacker-selected',
+      orgInn: '781234567890',
+      orgLegalName: 'Pending Registration LLC',
+      consentVersion: '1.2',
+    } as any) as any;
+
+    expect(result.status).toBe('PENDING_ORGANIZATION_VERIFICATION');
+    expect(result.user.orgId).not.toBe('org-attacker-selected');
+    const organization = await first.prisma.organization.findUnique({ where: { id: result.user.orgId } });
+    expect(organization?.status).toBe('PENDING');
+    await expect(
+      second.auth.login({ email: 'pending-registration@auth.test', password: PASSWORD }),
+    ).rejects.toThrow(/ORGANIZATION_NOT_VERIFIED/);
+  });
+
+  it('writes chained auth audit evidence', async () => {
+    const rows = await first.prisma.$queryRaw<Array<{
+      id: string;
+      session_id: string | null;
+      user_id: string | null;
+      hash: string;
+      prev_hash: string | null;
+    }>>`
+      SELECT id, session_id, user_id, hash, prev_hash
+      FROM auth.audit_events
+      ORDER BY created_at ASC, id ASC
+    `;
+    expect(rows.length).toBeGreaterThan(10);
+    expect(new Set(rows.map((row) => row.hash)).size).toBe(rows.length);
+    expect(rows.every((row) => /^[a-f0-9]{64}$/.test(row.hash))).toBe(true);
+
+    const chains = new Map<string, typeof rows>();
+    for (const row of rows) {
+      const key = row.session_id ?? row.user_id ?? 'global';
+      const chain = chains.get(key) ?? [];
+      chain.push(row);
+      chains.set(key, chain);
+    }
+    for (const chain of chains.values()) {
+      for (let index = 1; index < chain.length; index += 1) {
+        expect(chain[index].prev_hash).toBe(chain[index - 1].hash);
+      }
+    }
+  });
+});
+
+function hashCode(value: string): number {
+  let hash = 0;
+  for (const char of value) hash = ((hash << 5) - hash + char.charCodeAt(0)) | 0;
+  return hash;
+}

--- a/apps/api/test/auth/persistent-auth.e2e-spec.ts
+++ b/apps/api/test/auth/persistent-auth.e2e-spec.ts
@@ -2,7 +2,10 @@ import { createHmac } from 'crypto';
 import * as bcrypt from 'bcryptjs';
 import * as jwt from 'jsonwebtoken';
 import { PrismaService } from '../../src/common/prisma/prisma.service';
-import { Role } from '../../src/common/types/request-user';
+import {
+  FINANCIAL_MFA_THRESHOLD_KOPECKS,
+  Role,
+} from '../../src/common/types/request-user';
 import { AuthService } from '../../src/modules/auth/auth.service';
 import { PersistentAuthRepository } from '../../src/modules/auth/persistent-auth.repository';
 
@@ -135,6 +138,28 @@ describe('persistent PostgreSQL identity, session rotation, revocation and MFA',
     expect(decoded).not.toHaveProperty('role');
     expect(decoded).not.toHaveProperty('orgId');
     expect(decoded).not.toHaveProperty('tenantId');
+    const sessionId = String(decoded.sid);
+
+    const sessions = await first.prisma.$queryRaw<Array<{
+      user_id: string;
+      membership_id: string;
+      organization_id: string;
+      tenant_id: string;
+      status: string;
+    }>>`
+      SELECT user_id, membership_id, organization_id, tenant_id, status
+      FROM auth.sessions
+      WHERE id = ${sessionId}
+    `;
+    expect(sessions).toEqual([
+      {
+        user_id: identity.userId,
+        membership_id: identity.membership.id,
+        organization_id: identity.organizationId,
+        tenant_id: identity.tenantId,
+        status: 'ACTIVE',
+      },
+    ]);
 
     await expect(second.auth.verifyAccessToken(login.accessToken)).resolves.toMatchObject({
       id: identity.userId,
@@ -144,6 +169,17 @@ describe('persistent PostgreSQL identity, session rotation, revocation and MFA',
       membershipId: identity.membership.id,
       mfaVerified: false,
     });
+
+    const restarted = runtime();
+    await restarted.prisma.$connect();
+    try {
+      await expect(restarted.auth.verifyAccessToken(login.accessToken)).resolves.toMatchObject({
+        id: identity.userId,
+        membershipId: identity.membership.id,
+      });
+    } finally {
+      await restarted.prisma.$disconnect();
+    }
   });
 
   it('rotates refresh once and revokes the complete family on old-token reuse across instances', async () => {
@@ -168,6 +204,22 @@ describe('persistent PostgreSQL identity, session rotation, revocation and MFA',
     expect(sessions).toEqual([
       expect.objectContaining({ status: 'REVOKED', revocation_reason: 'REFRESH_TOKEN_REUSE_DETECTED' }),
     ]);
+  });
+
+  it('allows exactly one concurrent refresh winner and revokes its family after reuse detection', async () => {
+    const identity = await seedIdentity('concurrent-refresh', Role.FARMER);
+    const login = await first.auth.login({ email: identity.email, password: PASSWORD }) as any;
+    const attempts = await Promise.allSettled([
+      first.auth.refresh({ refreshToken: login.refreshToken }, 'auth-e2e-race-1', '127.0.0.5'),
+      second.auth.refresh({ refreshToken: login.refreshToken }, 'auth-e2e-race-2', '127.0.0.6'),
+    ]);
+
+    expect(attempts.filter((attempt) => attempt.status === 'fulfilled')).toHaveLength(1);
+    expect(attempts.filter((attempt) => attempt.status === 'rejected')).toHaveLength(1);
+    const winner = attempts.find((attempt): attempt is PromiseFulfilledResult<any> => attempt.status === 'fulfilled');
+    const rejected = attempts.find((attempt): attempt is PromiseRejectedResult => attempt.status === 'rejected');
+    expect(String(rejected?.reason?.message ?? rejected?.reason)).toMatch(/reuse detected/i);
+    await expect(second.auth.verifyAccessToken(winner!.value.accessToken)).rejects.toThrow(/revoked|not active/i);
   });
 
   it('persists brute-force lockout across a fresh AuthService instance', async () => {
@@ -207,6 +259,23 @@ describe('persistent PostgreSQL identity, session rotation, revocation and MFA',
       mfaVerifiedAt: expect.any(String),
     });
 
+    expect(() => first.auth.assertRecentFinancialMfa(
+      { ...user, mfaVerified: false, mfaVerifiedAt: undefined },
+      FINANCIAL_MFA_THRESHOLD_KOPECKS,
+    )).toThrow(/Recent MFA verification is required/i);
+    expect(() => first.auth.assertRecentFinancialMfa(
+      user,
+      FINANCIAL_MFA_THRESHOLD_KOPECKS,
+    )).not.toThrow();
+    expect(() => first.auth.assertRecentFinancialMfa(
+      { ...user, mfaVerifiedAt: new Date(Date.now() - 16 * 60 * 1000).toISOString() },
+      FINANCIAL_MFA_THRESHOLD_KOPECKS,
+    )).toThrow(/too old/i);
+    expect(() => first.auth.assertRecentFinancialMfa(
+      { ...user, mfaVerified: false, mfaVerifiedAt: undefined },
+      FINANCIAL_MFA_THRESHOLD_KOPECKS - 1,
+    )).not.toThrow();
+
     await first.auth.logout({}, user.sessionId);
     await expect(second.auth.verifyAccessToken(verified.accessToken)).rejects.toThrow(/revoked|not active/i);
   });
@@ -220,13 +289,54 @@ describe('persistent PostgreSQL identity, session rotation, revocation and MFA',
     await first.auth.revokeUserSessions(revokedIdentity.userId, 'SECURITY_REVIEW');
     await expect(second.auth.verifyAccessToken(revokedLogin.accessToken)).rejects.toThrow(/revoked|not active/i);
 
+    const membershipIdentity = await seedIdentity('membership-change', Role.BUYER);
+    const membershipLogin = await first.auth.login({ email: membershipIdentity.email, password: PASSWORD }) as any;
+    const replacementOrganization = await first.prisma.organization.upsert({
+      where: { id: 'auth-org-membership-replacement' },
+      update: {
+        status: 'VERIFIED',
+        tenantId: 'auth-tenant-membership-replacement',
+      },
+      create: {
+        id: 'auth-org-membership-replacement',
+        inn: '770000099999',
+        name: 'Auth Membership Replacement',
+        status: 'VERIFIED',
+        tenantId: 'auth-tenant-membership-replacement',
+        kycStatus: 'APPROVED',
+        amlStatus: 'CLEAR',
+        verifiedAt: new Date(),
+      },
+    });
+    await first.prisma.userOrg.update({
+      where: { id: membershipIdentity.membership.id },
+      data: { organizationId: replacementOrganization.id },
+    });
+    await expect(second.auth.verifyAccessToken(membershipLogin.accessToken)).rejects.toThrow(/not active/i);
+    const membershipSessions = await first.prisma.$queryRaw<Array<{
+      status: string;
+      revocation_reason: string | null;
+    }>>`
+      SELECT status, revocation_reason
+      FROM auth.sessions
+      WHERE user_id = ${membershipIdentity.userId}
+    `;
+    expect(membershipSessions).toEqual([
+      expect.objectContaining({ status: 'REVOKED', revocation_reason: 'MEMBERSHIP_CHANGED' }),
+    ]);
+    await first.prisma.userOrg.update({
+      where: { id: membershipIdentity.membership.id },
+      data: { organizationId: membershipIdentity.organizationId },
+    });
+    await expect(second.auth.verifyAccessToken(membershipLogin.accessToken)).rejects.toThrow(/revoked|not active/i);
+
     const suspendedIdentity = await seedIdentity('suspended-org', Role.ELEVATOR);
     const suspendedLogin = await first.auth.login({ email: suspendedIdentity.email, password: PASSWORD }) as any;
     await first.prisma.organization.update({
       where: { id: suspendedIdentity.organizationId },
       data: { status: 'SUSPENDED' },
     });
-    await expect(second.auth.verifyAccessToken(suspendedLogin.accessToken)).rejects.toThrow(/not active/i);
+    await expect(second.auth.verifyAccessToken(suspendedLogin.accessToken)).rejects.toThrow(/revoked|not active/i);
   });
 
   it('ignores client orgId during self-registration and creates a pending organization', async () => {
@@ -255,10 +365,13 @@ describe('persistent PostgreSQL identity, session rotation, revocation and MFA',
       id: string;
       session_id: string | null;
       user_id: string | null;
+      action: string;
+      outcome: string;
+      reason: string | null;
       hash: string;
       prev_hash: string | null;
     }>>`
-      SELECT id, session_id, user_id, hash, prev_hash
+      SELECT id, session_id, user_id, action, outcome, reason, hash, prev_hash
       FROM auth.audit_events
       ORDER BY created_at ASC, id ASC
     `;
@@ -278,6 +391,35 @@ describe('persistent PostgreSQL identity, session rotation, revocation and MFA',
         expect(chain[index].prev_hash).toBe(chain[index - 1].hash);
       }
     }
+
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: 'auth.login', outcome: 'SUCCESS' }),
+      expect.objectContaining({ action: 'auth.refresh', outcome: 'SUCCESS' }),
+      expect.objectContaining({
+        action: 'auth.refresh.reuse',
+        outcome: 'DENIED',
+        reason: 'REFRESH_TOKEN_REUSE_DETECTED',
+      }),
+      expect.objectContaining({ action: 'auth.mfa.verify', outcome: 'SUCCESS' }),
+      expect.objectContaining({ action: 'auth.logout', outcome: 'SUCCESS' }),
+      expect.objectContaining({ action: 'auth.sessions.revoke_all', outcome: 'SUCCESS' }),
+      expect.objectContaining({ action: 'auth.access', outcome: 'DENIED' }),
+    ]));
+
+    const beforeCount = rows.length;
+    await expect(first.prisma.$executeRaw`
+      UPDATE auth.audit_events SET reason = 'TAMPERED' WHERE id = ${rows[0].id}
+    `).rejects.toThrow(/append-only/i);
+    await expect(first.prisma.$executeRaw`
+      DELETE FROM auth.audit_events WHERE id = ${rows[0].id}
+    `).rejects.toThrow(/append-only/i);
+    await expect(first.prisma.$executeRaw`
+      TRUNCATE TABLE auth.audit_events
+    `).rejects.toThrow(/append-only/i);
+    const [{ count }] = await first.prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(*)::bigint AS count FROM auth.audit_events
+    `;
+    expect(Number(count)).toBe(beforeCount);
   });
 });
 

--- a/apps/api/test/one-deal/seed.ts
+++ b/apps/api/test/one-deal/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaService } from '../../src/common/prisma/prisma.service';
 import { AuthService } from '../../src/modules/auth/auth.service';
+import { PersistentAuthRepository } from '../../src/modules/auth/persistent-auth.repository';
 import { CanonicalTestDealSeedService } from '../../src/modules/deals/canonical-test-deal.seed';
 import { CANONICAL_TEST_DEAL_ID } from '../../src/modules/deals/deal-command.policy';
 
@@ -14,7 +15,8 @@ async function main(): Promise<void> {
   const prisma = new PrismaService();
   await prisma.$connect();
   try {
-    const auth = new AuthService();
+    const authRepository = new PersistentAuthRepository(prisma);
+    const auth = new AuthService(authRepository);
     const seed = new CanonicalTestDealSeedService(prisma, auth);
     await seed.onModuleInit();
 

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -5,7 +5,7 @@
   "currentStatus": "in_progress",
   "current": "Persistent Identity, Session, Refresh-Family Revocation and MFA.",
   "fullTzReadinessPercent": 87,
-  "openPr": null,
+  "openPr": "#2276",
   "lastClosed": [
     "#2274 PostgreSQL One Deal Recovery Matrix",
     "#2270 Industrial one-deal PostgreSQL 16 E2E exploitation gate",
@@ -26,7 +26,7 @@
     "live bank FGIS EDO and signature evidence",
     "production load restore and DR acceptance"
   ],
-  "blockerNotes": "The recovery matrix is merged as cc10110293d9716c2f93790e7756589ead017afd. Current work replaces process-memory identity/session authority with PostgreSQL users, memberships, sessions, refresh families, revocation and MFA. Client role, organization and tenant input remain untrusted and UI files remain locked.",
+  "blockerNotes": "PR #2276 replaces process-memory identity/session authority with PostgreSQL users, memberships, sessions, refresh families, revocation and MFA. Client role, organization and tenant input remain untrusted and all UI files remain locked until verified server session projection is proven.",
   "lockedUntilCurrentGreen": [
     "platform UI implementation",
     "client role shell migration",
@@ -71,6 +71,7 @@
     "mergeCommit": "cc10110293d9716c2f93790e7756589ead017afd"
   },
   "persistentIdentity": {
+    "implementationPr": "#2276",
     "status": "in_progress",
     "requiredEvidence": [
       "PostgreSQL users memberships sessions refresh families and MFA challenges",

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -1,12 +1,13 @@
 {
   "project": "platform-v7",
-  "mode": "industrial-one-deal-recovery",
+  "mode": "persistent-identity-session-mfa",
   "status": "active",
-  "currentStatus": "ready",
-  "current": "PostgreSQL One Deal Recovery Matrix.",
+  "currentStatus": "in_progress",
+  "current": "Persistent Identity, Session, Refresh-Family Revocation and MFA.",
   "fullTzReadinessPercent": 87,
-  "openPr": "#2274",
+  "openPr": null,
   "lastClosed": [
+    "#2274 PostgreSQL One Deal Recovery Matrix",
     "#2270 Industrial one-deal PostgreSQL 16 E2E exploitation gate",
     "#2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
     "#2245 VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
@@ -25,10 +26,10 @@
     "live bank FGIS EDO and signature evidence",
     "production load restore and DR acceptance"
   ],
-  "blockerNotes": "PR #2274 is green on isolated PostgreSQL 16. It proves one valid concurrent command winner, stable partner+event callback replay, material replay mismatch rejection, out-of-order callback rollback, fresh runtime continuation, atomic forced rollback, transaction-local RLS pool isolation and deterministic full replay after CLOSED. The next authorized scope is backend-only persistent identity/session/MFA; platform UI and client authority remain locked.",
+  "blockerNotes": "The recovery matrix is merged as cc10110293d9716c2f93790e7756589ead017afd. Current work replaces process-memory identity/session authority with PostgreSQL users, memberships, sessions, refresh families, revocation and MFA. Client role, organization and tenant input remain untrusted and UI files remain locked.",
   "lockedUntilCurrentGreen": [
-    "persistent identity session MFA changes",
     "platform UI implementation",
+    "client role shell migration",
     "live external integration activation",
     "production migration execution",
     "production load and disaster-recovery claims"
@@ -36,62 +37,54 @@
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "apps/api/src/modules/deals/industrial-deal-command.gateway.ts",
-    "apps/api/src/modules/deals/industrial-deal-command.gateway.spec.ts",
-    "apps/api/test/one-deal/**",
-    "scripts/platform-v7-one-deal-*.mjs",
-    "scripts/platform-v7-one-deal-*.sh",
+    "apps/api/prisma/schema.prisma",
+    "apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql",
+    "apps/api/src/modules/auth/**",
+    "apps/api/src/common/guards/**",
+    "apps/api/src/common/types/request-user.ts",
+    "apps/api/test/auth/**",
     ".github/workflows/ci.yml"
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
     "docs/platform-v7/execution-queue.md",
-    "apps/api/src/modules/deals/industrial-deal-command.gateway.ts",
-    "apps/api/src/modules/deals/industrial-deal-command.gateway.spec.ts",
-    "apps/api/test/one-deal/**",
-    "scripts/platform-v7-one-deal-*.mjs",
-    "scripts/platform-v7-one-deal-*.sh",
+    "apps/api/prisma/schema.prisma",
+    "apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql",
+    "apps/api/src/modules/auth/**",
+    "apps/api/src/common/guards/**",
+    "apps/api/src/common/types/request-user.ts",
+    "apps/api/test/auth/**",
     ".github/workflows/ci.yml"
   ],
   "industrialOneDealFoundation": {
-    "layer": "Canonical PostgreSQL deal command path and shared role workspace",
-    "implementationPr": "#2260",
-    "consolidationPr": "#2267",
     "status": "merged_green",
     "canonicalDealId": "DEAL-INDUSTRIAL-001"
   },
   "industrialOneDealE2e": {
-    "layer": "Industrial One Deal Ephemeral PostgreSQL E2E Harness",
     "implementationPr": "#2270",
     "status": "merged_green",
-    "mergeCommit": "45a7fd7826eade875b81c1c631eb3a049c3fba94",
-    "canonicalDealId": "DEAL-INDUSTRIAL-001"
+    "mergeCommit": "45a7fd7826eade875b81c1c631eb3a049c3fba94"
   },
   "industrialOneDealRecovery": {
-    "layer": "Concurrency Replay Restart Rollback and RLS Pool Isolation",
     "implementationPr": "#2274",
-    "status": "green_ready_for_merge",
-    "canonicalDealId": "DEAL-INDUSTRIAL-001",
-    "resolvedDefect": {
-      "code": "BANK_CALLBACK_RECEIPT_MISSED_AFTER_STATE_CHANGE",
-      "file": "apps/api/src/modules/deals/industrial-deal-command.gateway.ts",
-      "correction": "successful callbacks now use stable verified partner plus event identity while a material payload digest remains bound to commandId for replay mismatch rejection"
-    },
-    "provenEvidence": [
-      "exactly one concurrent command winner and one aggregate version",
-      "duplicate bank callbacks return the original receipt without duplicate transition event ledger or outbox evidence",
-      "same partner event ID with different material payload is rejected as BANK_EVENT_REPLAY_MISMATCH",
-      "out-of-order callbacks fail with no evidence mutation",
-      "fresh Prisma and service instances continue from persisted pending operations and receipts",
-      "forced transaction failure rolls back Deal event audit ledger and outbox atomically",
-      "transaction-local RLS context does not leak through sequential or parallel pooled connection reuse",
-      "full user command and bank callback replay is deterministic and idempotent after CLOSED",
-      "evidence snapshots remain stable after replay and restart"
+    "status": "merged_green",
+    "mergeCommit": "cc10110293d9716c2f93790e7756589ead017afd"
+  },
+  "persistentIdentity": {
+    "status": "in_progress",
+    "requiredEvidence": [
+      "PostgreSQL users memberships sessions refresh families and MFA challenges",
+      "opaque session identity re-authorized against database state",
+      "refresh rotation and family-wide reuse revocation",
+      "logout password reset organization suspension and administrator revoke invalidate sessions",
+      "mandatory MFA for privileged roles and threshold financial actions",
+      "role tenant and organization derived only from persistent membership",
+      "immutable audit evidence for login refresh MFA logout revoke reuse and denial",
+      "fresh API instance continues session truth after restart"
     ]
   },
   "nextAfterCurrentGreen": [
-    "persistent identity session refresh-family revoke and MFA after blocker #2115",
-    "durable outbox worker and bank reconciliation",
+    "durable outbox worker bank reconciliation and partner-key rotation",
     "truthful driver offline acknowledgement",
     "server-rendered RU EN ZH i18n",
     "complete mobile-first design-system and role-cabinet migration",
@@ -116,7 +109,6 @@
     "apps/web/components/v7r",
     "apps/web/lib/platform-v7",
     "apps/web/app/api",
-    "apps/api/prisma/migrations/** except explicitly authorized current migration",
     "package.json",
     "package-lock.json",
     "pnpm-lock.yaml",
@@ -126,6 +118,7 @@
   "maturityLanguage": [
     "isolated-postgresql-e2e-proven",
     "isolated-recovery-matrix-proven",
+    "persistent-identity-in-progress",
     "platform-temporarily-without-external-integrations"
   ],
   "forbiddenClaims": [
@@ -136,5 +129,5 @@
     "live bank money movement",
     "production scale proven"
   ],
-  "readiness": "87% honest architectural readiness. The isolated PostgreSQL lifecycle and recovery matrix are proven. Persistent identity, live integrations, production migration, load, restore and DR remain unproven. Production exploitation remains NO-GO."
+  "readiness": "87% honest architectural readiness. Deal execution and isolated recovery are proven. Persistent identity/session/MFA is in progress. Live integrations, production migration, load, restore and DR remain unproven. Production exploitation remains NO-GO."
 }

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -22,11 +22,12 @@
   "openBlockers": [
     "#2113 repository settings cleanup",
     "#2115 persistent auth write path",
+    "legacy one-deal seed directly constructs AuthService without repository",
     "production migration and RLS execution evidence",
     "live bank FGIS EDO and signature evidence",
     "production load restore and DR acceptance"
   ],
-  "blockerNotes": "PR #2276 replaces process-memory identity/session authority with PostgreSQL users, memberships, sessions, refresh families, revocation and MFA. Client role, organization and tenant input remain untrusted and all UI files remain locked until verified server session projection is proven.",
+  "blockerNotes": "PR #2276 replaces process-memory identity/session authority with PostgreSQL users, memberships, sessions, refresh families, revocation and MFA. Typecheck exposed one exact test-bootstrap defect: apps/api/test/one-deal/seed.ts constructs AuthService without its persistent repository. That single file is temporarily unlocked for explicit PostgreSQL DI; production AuthService keeps mandatory repository injection. Client role, organization and tenant input remain untrusted and all UI files remain locked.",
   "lockedUntilCurrentGreen": [
     "platform UI implementation",
     "client role shell migration",
@@ -43,6 +44,7 @@
     "apps/api/src/common/guards/**",
     "apps/api/src/common/types/request-user.ts",
     "apps/api/test/auth/**",
+    "apps/api/test/one-deal/seed.ts",
     ".github/workflows/ci.yml"
   ],
   "agentWritableScope": [
@@ -54,6 +56,7 @@
     "apps/api/src/common/guards/**",
     "apps/api/src/common/types/request-user.ts",
     "apps/api/test/auth/**",
+    "apps/api/test/one-deal/seed.ts",
     ".github/workflows/ci.yml"
   ],
   "industrialOneDealFoundation": {
@@ -73,6 +76,11 @@
   "persistentIdentity": {
     "implementationPr": "#2276",
     "status": "in_progress",
+    "lastFailure": {
+      "code": "AUTH_SERVICE_REPOSITORY_REQUIRED_IN_ONE_DEAL_SEED",
+      "file": "apps/api/test/one-deal/seed.ts",
+      "reason": "test bootstrap directly called new AuthService() after production service moved to explicit PersistentAuthRepository injection"
+    },
     "requiredEvidence": [
       "PostgreSQL users memberships sessions refresh families and MFA challenges",
       "opaque session identity re-authorized against database state",

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -27,7 +27,7 @@
     "live bank FGIS EDO and signature evidence",
     "production load restore and DR acceptance"
   ],
-  "blockerNotes": "PR #2276 replaces process-memory identity/session authority with PostgreSQL users, memberships, sessions, refresh families, revocation and MFA. The first PostgreSQL auth job stopped before executing tests because its isolated CI job did not generate Prisma Client. The correction adds explicit generation, FK-safe refresh rotation, immediate durable revoke on membership, organization or user authority changes, and expanded exploitation evidence. Client role, organization and tenant claims remain untrusted and all UI files remain locked until the gate is green.",
+  "blockerNotes": "PR #2276 replaces process-memory identity/session authority with PostgreSQL users, memberships, sessions, refresh families, revocation and MFA. The first PostgreSQL auth job stopped before executing tests because its isolated CI job did not generate Prisma Client. The next run reached all tests and exposed one shared audit-lock defect: Prisma cannot deserialize PostgreSQL void from pg_advisory_xact_lock. The corrected query still acquires the transaction lock but returns a supported integer projection. Client role, organization and tenant claims remain untrusted and all UI files remain locked until the gate is green.",
   "lockedUntilCurrentGreen": [
     "durable outbox worker bank reconciliation and partner-key rotation",
     "platform UI implementation",
@@ -84,9 +84,9 @@
     "implementationPr": "#2276",
     "status": "in_progress",
     "lastFailure": {
-      "code": "AUTH_E2E_PRISMA_CLIENT_NOT_GENERATED",
-      "file": ".github/workflows/ci.yml",
-      "reason": "the isolated persistent-auth job ran ts-jest before prisma generate, so generated PrismaService methods and model delegates were absent from TypeScript",
+      "code": "AUTH_AUDIT_LOCK_VOID_DESERIALIZATION",
+      "file": "apps/api/src/modules/auth/persistent-auth.repository.ts",
+      "reason": "pg_advisory_xact_lock returns PostgreSQL void and Prisma queryRaw cannot deserialize that projected type",
       "status": "corrected_awaiting_ci"
     },
     "requiredEvidence": [

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -27,7 +27,7 @@
     "live bank FGIS EDO and signature evidence",
     "production load restore and DR acceptance"
   ],
-  "blockerNotes": "PR #2276 replaces process-memory identity/session authority with PostgreSQL users, memberships, sessions, refresh families, revocation and MFA. The first PostgreSQL auth job stopped before executing tests because its isolated CI job did not generate Prisma Client. The next run reached all tests and exposed one shared audit-lock defect: Prisma cannot deserialize PostgreSQL void from pg_advisory_xact_lock. The corrected query still acquires the transaction lock but returns a supported integer projection. Client role, organization and tenant claims remain untrusted and all UI files remain locked until the gate is green.",
+  "blockerNotes": "PR #2276 replaces process-memory identity/session authority with PostgreSQL users, memberships, sessions, refresh families, revocation and MFA. The current PostgreSQL auth run passed seven of eight exploitation tests. The remaining concurrent-refresh test exposed a SERIALIZABLE 40001 conflict before the losing request could record refresh reuse and revoke the family. Auth transactions now retry only bounded PostgreSQL serialization/deadlock conflicts; the retry observes the rotated token and deterministically executes family-wide reuse revocation. Client role, organization and tenant claims remain untrusted and all UI files remain locked until the gate is green.",
   "lockedUntilCurrentGreen": [
     "durable outbox worker bank reconciliation and partner-key rotation",
     "platform UI implementation",
@@ -84,9 +84,9 @@
     "implementationPr": "#2276",
     "status": "in_progress",
     "lastFailure": {
-      "code": "AUTH_AUDIT_LOCK_VOID_DESERIALIZATION",
+      "code": "AUTH_REFRESH_SERIALIZATION_CONFLICT_NOT_RETRIED",
       "file": "apps/api/src/modules/auth/persistent-auth.repository.ts",
-      "reason": "pg_advisory_xact_lock returns PostgreSQL void and Prisma queryRaw cannot deserialize that projected type",
+      "reason": "the losing concurrent refresh transaction surfaced PostgreSQL 40001 before reuse detection and family revocation could run",
       "status": "corrected_awaiting_ci"
     },
     "requiredEvidence": [

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -7,8 +7,6 @@
   "fullTzReadinessPercent": 87,
   "openPr": "#2276",
   "lastClosed": [
-    "#2274 PostgreSQL One Deal Recovery Matrix",
-    "#2270 Industrial one-deal PostgreSQL 16 E2E exploitation gate",
     "#2241 VP-3.33 Runtime Persistence Prisma Schema and Migration Implementation",
     "#2245 VP-3.37 Runtime Persistence Postgres Repository Adapter Implementation",
     "#2250 VP-3.41 Runtime Persistence Internal Service Wiring Implementation",
@@ -17,18 +15,21 @@
     "#2256 VP-3.44 Runtime Persistence Trusted Transaction Binding",
     "#2258 VP-3.45 Physical Table RLS Policy Alignment and Rehearsal",
     "#2260 Industrial one-deal foundation",
-    "#2267 Canonical gateway consolidation"
+    "#2267 Canonical gateway consolidation",
+    "#2270 Industrial one-deal PostgreSQL 16 E2E exploitation gate",
+    "#2274 PostgreSQL One Deal Recovery Matrix"
   ],
   "openBlockers": [
     "#2113 repository settings cleanup",
     "#2115 persistent auth write path",
-    "legacy one-deal seed directly constructs AuthService without repository",
+    "PostgreSQL persistent-auth exploitation gate green evidence pending",
     "production migration and RLS execution evidence",
     "live bank FGIS EDO and signature evidence",
     "production load restore and DR acceptance"
   ],
-  "blockerNotes": "PR #2276 replaces process-memory identity/session authority with PostgreSQL users, memberships, sessions, refresh families, revocation and MFA. Typecheck exposed one exact test-bootstrap defect: apps/api/test/one-deal/seed.ts constructs AuthService without its persistent repository. That single file is temporarily unlocked for explicit PostgreSQL DI; production AuthService keeps mandatory repository injection. Client role, organization and tenant input remain untrusted and all UI files remain locked.",
+  "blockerNotes": "PR #2276 replaces process-memory identity/session authority with PostgreSQL users, memberships, sessions, refresh families, revocation and MFA. The first PostgreSQL auth job stopped before executing tests because its isolated CI job did not generate Prisma Client. The correction adds explicit generation, FK-safe refresh rotation, immediate durable revoke on membership, organization or user authority changes, and expanded exploitation evidence. Client role, organization and tenant claims remain untrusted and all UI files remain locked until the gate is green.",
   "lockedUntilCurrentGreen": [
+    "durable outbox worker bank reconciliation and partner-key rotation",
     "platform UI implementation",
     "client role shell migration",
     "live external integration activation",
@@ -37,6 +38,9 @@
   ],
   "allowedCurrentScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
+    "docs/platform-v7/autopilot/progress.json",
+    "docs/platform-v7/autopilot/prompts/current-codex-task.md",
+    "docs/platform-v7/autopilot/prompts/current-review-task.md",
     "docs/platform-v7/execution-queue.md",
     "apps/api/prisma/schema.prisma",
     "apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql",
@@ -49,6 +53,9 @@
   ],
   "agentWritableScope": [
     "docs/platform-v7/autopilot/autopilot-state.json",
+    "docs/platform-v7/autopilot/progress.json",
+    "docs/platform-v7/autopilot/prompts/current-codex-task.md",
+    "docs/platform-v7/autopilot/prompts/current-review-task.md",
     "docs/platform-v7/execution-queue.md",
     "apps/api/prisma/schema.prisma",
     "apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql",
@@ -77,9 +84,10 @@
     "implementationPr": "#2276",
     "status": "in_progress",
     "lastFailure": {
-      "code": "AUTH_SERVICE_REPOSITORY_REQUIRED_IN_ONE_DEAL_SEED",
-      "file": "apps/api/test/one-deal/seed.ts",
-      "reason": "test bootstrap directly called new AuthService() after production service moved to explicit PersistentAuthRepository injection"
+      "code": "AUTH_E2E_PRISMA_CLIENT_NOT_GENERATED",
+      "file": ".github/workflows/ci.yml",
+      "reason": "the isolated persistent-auth job ran ts-jest before prisma generate, so generated PrismaService methods and model delegates were absent from TypeScript",
+      "status": "corrected_awaiting_ci"
     },
     "requiredEvidence": [
       "PostgreSQL users memberships sessions refresh families and MFA challenges",

--- a/docs/platform-v7/autopilot/progress.json
+++ b/docs/platform-v7/autopilot/progress.json
@@ -1,12 +1,14 @@
 {
   "project": "platform-v7 / Прозрачная Цена",
-  "fullTzReadinessPercent": 72,
-  "currentStep": "P0 execution/evidence scenario runner implementation boundary for issue #2096. The next code PR may only compose existing domain-core execution-simulation primitives into one deterministic controlled-pilot scenario runner and one unit test.",
-  "lastCompletedStep": "#2163 synced source-of-truth after #2154, #2155, #2158, #2162 and #2113 cleanup.",
-  "openPr": "x2165",
-  "blockedBy": ["#2115", "#2159"],
-  "nextStep": "Implement scenario-runner.ts, export it from execution-simulation/index.ts, and add one unit test. Do not touch app routes, backend auth, API, storage, package or lock files.",
-  "updatedAt": "2026-07-01T00:30:00.000Z",
+  "fullTzReadinessPercent": 87,
+  "currentStep": "Persistent Identity, Session, Refresh-Family Revocation and MFA.",
+  "lastCompletedStep": "#2274 PostgreSQL One Deal Recovery Matrix",
+  "openPr": "#2276",
+  "blockedBy": [
+    "Persistent Identity, Session, Refresh-Family Revocation and MFA. is not green/closed/mergeable. Dispatcher will not advance to durable outbox worker bank reconciliation and partner-key rotation."
+  ],
+  "nextStep": "Persistent Identity, Session, Refresh-Family Revocation and MFA.",
+  "updatedAt": "2026-07-10T16:02:10.524Z",
   "rules": {
     "noAppsLanding": true,
     "noFakeLiveClaims": true,

--- a/docs/platform-v7/autopilot/progress.json
+++ b/docs/platform-v7/autopilot/progress.json
@@ -8,7 +8,7 @@
     "Persistent Identity, Session, Refresh-Family Revocation and MFA. is not green/closed/mergeable. Dispatcher will not advance to durable outbox worker bank reconciliation and partner-key rotation."
   ],
   "nextStep": "Persistent Identity, Session, Refresh-Family Revocation and MFA.",
-  "updatedAt": "2026-07-10T16:07:08.735Z",
+  "updatedAt": "2026-07-10T16:10:14.823Z",
   "rules": {
     "noAppsLanding": true,
     "noFakeLiveClaims": true,

--- a/docs/platform-v7/autopilot/progress.json
+++ b/docs/platform-v7/autopilot/progress.json
@@ -8,7 +8,7 @@
     "Persistent Identity, Session, Refresh-Family Revocation and MFA. is not green/closed/mergeable. Dispatcher will not advance to durable outbox worker bank reconciliation and partner-key rotation."
   ],
   "nextStep": "Persistent Identity, Session, Refresh-Family Revocation and MFA.",
-  "updatedAt": "2026-07-10T16:02:10.524Z",
+  "updatedAt": "2026-07-10T16:07:08.735Z",
   "rules": {
     "noAppsLanding": true,
     "noFakeLiveClaims": true,

--- a/docs/platform-v7/autopilot/prompts/current-codex-task.md
+++ b/docs/platform-v7/autopilot/prompts/current-codex-task.md
@@ -1,8 +1,9 @@
-# Codex current task — P0 execution/evidence scenario runner
+# Codex current task — Persistent Identity, Session, Refresh-Family Revocation and MFA.
 
 Maturity: controlled-pilot / pre-integration.
-
-Do not overstate maturity. Do not imply external connections are active. Do not change apps/landing, app routes, backend auth, API, storage, packages or lockfiles.
+Do not overstate maturity or imply live external integrations.
+Do not change apps/landing, production UI, visual/theme/onboarding, adapters, server actions, AI gateway runtime, DB/migrations or lockfiles unless the current step explicitly allows it.
+Do not auto-merge. Human review and green checks are required.
 
 ## Source of truth
 
@@ -12,53 +13,127 @@ Do not overstate maturity. Do not imply external connections are active. Do not 
 
 ## Current step
 
-Implement one deterministic scenario runner for issue #2096.
+Persistent Identity, Session, Refresh-Family Revocation and MFA.
 
-Use existing primitives from `packages/domain-core/src/execution-simulation`:
+## Next candidate
 
-- `createExecutionSimulationState`
-- `createExecutionDomainStore`
-- `runPlatformAction`
-- `transitionDeal` guard behavior through the action engine
-- existing types and KPI helpers where useful
+durable outbox worker bank reconciliation and partner-key rotation
+
+## Transition guard
+
+- BLOCKED: Persistent Identity, Session, Refresh-Family Revocation and MFA. is not green/closed/mergeable. Dispatcher will not advance to durable outbox worker bank reconciliation and partner-key rotation.
 
 ## Allowed current scope
 
-Use only the exact paths listed in `allowedCurrentScope` in `autopilot-state.json`.
+- docs/platform-v7/autopilot/autopilot-state.json
+- docs/platform-v7/autopilot/progress.json
+- docs/platform-v7/autopilot/prompts/current-codex-task.md
+- docs/platform-v7/autopilot/prompts/current-review-task.md
+- docs/platform-v7/execution-queue.md
+- apps/api/prisma/schema.prisma
+- apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
+- apps/api/src/modules/auth/**
+- apps/api/src/common/guards/**
+- apps/api/src/common/types/request-user.ts
+- apps/api/test/auth/**
+- apps/api/test/one-deal/seed.ts
+- .github/workflows/ci.yml
 
-## Required implementation
+## Forbidden zones
 
-Add `packages/domain-core/src/execution-simulation/scenario-runner.ts`.
+- apps/landing
+- apps/web/app/platform-v7
+- apps/web/components/platform-v7
+- apps/web/components/v7r
+- apps/web/lib/platform-v7
+- apps/web/app/api
+- package.json
+- package-lock.json
+- pnpm-lock.yaml
+- .env files
+- production migration execution
 
-The runner must:
+## Active queue
 
-- start from a fresh simulation state;
-- run one deterministic happy path until the deal is closed;
-- collect passed step labels;
-- collect blocked guard checks;
-- return audit event count and timeline event count;
-- return a close readiness result;
-- keep all labels controlled-pilot / pre-integration;
-- avoid live integration claims.
+# platform-v7 execution queue
 
-Also export the runner from `packages/domain-core/src/execution-simulation/index.ts` and add one unit test at `apps/web/tests/unit/platformV7ExecutionScenarioRunner.test.ts`.
+CURRENT: Persistent Identity, Session, Refresh-Family Revocation and MFA.
 
-## Negative checks
+GOAL:
+Replace process-memory authentication and client-selected authority with persistent PostgreSQL identity, membership, session, refresh-family, revocation and MFA truth shared by all API instances.
 
-Cover at least:
+BASELINE PROVEN:
+- #2270 proves the canonical 12-role / 19-command Deal lifecycle on isolated PostgreSQL 16;
+- #2274 proves concurrency, replay, restart, rollback and RLS pool isolation;
+- merge baseline is `cc10110293d9716c2f93790e7756589ead017afd`.
 
-- missing reserve;
-- missing documents;
-- open dispute;
-- missing weight;
-- missing lab;
-- missing idempotency key.
+CURRENT ALLOWED:
+- docs/platform-v7/autopilot/autopilot-state.json
+- docs/platform-v7/autopilot/progress.json
+- docs/platform-v7/autopilot/prompts/current-codex-task.md
+- docs/platform-v7/autopilot/prompts/current-review-task.md
+- docs/platform-v7/execution-queue.md
+- apps/api/prisma/schema.prisma
+- apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
+- apps/api/src/modules/auth/**
+- apps/api/src/common/guards/**
+- apps/api/src/common/types/request-user.ts
+- apps/api/test/auth/**
+- apps/api/test/one-deal/seed.ts
+- .github/workflows/ci.yml
 
-## Acceptance criteria
+CURRENT CRITERIA:
+- PostgreSQL User and UserOrg are the only identity and membership source of truth;
+- persistent Session records contain status, current refresh family, MFA state, last activity and revocation reason;
+- refresh tokens are one-time opaque secrets stored only as hashes;
+- every refresh rotates the token; reuse revokes the entire family and creates audit evidence;
+- access tokens identify an opaque session and user, while role, tenant and organization are re-derived from current DB membership;
+- logout, password reset, user block, organization suspension and administrator revoke invalidate affected sessions;
+- ADMIN, COMPLIANCE_OFFICER and ARBITRATOR require MFA; financial actions at or above the configured threshold require recent MFA;
+- TOTP secrets are encrypted at rest and backup codes are stored only as hashes;
+- login, refresh, MFA verify, logout, revoke, refresh reuse and denied authorization are audited;
+- two fresh API instances observe the same session status and refresh-family rotation;
+- migration deploy and zero schema drift pass on clean PostgreSQL 16;
+- unit, integration, restart, concurrency and security tests pass;
+- production identity-provider and production deployment claims remain forbidden.
 
-- no apps/landing diff;
-- no app route diff;
-- no backend/auth/API/storage diff;
-- no package or lockfile diff;
-- readiness remains 72%;
-- GitHub Actions and Netlify checks green before merge.
+LOCKED:
+- all platform UI and client role-selection changes;
+- apps/landing;
+- package and lockfiles;
+- live ESIA, bank, ФГИС, ЭДО and signature activation;
+- production migration execution;
+- production load, restore and DR claims.
+
+NEXT:
+- Layer: Durable Outbox Workers, Bank Reconciliation and Partner-Key Rotation.
+- Allowed files:
+  - docs/platform-v7/autopilot/autopilot-state.json
+  - docs/platform-v7/execution-queue.md
+  - apps/api/prisma/schema.prisma
+  - apps/api/prisma/migrations/20260710160000_durable_outbox_reconciliation/migration.sql
+  - apps/api/src/modules/outbox/**
+  - apps/api/src/modules/settlement-engine/**
+  - apps/api/src/modules/integrations/**
+  - apps/api/test/outbox/**
+  - apps/api/test/settlement/**
+  - .github/workflows/ci.yml
+- Success criteria:
+  - outbox claiming uses database leases and `SKIP LOCKED` semantics;
+  - retries, dead-letter transition and restart recovery are deterministic;
+  - bank reconciliation compares platform operations, callbacks and ledger without mutating history;
+  - partner keys support versioning, overlap and revocation;
+  - duplicate workers and callbacks remain idempotent;
+  - production integration remains unclaimed.
+- Readiness remains 87% until persistent identity and subsequent operational layers are proven.
+
+AFTER NEXT:
+- Truthful driver offline acknowledgement and conflict handling.
+- Server-rendered RU/EN/ZH i18n.
+- Complete mobile-first design-system and role-cabinet migration with one server-derived shell, one primary action, visible blocker reason and next step, accessibility and visual regression gates.
+- Load, restore, DR and operational acceptance.
+
+
+## Implementation brief
+
+Implement Persistent Identity, Session, Refresh-Family Revocation and MFA. strictly inside the state allowed scope.

--- a/docs/platform-v7/autopilot/prompts/current-review-task.md
+++ b/docs/platform-v7/autopilot/prompts/current-review-task.md
@@ -1,31 +1,123 @@
-# Review current task — P0 scenario runner
+# Review current task — Persistent Identity, Session, Refresh-Family Revocation and MFA.
 
 Maturity: controlled-pilot / pre-integration.
+Do not overstate maturity or imply live external integrations.
+Do not change apps/landing, production UI, visual/theme/onboarding, adapters, server actions, AI gateway runtime, DB/migrations or lockfiles unless the current step explicitly allows it.
+Do not auto-merge. Human review and green checks are required.
 
-Review the diff, not the report.
+Review the diff, not the agent report.
 
-## Scope checks
+## Required scope checks
 
 - `apps/landing` diff must be 0.
-- App route diff must be 0.
-- Backend and API diff must be 0.
-- Package and lockfile diff must be 0.
-- Changed files must stay inside `allowedCurrentScope`.
-- Readiness must remain 72%.
+- UI/visual/theme/onboarding diff must be 0 unless explicitly allowed by the current step.
+- adapters/server-actions/AI gateway diff must be 0 unless explicitly allowed by the current step.
+- no auto-merge behavior.
+- no fake-live or maturity overclaim.
 
-## Product checks
+## Current allowed scope
 
-The PR must compose existing execution-simulation primitives into one deterministic scenario runner and one unit test.
+- docs/platform-v7/autopilot/autopilot-state.json
+- docs/platform-v7/autopilot/progress.json
+- docs/platform-v7/autopilot/prompts/current-codex-task.md
+- docs/platform-v7/autopilot/prompts/current-review-task.md
+- docs/platform-v7/execution-queue.md
+- apps/api/prisma/schema.prisma
+- apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
+- apps/api/src/modules/auth/**
+- apps/api/src/common/guards/**
+- apps/api/src/common/types/request-user.ts
+- apps/api/test/auth/**
+- apps/api/test/one-deal/seed.ts
+- .github/workflows/ci.yml
 
-Expected result:
+## Transition guard
 
-- happy path reaches `CLOSED`;
-- audit and timeline counts are returned;
-- blocked path checks are returned;
-- no maturity uplift.
+- BLOCKED: Persistent Identity, Session, Refresh-Family Revocation and MFA. is not green/closed/mergeable. Dispatcher will not advance to durable outbox worker bank reconciliation and partner-key rotation.
 
-## Merge gate
+## Queue snapshot
 
-PASS only if scope is clean, checks are green or skipped, Netlify preview is ready or success, and PR is mergeable.
+# platform-v7 execution queue
 
-Return PASS or BLOCKED with exact fix.
+CURRENT: Persistent Identity, Session, Refresh-Family Revocation and MFA.
+
+GOAL:
+Replace process-memory authentication and client-selected authority with persistent PostgreSQL identity, membership, session, refresh-family, revocation and MFA truth shared by all API instances.
+
+BASELINE PROVEN:
+- #2270 proves the canonical 12-role / 19-command Deal lifecycle on isolated PostgreSQL 16;
+- #2274 proves concurrency, replay, restart, rollback and RLS pool isolation;
+- merge baseline is `cc10110293d9716c2f93790e7756589ead017afd`.
+
+CURRENT ALLOWED:
+- docs/platform-v7/autopilot/autopilot-state.json
+- docs/platform-v7/autopilot/progress.json
+- docs/platform-v7/autopilot/prompts/current-codex-task.md
+- docs/platform-v7/autopilot/prompts/current-review-task.md
+- docs/platform-v7/execution-queue.md
+- apps/api/prisma/schema.prisma
+- apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
+- apps/api/src/modules/auth/**
+- apps/api/src/common/guards/**
+- apps/api/src/common/types/request-user.ts
+- apps/api/test/auth/**
+- apps/api/test/one-deal/seed.ts
+- .github/workflows/ci.yml
+
+CURRENT CRITERIA:
+- PostgreSQL User and UserOrg are the only identity and membership source of truth;
+- persistent Session records contain status, current refresh family, MFA state, last activity and revocation reason;
+- refresh tokens are one-time opaque secrets stored only as hashes;
+- every refresh rotates the token; reuse revokes the entire family and creates audit evidence;
+- access tokens identify an opaque session and user, while role, tenant and organization are re-derived from current DB membership;
+- logout, password reset, user block, organization suspension and administrator revoke invalidate affected sessions;
+- ADMIN, COMPLIANCE_OFFICER and ARBITRATOR require MFA; financial actions at or above the configured threshold require recent MFA;
+- TOTP secrets are encrypted at rest and backup codes are stored only as hashes;
+- login, refresh, MFA verify, logout, revoke, refresh reuse and denied authorization are audited;
+- two fresh API instances observe the same session status and refresh-family rotation;
+- migration deploy and zero schema drift pass on clean PostgreSQL 16;
+- unit, integration, restart, concurrency and security tests pass;
+- production identity-provider and production deployment claims remain forbidden.
+
+LOCKED:
+- all platform UI and client role-selection changes;
+- apps/landing;
+- package and lockfiles;
+- live ESIA, bank, ФГИС, ЭДО and signature activation;
+- production migration execution;
+- production load, restore and DR claims.
+
+NEXT:
+- Layer: Durable Outbox Workers, Bank Reconciliation and Partner-Key Rotation.
+- Allowed files:
+  - docs/platform-v7/autopilot/autopilot-state.json
+  - docs/platform-v7/execution-queue.md
+  - apps/api/prisma/schema.prisma
+  - apps/api/prisma/migrations/20260710160000_durable_outbox_reconciliation/migration.sql
+  - apps/api/src/modules/outbox/**
+  - apps/api/src/modules/settlement-engine/**
+  - apps/api/src/modules/integrations/**
+  - apps/api/test/outbox/**
+  - apps/api/test/settlement/**
+  - .github/workflows/ci.yml
+- Success criteria:
+  - outbox claiming uses database leases and `SKIP LOCKED` semantics;
+  - retries, dead-letter transition and restart recovery are deterministic;
+  - bank reconciliation compares platform operations, callbacks and ledger without mutating history;
+  - partner keys support versioning, overlap and revocation;
+  - duplicate workers and callbacks remain idempotent;
+  - production integration remains unclaimed.
+- Readiness remains 87% until persistent identity and subsequent operational layers are proven.
+
+AFTER NEXT:
+- Truthful driver offline acknowledgement and conflict handling.
+- Server-rendered RU/EN/ZH i18n.
+- Complete mobile-first design-system and role-cabinet migration with one server-derived shell, one primary action, visible blocker reason and next step, accessibility and visual regression gates.
+- Load, restore, DR and operational acceptance.
+
+
+## Review brief
+
+Review Persistent Identity, Session, Refresh-Family Revocation and MFA. strictly against the state allowed scope and queue.
+
+Return PASS or BLOCKED. If BLOCKED, include blocker, file, why risk and exact fix.

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -12,6 +12,9 @@ BASELINE PROVEN:
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
+- docs/platform-v7/autopilot/progress.json
+- docs/platform-v7/autopilot/prompts/current-codex-task.md
+- docs/platform-v7/autopilot/prompts/current-review-task.md
 - docs/platform-v7/execution-queue.md
 - apps/api/prisma/schema.prisma
 - apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
@@ -19,6 +22,7 @@ CURRENT ALLOWED:
 - apps/api/src/common/guards/**
 - apps/api/src/common/types/request-user.ts
 - apps/api/test/auth/**
+- apps/api/test/one-deal/seed.ts
 - .github/workflows/ci.yml
 
 CURRENT CRITERIA:

--- a/docs/platform-v7/execution-queue.md
+++ b/docs/platform-v7/execution-queue.md
@@ -1,88 +1,73 @@
 # platform-v7 execution queue
 
-CURRENT: PostgreSQL One Deal Recovery Matrix.
+CURRENT: Persistent Identity, Session, Refresh-Family Revocation and MFA.
 
-STATUS: READY FOR MERGE.
+GOAL:
+Replace process-memory authentication and client-selected authority with persistent PostgreSQL identity, membership, session, refresh-family, revocation and MFA truth shared by all API instances.
 
 BASELINE PROVEN:
-- PR #2270 merged to `main` as `45a7fd7826eade875b81c1c631eb3a049c3fba94`;
-- eight forward-only migrations apply to clean PostgreSQL 16 with zero schema drift;
-- strict tenant/object RLS is enforced through a non-owner `NOSUPERUSER NOBYPASSRLS` application role;
-- one canonical Deal has 12 ACTIVE DealParticipant assignments;
-- all 19 commands execute to `CLOSED` with signed bank callbacks and full reconciliation.
-
-RECOVERY EVIDENCE PROVEN IN PR #2274:
-- simultaneous commands preserve one aggregate version and exactly one valid winner;
-- successful bank callbacks use stable verified partner + event identity rather than mutable Deal version;
-- duplicate callback returns the original receipt without a second event, ledger entry, outbox write or transition;
-- same partner event ID with changed material payload fails as `BANK_EVENT_REPLAY_MISMATCH`;
-- out-of-order release callback fails before any mutation;
-- fresh Prisma/service/gateway instances continue from persisted Deal, pending BankOperation, outbox and receipt state;
-- forced failure rolls back Deal, DealEvent, AuditEvent, ledger and outbox atomically;
-- sequential and parallel transaction-local RLS contexts do not leak tenant, organization, role or session through the pool;
-- full command and callback rerun after `CLOSED` is deterministic and idempotent;
-- evidence snapshots remain byte-for-byte stable across replay and restart checks.
-
-CORRECTED PRODUCT DEFECT:
-- previous generic callback fingerprint included mutable `expectedUpdatedAt`;
-- the same verified event therefore missed its original receipt after `RESERVE_REQUESTED → RESERVED`;
-- correction keeps event identity stable by verified partner + event ID and binds the material payload hash to commandId;
-- HMAC verification, exact pending operation binding and state-machine rules remain unchanged.
+- #2270 proves the canonical 12-role / 19-command Deal lifecycle on isolated PostgreSQL 16;
+- #2274 proves concurrency, replay, restart, rollback and RLS pool isolation;
+- merge baseline is `cc10110293d9716c2f93790e7756589ead017afd`.
 
 CURRENT ALLOWED:
 - docs/platform-v7/autopilot/autopilot-state.json
 - docs/platform-v7/execution-queue.md
-- apps/api/src/modules/deals/industrial-deal-command.gateway.ts
-- apps/api/src/modules/deals/industrial-deal-command.gateway.spec.ts
-- apps/api/test/one-deal/**
-- scripts/platform-v7-one-deal-*.mjs
-- scripts/platform-v7-one-deal-*.sh
+- apps/api/prisma/schema.prisma
+- apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
+- apps/api/src/modules/auth/**
+- apps/api/src/common/guards/**
+- apps/api/src/common/types/request-user.ts
+- apps/api/test/auth/**
 - .github/workflows/ci.yml
 
+CURRENT CRITERIA:
+- PostgreSQL User and UserOrg are the only identity and membership source of truth;
+- persistent Session records contain status, current refresh family, MFA state, last activity and revocation reason;
+- refresh tokens are one-time opaque secrets stored only as hashes;
+- every refresh rotates the token; reuse revokes the entire family and creates audit evidence;
+- access tokens identify an opaque session and user, while role, tenant and organization are re-derived from current DB membership;
+- logout, password reset, user block, organization suspension and administrator revoke invalidate affected sessions;
+- ADMIN, COMPLIANCE_OFFICER and ARBITRATOR require MFA; financial actions at or above the configured threshold require recent MFA;
+- TOTP secrets are encrypted at rest and backup codes are stored only as hashes;
+- login, refresh, MFA verify, logout, revoke, refresh reuse and denied authorization are audited;
+- two fresh API instances observe the same session status and refresh-family rotation;
+- migration deploy and zero schema drift pass on clean PostgreSQL 16;
+- unit, integration, restart, concurrency and security tests pass;
+- production identity-provider and production deployment claims remain forbidden.
+
 LOCKED:
-- every production file outside the exact gateway and unit-spec listed above;
-- production migration or RLS execution;
-- persistent identity/session/revocation/MFA implementation until this PR merges;
-- live bank, ФГИС, ЭДО and signature activation;
-- platform UI implementation during this recovery proof;
+- all platform UI and client role-selection changes;
 - apps/landing;
 - package and lockfiles;
-- production load, restore and disaster-recovery claims.
+- live ESIA, bank, ФГИС, ЭДО and signature activation;
+- production migration execution;
+- production load, restore and DR claims.
 
 NEXT:
-- Layer: Persistent Identity, Session, Refresh-Family Revocation and MFA.
+- Layer: Durable Outbox Workers, Bank Reconciliation and Partner-Key Rotation.
 - Allowed files:
   - docs/platform-v7/autopilot/autopilot-state.json
   - docs/platform-v7/execution-queue.md
   - apps/api/prisma/schema.prisma
-  - apps/api/prisma/migrations/20260710150000_persistent_identity_sessions/migration.sql
-  - apps/api/src/modules/auth/**
-  - apps/api/src/common/guards/**
-  - apps/api/src/common/types/request-user.ts
-  - apps/api/test/auth/**
+  - apps/api/prisma/migrations/20260710160000_durable_outbox_reconciliation/migration.sql
+  - apps/api/src/modules/outbox/**
+  - apps/api/src/modules/settlement-engine/**
+  - apps/api/src/modules/integrations/**
+  - apps/api/test/outbox/**
+  - apps/api/test/settlement/**
   - .github/workflows/ci.yml
 - Success criteria:
-  - persistent PostgreSQL users, memberships, sessions and refresh-token families replace process memory as identity truth;
-  - access tokens carry only opaque session identity and are re-authorized against persistent session and membership state;
-  - refresh rotation invalidates the previous token and reuse revokes the complete token family;
-  - logout, password reset, organization suspension and administrator revoke invalidate affected sessions deterministically;
-  - privileged roles and threshold financial actions require verified MFA state from the persistent session;
-  - role, tenant and organization are derived from server-side membership, never URL, request DTO, localStorage or client cookies;
-  - login, refresh, MFA verify, logout, revoke, reuse detection and denied access produce immutable audit evidence;
-  - horizontal API instances share the same PostgreSQL session truth and survive process restart;
-  - migration deploy, zero drift, unit, integration, security and restart tests are mandatory;
-  - production readiness and live identity-provider integration remain unclaimed.
-- Readiness remains 87% honest architectural readiness until persistent identity, live integrations, production load, restore and DR are independently proven.
+  - outbox claiming uses database leases and `SKIP LOCKED` semantics;
+  - retries, dead-letter transition and restart recovery are deterministic;
+  - bank reconciliation compares platform operations, callbacks and ledger without mutating history;
+  - partner keys support versioning, overlap and revocation;
+  - duplicate workers and callbacks remain idempotent;
+  - production integration remains unclaimed.
+- Readiness remains 87% until persistent identity and subsequent operational layers are proven.
 
 AFTER NEXT:
-- Durable outbox workers, bank reconciliation and partner-key rotation.
 - Truthful driver offline acknowledgement and conflict handling.
 - Server-rendered RU/EN/ZH i18n.
-- Complete mobile-first design-system and role-cabinet migration:
-  - one server-derived shell;
-  - one visual hierarchy;
-  - one primary action per state;
-  - status, blocker reason and next step visible without interpretation;
-  - removal of URL-derived role, client authority and CSS/hotfix cascade;
-  - accessibility and visual-regression acceptance.
-- Load, restore, DR and operational acceptance gates.
+- Complete mobile-first design-system and role-cabinet migration with one server-derived shell, one primary action, visible blocker reason and next step, accessibility and visual regression gates.
+- Load, restore, DR and operational acceptance.


### PR DESCRIPTION
## Суть

Промышленный backend identity-layer после merged PostgreSQL Deal/recovery proofs.

## Цель

Заменить process-memory auth и клиентский выбор роли на PostgreSQL users, memberships, sessions, one-time refresh families, revocation и MFA.

## Обязательные гарантии

- role/tenant/org выводятся только из актуального UserOrg и persistent Session;
- access token содержит opaque session identity, а не доверенную клиентскую роль;
- refresh rotation одноразовая; reuse отзывает всю family;
- logout/password reset/user block/org suspension/admin revoke инвалидируют сессии;
- privileged roles и threshold financial actions требуют MFA;
- TOTP secret encrypted, backup codes hashed;
- auth/revoke/reuse/denial audit trail;
- несколько API instances и restart используют одну PostgreSQL session truth;
- migration deploy, zero drift, concurrency/security/restart tests.

## Граница

UI и client shell не меняются в этом PR. Live ESIA и production deployment не заявляются.