### PR TITLE
P0 runtime separation of auth and deal PostgreSQL principals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,16 @@ NEXT_PUBLIC_API_URL=http://localhost:4000/api
 ACCESS_TOKEN_SECRET=change-me
 REFRESH_TOKEN_SECRET=change-me
 
+# PostgreSQL runtime principals
+# Both URLs may target the same PostgreSQL database, but MUST use different roles.
+# DATABASE_URL: deal/runtime role, NOSUPERUSER + NOBYPASSRLS + not table owner.
+# AUTH_DATABASE_URL: identity role, NOSUPERUSER + BYPASSRLS, with no privileges on public.deals.
+# Production startup fails closed when URLs are missing, identical, or role boundaries are unsafe.
+DATABASE_URL=
+AUTH_DATABASE_URL=
+# Optional outside production. Production always enforces the boundary.
+DB_PRINCIPAL_BOUNDARY_ENFORCED=false
+
 # =====================================================================
 # Security — REQUIRED in production (the API fails closed at startup if
 # any of these is unset or shorter than 32 chars; there is NO built-in
@@ -13,6 +23,8 @@ REFRESH_TOKEN_SECRET=change-me
 # Generate with: openssl rand -hex 32
 # =====================================================================
 JWT_SECRET=                       # signs/verifies access tokens (>= 32 chars)
+AUTH_TOKEN_PEPPER=                # HMAC pepper for refresh/challenge/backup-code hashes
+MFA_ENCRYPTION_KEY=               # encrypts TOTP secrets with AES-256-GCM
 BANK_HMAC_SECRET=                 # verifies Safe-Deals bank callbacks (>= 32 chars)
 FGIS_WEBHOOK_SECRET=              # verifies ФГИС Зерно webhooks (>= 32 chars)
 EDO_WEBHOOK_SECRET=               # verifies ЭДО (Диадок/СБИС/СберКорус) webhooks (>= 32 chars)

--- a/apps/api/src/common/prisma/database-principal-boundary.spec.ts
+++ b/apps/api/src/common/prisma/database-principal-boundary.spec.ts
@@ -1,0 +1,109 @@
+import {
+  DatabasePrincipalSnapshot,
+  evaluateAuthPrincipalBoundary,
+  evaluateDealPrincipalBoundary,
+  resolveAuthDatabaseUrl,
+  shouldEnforceDatabasePrincipalBoundary,
+} from './database-principal-boundary';
+
+const safeSnapshot: DatabasePrincipalSnapshot = {
+  currentUser: 'safe',
+  superuser: false,
+  bypassRls: false,
+  ownsDeals: false,
+  dealsRlsEnabled: true,
+  dealsForceRls: true,
+  rowSecurity: 'on',
+  dealSelect: true,
+  dealInsert: true,
+  dealUpdate: true,
+  dealDelete: true,
+  authSchemaUsage: true,
+  usersSelect: true,
+  usersInsert: true,
+  usersUpdate: true,
+  userOrgsSelect: true,
+  userOrgsInsert: true,
+  userOrgsUpdate: true,
+  organizationsSelect: true,
+  organizationsInsert: true,
+  organizationsUpdate: true,
+  authTablesReadWrite: true,
+  authAuditReadInsert: true,
+};
+
+describe('database principal boundaries', () => {
+  it('accepts a least-privilege FORCE-RLS deal principal', () => {
+    expect(evaluateDealPrincipalBoundary(safeSnapshot)).toEqual([]);
+  });
+
+  it('rejects a deal principal that owns tables or bypasses RLS', () => {
+    expect(evaluateDealPrincipalBoundary({
+      ...safeSnapshot,
+      superuser: true,
+      bypassRls: true,
+      ownsDeals: true,
+      dealsForceRls: false,
+      rowSecurity: 'off',
+    })).toEqual(expect.arrayContaining([
+      expect.stringMatching(/SUPERUSER/),
+      expect.stringMatching(/BYPASSRLS/),
+      expect.stringMatching(/must not own/),
+      expect.stringMatching(/FORCE RLS/),
+      expect.stringMatching(/row_security/),
+    ]));
+  });
+
+  it('accepts an auth principal only when it cannot access deals', () => {
+    const authSnapshot: DatabasePrincipalSnapshot = {
+      ...safeSnapshot,
+      currentUser: 'auth_runtime',
+      bypassRls: true,
+      dealSelect: false,
+      dealInsert: false,
+      dealUpdate: false,
+      dealDelete: false,
+    };
+    expect(evaluateAuthPrincipalBoundary(authSnapshot)).toEqual([]);
+  });
+
+  it('rejects an auth principal with deal privileges or incomplete identity grants', () => {
+    expect(evaluateAuthPrincipalBoundary({
+      ...safeSnapshot,
+      bypassRls: true,
+      dealSelect: true,
+      usersInsert: false,
+      authTablesReadWrite: false,
+      authAuditReadInsert: false,
+    })).toEqual(expect.arrayContaining([
+      expect.stringMatching(/no privileges on public\.deals/),
+      expect.stringMatching(/public\.users/),
+      expect.stringMatching(/persistent auth state/),
+      expect.stringMatching(/auth\.audit_events/),
+    ]));
+  });
+
+  it('requires separate auth and deal URLs in production', () => {
+    expect(() => resolveAuthDatabaseUrl({
+      NODE_ENV: 'production',
+      DATABASE_URL: 'postgresql://same@db/platform',
+      AUTH_DATABASE_URL: 'postgresql://same@db/platform',
+    })).toThrow(/different PostgreSQL principal/);
+
+    expect(resolveAuthDatabaseUrl({
+      NODE_ENV: 'production',
+      DATABASE_URL: 'postgresql://deal@db/platform',
+      AUTH_DATABASE_URL: 'postgresql://auth@db/platform',
+    })).toBe('postgresql://auth@db/platform');
+  });
+
+  it('allows non-production fallback but enforces boundaries when explicitly requested', () => {
+    expect(resolveAuthDatabaseUrl({ NODE_ENV: 'test', DATABASE_URL: 'postgresql://dev@db/platform' }))
+      .toBe('postgresql://dev@db/platform');
+    expect(shouldEnforceDatabasePrincipalBoundary({ NODE_ENV: 'test' })).toBe(false);
+    expect(shouldEnforceDatabasePrincipalBoundary({
+      NODE_ENV: 'test',
+      DB_PRINCIPAL_BOUNDARY_ENFORCED: 'true',
+    })).toBe(true);
+  });
+});

--- a/apps/api/src/common/prisma/database-principal-boundary.spec.ts
+++ b/apps/api/src/common/prisma/database-principal-boundary.spec.ts
@@ -10,6 +10,8 @@ const safeSnapshot: DatabasePrincipalSnapshot = {
   currentUser: 'safe',
   superuser: false,
   bypassRls: false,
+  roleInherit: false,
+  hasRoleMemberships: false,
   ownsDeals: false,
   dealsRlsEnabled: true,
   dealsForceRls: true,
@@ -51,6 +53,29 @@ describe('database principal boundaries', () => {
       expect.stringMatching(/must not own/),
       expect.stringMatching(/FORCE RLS/),
       expect.stringMatching(/row_security/),
+    ]));
+  });
+
+  it('rejects inherited PostgreSQL authority for both runtime principals', () => {
+    const inherited = {
+      ...safeSnapshot,
+      roleInherit: true,
+      hasRoleMemberships: true,
+    };
+    expect(evaluateDealPrincipalBoundary(inherited)).toEqual(expect.arrayContaining([
+      expect.stringMatching(/NOINHERIT/),
+      expect.stringMatching(/must not belong/),
+    ]));
+    expect(evaluateAuthPrincipalBoundary({
+      ...inherited,
+      bypassRls: true,
+      dealSelect: false,
+      dealInsert: false,
+      dealUpdate: false,
+      dealDelete: false,
+    })).toEqual(expect.arrayContaining([
+      expect.stringMatching(/NOINHERIT/),
+      expect.stringMatching(/must not belong/),
     ]));
   });
 

--- a/apps/api/src/common/prisma/database-principal-boundary.ts
+++ b/apps/api/src/common/prisma/database-principal-boundary.ts
@@ -2,6 +2,8 @@ export type DatabasePrincipalSnapshot = {
   currentUser: string;
   superuser: boolean;
   bypassRls: boolean;
+  roleInherit: boolean;
+  hasRoleMemberships: boolean;
   ownsDeals: boolean;
   dealsRlsEnabled: boolean;
   dealsForceRls: boolean;
@@ -60,8 +62,15 @@ export function resolveAuthDatabaseUrl(
   return authUrl || dealUrl || undefined;
 }
 
-export function evaluateDealPrincipalBoundary(snapshot: DatabasePrincipalSnapshot): string[] {
+function evaluateRoleIsolation(snapshot: DatabasePrincipalSnapshot, label: 'deal' | 'auth'): string[] {
   const errors: string[] = [];
+  if (snapshot.roleInherit) errors.push(`${label} principal must be NOINHERIT`);
+  if (snapshot.hasRoleMemberships) errors.push(`${label} principal must not belong to other PostgreSQL roles`);
+  return errors;
+}
+
+export function evaluateDealPrincipalBoundary(snapshot: DatabasePrincipalSnapshot): string[] {
+  const errors: string[] = [...evaluateRoleIsolation(snapshot, 'deal')];
   if (snapshot.superuser) errors.push('deal principal must not be SUPERUSER');
   if (snapshot.bypassRls) errors.push('deal principal must not have BYPASSRLS');
   if (snapshot.ownsDeals) errors.push('deal principal must not own public.deals');
@@ -75,7 +84,7 @@ export function evaluateDealPrincipalBoundary(snapshot: DatabasePrincipalSnapsho
 }
 
 export function evaluateAuthPrincipalBoundary(snapshot: DatabasePrincipalSnapshot): string[] {
-  const errors: string[] = [];
+  const errors: string[] = [...evaluateRoleIsolation(snapshot, 'auth')];
   if (snapshot.superuser) errors.push('auth principal must not be SUPERUSER');
   if (!snapshot.bypassRls) errors.push('auth principal must have BYPASSRLS for identity reads before deal context');
   if (snapshot.ownsDeals) errors.push('auth principal must not own public.deals');

--- a/apps/api/src/common/prisma/database-principal-boundary.ts
+++ b/apps/api/src/common/prisma/database-principal-boundary.ts
@@ -1,0 +1,102 @@
+export type DatabasePrincipalSnapshot = {
+  currentUser: string;
+  superuser: boolean;
+  bypassRls: boolean;
+  ownsDeals: boolean;
+  dealsRlsEnabled: boolean;
+  dealsForceRls: boolean;
+  rowSecurity: string;
+  dealSelect: boolean;
+  dealInsert: boolean;
+  dealUpdate: boolean;
+  dealDelete: boolean;
+  authSchemaUsage: boolean;
+  usersSelect: boolean;
+  usersInsert: boolean;
+  usersUpdate: boolean;
+  userOrgsSelect: boolean;
+  userOrgsInsert: boolean;
+  userOrgsUpdate: boolean;
+  organizationsSelect: boolean;
+  organizationsInsert: boolean;
+  organizationsUpdate: boolean;
+  authTablesReadWrite: boolean;
+  authAuditReadInsert: boolean;
+};
+
+export type DatabaseEnvironment = Record<string, string | undefined>;
+
+function enabled(value?: string): boolean {
+  return String(value ?? '').trim().toLowerCase() === 'true';
+}
+
+export function isProductionEnvironment(environment: DatabaseEnvironment = process.env): boolean {
+  return String(environment.NODE_ENV ?? '').trim().toLowerCase() === 'production';
+}
+
+export function shouldEnforceDatabasePrincipalBoundary(
+  environment: DatabaseEnvironment = process.env,
+): boolean {
+  return isProductionEnvironment(environment) || enabled(environment.DB_PRINCIPAL_BOUNDARY_ENFORCED);
+}
+
+export function resolveAuthDatabaseUrl(
+  environment: DatabaseEnvironment = process.env,
+): string | undefined {
+  const authUrl = String(environment.AUTH_DATABASE_URL ?? '').trim();
+  const dealUrl = String(environment.DATABASE_URL ?? '').trim();
+  const production = isProductionEnvironment(environment);
+
+  if (production && !dealUrl) {
+    throw new Error('DATABASE_URL is required in production.');
+  }
+  if (production && !authUrl) {
+    throw new Error('AUTH_DATABASE_URL is required in production.');
+  }
+  if (production && authUrl === dealUrl) {
+    throw new Error('AUTH_DATABASE_URL must use a different PostgreSQL principal than DATABASE_URL.');
+  }
+
+  return authUrl || dealUrl || undefined;
+}
+
+export function evaluateDealPrincipalBoundary(snapshot: DatabasePrincipalSnapshot): string[] {
+  const errors: string[] = [];
+  if (snapshot.superuser) errors.push('deal principal must not be SUPERUSER');
+  if (snapshot.bypassRls) errors.push('deal principal must not have BYPASSRLS');
+  if (snapshot.ownsDeals) errors.push('deal principal must not own public.deals');
+  if (!snapshot.dealsRlsEnabled) errors.push('public.deals must have RLS enabled');
+  if (!snapshot.dealsForceRls) errors.push('public.deals must have FORCE RLS enabled');
+  if (snapshot.rowSecurity.toLowerCase() !== 'on') errors.push('row_security must be on');
+  if (!snapshot.dealSelect || !snapshot.dealInsert || !snapshot.dealUpdate || !snapshot.dealDelete) {
+    errors.push('deal principal requires CRUD grants on public.deals, constrained by FORCE RLS');
+  }
+  return errors;
+}
+
+export function evaluateAuthPrincipalBoundary(snapshot: DatabasePrincipalSnapshot): string[] {
+  const errors: string[] = [];
+  if (snapshot.superuser) errors.push('auth principal must not be SUPERUSER');
+  if (!snapshot.bypassRls) errors.push('auth principal must have BYPASSRLS for identity reads before deal context');
+  if (snapshot.ownsDeals) errors.push('auth principal must not own public.deals');
+  if (snapshot.dealSelect || snapshot.dealInsert || snapshot.dealUpdate || snapshot.dealDelete) {
+    errors.push('auth principal must have no privileges on public.deals');
+  }
+  if (!snapshot.authSchemaUsage) errors.push('auth principal requires USAGE on schema auth');
+  if (!snapshot.usersSelect || !snapshot.usersInsert || !snapshot.usersUpdate) {
+    errors.push('auth principal requires SELECT, INSERT and UPDATE on public.users');
+  }
+  if (!snapshot.userOrgsSelect || !snapshot.userOrgsInsert || !snapshot.userOrgsUpdate) {
+    errors.push('auth principal requires SELECT, INSERT and UPDATE on public.user_orgs');
+  }
+  if (!snapshot.organizationsSelect || !snapshot.organizationsInsert || !snapshot.organizationsUpdate) {
+    errors.push('auth principal requires SELECT, INSERT and UPDATE on public.organizations');
+  }
+  if (!snapshot.authTablesReadWrite) {
+    errors.push('auth principal requires read/write privileges on persistent auth state tables');
+  }
+  if (!snapshot.authAuditReadInsert) {
+    errors.push('auth principal requires SELECT and INSERT on auth.audit_events');
+  }
+  return errors;
+}

--- a/apps/api/src/common/prisma/database-principal-inspection.ts
+++ b/apps/api/src/common/prisma/database-principal-inspection.ts
@@ -1,0 +1,114 @@
+import { Prisma } from '@prisma/client';
+import type { DatabasePrincipalSnapshot } from './database-principal-boundary';
+
+export type PrincipalInspectionClient = {
+  $queryRaw<T = unknown>(query: Prisma.Sql): Promise<T>;
+};
+
+type PrincipalInspectionRow = {
+  current_user: string;
+  superuser: boolean;
+  bypass_rls: boolean;
+  owns_deals: boolean;
+  deals_rls_enabled: boolean;
+  deals_force_rls: boolean;
+  row_security: string;
+  deal_select: boolean;
+  deal_insert: boolean;
+  deal_update: boolean;
+  deal_delete: boolean;
+  auth_schema_usage: boolean;
+  users_select: boolean;
+  users_insert: boolean;
+  users_update: boolean;
+  user_orgs_select: boolean;
+  user_orgs_insert: boolean;
+  user_orgs_update: boolean;
+  organizations_select: boolean;
+  organizations_insert: boolean;
+  organizations_update: boolean;
+  auth_tables_read_write: boolean;
+  auth_audit_read_insert: boolean;
+};
+
+export async function inspectDatabasePrincipal(
+  client: PrincipalInspectionClient,
+): Promise<DatabasePrincipalSnapshot> {
+  const rows = await client.$queryRaw<PrincipalInspectionRow[]>(Prisma.sql`
+    SELECT
+      current_user,
+      roles.rolsuper AS superuser,
+      roles.rolbypassrls AS bypass_rls,
+      deals.relowner = roles.oid AS owns_deals,
+      deals.relrowsecurity AS deals_rls_enabled,
+      deals.relforcerowsecurity AS deals_force_rls,
+      current_setting('row_security') AS row_security,
+      has_table_privilege(current_user, 'public.deals', 'SELECT') AS deal_select,
+      has_table_privilege(current_user, 'public.deals', 'INSERT') AS deal_insert,
+      has_table_privilege(current_user, 'public.deals', 'UPDATE') AS deal_update,
+      has_table_privilege(current_user, 'public.deals', 'DELETE') AS deal_delete,
+      has_schema_privilege(current_user, 'auth', 'USAGE') AS auth_schema_usage,
+      has_table_privilege(current_user, 'public.users', 'SELECT') AS users_select,
+      has_table_privilege(current_user, 'public.users', 'INSERT') AS users_insert,
+      has_table_privilege(current_user, 'public.users', 'UPDATE') AS users_update,
+      has_table_privilege(current_user, 'public.user_orgs', 'SELECT') AS user_orgs_select,
+      has_table_privilege(current_user, 'public.user_orgs', 'INSERT') AS user_orgs_insert,
+      has_table_privilege(current_user, 'public.user_orgs', 'UPDATE') AS user_orgs_update,
+      has_table_privilege(current_user, 'public.organizations', 'SELECT') AS organizations_select,
+      has_table_privilege(current_user, 'public.organizations', 'INSERT') AS organizations_insert,
+      has_table_privilege(current_user, 'public.organizations', 'UPDATE') AS organizations_update,
+      (
+        has_table_privilege(current_user, 'auth.login_throttles', 'SELECT')
+        AND has_table_privilege(current_user, 'auth.login_throttles', 'INSERT')
+        AND has_table_privilege(current_user, 'auth.login_throttles', 'UPDATE')
+        AND has_table_privilege(current_user, 'auth.credential_states', 'SELECT')
+        AND has_table_privilege(current_user, 'auth.credential_states', 'INSERT')
+        AND has_table_privilege(current_user, 'auth.credential_states', 'UPDATE')
+        AND has_table_privilege(current_user, 'auth.sessions', 'SELECT')
+        AND has_table_privilege(current_user, 'auth.sessions', 'INSERT')
+        AND has_table_privilege(current_user, 'auth.sessions', 'UPDATE')
+        AND has_table_privilege(current_user, 'auth.refresh_tokens', 'SELECT')
+        AND has_table_privilege(current_user, 'auth.refresh_tokens', 'INSERT')
+        AND has_table_privilege(current_user, 'auth.refresh_tokens', 'UPDATE')
+        AND has_table_privilege(current_user, 'auth.mfa_challenges', 'SELECT')
+        AND has_table_privilege(current_user, 'auth.mfa_challenges', 'INSERT')
+        AND has_table_privilege(current_user, 'auth.mfa_challenges', 'UPDATE')
+      ) AS auth_tables_read_write,
+      (
+        has_table_privilege(current_user, 'auth.audit_events', 'SELECT')
+        AND has_table_privilege(current_user, 'auth.audit_events', 'INSERT')
+      ) AS auth_audit_read_insert
+    FROM pg_roles roles
+    JOIN pg_class deals ON deals.oid = 'public.deals'::regclass
+    WHERE roles.rolname = current_user
+  `);
+
+  const row = rows[0];
+  if (!row) throw new Error('Unable to inspect current PostgreSQL principal.');
+
+  return {
+    currentUser: row.current_user,
+    superuser: row.superuser,
+    bypassRls: row.bypass_rls,
+    ownsDeals: row.owns_deals,
+    dealsRlsEnabled: row.deals_rls_enabled,
+    dealsForceRls: row.deals_force_rls,
+    rowSecurity: row.row_security,
+    dealSelect: row.deal_select,
+    dealInsert: row.deal_insert,
+    dealUpdate: row.deal_update,
+    dealDelete: row.deal_delete,
+    authSchemaUsage: row.auth_schema_usage,
+    usersSelect: row.users_select,
+    usersInsert: row.users_insert,
+    usersUpdate: row.users_update,
+    userOrgsSelect: row.user_orgs_select,
+    userOrgsInsert: row.user_orgs_insert,
+    userOrgsUpdate: row.user_orgs_update,
+    organizationsSelect: row.organizations_select,
+    organizationsInsert: row.organizations_insert,
+    organizationsUpdate: row.organizations_update,
+    authTablesReadWrite: row.auth_tables_read_write,
+    authAuditReadInsert: row.auth_audit_read_insert,
+  };
+}

--- a/apps/api/src/common/prisma/database-principal-inspection.ts
+++ b/apps/api/src/common/prisma/database-principal-inspection.ts
@@ -5,7 +5,9 @@ export type PrincipalInspectionClient = {
   $queryRaw<T = unknown>(query: Prisma.Sql): Promise<T>;
 };
 
-type PrincipalInspectionRow = {
+export type PrincipalInspectionScope = 'deal' | 'auth';
+
+type DealInspectionRow = {
   current_user: string;
   superuser: boolean;
   bypass_rls: boolean;
@@ -17,6 +19,9 @@ type PrincipalInspectionRow = {
   deal_insert: boolean;
   deal_update: boolean;
   deal_delete: boolean;
+};
+
+type AuthInspectionRow = DealInspectionRow & {
   auth_schema_usage: boolean;
   users_select: boolean;
   users_insert: boolean;
@@ -31,10 +36,63 @@ type PrincipalInspectionRow = {
   auth_audit_read_insert: boolean;
 };
 
-export async function inspectDatabasePrincipal(
+function baseSnapshot(row: DealInspectionRow): DatabasePrincipalSnapshot {
+  return {
+    currentUser: row.current_user,
+    superuser: row.superuser,
+    bypassRls: row.bypass_rls,
+    ownsDeals: row.owns_deals,
+    dealsRlsEnabled: row.deals_rls_enabled,
+    dealsForceRls: row.deals_force_rls,
+    rowSecurity: row.row_security,
+    dealSelect: row.deal_select,
+    dealInsert: row.deal_insert,
+    dealUpdate: row.deal_update,
+    dealDelete: row.deal_delete,
+    authSchemaUsage: false,
+    usersSelect: false,
+    usersInsert: false,
+    usersUpdate: false,
+    userOrgsSelect: false,
+    userOrgsInsert: false,
+    userOrgsUpdate: false,
+    organizationsSelect: false,
+    organizationsInsert: false,
+    organizationsUpdate: false,
+    authTablesReadWrite: false,
+    authAuditReadInsert: false,
+  };
+}
+
+async function inspectDealPrincipal(
   client: PrincipalInspectionClient,
 ): Promise<DatabasePrincipalSnapshot> {
-  const rows = await client.$queryRaw<PrincipalInspectionRow[]>(Prisma.sql`
+  const rows = await client.$queryRaw<DealInspectionRow[]>(Prisma.sql`
+    SELECT
+      current_user,
+      roles.rolsuper AS superuser,
+      roles.rolbypassrls AS bypass_rls,
+      deals.relowner = roles.oid AS owns_deals,
+      deals.relrowsecurity AS deals_rls_enabled,
+      deals.relforcerowsecurity AS deals_force_rls,
+      current_setting('row_security') AS row_security,
+      has_table_privilege(current_user, 'public.deals', 'SELECT') AS deal_select,
+      has_table_privilege(current_user, 'public.deals', 'INSERT') AS deal_insert,
+      has_table_privilege(current_user, 'public.deals', 'UPDATE') AS deal_update,
+      has_table_privilege(current_user, 'public.deals', 'DELETE') AS deal_delete
+    FROM pg_roles roles
+    JOIN pg_class deals ON deals.oid = 'public.deals'::regclass
+    WHERE roles.rolname = current_user
+  `);
+  const row = rows[0];
+  if (!row) throw new Error('Unable to inspect current deal PostgreSQL principal.');
+  return baseSnapshot(row);
+}
+
+async function inspectAuthPrincipal(
+  client: PrincipalInspectionClient,
+): Promise<DatabasePrincipalSnapshot> {
+  const rows = await client.$queryRaw<AuthInspectionRow[]>(Prisma.sql`
     SELECT
       current_user,
       roles.rolsuper AS superuser,
@@ -84,20 +142,9 @@ export async function inspectDatabasePrincipal(
   `);
 
   const row = rows[0];
-  if (!row) throw new Error('Unable to inspect current PostgreSQL principal.');
-
+  if (!row) throw new Error('Unable to inspect current auth PostgreSQL principal.');
   return {
-    currentUser: row.current_user,
-    superuser: row.superuser,
-    bypassRls: row.bypass_rls,
-    ownsDeals: row.owns_deals,
-    dealsRlsEnabled: row.deals_rls_enabled,
-    dealsForceRls: row.deals_force_rls,
-    rowSecurity: row.row_security,
-    dealSelect: row.deal_select,
-    dealInsert: row.deal_insert,
-    dealUpdate: row.deal_update,
-    dealDelete: row.deal_delete,
+    ...baseSnapshot(row),
     authSchemaUsage: row.auth_schema_usage,
     usersSelect: row.users_select,
     usersInsert: row.users_insert,
@@ -111,4 +158,13 @@ export async function inspectDatabasePrincipal(
     authTablesReadWrite: row.auth_tables_read_write,
     authAuditReadInsert: row.auth_audit_read_insert,
   };
+}
+
+export async function inspectDatabasePrincipal(
+  client: PrincipalInspectionClient,
+  scope: PrincipalInspectionScope,
+): Promise<DatabasePrincipalSnapshot> {
+  return scope === 'auth'
+    ? inspectAuthPrincipal(client)
+    : inspectDealPrincipal(client);
 }

--- a/apps/api/src/common/prisma/database-principal-inspection.ts
+++ b/apps/api/src/common/prisma/database-principal-inspection.ts
@@ -11,6 +11,8 @@ type DealInspectionRow = {
   current_user: string;
   superuser: boolean;
   bypass_rls: boolean;
+  role_inherit: boolean;
+  has_role_memberships: boolean;
   owns_deals: boolean;
   deals_rls_enabled: boolean;
   deals_force_rls: boolean;
@@ -41,6 +43,8 @@ function baseSnapshot(row: DealInspectionRow): DatabasePrincipalSnapshot {
     currentUser: row.current_user,
     superuser: row.superuser,
     bypassRls: row.bypass_rls,
+    roleInherit: row.role_inherit,
+    hasRoleMemberships: row.has_role_memberships,
     ownsDeals: row.owns_deals,
     dealsRlsEnabled: row.deals_rls_enabled,
     dealsForceRls: row.deals_force_rls,
@@ -72,6 +76,8 @@ async function inspectDealPrincipal(
       current_user,
       roles.rolsuper AS superuser,
       roles.rolbypassrls AS bypass_rls,
+      roles.rolinherit AS role_inherit,
+      EXISTS (SELECT 1 FROM pg_auth_members memberships WHERE memberships.member = roles.oid) AS has_role_memberships,
       deals.relowner = roles.oid AS owns_deals,
       deals.relrowsecurity AS deals_rls_enabled,
       deals.relforcerowsecurity AS deals_force_rls,
@@ -97,6 +103,8 @@ async function inspectAuthPrincipal(
       current_user,
       roles.rolsuper AS superuser,
       roles.rolbypassrls AS bypass_rls,
+      roles.rolinherit AS role_inherit,
+      EXISTS (SELECT 1 FROM pg_auth_members memberships WHERE memberships.member = roles.oid) AS has_role_memberships,
       deals.relowner = roles.oid AS owns_deals,
       deals.relrowsecurity AS deals_rls_enabled,
       deals.relforcerowsecurity AS deals_force_rls,

--- a/apps/api/src/common/prisma/prisma.service.ts
+++ b/apps/api/src/common/prisma/prisma.service.ts
@@ -15,7 +15,7 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
     try {
       await this.$connect();
       if (strict) {
-        const snapshot = await inspectDatabasePrincipal(this);
+        const snapshot = await inspectDatabasePrincipal(this, 'deal');
         const errors = evaluateDealPrincipalBoundary(snapshot);
         if (errors.length > 0) {
           throw new Error(

--- a/apps/api/src/common/prisma/prisma.service.ts
+++ b/apps/api/src/common/prisma/prisma.service.ts
@@ -1,20 +1,38 @@
 import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
+import {
+  evaluateDealPrincipalBoundary,
+  shouldEnforceDatabasePrincipalBoundary,
+} from './database-principal-boundary';
+import { inspectDatabasePrincipal } from './database-principal-inspection';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(PrismaService.name);
 
-  async onModuleInit() {
+  async onModuleInit(): Promise<void> {
+    const strict = shouldEnforceDatabasePrincipalBoundary();
     try {
       await this.$connect();
-      this.logger.log('Database connected');
-    } catch (err) {
-      this.logger.warn(`Database unavailable — running in degraded mode: ${(err as Error).message}`);
+      if (strict) {
+        const snapshot = await inspectDatabasePrincipal(this);
+        const errors = evaluateDealPrincipalBoundary(snapshot);
+        if (errors.length > 0) {
+          throw new Error(
+            `Deal PostgreSQL principal ${snapshot.currentUser} violates the production boundary: ${errors.join('; ')}`,
+          );
+        }
+        this.logger.log(`Deal database principal verified: ${snapshot.currentUser}`);
+      } else {
+        this.logger.log('Database connected');
+      }
+    } catch (error) {
+      if (strict) throw error;
+      this.logger.warn(`Database unavailable — running in degraded mode: ${(error as Error).message}`);
     }
   }
 
-  async onModuleDestroy() {
+  async onModuleDestroy(): Promise<void> {
     await this.$disconnect();
   }
 }

--- a/apps/api/src/modules/auth/auth-prisma.service.ts
+++ b/apps/api/src/modules/auth/auth-prisma.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../../common/prisma/prisma.service';
 import {
   evaluateAuthPrincipalBoundary,
   resolveAuthDatabaseUrl,
@@ -8,15 +8,15 @@ import {
 import { inspectDatabasePrincipal } from '../../common/prisma/database-principal-inspection';
 
 @Injectable()
-export class AuthPrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
-  private readonly logger = new Logger(AuthPrismaService.name);
+export class AuthPrismaService extends PrismaService {
+  private readonly authLogger = new Logger(AuthPrismaService.name);
 
   constructor() {
     const url = resolveAuthDatabaseUrl();
     super(url ? { datasources: { db: { url } } } : undefined);
   }
 
-  async onModuleInit(): Promise<void> {
+  override async onModuleInit(): Promise<void> {
     const strict = shouldEnforceDatabasePrincipalBoundary();
     try {
       await this.$connect();
@@ -28,17 +28,17 @@ export class AuthPrismaService extends PrismaClient implements OnModuleInit, OnM
             `Auth PostgreSQL principal ${snapshot.currentUser} violates the production boundary: ${errors.join('; ')}`,
           );
         }
-        this.logger.log(`Auth database principal verified: ${snapshot.currentUser}`);
+        this.authLogger.log(`Auth database principal verified: ${snapshot.currentUser}`);
       } else {
-        this.logger.log('Auth database connected');
+        this.authLogger.log('Auth database connected');
       }
     } catch (error) {
       if (strict) throw error;
-      this.logger.warn(`Auth database unavailable in non-production mode: ${(error as Error).message}`);
+      this.authLogger.warn(`Auth database unavailable in non-production mode: ${(error as Error).message}`);
     }
   }
 
-  async onModuleDestroy(): Promise<void> {
+  override async onModuleDestroy(): Promise<void> {
     await this.$disconnect();
   }
 }

--- a/apps/api/src/modules/auth/auth-prisma.service.ts
+++ b/apps/api/src/modules/auth/auth-prisma.service.ts
@@ -21,7 +21,7 @@ export class AuthPrismaService extends PrismaService {
     try {
       await this.$connect();
       if (strict) {
-        const snapshot = await inspectDatabasePrincipal(this);
+        const snapshot = await inspectDatabasePrincipal(this, 'auth');
         const errors = evaluateAuthPrincipalBoundary(snapshot);
         if (errors.length > 0) {
           throw new Error(

--- a/apps/api/src/modules/auth/auth-prisma.service.ts
+++ b/apps/api/src/modules/auth/auth-prisma.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import {
+  evaluateAuthPrincipalBoundary,
+  resolveAuthDatabaseUrl,
+  shouldEnforceDatabasePrincipalBoundary,
+} from '../../common/prisma/database-principal-boundary';
+import { inspectDatabasePrincipal } from '../../common/prisma/database-principal-inspection';
+
+@Injectable()
+export class AuthPrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(AuthPrismaService.name);
+
+  constructor() {
+    const url = resolveAuthDatabaseUrl();
+    super(url ? { datasources: { db: { url } } } : undefined);
+  }
+
+  async onModuleInit(): Promise<void> {
+    const strict = shouldEnforceDatabasePrincipalBoundary();
+    try {
+      await this.$connect();
+      if (strict) {
+        const snapshot = await inspectDatabasePrincipal(this);
+        const errors = evaluateAuthPrincipalBoundary(snapshot);
+        if (errors.length > 0) {
+          throw new Error(
+            `Auth PostgreSQL principal ${snapshot.currentUser} violates the production boundary: ${errors.join('; ')}`,
+          );
+        }
+        this.logger.log(`Auth database principal verified: ${snapshot.currentUser}`);
+      } else {
+        this.logger.log('Auth database connected');
+      }
+    } catch (error) {
+      if (strict) throw error;
+      this.logger.warn(`Auth database unavailable in non-production mode: ${(error as Error).message}`);
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.$disconnect();
+  }
+}

--- a/apps/api/src/modules/auth/auth.module.spec.ts
+++ b/apps/api/src/modules/auth/auth.module.spec.ts
@@ -1,0 +1,20 @@
+import { Test } from '@nestjs/testing';
+import { AuthModule } from './auth.module';
+import { AuthPrismaService } from './auth-prisma.service';
+import { PersistentAuthRepository } from './persistent-auth.repository';
+
+jest.setTimeout(10_000);
+
+describe('AuthModule database wiring', () => {
+  it('binds PersistentAuthRepository exclusively to AuthPrismaService', async () => {
+    const moduleRef = await Test.createTestingModule({ imports: [AuthModule] }).compile();
+    try {
+      const repository = moduleRef.get(PersistentAuthRepository);
+      const authPrisma = moduleRef.get(AuthPrismaService);
+      expect(repository.prisma).toBe(authPrisma);
+      expect(repository.prisma).toBeInstanceOf(AuthPrismaService);
+    } finally {
+      await moduleRef.close();
+    }
+  });
+});

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -1,13 +1,22 @@
 import { Module } from '@nestjs/common';
 import { BusinessReputationModule } from '../business-reputation/business-reputation.module';
 import { AuthController } from './auth.controller';
+import { AuthPrismaService } from './auth-prisma.service';
 import { AuthService } from './auth.service';
 import { PersistentAuthRepository } from './persistent-auth.repository';
 
 @Module({
   imports: [BusinessReputationModule],
   controllers: [AuthController],
-  providers: [PersistentAuthRepository, AuthService],
-  exports: [AuthService, PersistentAuthRepository],
+  providers: [
+    AuthPrismaService,
+    {
+      provide: PersistentAuthRepository,
+      inject: [AuthPrismaService],
+      useFactory: (prisma: AuthPrismaService) => new PersistentAuthRepository(prisma),
+    },
+    AuthService,
+  ],
+  exports: [AuthService, PersistentAuthRepository, AuthPrismaService],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/mfa/mfa.module.ts
+++ b/apps/api/src/modules/mfa/mfa.module.ts
@@ -1,12 +1,10 @@
 import { Module } from '@nestjs/common';
-import { AuthModule } from '../auth/auth.module';
-import { MfaController } from './mfa.controller';
 import { MfaService } from './mfa.service';
+import { MfaController } from './mfa.controller';
 
 @Module({
-  imports: [AuthModule],
-  controllers: [MfaController],
   providers: [MfaService],
+  controllers: [MfaController],
   exports: [MfaService],
 })
 export class MfaModule {}

--- a/apps/api/src/modules/mfa/mfa.module.ts
+++ b/apps/api/src/modules/mfa/mfa.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
-import { MfaService } from './mfa.service';
+import { AuthModule } from '../auth/auth.module';
 import { MfaController } from './mfa.controller';
+import { MfaService } from './mfa.service';
 
 @Module({
-  providers: [MfaService],
+  imports: [AuthModule],
   controllers: [MfaController],
+  providers: [MfaService],
   exports: [MfaService],
 })
 export class MfaModule {}

--- a/apps/api/test/one-deal/persistent-auth-actors.ts
+++ b/apps/api/test/one-deal/persistent-auth-actors.ts
@@ -1,7 +1,7 @@
 import { createHmac } from 'crypto';
 import * as jwt from 'jsonwebtoken';
-import { PrismaService } from '../../src/common/prisma/prisma.service';
 import { RequestUser, Role } from '../../src/common/types/request-user';
+import { AuthPrismaService } from '../../src/modules/auth/auth-prisma.service';
 import { AuthService } from '../../src/modules/auth/auth.service';
 import { PersistentAuthRepository } from '../../src/modules/auth/persistent-auth.repository';
 
@@ -34,8 +34,8 @@ export type PersistentActorHarness = {
   accessTokensByRole: Map<Role, string>;
   primaryAuth: AuthService;
   verifierAuth: AuthService;
-  primaryPrisma: PrismaService;
-  verifierPrisma: PrismaService;
+  primaryPrisma: AuthPrismaService;
+  verifierPrisma: AuthPrismaService;
   verifyWithFreshInstance(): Promise<void>;
   disconnect(): Promise<void>;
 };
@@ -72,10 +72,6 @@ function totp(secret: string, unixMs = Date.now()): string {
   return String(binary % 1_000_000).padStart(6, '0');
 }
 
-function authPrisma(databaseUrl: string): PrismaService {
-  return new PrismaService({ datasources: { db: { url: databaseUrl } } });
-}
-
 function assertOpaqueAccessToken(accessToken: string, expectedUserId: string): OpaqueAccessClaims {
   const decoded = jwt.decode(accessToken);
   if (!decoded || typeof decoded === 'string') throw new Error('Access token did not decode to JWT claims');
@@ -93,16 +89,16 @@ function assertOpaqueAccessToken(accessToken: string, expectedUserId: string): O
 export async function createPersistentActorHarness(
   organizationIds: readonly string[],
 ): Promise<PersistentActorHarness> {
-  const authUrl = String(process.env.ONE_DEAL_AUTH_URL ?? '').trim();
+  const authUrl = String(process.env.AUTH_DATABASE_URL ?? '').trim();
   const jwtSecret = String(process.env.JWT_SECRET ?? '').trim();
-  if (!authUrl) throw new Error('ONE_DEAL_AUTH_URL is required for persistent auth actor proof');
+  if (!authUrl) throw new Error('AUTH_DATABASE_URL is required for persistent auth actor proof');
   if (!jwtSecret) throw new Error('JWT_SECRET is required for persistent auth actor proof');
 
-  const primaryPrisma = authPrisma(authUrl);
-  const verifierPrisma = authPrisma(authUrl);
+  const primaryPrisma = new AuthPrismaService();
+  const verifierPrisma = new AuthPrismaService();
   const primaryAuth = new AuthService(new PersistentAuthRepository(primaryPrisma));
   const verifierAuth = new AuthService(new PersistentAuthRepository(verifierPrisma));
-  await Promise.all([primaryPrisma.$connect(), verifierPrisma.$connect()]);
+  await Promise.all([primaryPrisma.onModuleInit(), verifierPrisma.onModuleInit()]);
 
   try {
     const [{ current_user: currentUser }] = await primaryPrisma.$queryRaw<Array<{ current_user: string }>>`
@@ -234,9 +230,9 @@ export async function createPersistentActorHarness(
       primaryPrisma,
       verifierPrisma,
       verifyWithFreshInstance: async () => {
-        const freshPrisma = authPrisma(authUrl);
+        const freshPrisma = new AuthPrismaService();
         const freshAuth = new AuthService(new PersistentAuthRepository(freshPrisma));
-        await freshPrisma.$connect();
+        await freshPrisma.onModuleInit();
         try {
           for (const [role, token] of accessTokensByRole) {
             const expected = actorsByRole.get(role);
@@ -246,15 +242,15 @@ export async function createPersistentActorHarness(
             }
           }
         } finally {
-          await freshPrisma.$disconnect();
+          await freshPrisma.onModuleDestroy();
         }
       },
       disconnect: async () => {
-        await Promise.all([primaryPrisma.$disconnect(), verifierPrisma.$disconnect()]);
+        await Promise.all([primaryPrisma.onModuleDestroy(), verifierPrisma.onModuleDestroy()]);
       },
     };
   } catch (error) {
-    await Promise.allSettled([primaryPrisma.$disconnect(), verifierPrisma.$disconnect()]);
+    await Promise.allSettled([primaryPrisma.onModuleDestroy(), verifierPrisma.onModuleDestroy()]);
     throw error;
   }
 }

--- a/apps/api/test/one-deal/runtime-principal-startup-proof.ts
+++ b/apps/api/test/one-deal/runtime-principal-startup-proof.ts
@@ -1,0 +1,72 @@
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../src/common/prisma/prisma.service';
+import { AuthPrismaService } from '../../src/modules/auth/auth-prisma.service';
+
+async function main(): Promise<void> {
+  if (String(process.env.DB_PRINCIPAL_BOUNDARY_ENFORCED).toLowerCase() !== 'true') {
+    throw new Error('DB_PRINCIPAL_BOUNDARY_ENFORCED=true is required for runtime principal proof.');
+  }
+
+  const dealPrisma = new PrismaService();
+  const authPrisma = new AuthPrismaService();
+  await Promise.all([dealPrisma.onModuleInit(), authPrisma.onModuleInit()]);
+
+  try {
+    const [dealIdentity, authIdentity] = await Promise.all([
+      dealPrisma.$queryRaw<Array<{ current_user: string }>>(Prisma.sql`SELECT current_user`),
+      authPrisma.$queryRaw<Array<{ current_user: string }>>(Prisma.sql`SELECT current_user`),
+    ]);
+    if (dealIdentity[0]?.current_user !== 'one_deal_app') {
+      throw new Error(`Deal runtime connected as ${dealIdentity[0]?.current_user ?? 'unknown'}`);
+    }
+    if (authIdentity[0]?.current_user !== 'one_deal_auth') {
+      throw new Error(`Auth runtime connected as ${authIdentity[0]?.current_user ?? 'unknown'}`);
+    }
+
+    let authDealDenied = false;
+    try {
+      await authPrisma.$queryRaw(Prisma.sql`SELECT id FROM public.deals LIMIT 1`);
+    } catch (error) {
+      const candidate = error as { code?: string; meta?: { code?: string }; message?: string };
+      authDealDenied = candidate.code === 'P2010'
+        || candidate.meta?.code === '42501'
+        || /permission denied/i.test(String(candidate.message ?? ''));
+    }
+    if (!authDealDenied) {
+      throw new Error('Auth runtime unexpectedly read public.deals.');
+    }
+
+    const crossTenantCount = await dealPrisma.$transaction(async (tx) => {
+      await tx.$executeRaw(Prisma.sql`SELECT set_config('app.current_user_id', 'buyer-e2e', true)`);
+      await tx.$executeRaw(Prisma.sql`SELECT set_config('app.current_org_id', 'org-canonical-buyer', true)`);
+      await tx.$executeRaw(Prisma.sql`SELECT set_config('app.current_tenant_id', 'tenant-other', true)`);
+      await tx.$executeRaw(Prisma.sql`SELECT set_config('app.current_role', 'BUYER', true)`);
+      await tx.$executeRaw(Prisma.sql`SELECT set_config('app.current_session_id', 'runtime-principal-proof', true)`);
+      const rows = await tx.$queryRaw<Array<{ count: bigint }>>(Prisma.sql`
+        SELECT COUNT(*)::bigint AS count
+        FROM public.deals
+        WHERE id = 'DEAL-INDUSTRIAL-001'
+      `);
+      return Number(rows[0]?.count ?? 0n);
+    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+
+    if (crossTenantCount !== 0) {
+      throw new Error(`Deal runtime exposed ${crossTenantCount} cross-tenant row(s).`);
+    }
+
+    process.stdout.write(`${JSON.stringify({
+      runtimePrincipalBoundary: 'passed',
+      dealPrincipal: dealIdentity[0].current_user,
+      authPrincipal: authIdentity[0].current_user,
+      authDealDenied,
+      crossTenantCount,
+    })}\n`);
+  } finally {
+    await Promise.all([dealPrisma.onModuleDestroy(), authPrisma.onModuleDestroy()]);
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/platform-v7-one-deal-e2e.sh
+++ b/scripts/platform-v7-one-deal-e2e.sh
@@ -115,8 +115,7 @@ END
 $one_deal_auth_role$;
 GRANT CONNECT ON DATABASE one_deal_e2e TO one_deal_auth;
 GRANT USAGE ON SCHEMA public, auth TO one_deal_auth;
-GRANT SELECT, UPDATE ON public.users, public.user_orgs TO one_deal_auth;
-GRANT SELECT ON public.organizations TO one_deal_auth;
+GRANT SELECT, INSERT, UPDATE ON public.users, public.user_orgs, public.organizations TO one_deal_auth;
 GRANT SELECT, INSERT, UPDATE ON
   auth.login_throttles,
   auth.credential_states,
@@ -183,10 +182,18 @@ if [[ "$CROSS_TENANT_PARTICIPANTS" != "0" ]]; then
   exit 1
 fi
 
+echo "[one-deal] proving strict Nest runtime datasource boundaries"
+NODE_ENV=test \
+DATABASE_URL="$APP_URL" \
+AUTH_DATABASE_URL="$AUTH_URL" \
+DB_PRINCIPAL_BOUNDARY_ENFORCED=true \
+pnpm --filter @pc/api exec ts-node test/one-deal/runtime-principal-startup-proof.ts
+
 echo "[one-deal] running persistent-auth-backed exploitation suite"
 NODE_ENV=test \
 DATABASE_URL="$APP_URL" \
-ONE_DEAL_AUTH_URL="$AUTH_URL" \
+AUTH_DATABASE_URL="$AUTH_URL" \
+DB_PRINCIPAL_BOUNDARY_ENFORCED=true \
 JWT_SECRET="$JWT_SECRET" \
 AUTH_TOKEN_PEPPER="$AUTH_TOKEN_PEPPER" \
 MFA_ENCRYPTION_KEY="$MFA_ENCRYPTION_KEY" \


### PR DESCRIPTION
## Суть

Физически разделены PostgreSQL connection pools реального Nest runtime:

- `PrismaService` — deal/runtime datasource из `DATABASE_URL`;
- `AuthPrismaService` — identity datasource из `AUTH_DATABASE_URL`;
- `PersistentAuthRepository` в `AuthModule` создаётся только с `AuthPrismaService`.

## Fail-closed startup

При production или `DB_PRINCIPAL_BOUNDARY_ENFORCED=true`:

- deal principal обязан быть `NOSUPERUSER`, `NOBYPASSRLS`, `NOINHERIT`, не owner и без membership в других PostgreSQL roles;
- для `public.deals` обязательны `ENABLE + FORCE RLS` и `row_security=on`;
- auth principal обязан быть `NOSUPERUSER`, `BYPASSRLS`, `NOINHERIT`, без role memberships и без каких-либо прав на `public.deals`;
- auth principal получает только необходимые identity/auth grants;
- отсутствующий или совпадающий с `DATABASE_URL` `AUTH_DATABASE_URL` в production блокирует запуск;
- нарушение boundary блокирует startup, а не переводит production в degraded mode.

## Доказательства head `ee994480dafd086241fecf8e004ef65ad383b139`

- unit policy tests — success;
- Nest DI proof: repository использует только auth pool — success;
- runtime startup обоих pools под отдельными restricted roles — success;
- auth pool → `public.deals` — permission denied;
- deal pool cross-tenant visibility — `0`;
- persistent auth / rotation / MFA / revoke — success;
- 12 roles · 19 commands · PostgreSQL RLS — success;
- final deal state — `CLOSED`;
- Node CI, production build, Security Scan, Security Quality Gate, Dependency Review — success.

## Граница

Это runtime/CI security boundary. Production credentials и production DB не использовались. Production migration/deployment, backup/restore и DR acceptance этим PR не заявляются.

Closes #2285