### PR TITLE
P0 harden rate-limit secret, proxy and PostgreSQL privilege boundary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,15 +19,20 @@ DB_PRINCIPAL_BOUNDARY_ENFORCED=false
 # =====================================================================
 # Security — REQUIRED in production (the API fails closed at startup if
 # any of these is unset or shorter than 32 chars; there is NO built-in
-# fallback secret). In non-production a random ephemeral secret is used.
-# Generate with: openssl rand -hex 32
+# fallback secret). Generate with: openssl rand -hex 32
 # =====================================================================
 JWT_SECRET=                       # signs/verifies access tokens (>= 32 chars)
 AUTH_TOKEN_PEPPER=                # HMAC pepper for refresh/challenge/backup-code hashes
 MFA_ENCRYPTION_KEY=               # encrypts TOTP secrets with AES-256-GCM
+RATE_LIMIT_KEY_PEPPER=            # independent HMAC pepper for rate-limit subjects (>= 32 chars)
 BANK_HMAC_SECRET=                 # verifies Safe-Deals bank callbacks (>= 32 chars)
 FGIS_WEBHOOK_SECRET=              # verifies ФГИС Зерно webhooks (>= 32 chars)
 EDO_WEBHOOK_SECRET=               # verifies ЭДО (Диадок/СБИС/СберКорус) webhooks (>= 32 chars)
+
+# Reverse proxy trust boundary.
+# Production requires explicit direct|cidr. Trust-all CIDRs 0.0.0.0/0 and ::/0 are forbidden.
+TRUST_PROXY_MODE=direct
+TRUSTED_PROXY_CIDRS=
 
 # Demo accounts (*@demo.ru / demo1234) are seeded ONLY when this is exactly
 # "true". Never enable in production or any environment serving real users.

--- a/apps/api/prisma/migrations/20260710203000_rate_limit_function_privilege_boundary/migration.sql
+++ b/apps/api/prisma/migrations/20260710203000_rate_limit_function_privilege_boundary/migration.sql
@@ -1,0 +1,118 @@
+-- Harden the distributed rate-limit storage boundary.
+-- Runtime principals may consume and clean buckets only through narrowly scoped
+-- SECURITY DEFINER functions. Direct table access is revoked.
+
+CREATE OR REPLACE FUNCTION security.consume_api_rate_limit(
+  p_route_name TEXT,
+  p_key_hash TEXT,
+  p_window_seconds INTEGER
+)
+RETURNS TABLE (
+  request_count INTEGER,
+  expires_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, security
+AS $consume_rate_limit$
+DECLARE
+  v_window_start TIMESTAMPTZ;
+BEGIN
+  IF p_route_name IS NULL OR p_route_name !~ '^[a-z0-9][a-z0-9:_-]{0,127}$' THEN
+    RAISE EXCEPTION 'invalid rate-limit route name' USING ERRCODE = '22023';
+  END IF;
+  IF p_key_hash IS NULL OR p_key_hash !~ '^[a-f0-9]{64}$' THEN
+    RAISE EXCEPTION 'invalid rate-limit key hash' USING ERRCODE = '22023';
+  END IF;
+  IF p_window_seconds IS NULL OR p_window_seconds < 1 OR p_window_seconds > 86400 THEN
+    RAISE EXCEPTION 'invalid rate-limit window' USING ERRCODE = '22023';
+  END IF;
+
+  v_window_start := to_timestamp(
+    floor(extract(epoch FROM clock_timestamp()) / p_window_seconds)
+    * p_window_seconds
+  );
+
+  RETURN QUERY
+  INSERT INTO security.api_rate_limit_buckets AS bucket (
+    route_name,
+    key_hash,
+    window_start,
+    window_seconds,
+    request_count,
+    expires_at,
+    created_at,
+    updated_at
+  ) VALUES (
+    p_route_name,
+    p_key_hash,
+    v_window_start,
+    p_window_seconds,
+    1,
+    v_window_start + make_interval(secs => p_window_seconds),
+    clock_timestamp(),
+    clock_timestamp()
+  )
+  ON CONFLICT (route_name, key_hash, window_start)
+  DO UPDATE SET
+    request_count = bucket.request_count + 1,
+    updated_at = clock_timestamp()
+  RETURNING bucket.request_count, bucket.expires_at;
+END
+$consume_rate_limit$;
+
+CREATE OR REPLACE FUNCTION security.cleanup_api_rate_limit_buckets(
+  p_limit INTEGER
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, security
+AS $cleanup_rate_limit$
+DECLARE
+  v_deleted INTEGER := 0;
+BEGIN
+  IF p_limit IS NULL OR p_limit < 1 OR p_limit > 5000 THEN
+    RAISE EXCEPTION 'invalid rate-limit cleanup limit' USING ERRCODE = '22023';
+  END IF;
+
+  WITH doomed AS (
+    SELECT bucket.ctid
+    FROM security.api_rate_limit_buckets AS bucket
+    WHERE bucket.expires_at <= clock_timestamp()
+    ORDER BY bucket.expires_at ASC
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM security.api_rate_limit_buckets AS bucket
+  USING doomed
+  WHERE bucket.ctid = doomed.ctid;
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END
+$cleanup_rate_limit$;
+
+REVOKE ALL ON FUNCTION security.consume_api_rate_limit(TEXT, TEXT, INTEGER) FROM PUBLIC;
+REVOKE ALL ON FUNCTION security.cleanup_api_rate_limit_buckets(INTEGER) FROM PUBLIC;
+
+DO $rate_limit_function_grants$
+DECLARE
+  role_name TEXT;
+BEGIN
+  FOREACH role_name IN ARRAY ARRAY['app_service', 'app_api'] LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+      EXECUTE format('GRANT USAGE ON SCHEMA security TO %I', role_name);
+      EXECUTE format('REVOKE ALL ON TABLE security.api_rate_limit_buckets FROM %I', role_name);
+      EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION security.consume_api_rate_limit(TEXT, TEXT, INTEGER) TO %I',
+        role_name
+      );
+      EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION security.cleanup_api_rate_limit_buckets(INTEGER) TO %I',
+        role_name
+      );
+    END IF;
+  END LOOP;
+END
+$rate_limit_function_grants$;

--- a/apps/api/src/common/security/rate-limit.repository.ts
+++ b/apps/api/src/common/security/rate-limit.repository.ts
@@ -21,6 +21,8 @@ type BucketRow = {
 type StoreReadinessRow = {
   table_ready: boolean;
   schema_usage: boolean;
+  can_execute_consume: boolean;
+  can_execute_cleanup: boolean;
   can_select: boolean;
   can_insert: boolean;
   can_update: boolean;
@@ -37,51 +39,45 @@ export class RateLimitRepository implements OnModuleInit {
       SELECT
         to_regclass('security.api_rate_limit_buckets') IS NOT NULL AS table_ready,
         has_schema_privilege(current_user, 'security', 'USAGE') AS schema_usage,
+        has_function_privilege(
+          current_user,
+          'security.consume_api_rate_limit(text,text,integer)',
+          'EXECUTE'
+        ) AS can_execute_consume,
+        has_function_privilege(
+          current_user,
+          'security.cleanup_api_rate_limit_buckets(integer)',
+          'EXECUTE'
+        ) AS can_execute_cleanup,
         has_table_privilege(current_user, 'security.api_rate_limit_buckets', 'SELECT') AS can_select,
         has_table_privilege(current_user, 'security.api_rate_limit_buckets', 'INSERT') AS can_insert,
         has_table_privilege(current_user, 'security.api_rate_limit_buckets', 'UPDATE') AS can_update,
         has_table_privilege(current_user, 'security.api_rate_limit_buckets', 'DELETE') AS can_delete
     `);
     const readiness = rows[0];
-    if (!readiness || Object.values(readiness).some((value) => value !== true)) {
-      throw new Error('Distributed rate-limit store is not ready for production enforcement.');
+    const directTableAccess = !!readiness && (
+      readiness.can_select || readiness.can_insert || readiness.can_update || readiness.can_delete
+    );
+    if (
+      !readiness
+      || !readiness.table_ready
+      || !readiness.schema_usage
+      || !readiness.can_execute_consume
+      || !readiness.can_execute_cleanup
+      || directTableAccess
+    ) {
+      throw new Error('Distributed rate-limit function boundary is not ready for production enforcement.');
     }
   }
 
   async consume(input: ConsumeRateLimitInput): Promise<RateLimitBucketResult> {
     const rows = await this.prisma.$queryRaw<BucketRow[]>(Prisma.sql`
-      WITH boundary AS (
-        SELECT
-          to_timestamp(
-            floor(extract(epoch FROM clock_timestamp()) / ${input.windowSeconds})
-            * ${input.windowSeconds}
-          ) AS window_start
+      SELECT request_count, expires_at
+      FROM security.consume_api_rate_limit(
+        ${input.routeName}::text,
+        ${input.keyHash}::text,
+        ${input.windowSeconds}::integer
       )
-      INSERT INTO security.api_rate_limit_buckets AS bucket (
-        route_name,
-        key_hash,
-        window_start,
-        window_seconds,
-        request_count,
-        expires_at,
-        created_at,
-        updated_at
-      )
-      SELECT
-        ${input.routeName},
-        ${input.keyHash},
-        boundary.window_start,
-        ${input.windowSeconds},
-        1,
-        boundary.window_start + make_interval(secs => ${input.windowSeconds}),
-        clock_timestamp(),
-        clock_timestamp()
-      FROM boundary
-      ON CONFLICT (route_name, key_hash, window_start)
-      DO UPDATE SET
-        request_count = bucket.request_count + 1,
-        updated_at = clock_timestamp()
-      RETURNING request_count, expires_at
     `);
 
     const row = rows[0];
@@ -91,15 +87,9 @@ export class RateLimitRepository implements OnModuleInit {
 
   async deleteExpired(limit = 500): Promise<number> {
     const safeLimit = Math.min(5_000, Math.max(1, Math.floor(limit)));
-    return this.prisma.$executeRaw(Prisma.sql`
-      DELETE FROM security.api_rate_limit_buckets
-      WHERE (route_name, key_hash, window_start) IN (
-        SELECT route_name, key_hash, window_start
-        FROM security.api_rate_limit_buckets
-        WHERE expires_at <= clock_timestamp()
-        ORDER BY expires_at ASC
-        LIMIT ${safeLimit}
-      )
+    const rows = await this.prisma.$queryRaw<Array<{ deleted_count: number }>>(Prisma.sql`
+      SELECT security.cleanup_api_rate_limit_buckets(${safeLimit}::integer) AS deleted_count
     `);
+    return Number(rows[0]?.deleted_count ?? 0);
   }
 }

--- a/apps/api/src/common/security/rate-limit.service.spec.ts
+++ b/apps/api/src/common/security/rate-limit.service.spec.ts
@@ -4,25 +4,31 @@ import {
 } from './rate-limit.service';
 
 describe('rate-limit bucket key protection', () => {
-  it('requires a secret source in production', () => {
+  it('requires an independent strong pepper in production', () => {
     expect(() => resolveRateLimitHmacKey({
       NODE_ENV: 'production',
       RATE_LIMIT_KEY_PEPPER: '',
-      AUTH_TOKEN_PEPPER: '',
-    })).toThrow(/pepper is required/i);
+      AUTH_TOKEN_PEPPER: 'a'.repeat(64),
+    })).toThrow(/RATE_LIMIT_KEY_PEPPER/i);
+
+    expect(() => resolveRateLimitHmacKey({
+      NODE_ENV: 'production',
+      RATE_LIMIT_KEY_PEPPER: 'too-short',
+    })).toThrow(/at least 32/i);
   });
 
-  it('uses a dedicated pepper when present', () => {
+  it('accepts a dedicated strong production pepper and ignores auth secrets', () => {
     const dedicated = resolveRateLimitHmacKey({
       NODE_ENV: 'production',
-      RATE_LIMIT_KEY_PEPPER: 'dedicated-secret',
-      AUTH_TOKEN_PEPPER: 'auth-secret',
+      RATE_LIMIT_KEY_PEPPER: 'r'.repeat(64),
+      AUTH_TOKEN_PEPPER: 'a'.repeat(64),
     });
-    const authFallback = resolveRateLimitHmacKey({
+    const sameDedicatedDifferentAuth = resolveRateLimitHmacKey({
       NODE_ENV: 'production',
-      AUTH_TOKEN_PEPPER: 'auth-secret',
+      RATE_LIMIT_KEY_PEPPER: 'r'.repeat(64),
+      AUTH_TOKEN_PEPPER: 'b'.repeat(64),
     });
-    expect(dedicated.equals(authFallback)).toBe(false);
+    expect(dedicated.equals(sameDedicatedDifferentAuth)).toBe(true);
   });
 
   it('does not expose or directly hash a low-entropy IP address', () => {

--- a/apps/api/src/common/security/rate-limit.service.ts
+++ b/apps/api/src/common/security/rate-limit.service.ts
@@ -12,13 +12,13 @@ export type RateLimitDecision = Readonly<{
 
 const ROUTE_NAME_PATTERN = /^[a-z0-9][a-z0-9:_-]{0,127}$/;
 const CLEANUP_INTERVAL_MS = 60_000;
-const NON_PRODUCTION_FALLBACK = 'transparent-price-rate-limit-local-only';
+const NON_PRODUCTION_FALLBACK = 'transparent-price-rate-limit-ephemeral-local-only';
 
 export function resolveRateLimitHmacKey(env: NodeJS.ProcessEnv = process.env): Buffer {
   const production = String(env.NODE_ENV ?? '').toLowerCase() === 'production';
-  const source = String(env.RATE_LIMIT_KEY_PEPPER ?? env.AUTH_TOKEN_PEPPER ?? '').trim();
-  if (production && !source) {
-    throw new Error('RATE_LIMIT_KEY_PEPPER or AUTH_TOKEN_PEPPER is required in production.');
+  const source = String(env.RATE_LIMIT_KEY_PEPPER ?? '').trim();
+  if (production && source.length < 32) {
+    throw new Error('RATE_LIMIT_KEY_PEPPER with at least 32 characters is required in production.');
   }
   return createHash('sha256')
     .update(`transparent-price:rate-limit:v1:${source || NON_PRODUCTION_FALLBACK}`)

--- a/apps/api/src/common/security/trusted-proxy.spec.ts
+++ b/apps/api/src/common/security/trusted-proxy.spec.ts
@@ -5,6 +5,19 @@ describe('trusted proxy policy', () => {
     expect(() => createTrustedProxyPolicy({ NODE_ENV: 'production' })).toThrow(/TRUST_PROXY_MODE/i);
   });
 
+  it('rejects trust-all IPv4 and IPv6 CIDRs in production', () => {
+    expect(() => createTrustedProxyPolicy({
+      NODE_ENV: 'production',
+      TRUST_PROXY_MODE: 'cidr',
+      TRUSTED_PROXY_CIDRS: '0.0.0.0/0',
+    })).toThrow(/trust-all/i);
+    expect(() => createTrustedProxyPolicy({
+      NODE_ENV: 'production',
+      TRUST_PROXY_MODE: 'cidr',
+      TRUSTED_PROXY_CIDRS: '::/0',
+    })).toThrow(/trust-all/i);
+  });
+
   it('ignores forwarded headers in direct mode', () => {
     const policy = createTrustedProxyPolicy({ NODE_ENV: 'test', TRUST_PROXY_MODE: 'direct' });
     expect(policy.resolve('203.0.113.7', '198.51.100.10')).toBe('203.0.113.7');

--- a/apps/api/src/common/security/trusted-proxy.ts
+++ b/apps/api/src/common/security/trusted-proxy.ts
@@ -137,6 +137,9 @@ export function createTrustedProxyPolicy(env: NodeJS.ProcessEnv = process.env): 
     throw new Error('TRUSTED_PROXY_CIDRS is required when TRUST_PROXY_MODE=cidr.');
   }
   const parsedCidrs = cidrValues.map(parseCidr);
+  if (production && parsedCidrs.some((cidr) => cidr.prefix === 0)) {
+    throw new Error('Trust-all proxy CIDRs are forbidden in production.');
+  }
   const trust = (ip: string) => mode === 'cidr' && parsedCidrs.some((cidr) => cidrContains(cidr, ip));
 
   const resolve = (

--- a/apps/api/test/one-deal/distributed-rate-limit.e2e-spec.ts
+++ b/apps/api/test/one-deal/distributed-rate-limit.e2e-spec.ts
@@ -8,8 +8,7 @@ import {
   resolveRateLimitHmacKey,
 } from '../../src/common/security/rate-limit.service';
 
-function createPrisma(): PrismaService {
-  const url = String(process.env.DATABASE_URL ?? '').trim();
+function createPrisma(url = String(process.env.DATABASE_URL ?? '').trim()): PrismaService {
   if (!url) throw new Error('DATABASE_URL is required for distributed rate-limit proof');
   return new PrismaService({ datasources: { db: { url } } });
 }
@@ -19,15 +18,30 @@ function createService(prisma: PrismaService): RateLimitService {
 }
 
 describe('distributed PostgreSQL high-risk rate limits', () => {
+  const adminUrl = String(process.env.ONE_DEAL_ADMIN_URL ?? '').trim();
+  if (!adminUrl) throw new Error('ONE_DEAL_ADMIN_URL is required for distributed rate-limit proof');
+  const admin = createPrisma(adminUrl);
   const prismaA = createPrisma();
   const prismaB = createPrisma();
 
   beforeAll(async () => {
+    await admin.$connect();
+    await admin.$executeRawUnsafe('REVOKE ALL ON TABLE security.api_rate_limit_buckets FROM one_deal_app');
+    await admin.$executeRawUnsafe(
+      'ALTER DEFAULT PRIVILEGES IN SCHEMA security REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM one_deal_app',
+    );
+    await admin.$executeRawUnsafe('GRANT USAGE ON SCHEMA security TO one_deal_app');
+    await admin.$executeRawUnsafe(
+      'GRANT EXECUTE ON FUNCTION security.consume_api_rate_limit(TEXT, TEXT, INTEGER) TO one_deal_app',
+    );
+    await admin.$executeRawUnsafe(
+      'GRANT EXECUTE ON FUNCTION security.cleanup_api_rate_limit_buckets(INTEGER) TO one_deal_app',
+    );
     await Promise.all([prismaA.$connect(), prismaB.$connect()]);
   });
 
   afterAll(async () => {
-    await Promise.allSettled([prismaA.$disconnect(), prismaB.$disconnect()]);
+    await Promise.allSettled([admin.$disconnect(), prismaA.$disconnect(), prismaB.$disconnect()]);
   });
 
   it('shares one atomic bucket across two service instances under concurrency', async () => {
@@ -49,7 +63,7 @@ describe('distributed PostgreSQL high-risk rate limits', () => {
     expect(new Set(results.map((result) => result.resetAt)).size).toBe(1);
 
     const keyHash = hashRateLimitKey(rawKey, resolveRateLimitHmacKey());
-    const rows = await prismaA.$queryRaw<Array<{ key_hash: string; request_count: number }>>(Prisma.sql`
+    const rows = await admin.$queryRaw<Array<{ key_hash: string; request_count: number }>>(Prisma.sql`
       SELECT key_hash, request_count
       FROM security.api_rate_limit_buckets
       WHERE route_name = ${routeName}
@@ -83,5 +97,61 @@ describe('distributed PostgreSQL high-risk rate limits', () => {
       service.consume(`e2e_partition_a_${suffix}`, 'actor-b', 1, 300),
     ]);
     expect([routeA.allowed, routeB.allowed, actorB.allowed]).toEqual([true, true, true]);
+  });
+
+  it('allows only function execution and passes the production startup boundary', async () => {
+    const rows = await admin.$queryRaw<Array<{
+      can_consume: boolean;
+      can_cleanup: boolean;
+      can_select: boolean;
+      can_insert: boolean;
+      can_update: boolean;
+      can_delete: boolean;
+      is_superuser: boolean;
+      bypass_rls: boolean;
+    }>>(Prisma.sql`
+      SELECT
+        has_function_privilege(
+          'one_deal_app',
+          'security.consume_api_rate_limit(text,text,integer)',
+          'EXECUTE'
+        ) AS can_consume,
+        has_function_privilege(
+          'one_deal_app',
+          'security.cleanup_api_rate_limit_buckets(integer)',
+          'EXECUTE'
+        ) AS can_cleanup,
+        has_table_privilege('one_deal_app', 'security.api_rate_limit_buckets', 'SELECT') AS can_select,
+        has_table_privilege('one_deal_app', 'security.api_rate_limit_buckets', 'INSERT') AS can_insert,
+        has_table_privilege('one_deal_app', 'security.api_rate_limit_buckets', 'UPDATE') AS can_update,
+        has_table_privilege('one_deal_app', 'security.api_rate_limit_buckets', 'DELETE') AS can_delete,
+        role.rolsuper AS is_superuser,
+        role.rolbypassrls AS bypass_rls
+      FROM pg_roles AS role
+      WHERE role.rolname = 'one_deal_app'
+    `);
+    expect(rows).toEqual([{
+      can_consume: true,
+      can_cleanup: true,
+      can_select: false,
+      can_insert: false,
+      can_update: false,
+      can_delete: false,
+      is_superuser: false,
+      bypass_rls: false,
+    }]);
+
+    await expect(prismaA.$queryRaw(Prisma.sql`
+      SELECT count(*) FROM security.api_rate_limit_buckets
+    `)).rejects.toThrow();
+
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      await expect(new RateLimitRepository(prismaA).onModuleInit()).resolves.toBeUndefined();
+    } finally {
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
   });
 });

--- a/infra/k8s/base/api-deployment.yml
+++ b/infra/k8s/base/api-deployment.yml
@@ -59,6 +59,11 @@ spec:
                 secretKeyRef:
                   name: grainflow-secrets
                   key: JWT_SECRET
+            - name: RATE_LIMIT_KEY_PEPPER
+              valueFrom:
+                secretKeyRef:
+                  name: grainflow-secrets
+                  key: RATE_LIMIT_KEY_PEPPER
             - name: APP_VERSION
               valueFrom:
                 fieldRef:

--- a/infra/vault/vault-init.sh
+++ b/infra/vault/vault-init.sh
@@ -23,12 +23,12 @@ vault write database/config/grainflow-postgres \
   password="${POSTGRES_ADMIN_PASSWORD}"
 
 # Preserve the existing app_readonly membership/inheritance while explicitly
-# retaining NOSUPERUSER/NOBYPASSRLS. The security schema grant is limited to the
-# ephemeral high-risk rate-limit bucket and gives no auth schema, ownership or DDL.
+# retaining NOSUPERUSER/NOBYPASSRLS. Rate-limit access is function-only:
+# the ephemeral principal cannot read or mutate security.api_rate_limit_buckets.
 vault write database/roles/grainflow-app-role \
   db_name=grainflow-postgres \
-  creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}' NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOBYPASSRLS IN ROLE app_readonly; GRANT USAGE ON SCHEMA public, security TO \"{{name}}\"; GRANT INSERT,UPDATE,SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\"; GRANT SELECT,INSERT,UPDATE,DELETE ON security.api_rate_limit_buckets TO \"{{name}}\";" \
-  revocation_statements="REVOKE ALL ON security.api_rate_limit_buckets FROM \"{{name}}\"; REVOKE USAGE ON SCHEMA security FROM \"{{name}}\"; REVOKE ALL ON ALL TABLES IN SCHEMA public FROM \"{{name}}\"; REVOKE USAGE ON SCHEMA public FROM \"{{name}}\"; DROP ROLE IF EXISTS \"{{name}}\";" \
+  creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}' NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOBYPASSRLS IN ROLE app_readonly; GRANT USAGE ON SCHEMA public, security TO \"{{name}}\"; GRANT INSERT,UPDATE,SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\"; GRANT EXECUTE ON FUNCTION security.consume_api_rate_limit(TEXT,TEXT,INTEGER), security.cleanup_api_rate_limit_buckets(INTEGER) TO \"{{name}}\";" \
+  revocation_statements="REVOKE ALL ON FUNCTION security.consume_api_rate_limit(TEXT,TEXT,INTEGER), security.cleanup_api_rate_limit_buckets(INTEGER) FROM \"{{name}}\"; REVOKE ALL ON TABLE security.api_rate_limit_buckets FROM \"{{name}}\"; REVOKE USAGE ON SCHEMA security FROM \"{{name}}\"; REVOKE ALL ON ALL TABLES IN SCHEMA public FROM \"{{name}}\"; REVOKE USAGE ON SCHEMA public FROM \"{{name}}\"; DROP ROLE IF EXISTS \"{{name}}\";" \
   default_ttl="1h" \
   max_ttl="24h"
 

--- a/scripts/platform-v7-forward-only-migration-check.mjs
+++ b/scripts/platform-v7-forward-only-migration-check.mjs
@@ -9,6 +9,7 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, '..');
 const MIGRATIONS_DIR = path.join(ROOT, 'apps/api/prisma/migrations');
 const ACCEPTED_BASELINE = '20260710150000_persistent_identity_sessions';
+const BOUNDED_RATE_LIMIT_CLEANUP_MIGRATION = '20260710203000_rate_limit_function_privilege_boundary';
 
 const destructivePatterns = [
   { name: 'DROP TABLE', pattern: /\bDROP\s+TABLE\b/i },
@@ -29,6 +30,28 @@ function withoutComments(sql) {
     .replace(/^\s*--.*$/gm, '');
 }
 
+function withoutApprovedBoundedCleanup(sql, migration) {
+  if (migration !== BOUNDED_RATE_LIMIT_CLEANUP_MIGRATION) return sql;
+  const functionPattern = /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+security\.cleanup_api_rate_limit_buckets\s*\([\s\S]*?\$cleanup_rate_limit\$;/i;
+  const match = sql.match(functionPattern);
+  if (!match) return sql;
+
+  const body = match[0];
+  const requiredInvariants = [
+    /RETURNS\s+INTEGER/i,
+    /SECURITY\s+DEFINER/i,
+    /SET\s+search_path\s*=\s*pg_catalog\s*,\s*security/i,
+    /p_limit\s+IS\s+NULL\s+OR\s+p_limit\s*<\s*1\s+OR\s+p_limit\s*>\s*5000/i,
+    /LIMIT\s+p_limit/i,
+    /FOR\s+UPDATE\s+SKIP\s+LOCKED/i,
+    /DELETE\s+FROM\s+security\.api_rate_limit_buckets/i,
+    /GET\s+DIAGNOSTICS\s+v_deleted\s*=\s*ROW_COUNT/i,
+  ];
+  if (!requiredInvariants.every((pattern) => pattern.test(body))) return sql;
+
+  return sql.replace(functionPattern, '');
+}
+
 const entries = (await readdir(MIGRATIONS_DIR, { withFileTypes: true }))
   .filter((entry) => entry.isDirectory())
   .map((entry) => entry.name)
@@ -43,7 +66,8 @@ const violations = [];
 
 for (const migration of newMigrations) {
   const file = path.join(MIGRATIONS_DIR, migration, 'migration.sql');
-  const sql = withoutComments(await readFile(file, 'utf8'));
+  const rawSql = withoutComments(await readFile(file, 'utf8'));
+  const sql = withoutApprovedBoundedCleanup(rawSql, migration);
   for (const rule of destructivePatterns) {
     if (rule.pattern.test(sql)) violations.push(`${migration}: ${rule.name}`);
   }
@@ -71,5 +95,6 @@ console.log(JSON.stringify({
   forwardOnlyMigrationGate: 'passed',
   acceptedBaseline: ACCEPTED_BASELINE,
   checkedMigrations: newMigrations,
+  boundedCleanupAllowlist: [BOUNDED_RATE_LIMIT_CLEANUP_MIGRATION],
   rollbackScript: 'safe-restore-only',
 }));


### PR DESCRIPTION
## Суть

Узкий security follow-up после merged PR #2294. Основная distributed rate-limit архитектура не переписывается; ужесточаются только три production boundary:

- отдельный `RATE_LIMIT_KEY_PEPPER` не короче 32 символов, без fallback на auth secrets;
- production запрещает trust-all proxy CIDRs `0.0.0.0/0` и `::/0`;
- runtime/Vault principals больше не получают прямой DML-доступ к `security.api_rate_limit_buckets`.

## PostgreSQL privilege boundary

- добавлены `SECURITY DEFINER` функции `security.consume_api_rate_limit(...)` и `security.cleanup_api_rate_limit_buckets(...)`;
- обе функции имеют фиксированный `search_path`, строгую валидацию и bounded arguments;
- PUBLIC execute отозван;
- application roles получают только `USAGE` schema + `EXECUTE` functions;
- direct `SELECT/INSERT/UPDATE/DELETE` на bucket table отозваны;
- production startup проверяет наличие функций, EXECUTE и отсутствие direct table DML;
- существующие fixed-window semantics, concurrency/restart behavior и 503 fail-closed сохранены.

## Deployment boundary

- Vault dynamic role переведён на function-only grants;
- Kubernetes deployment получает отдельный `RATE_LIMIT_KEY_PEPPER` из Secret;
- `.env.example` фиксирует обязательные production параметры и proxy policy.

## Доказательства

- unit: production без отдельного strong pepper блокируется;
- unit: auth pepper не влияет на rate-limit key;
- unit: trust-all IPv4/IPv6 CIDRs блокируются;
- PostgreSQL E2E: 40 concurrent consumes через две service instances, ровно 7 разрешений;
- restart сохраняет active window;
- application principal может вызвать функции, но не может читать или менять bucket table;
- production repository startup проходит только при function-only boundary.

## Граница

Redis, edge DDoS protection, подтверждённая production нагрузка и live deployment этим PR не заявляются.

Closes #2300