### PR TITLE
P0 persistent-auth-backed 12-role one-deal execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
     env:
       NODE_ENV: test
       ONE_DEAL_ADMIN_URL: postgresql://one_deal_admin:ephemeral_one_deal_admin_only@127.0.0.1:5432/one_deal_e2e
+      ONE_DEAL_AUTH_URL: postgresql://one_deal_auth:ephemeral_one_deal_auth_only@127.0.0.1:5432/one_deal_e2e
       ONE_DEAL_APP_URL: postgresql://one_deal_app:ephemeral_one_deal_app_only@127.0.0.1:5432/one_deal_e2e
       ONE_DEAL_EVIDENCE_LOG: /tmp/platform-v7-one-deal-e2e.log
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,8 @@ jobs:
         shell: bash
         run: |
           echo "JWT_SECRET=$(openssl rand -hex 48)" >> "$GITHUB_ENV"
+          echo "AUTH_TOKEN_PEPPER=$(openssl rand -hex 48)" >> "$GITHUB_ENV"
+          echo "MFA_ENCRYPTION_KEY=$(openssl rand -hex 48)" >> "$GITHUB_ENV"
           echo "BANK_HMAC_SECRET=$(openssl rand -hex 48)" >> "$GITHUB_ENV"
 
       - name: Run industrial one-deal exploitation gate

--- a/apps/api/src/modules/deals/canonical-test-deal.seed.ts
+++ b/apps/api/src/modules/deals/canonical-test-deal.seed.ts
@@ -1,7 +1,8 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
 import { PrismaService } from '../../common/prisma/prisma.service';
-import { AuthService } from '../auth/auth.service';
+import { PersistentAuthRepository } from '../auth/persistent-auth.repository';
 import { Role } from '../../common/types/request-user';
 import { CANONICAL_TEST_DEAL_ID } from './deal-command.policy';
 
@@ -10,26 +11,26 @@ const TEST_PASSWORD = 'demo1234';
 const enabled = (name: string) => String(process.env[name] ?? '').toLowerCase() === 'true';
 
 const identities = [
-  { email: 'farmer@demo.ru', fullName: 'Тестовый продавец', role: Role.FARMER, orgId: 'org-canonical-seller' },
-  { email: 'buyer@demo.ru', fullName: 'Тестовый покупатель', role: Role.BUYER, orgId: 'org-canonical-buyer' },
-  { email: 'logistician@demo.ru', fullName: 'Тестовый логист', role: Role.LOGISTICIAN, orgId: 'org-canonical-logistics' },
-  { email: 'driver@demo.ru', fullName: 'Тестовый водитель', role: Role.DRIVER, orgId: 'org-canonical-logistics' },
-  { email: 'surveyor@demo.ru', fullName: 'Тестовый сюрвейер', role: Role.SURVEYOR, orgId: 'org-canonical-surveyor' },
-  { email: 'elevator@demo.ru', fullName: 'Тестовый элеватор', role: Role.ELEVATOR, orgId: 'org-canonical-elevator' },
-  { email: 'lab@demo.ru', fullName: 'Тестовая лаборатория', role: Role.LAB, orgId: 'org-canonical-lab' },
-  { email: 'accounting@demo.ru', fullName: 'Тестовый банковский сотрудник', role: Role.ACCOUNTING, orgId: 'org-canonical-bank' },
-  { email: 'compliance@demo.ru', fullName: 'Тестовый комплаенс', role: Role.COMPLIANCE_OFFICER, orgId: 'org-canonical-platform' },
-  { email: 'arbitrator@demo.ru', fullName: 'Тестовый арбитр', role: Role.ARBITRATOR, orgId: 'org-canonical-platform' },
-  { email: 'operator@demo.ru', fullName: 'Тестовый оператор', role: Role.SUPPORT_MANAGER, orgId: 'org-canonical-platform' },
-  { email: 'executive@demo.ru', fullName: 'Тестовый руководитель', role: Role.EXECUTIVE, orgId: 'org-canonical-platform' },
+  { userId: 'farmer-e2e', email: 'farmer@demo.ru', fullName: 'Тестовый продавец', role: Role.FARMER, orgId: 'org-canonical-seller', requireMfa: false },
+  { userId: 'buyer-e2e', email: 'buyer@demo.ru', fullName: 'Тестовый покупатель', role: Role.BUYER, orgId: 'org-canonical-buyer', requireMfa: true },
+  { userId: 'logistician-e2e', email: 'logistician@demo.ru', fullName: 'Тестовый логист', role: Role.LOGISTICIAN, orgId: 'org-canonical-logistics', requireMfa: false },
+  { userId: 'driver-e2e', email: 'driver@demo.ru', fullName: 'Тестовый водитель', role: Role.DRIVER, orgId: 'org-canonical-logistics', requireMfa: false },
+  { userId: 'surveyor-e2e', email: 'surveyor@demo.ru', fullName: 'Тестовый сюрвейер', role: Role.SURVEYOR, orgId: 'org-canonical-surveyor', requireMfa: false },
+  { userId: 'elevator-e2e', email: 'elevator@demo.ru', fullName: 'Тестовый элеватор', role: Role.ELEVATOR, orgId: 'org-canonical-elevator', requireMfa: false },
+  { userId: 'lab-e2e', email: 'lab@demo.ru', fullName: 'Тестовая лаборатория', role: Role.LAB, orgId: 'org-canonical-lab', requireMfa: false },
+  { userId: 'accounting-e2e', email: 'accounting@demo.ru', fullName: 'Тестовый банковский сотрудник', role: Role.ACCOUNTING, orgId: 'org-canonical-bank', requireMfa: true },
+  { userId: 'compliance-e2e', email: 'compliance@demo.ru', fullName: 'Тестовый комплаенс', role: Role.COMPLIANCE_OFFICER, orgId: 'org-canonical-platform', requireMfa: false },
+  { userId: 'arbitrator-e2e', email: 'arbitrator@demo.ru', fullName: 'Тестовый арбитр', role: Role.ARBITRATOR, orgId: 'org-canonical-platform', requireMfa: false },
+  { userId: 'operator-e2e', email: 'operator@demo.ru', fullName: 'Тестовый оператор', role: Role.SUPPORT_MANAGER, orgId: 'org-canonical-platform', requireMfa: false },
+  { userId: 'executive-e2e', email: 'executive@demo.ru', fullName: 'Тестовый руководитель', role: Role.EXECUTIVE, orgId: 'org-canonical-platform', requireMfa: false },
 ] as const;
 
 function participantAccess(role: Role): 'READ' | 'WORK' | 'APPROVE' {
   if (role === Role.EXECUTIVE) return 'READ';
   if (
-    role === Role.COMPLIANCE_OFFICER ||
-    role === Role.ARBITRATOR ||
-    role === Role.SUPPORT_MANAGER
+    role === Role.COMPLIANCE_OFFICER
+    || role === Role.ARBITRATOR
+    || role === Role.SUPPORT_MANAGER
   ) return 'APPROVE';
   return 'WORK';
 }
@@ -40,7 +41,7 @@ export class CanonicalTestDealSeedService implements OnModuleInit {
 
   constructor(
     private readonly prisma: PrismaService,
-    private readonly auth: AuthService,
+    private readonly authRepository: PersistentAuthRepository,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -120,8 +121,8 @@ export class CanonicalTestDealSeedService implements OnModuleInit {
           nextAction: 'Подтвердить допуск участников',
           meta: JSON.stringify({
             canonicalTestDeal: true,
-            purpose: 'single-role-consistent-industrial-flow',
-            synthetic: true,
+            purpose: 'persistent-auth-backed-industrial-flow',
+            isolatedE2EFixture: true,
           }),
         },
       });
@@ -139,48 +140,53 @@ export class CanonicalTestDealSeedService implements OnModuleInit {
       });
     });
 
-    await this.seedIdentitiesMembershipsAndParticipants();
+    await this.seedPersistentIdentitiesMembershipsAndParticipants();
   }
 
-  private async seedIdentitiesMembershipsAndParticipants(): Promise<void> {
+  private async seedPersistentIdentitiesMembershipsAndParticipants(): Promise<void> {
     const passwordHash = bcrypt.hashSync(TEST_PASSWORD, 10);
 
     for (const identity of identities) {
-      let user = this.auth.listUsers().find((item) => item.email.toLowerCase() === identity.email);
-      if (!user) {
-        const registered = await this.auth.register({
-          email: identity.email,
-          password: TEST_PASSWORD,
-          role: Role.DRIVER,
-          orgId: identity.orgId,
-          fullName: identity.fullName,
-          consentVersion: '1.2',
-        });
-        user = registered.user;
-      }
-
-      this.auth.updateUserRole(user.id, identity.role);
-      this.auth.updateUserOrg(user.id, identity.orgId);
-
       await this.prisma.$transaction(async (tx) => {
-        await tx.user.upsert({
-          where: { id: user.id },
+        const user = await tx.user.upsert({
+          where: { id: identity.userId },
           update: {
             email: identity.email,
             passwordHash,
             fullName: identity.fullName,
             status: 'ACTIVE',
+            mfaEnabled: identity.requireMfa,
+            deletedAt: null,
           },
           create: {
-            id: user.id,
+            id: identity.userId,
             email: identity.email,
             passwordHash,
             fullName: identity.fullName,
             status: 'ACTIVE',
+            mfaEnabled: identity.requireMfa,
           },
         });
 
-        await tx.userOrg.upsert({
+        await this.authRepository.ensureCredentialState(tx, user.id, '1.2', new Date());
+        await tx.$executeRaw(Prisma.sql`
+          UPDATE auth.credential_states
+          SET credential_version = 1,
+              failed_login_count = 0,
+              locked_until = NULL,
+              password_changed_at = NULL,
+              last_login_at = NULL,
+              mfa_enabled = ${identity.requireMfa},
+              mfa_secret_ciphertext = NULL,
+              mfa_key_version = NULL,
+              mfa_backup_hashes = NULL,
+              consent_version = '1.2',
+              consent_at = NOW(),
+              updated_at = NOW()
+          WHERE user_id = ${user.id}
+        `);
+
+        const membership = await tx.userOrg.upsert({
           where: {
             userId_organizationId: {
               userId: user.id,
@@ -225,6 +231,8 @@ export class CanonicalTestDealSeedService implements OnModuleInit {
             status: 'ACTIVE',
           },
         });
+
+        if (!membership.id) throw new Error(`Persistent membership was not created for ${identity.role}`);
       });
     }
   }

--- a/apps/api/test/one-deal/industrial-one-deal.e2e-spec.ts
+++ b/apps/api/test/one-deal/industrial-one-deal.e2e-spec.ts
@@ -16,13 +16,16 @@ import {
   buildBankSignaturePayload,
   SettlementEngineController,
 } from '../../src/modules/settlement-engine/settlement-engine.controller';
+import {
+  createPersistentActorHarness,
+  type PersistentActorHarness,
+} from './persistent-auth-actors';
 
-const TENANT_ID = 'tenant-canonical-test';
 const BANK_SECRET = process.env.BANK_HMAC_SECRET ?? '';
 const BANK_PARTNER_ID = process.env.BANK_PARTNER_ID ?? 'safe-deals';
 const BANK_KEY_ID = process.env.BANK_HMAC_KEY_ID ?? 'primary';
-
-const CANONICAL_ORG_IDS = new Set([
+const DEAL_AMOUNT_KOPECKS = 240_000_000;
+const CANONICAL_ORG_IDS = [
   'org-canonical-seller',
   'org-canonical-buyer',
   'org-canonical-logistics',
@@ -31,15 +34,10 @@ const CANONICAL_ORG_IDS = new Set([
   'org-canonical-lab',
   'org-canonical-bank',
   'org-canonical-platform',
-]);
+] as const;
 
 type UserActionId = Exclude<DealActionId, 'confirm_reserve' | 'confirm_release'>;
 type Workspace = Awaited<ReturnType<IndustrialDealCommandGateway['workspace']>>;
-type MembershipRow = {
-  organizationId: string;
-  role: string;
-  user: { id: string; email: string; fullName: string };
-};
 type CommandReceipt = {
   duplicate: boolean;
   commandId: string;
@@ -197,45 +195,31 @@ async function submitBankCallback(
   );
 }
 
-describe('industrial one-deal PostgreSQL exploitation and recovery gate', () => {
+describe('persistent-auth-backed industrial one-deal exploitation and recovery gate', () => {
   const primary = createRuntime();
   const { prisma, rls, gateway, settlement } = primary;
   const usersByRole = new Map<Role, RequestUser>();
   const issuedUserCommands: IssuedUserCommand[] = [];
+  let authHarness: PersistentActorHarness;
 
   beforeAll(async () => {
     if (!BANK_SECRET) throw new Error('BANK_HMAC_SECRET is required for signed callback fixtures.');
     await prisma.$connect();
-
-    const memberships = (await prisma.userOrg.findMany({
-      where: { organizationId: { in: [...CANONICAL_ORG_IDS] } },
-      include: { user: true },
-      orderBy: { role: 'asc' },
-    })) as MembershipRow[];
-
-    for (const membership of memberships) {
-      usersByRole.set(membership.role as Role, {
-        id: membership.user.id,
-        email: membership.user.email,
-        fullName: membership.user.fullName,
-        role: membership.role as Role,
-        orgId: membership.organizationId,
-        tenantId: TENANT_ID,
-        sessionId: `e2e-session-${membership.role.toLowerCase()}`,
-        mfaVerified: true,
-      });
-    }
-
+    authHarness = await createPersistentActorHarness(CANONICAL_ORG_IDS);
+    for (const [role, actor] of authHarness.actorsByRole) usersByRole.set(role, actor);
     expect(usersByRole.size).toBe(12);
   });
 
   afterAll(async () => {
-    await prisma.$disconnect();
+    await Promise.allSettled([
+      prisma.$disconnect(),
+      authHarness?.disconnect(),
+    ]);
   });
 
   function actor(role: Role): RequestUser {
     const user = usersByRole.get(role);
-    if (!user) throw new Error(`Missing seeded membership for role ${role}`);
+    if (!user) throw new Error(`Missing persistent authenticated actor for role ${role}`);
     return user;
   }
 
@@ -258,6 +242,10 @@ describe('industrial one-deal PostgreSQL exploitation and recovery gate', () => 
     options: { expectedUpdatedAt?: string; idempotencyKey?: string; commandId?: string } = {},
   ) {
     const role = actionRole[actionId];
+    const authenticatedActor = actor(role);
+    if (actionId === 'request_reserve' || actionId === 'request_release') {
+      authHarness.primaryAuth.assertRecentFinancialMfa(authenticatedActor, DEAL_AMOUNT_KOPECKS);
+    }
     const current = await workspace(role);
     const dto: ExecuteDealCommandDto = {
       commandId: options.commandId ?? `command-${actionId}`,
@@ -265,7 +253,7 @@ describe('industrial one-deal PostgreSQL exploitation and recovery gate', () => 
       expectedUpdatedAt: options.expectedUpdatedAt ?? current.deal.updatedAt,
       payload: payload(actionId),
     };
-    const raw = await gateway.executeUser(CANONICAL_TEST_DEAL_ID, actionId, dto, actor(role));
+    const raw = await gateway.executeUser(CANONICAL_TEST_DEAL_ID, actionId, dto, authenticatedActor);
     const receipt = requireReceipt(raw);
     issuedUserCommands.push({ actionId, role, dto, receipt });
     return receipt;
@@ -426,7 +414,7 @@ describe('industrial one-deal PostgreSQL exploitation and recovery gate', () => 
 
     const sequentialValidAgain = await probe(valid);
     expect(sequentialValidAgain.dealCount).toBe(1);
-    expect(sequentialValidAgain.settings?.tenant_id).toBe(TENANT_ID);
+    expect(sequentialValidAgain.settings?.tenant_id).toBe(valid.tenantId);
 
     const parallel = await Promise.all(
       Array.from({ length: 16 }, (_, index) => {
@@ -472,12 +460,14 @@ describe('industrial one-deal PostgreSQL exploitation and recovery gate', () => 
     });
   }
 
-  it('executes one factual deal and proves concurrency replay restart rollback and RLS isolation', async () => {
+  it('executes one factual deal with persistent identity, MFA, recovery and RLS isolation', async () => {
     const roleViews = await Promise.all(
       [...usersByRole.keys()].map(async (role) => ({ role, view: await workspace(role) })),
     );
     expect(new Set(roleViews.map(({ view }) => view.deal.id))).toEqual(new Set([CANONICAL_TEST_DEAL_ID]));
     expect(new Set(roleViews.map(({ view }) => view.deal.status))).toEqual(new Set(['DRAFT']));
+
+    await authHarness.verifyWithFreshInstance();
 
     const sellerWithSpoofedOrg = { ...actor(Role.FARMER), orgId: 'org-canonical-buyer' };
     await expect(gateway.workspace(CANONICAL_TEST_DEAL_ID, sellerWithSpoofedOrg)).resolves.toMatchObject({
@@ -602,7 +592,6 @@ describe('industrial one-deal PostgreSQL exploitation and recovery gate', () => 
     const reserveCallback = bankCallbackFixture('RESERVE');
     await withFreshRuntime(async (fresh) => {
       expect((await workspace(Role.ACCOUNTING, fresh.gateway)).deal.status).toBe('RESERVE_REQUESTED');
-
       const durablePending = await fresh.rls.withTrustedContext(actor(Role.ACCOUNTING), async (tx) => {
         const [operation, pendingOutbox, receipt] = await Promise.all([
           tx.bankOperation.findUnique({ where: { id: `bank-reserve:${CANONICAL_TEST_DEAL_ID}` } }),
@@ -627,7 +616,6 @@ describe('industrial one-deal PostgreSQL exploitation and recovery gate', () => 
       expect(durablePending.operation).toMatchObject({ type: 'RESERVE', status: 'PENDING' });
       expect(durablePending.pendingOutbox).not.toBeNull();
       expect(durablePending.receipt).not.toBeNull();
-
       await expect(
         submitBankCallback(fresh.settlement, reserveCallback, { proveInvalidSignature: true }),
       ).resolves.toMatchObject({ status: 'RESERVED', duplicate: false });
@@ -670,7 +658,20 @@ describe('industrial one-deal PostgreSQL exploitation and recovery gate', () => 
 
     const operator = actor(Role.SUPPORT_MANAGER);
     const reconciled = await rls.withTrustedContext(operator, async (tx) => {
-      const [deal, participants, events, audits, outbox, documents, shipment, sample, acceptance, payment, bankOperations, ledger] = await Promise.all([
+      const [
+        deal,
+        participants,
+        events,
+        audits,
+        outbox,
+        documents,
+        shipment,
+        sample,
+        acceptance,
+        payment,
+        bankOperations,
+        ledger,
+      ] = await Promise.all([
         tx.deal.findUnique({ where: { id: CANONICAL_TEST_DEAL_ID } }),
         tx.dealParticipant.findMany({ where: { dealId: CANONICAL_TEST_DEAL_ID }, orderBy: { id: 'asc' } }),
         tx.dealEvent.findMany({ where: { dealId: CANONICAL_TEST_DEAL_ID }, orderBy: { createdAt: 'asc' } }),
@@ -684,10 +685,23 @@ describe('industrial one-deal PostgreSQL exploitation and recovery gate', () => 
         tx.bankOperation.findMany({ where: { dealId: CANONICAL_TEST_DEAL_ID }, orderBy: { type: 'asc' } }),
         tx.ledgerEntry.findMany({ where: { dealId: CANONICAL_TEST_DEAL_ID }, orderBy: { createdAt: 'asc' } }),
       ]);
-      return { deal, participants, events, audits, outbox, documents, shipment, sample, acceptance, payment, bankOperations, ledger };
+      return {
+        deal,
+        participants,
+        events,
+        audits,
+        outbox,
+        documents,
+        shipment,
+        sample,
+        acceptance,
+        payment,
+        bankOperations,
+        ledger,
+      };
     });
 
-    expect(reconciled.deal).toMatchObject({ status: 'CLOSED', totalKopecks: 240_000_000 });
+    expect(reconciled.deal).toMatchObject({ status: 'CLOSED', totalKopecks: DEAL_AMOUNT_KOPECKS });
     expect(reconciled.participants).toHaveLength(12);
     expect(reconciled.participants.filter((item) => item.role === Role.EXECUTIVE)).toEqual([
       expect.objectContaining({ accessLevel: 'READ', status: 'ACTIVE' }),
@@ -701,7 +715,11 @@ describe('industrial one-deal PostgreSQL exploitation and recovery gate', () => 
     expect(reconciled.sample).toMatchObject({ status: 'DONE', protocol: 'LAB-E2E-001' });
     expect(reconciled.sample?.tests).toHaveLength(2);
     expect(reconciled.acceptance).toMatchObject({ status: 'ACCEPTED', qualityStatus: 'PASSED' });
-    expect(reconciled.payment).toMatchObject({ status: 'RELEASED', callbackState: 'CONFIRMED', bankRef: 'release-ref-e2e' });
+    expect(reconciled.payment).toMatchObject({
+      status: 'RELEASED',
+      callbackState: 'CONFIRMED',
+      bankRef: 'release-ref-e2e',
+    });
     expect(reconciled.bankOperations).toHaveLength(2);
     expect(reconciled.bankOperations.every((item) => item.status === 'DONE')).toBe(true);
     expect(reconciled.ledger.map((item) => item.entryType)).toEqual(['RESERVE', 'RELEASE']);
@@ -734,8 +752,25 @@ describe('industrial one-deal PostgreSQL exploitation and recovery gate', () => 
     });
     expect(await evidenceSnapshot(rls, operator)).toEqual(beforeFullRecoveryReplay);
 
+    const executive = actor(Role.EXECUTIVE);
+    const executiveToken = authHarness.accessTokensByRole.get(Role.EXECUTIVE);
+    if (!executive.membershipId || !executiveToken) throw new Error('Executive persistent session proof is incomplete');
+    await authHarness.primaryPrisma.userOrg.update({
+      where: { id: executive.membershipId },
+      data: { role: Role.GUEST },
+    });
+    await expect(authHarness.verifierAuth.verifyAccessToken(executiveToken)).rejects.toThrow(/revoked|not active/i);
+    await authHarness.primaryPrisma.userOrg.update({
+      where: { id: executive.membershipId },
+      data: { role: Role.EXECUTIVE },
+    });
+
     process.stdout.write(`${JSON.stringify({
       e2e: 'passed',
+      identity: 'persistent-postgresql',
+      mfa: 'passed',
+      authRestart: 'passed',
+      membershipRevocation: 'passed',
       recovery: 'passed',
       dealId: reconciled.deal?.id,
       status: reconciled.deal?.status,

--- a/apps/api/test/one-deal/persistent-auth-actors.ts
+++ b/apps/api/test/one-deal/persistent-auth-actors.ts
@@ -28,6 +28,7 @@ export type PersistentActorHarness = {
   verifierAuth: AuthService;
   primaryPrisma: PrismaService;
   verifierPrisma: PrismaService;
+  verifyWithFreshInstance(): Promise<void>;
   disconnect(): Promise<void>;
 };
 
@@ -186,6 +187,22 @@ export async function createPersistentActorHarness(
       verifierAuth,
       primaryPrisma,
       verifierPrisma,
+      verifyWithFreshInstance: async () => {
+        const freshPrisma = authPrisma(adminUrl);
+        const freshAuth = new AuthService(new PersistentAuthRepository(freshPrisma));
+        await freshPrisma.$connect();
+        try {
+          for (const [role, token] of accessTokensByRole) {
+            const expected = actorsByRole.get(role);
+            const verified = await freshAuth.verifyAccessToken(token);
+            if (!expected || verified.id !== expected.id || verified.sessionId !== expected.sessionId || verified.role !== role) {
+              throw new Error(`Fresh API instance did not recover persistent session for ${role}`);
+            }
+          }
+        } finally {
+          await freshPrisma.$disconnect();
+        }
+      },
       disconnect: async () => {
         await Promise.all([primaryPrisma.$disconnect(), verifierPrisma.$disconnect()]);
       },

--- a/apps/api/test/one-deal/persistent-auth-actors.ts
+++ b/apps/api/test/one-deal/persistent-auth-actors.ts
@@ -1,0 +1,197 @@
+import { createHmac } from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { PrismaService } from '../../src/common/prisma/prisma.service';
+import { RequestUser, Role } from '../../src/common/types/request-user';
+import { AuthService } from '../../src/modules/auth/auth.service';
+import { PersistentAuthRepository } from '../../src/modules/auth/persistent-auth.repository';
+
+const TEST_PASSWORD = 'demo1234';
+const MFA_REQUIRED_FIXTURE_ROLES = new Set<Role>([
+  Role.BUYER,
+  Role.ACCOUNTING,
+  Role.COMPLIANCE_OFFICER,
+  Role.ARBITRATOR,
+]);
+
+type MembershipRow = {
+  id: string;
+  organizationId: string;
+  role: string;
+  organization: { tenantId: string };
+  user: { id: string; email: string; fullName: string };
+};
+
+export type PersistentActorHarness = {
+  actorsByRole: Map<Role, RequestUser>;
+  accessTokensByRole: Map<Role, string>;
+  primaryAuth: AuthService;
+  verifierAuth: AuthService;
+  primaryPrisma: PrismaService;
+  verifierPrisma: PrismaService;
+  disconnect(): Promise<void>;
+};
+
+function base32Decode(input: string): Buffer {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const normalized = input.toUpperCase().replace(/[^A-Z2-7]/g, '');
+  let bits = 0;
+  let value = 0;
+  const bytes: number[] = [];
+  for (const char of normalized) {
+    const index = alphabet.indexOf(char);
+    if (index < 0) throw new Error('Invalid base32 character in TOTP setup secret');
+    value = (value << 5) | index;
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 255);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(bytes);
+}
+
+function totp(secret: string, unixMs = Date.now()): string {
+  const counter = BigInt(Math.floor(unixMs / 30_000));
+  const counterBuffer = Buffer.alloc(8);
+  counterBuffer.writeBigUInt64BE(counter);
+  const digest = createHmac('sha1', base32Decode(secret)).update(counterBuffer).digest();
+  const offset = digest[digest.length - 1] & 0x0f;
+  const binary = ((digest[offset] & 0x7f) << 24)
+    | ((digest[offset + 1] & 0xff) << 16)
+    | ((digest[offset + 2] & 0xff) << 8)
+    | (digest[offset + 3] & 0xff);
+  return String(binary % 1_000_000).padStart(6, '0');
+}
+
+function authPrisma(databaseUrl: string): PrismaService {
+  return new PrismaService({ datasources: { db: { url: databaseUrl } } });
+}
+
+function assertOpaqueAccessToken(accessToken: string, expectedUserId: string): void {
+  const decoded = jwt.decode(accessToken);
+  if (!decoded || typeof decoded === 'string') throw new Error('Access token did not decode to JWT claims');
+  if (decoded.sub !== expectedUserId || decoded.typ !== 'access' || typeof decoded.sid !== 'string') {
+    throw new Error('Access token does not contain the expected opaque identity claims');
+  }
+  for (const forbidden of ['role', 'orgId', 'organizationId', 'tenantId', 'membershipId']) {
+    if (Object.prototype.hasOwnProperty.call(decoded, forbidden)) {
+      throw new Error(`Access token leaked server-authoritative claim: ${forbidden}`);
+    }
+  }
+}
+
+export async function createPersistentActorHarness(
+  organizationIds: readonly string[],
+): Promise<PersistentActorHarness> {
+  const adminUrl = String(process.env.ONE_DEAL_ADMIN_URL ?? '').trim();
+  if (!adminUrl) throw new Error('ONE_DEAL_ADMIN_URL is required for persistent auth actor proof');
+
+  const primaryPrisma = authPrisma(adminUrl);
+  const verifierPrisma = authPrisma(adminUrl);
+  const primaryAuth = new AuthService(new PersistentAuthRepository(primaryPrisma));
+  const verifierAuth = new AuthService(new PersistentAuthRepository(verifierPrisma));
+  await Promise.all([primaryPrisma.$connect(), verifierPrisma.$connect()]);
+
+  try {
+    const memberships = (await primaryPrisma.userOrg.findMany({
+      where: { organizationId: { in: [...organizationIds] } },
+      include: { user: true, organization: true },
+      orderBy: { role: 'asc' },
+    })) as MembershipRow[];
+
+    const actorsByRole = new Map<Role, RequestUser>();
+    const accessTokensByRole = new Map<Role, string>();
+
+    for (const membership of memberships) {
+      const role = membership.role as Role;
+      const login = await primaryAuth.login({
+        email: membership.user.email,
+        password: TEST_PASSWORD,
+      }) as any;
+      const expectedMfa = MFA_REQUIRED_FIXTURE_ROLES.has(role);
+      if (Boolean(login.mfaRequired) !== expectedMfa) {
+        throw new Error(`Unexpected MFA requirement for ${role}: ${String(login.mfaRequired)}`);
+      }
+
+      let accessToken: string;
+      if (expectedMfa) {
+        if (login.accessToken || !login.challengeToken || !login.setupSecret) {
+          throw new Error(`Role ${role} bypassed mandatory MFA enrollment`);
+        }
+        const verified = await verifierAuth.verifyMfa({
+          challengeToken: login.challengeToken,
+          code: totp(login.setupSecret),
+        }) as any;
+        accessToken = verified.accessToken;
+        if (!accessToken || !verified.refreshToken) {
+          throw new Error(`MFA verification did not issue tokens for ${role}`);
+        }
+      } else {
+        accessToken = login.accessToken;
+        if (!accessToken || !login.refreshToken) {
+          throw new Error(`Persistent login did not issue tokens for ${role}`);
+        }
+      }
+
+      assertOpaqueAccessToken(accessToken, membership.user.id);
+      const actor = await verifierAuth.verifyAccessToken(accessToken);
+      if (
+        actor.id !== membership.user.id
+        || actor.role !== role
+        || actor.orgId !== membership.organizationId
+        || actor.tenantId !== membership.organization.tenantId
+        || actor.membershipId !== membership.id
+        || !actor.sessionId
+      ) {
+        throw new Error(`PostgreSQL session projection mismatch for ${role}`);
+      }
+      if (expectedMfa && (!actor.mfaVerified || !actor.mfaVerifiedAt)) {
+        throw new Error(`MFA state was not persisted for ${role}`);
+      }
+
+      const sessions = await primaryPrisma.$queryRaw<Array<{
+        id: string;
+        status: string;
+        membership_id: string;
+        organization_id: string;
+        tenant_id: string;
+      }>>`
+        SELECT id, status, membership_id, organization_id, tenant_id
+        FROM auth.sessions
+        WHERE id = ${actor.sessionId}
+      `;
+      const session = sessions[0];
+      if (
+        !session
+        || session.status !== 'ACTIVE'
+        || session.membership_id !== membership.id
+        || session.organization_id !== membership.organizationId
+        || session.tenant_id !== membership.organization.tenantId
+      ) {
+        throw new Error(`Persistent session row mismatch for ${role}`);
+      }
+
+      actorsByRole.set(role, actor);
+      accessTokensByRole.set(role, accessToken);
+    }
+
+    if (actorsByRole.size !== 12 || accessTokensByRole.size !== 12) {
+      throw new Error(`Expected 12 persistent actors, got ${actorsByRole.size}/${accessTokensByRole.size}`);
+    }
+
+    return {
+      actorsByRole,
+      accessTokensByRole,
+      primaryAuth,
+      verifierAuth,
+      primaryPrisma,
+      verifierPrisma,
+      disconnect: async () => {
+        await Promise.all([primaryPrisma.$disconnect(), verifierPrisma.$disconnect()]);
+      },
+    };
+  } catch (error) {
+    await Promise.allSettled([primaryPrisma.$disconnect(), verifierPrisma.$disconnect()]);
+    throw error;
+  }
+}

--- a/apps/api/test/one-deal/persistent-auth-actors.ts
+++ b/apps/api/test/one-deal/persistent-auth-actors.ts
@@ -84,16 +84,23 @@ function assertOpaqueAccessToken(accessToken: string, expectedUserId: string): v
 export async function createPersistentActorHarness(
   organizationIds: readonly string[],
 ): Promise<PersistentActorHarness> {
-  const adminUrl = String(process.env.ONE_DEAL_ADMIN_URL ?? '').trim();
-  if (!adminUrl) throw new Error('ONE_DEAL_ADMIN_URL is required for persistent auth actor proof');
+  const authUrl = String(process.env.ONE_DEAL_AUTH_URL ?? '').trim();
+  if (!authUrl) throw new Error('ONE_DEAL_AUTH_URL is required for persistent auth actor proof');
 
-  const primaryPrisma = authPrisma(adminUrl);
-  const verifierPrisma = authPrisma(adminUrl);
+  const primaryPrisma = authPrisma(authUrl);
+  const verifierPrisma = authPrisma(authUrl);
   const primaryAuth = new AuthService(new PersistentAuthRepository(primaryPrisma));
   const verifierAuth = new AuthService(new PersistentAuthRepository(verifierPrisma));
   await Promise.all([primaryPrisma.$connect(), verifierPrisma.$connect()]);
 
   try {
+    const [{ current_user: currentUser }] = await primaryPrisma.$queryRaw<Array<{ current_user: string }>>`
+      SELECT current_user
+    `;
+    if (currentUser !== 'one_deal_auth') {
+      throw new Error(`Persistent auth harness connected as unexpected principal ${currentUser}`);
+    }
+
     const memberships = (await primaryPrisma.userOrg.findMany({
       where: { organizationId: { in: [...organizationIds] } },
       include: { user: true, organization: true },
@@ -188,7 +195,7 @@ export async function createPersistentActorHarness(
       primaryPrisma,
       verifierPrisma,
       verifyWithFreshInstance: async () => {
-        const freshPrisma = authPrisma(adminUrl);
+        const freshPrisma = authPrisma(authUrl);
         const freshAuth = new AuthService(new PersistentAuthRepository(freshPrisma));
         await freshPrisma.$connect();
         try {

--- a/apps/api/test/one-deal/seed.ts
+++ b/apps/api/test/one-deal/seed.ts
@@ -1,5 +1,4 @@
 import { PrismaService } from '../../src/common/prisma/prisma.service';
-import { AuthService } from '../../src/modules/auth/auth.service';
 import { PersistentAuthRepository } from '../../src/modules/auth/persistent-auth.repository';
 import { CanonicalTestDealSeedService } from '../../src/modules/deals/canonical-test-deal.seed';
 import { CANONICAL_TEST_DEAL_ID } from '../../src/modules/deals/deal-command.policy';
@@ -16,16 +15,26 @@ async function main(): Promise<void> {
   await prisma.$connect();
   try {
     const authRepository = new PersistentAuthRepository(prisma);
-    const auth = new AuthService(authRepository);
-    const seed = new CanonicalTestDealSeedService(prisma, auth);
+    const seed = new CanonicalTestDealSeedService(prisma, authRepository);
     await seed.onModuleInit();
 
-    const [deal, memberships] = await Promise.all([
+    const [deal, memberships, credentialStates] = await Promise.all([
       prisma.deal.findUnique({ where: { id: CANONICAL_TEST_DEAL_ID } }),
       prisma.userOrg.findMany({
         where: { organization: { tenantId: 'tenant-canonical-test' } },
         include: { user: true, organization: true },
       }),
+      prisma.$queryRaw<Array<{ user_id: string }>>`
+        SELECT user_id
+        FROM auth.credential_states
+        WHERE user_id IN (
+          SELECT u.id
+          FROM public.users u
+          JOIN public.user_orgs uo ON uo."userId" = u.id
+          JOIN public.organizations o ON o.id = uo."organizationId"
+          WHERE o."tenantId" = 'tenant-canonical-test'
+        )
+      `,
     ]);
 
     if (!deal || deal.status !== 'DRAFT' || deal.tenantId !== 'tenant-canonical-test') {
@@ -33,16 +42,38 @@ async function main(): Promise<void> {
     }
 
     const roles = new Set(memberships.map((item) => item.role));
-    if (memberships.length !== 12 || roles.size !== 12) {
-      throw new Error(`Expected 12 canonical memberships and roles, got ${memberships.length}/${roles.size}.`);
+    if (memberships.length !== 12 || roles.size !== 12 || credentialStates.length !== 12) {
+      throw new Error(
+        `Expected 12 PostgreSQL memberships, roles and credential states, got ${memberships.length}/${roles.size}/${credentialStates.length}.`,
+      );
+    }
+
+    const deterministicIds = new Set(memberships.map((item) => item.userId));
+    for (const expectedId of [
+      'farmer-e2e',
+      'buyer-e2e',
+      'logistician-e2e',
+      'driver-e2e',
+      'surveyor-e2e',
+      'elevator-e2e',
+      'lab-e2e',
+      'accounting-e2e',
+      'compliance-e2e',
+      'arbitrator-e2e',
+      'operator-e2e',
+      'executive-e2e',
+    ]) {
+      if (!deterministicIds.has(expectedId)) throw new Error(`Missing deterministic persistent identity ${expectedId}`);
     }
 
     process.stdout.write(`${JSON.stringify({
       seeded: true,
+      identityMode: 'persistent-postgresql',
       dealId: deal.id,
       status: deal.status,
       tenantId: deal.tenantId,
       memberships: memberships.length,
+      credentialStates: credentialStates.length,
       roles: [...roles].sort(),
     })}\n`);
   } finally {

--- a/scripts/platform-v7-one-deal-e2e.sh
+++ b/scripts/platform-v7-one-deal-e2e.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ADMIN_URL="${ONE_DEAL_ADMIN_URL:?ONE_DEAL_ADMIN_URL is required}"
+AUTH_URL="${ONE_DEAL_AUTH_URL:?ONE_DEAL_AUTH_URL is required}"
 APP_URL="${ONE_DEAL_APP_URL:?ONE_DEAL_APP_URL is required}"
 EVIDENCE_LOG="${ONE_DEAL_EVIDENCE_LOG:-/tmp/platform-v7-one-deal-e2e.log}"
 DRIFT_SQL="${ONE_DEAL_DRIFT_SQL:-/tmp/platform-v7-one-deal-schema-drift.sql}"
@@ -15,16 +16,14 @@ if [[ -n "${DATABASE_URL:-}" && "$ADMIN_URL" == "$DATABASE_URL" ]]; then
   echo "Refusing one-deal E2E: admin URL equals ambient DATABASE_URL" >&2
   exit 2
 fi
-if [[ "$ADMIN_URL" =~ (^|[^a-z])(prod|production)([^a-z]|$) ]]; then
-  echo "Refusing one-deal E2E: admin URL appears production-like" >&2
-  exit 2
-fi
-if [[ "$APP_URL" =~ (^|[^a-z])(prod|production)([^a-z]|$) ]]; then
-  echo "Refusing one-deal E2E: application URL appears production-like" >&2
-  exit 2
-fi
-if [[ "$ADMIN_URL" == "$APP_URL" ]]; then
-  echo "Refusing one-deal E2E: admin and application URLs must differ" >&2
+for candidate in "$ADMIN_URL" "$AUTH_URL" "$APP_URL"; do
+  if [[ "$candidate" =~ (^|[^a-z])(prod|production)([^a-z]|$) ]]; then
+    echo "Refusing one-deal E2E: datasource appears production-like" >&2
+    exit 2
+  fi
+done
+if [[ "$ADMIN_URL" == "$AUTH_URL" || "$ADMIN_URL" == "$APP_URL" || "$AUTH_URL" == "$APP_URL" ]]; then
+  echo "Refusing one-deal E2E: admin, auth and application URLs must differ" >&2
   exit 2
 fi
 
@@ -62,10 +61,12 @@ fi
 echo "[one-deal] generating Prisma client from the migrated PostgreSQL schema"
 DATABASE_URL="$ADMIN_URL" pnpm --filter @pc/api exec prisma generate --schema prisma/schema.prisma
 
-echo "[one-deal] seeding canonical deal, memberships and DealParticipant assignments"
+echo "[one-deal] seeding canonical deal and persistent PostgreSQL identities"
 NODE_ENV=test \
 DATABASE_URL="$ADMIN_URL" \
 JWT_SECRET="${JWT_SECRET:?JWT_SECRET is required}" \
+AUTH_TOKEN_PEPPER="${AUTH_TOKEN_PEPPER:?AUTH_TOKEN_PEPPER is required}" \
+MFA_ENCRYPTION_KEY="${MFA_ENCRYPTION_KEY:?MFA_ENCRYPTION_KEY is required}" \
 BANK_HMAC_SECRET="${BANK_HMAC_SECRET:?BANK_HMAC_SECRET is required}" \
 SEED_CANONICAL_TEST_DEAL=true \
 pnpm --filter @pc/api exec ts-node test/one-deal/seed.ts
@@ -80,7 +81,7 @@ fi
 echo "[one-deal] applying canonical PostgreSQL RLS policies"
 psql "$ADMIN_URL" -X --set ON_ERROR_STOP=1 --file infra/sql/production-rls-policies.sql
 
-echo "[one-deal] creating non-superuser, non-bypass application principal"
+echo "[one-deal] creating restricted deal-execution principal"
 psql "$ADMIN_URL" -X --set ON_ERROR_STOP=1 <<'SQL'
 DO $one_deal_role$
 BEGIN
@@ -101,9 +102,40 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO on
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO one_deal_app;
 SQL
 
+echo "[one-deal] creating isolated trusted identity principal"
+psql "$ADMIN_URL" -X --set ON_ERROR_STOP=1 <<'SQL'
+DO $one_deal_auth_role$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'one_deal_auth') THEN
+    DROP OWNED BY one_deal_auth;
+    DROP ROLE one_deal_auth;
+  END IF;
+  CREATE ROLE one_deal_auth LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT BYPASSRLS PASSWORD 'ephemeral_one_deal_auth_only';
+END
+$one_deal_auth_role$;
+GRANT CONNECT ON DATABASE one_deal_e2e TO one_deal_auth;
+GRANT USAGE ON SCHEMA public, auth TO one_deal_auth;
+GRANT SELECT, UPDATE ON public.users, public.user_orgs TO one_deal_auth;
+GRANT SELECT ON public.organizations TO one_deal_auth;
+GRANT SELECT, INSERT, UPDATE ON
+  auth.login_throttles,
+  auth.credential_states,
+  auth.sessions,
+  auth.refresh_tokens,
+  auth.mfa_challenges
+TO one_deal_auth;
+GRANT SELECT, INSERT ON auth.audit_events TO one_deal_auth;
+SQL
+
 ROLE_PROOF="$(psql "$ADMIN_URL" -X -At --set ON_ERROR_STOP=1 -c "SELECT rolsuper::text || ':' || rolbypassrls::text FROM pg_roles WHERE rolname='one_deal_app'")"
 if [[ "$ROLE_PROOF" != "false:false" && "$ROLE_PROOF" != "f:f" ]]; then
-  echo "Application principal is not NOSUPERUSER NOBYPASSRLS: $ROLE_PROOF" >&2
+  echo "Deal application principal is not NOSUPERUSER NOBYPASSRLS: $ROLE_PROOF" >&2
+  exit 1
+fi
+AUTH_ROLE_PROOF="$(psql "$ADMIN_URL" -X -At --set ON_ERROR_STOP=1 -c "SELECT rolsuper::text || ':' || rolbypassrls::text || ':' || has_table_privilege('one_deal_auth','public.deals','SELECT')::text FROM pg_roles WHERE rolname='one_deal_auth'")"
+echo "[one-deal] auth principal proof super:bypass:deal-select = $AUTH_ROLE_PROOF"
+if [[ "$AUTH_ROLE_PROOF" != "false:true:false" && "$AUTH_ROLE_PROOF" != "f:t:f" ]]; then
+  echo "Auth principal privilege boundary is invalid: $AUTH_ROLE_PROOF" >&2
   exit 1
 fi
 
@@ -151,10 +183,13 @@ if [[ "$CROSS_TENANT_PARTICIPANTS" != "0" ]]; then
   exit 1
 fi
 
-echo "[one-deal] running exploitation suite through the restricted application principal"
+echo "[one-deal] running persistent-auth-backed exploitation suite"
 NODE_ENV=test \
 DATABASE_URL="$APP_URL" \
+ONE_DEAL_AUTH_URL="$AUTH_URL" \
 JWT_SECRET="$JWT_SECRET" \
+AUTH_TOKEN_PEPPER="$AUTH_TOKEN_PEPPER" \
+MFA_ENCRYPTION_KEY="$MFA_ENCRYPTION_KEY" \
 BANK_HMAC_SECRET="$BANK_HMAC_SECRET" \
 pnpm --filter @pc/api exec jest --runInBand --config test/one-deal/jest.config.json
 


### PR DESCRIPTION
## Суть

Устраняются два последних identity bypass в промышленном one-deal acceptance:

- canonical seed больше не использует process-local `AuthService.listUsers/updateUserRole/updateUserOrg`;
- 12-ролевой E2E больше не собирает `RequestUser` вручную.

## Реализация

- deterministic users, memberships, credential states и DealParticipant создаются напрямую в PostgreSQL;
- auth и deal execution используют разные datasource/principal в изолированной БД;
- все 12 actors проходят real login;
- BUYER, ACCOUNTING, COMPLIANCE_OFFICER и ARBITRATOR проходят TOTP MFA enrollment;
- access JWT содержит только opaque user/session identity;
- role/org/tenant/membership повторно извлекаются из PostgreSQL вторым AuthService instance;
- fresh AuthService instance повторно подтверждает все 12 sessions;
- перед reserve/release проверяется свежесть MFA по действующему финансовому порогу;
- membership role change отзывает существующую session;
- сохранены 19 команд, RLS, optimistic concurrency, rollback, signed bank callbacks, replay и reconciliation.

## Граница

Изолированный PostgreSQL acceptance. Production migration/deployment, live банк, ФГИС, ЭДО и ЕСИА не заявляются.

Closes #2281