### PR TITLE
P0 finish rate-limit deployment and proxy hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,15 +19,20 @@ DB_PRINCIPAL_BOUNDARY_ENFORCED=false
 # =====================================================================
 # Security — REQUIRED in production (the API fails closed at startup if
 # any of these is unset or shorter than 32 chars; there is NO built-in
-# fallback secret). In non-production a random ephemeral secret is used.
-# Generate with: openssl rand -hex 32
+# fallback secret). Generate with: openssl rand -hex 32
 # =====================================================================
 JWT_SECRET=                       # signs/verifies access tokens (>= 32 chars)
 AUTH_TOKEN_PEPPER=                # HMAC pepper for refresh/challenge/backup-code hashes
 MFA_ENCRYPTION_KEY=               # encrypts TOTP secrets with AES-256-GCM
+RATE_LIMIT_KEY_PEPPER=            # independent HMAC pepper for rate-limit subjects (>= 32 chars)
 BANK_HMAC_SECRET=                 # verifies Safe-Deals bank callbacks (>= 32 chars)
 FGIS_WEBHOOK_SECRET=              # verifies ФГИС Зерно webhooks (>= 32 chars)
 EDO_WEBHOOK_SECRET=               # verifies ЭДО (Диадок/СБИС/СберКорус) webhooks (>= 32 chars)
+
+# Reverse proxy trust boundary.
+# Production requires explicit direct|cidr. Trust-all CIDRs 0.0.0.0/0 and ::/0 are forbidden.
+TRUST_PROXY_MODE=direct
+TRUSTED_PROXY_CIDRS=
 
 # Demo accounts (*@demo.ru / demo1234) are seeded ONLY when this is exactly
 # "true". Never enable in production or any environment serving real users.

--- a/apps/api/src/common/security/trusted-proxy.spec.ts
+++ b/apps/api/src/common/security/trusted-proxy.spec.ts
@@ -5,6 +5,19 @@ describe('trusted proxy policy', () => {
     expect(() => createTrustedProxyPolicy({ NODE_ENV: 'production' })).toThrow(/TRUST_PROXY_MODE/i);
   });
 
+  it('rejects trust-all IPv4 and IPv6 CIDRs in production', () => {
+    expect(() => createTrustedProxyPolicy({
+      NODE_ENV: 'production',
+      TRUST_PROXY_MODE: 'cidr',
+      TRUSTED_PROXY_CIDRS: '0.0.0.0/0',
+    })).toThrow(/trust-all/i);
+    expect(() => createTrustedProxyPolicy({
+      NODE_ENV: 'production',
+      TRUST_PROXY_MODE: 'cidr',
+      TRUSTED_PROXY_CIDRS: '::/0',
+    })).toThrow(/trust-all/i);
+  });
+
   it('ignores forwarded headers in direct mode', () => {
     const policy = createTrustedProxyPolicy({ NODE_ENV: 'test', TRUST_PROXY_MODE: 'direct' });
     expect(policy.resolve('203.0.113.7', '198.51.100.10')).toBe('203.0.113.7');

--- a/apps/api/src/common/security/trusted-proxy.ts
+++ b/apps/api/src/common/security/trusted-proxy.ts
@@ -137,6 +137,9 @@ export function createTrustedProxyPolicy(env: NodeJS.ProcessEnv = process.env): 
     throw new Error('TRUSTED_PROXY_CIDRS is required when TRUST_PROXY_MODE=cidr.');
   }
   const parsedCidrs = cidrValues.map(parseCidr);
+  if (production && parsedCidrs.some((cidr) => cidr.prefix === 0)) {
+    throw new Error('Trust-all proxy CIDRs are forbidden in production.');
+  }
   const trust = (ip: string) => mode === 'cidr' && parsedCidrs.some((cidr) => cidrContains(cidr, ip));
 
   const resolve = (

--- a/infra/k8s/base/api-deployment.yml
+++ b/infra/k8s/base/api-deployment.yml
@@ -59,6 +59,11 @@ spec:
                 secretKeyRef:
                   name: grainflow-secrets
                   key: JWT_SECRET
+            - name: RATE_LIMIT_KEY_PEPPER
+              valueFrom:
+                secretKeyRef:
+                  name: grainflow-secrets
+                  key: RATE_LIMIT_KEY_PEPPER
             - name: APP_VERSION
               valueFrom:
                 fieldRef:

--- a/infra/vault/vault-init.sh
+++ b/infra/vault/vault-init.sh
@@ -23,12 +23,12 @@ vault write database/config/grainflow-postgres \
   password="${POSTGRES_ADMIN_PASSWORD}"
 
 # Preserve the existing app_readonly membership/inheritance while explicitly
-# retaining NOSUPERUSER/NOBYPASSRLS. The security schema grant is limited to the
-# ephemeral high-risk rate-limit bucket and gives no auth schema, ownership or DDL.
+# retaining NOSUPERUSER/NOBYPASSRLS. Rate-limit access is EXECUTE-only:
+# the ephemeral principal cannot read or mutate either rate-limit table.
 vault write database/roles/grainflow-app-role \
   db_name=grainflow-postgres \
-  creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}' NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOBYPASSRLS IN ROLE app_readonly; GRANT USAGE ON SCHEMA public, security TO \"{{name}}\"; GRANT INSERT,UPDATE,SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\"; GRANT SELECT,INSERT,UPDATE,DELETE ON security.api_rate_limit_buckets TO \"{{name}}\";" \
-  revocation_statements="REVOKE ALL ON security.api_rate_limit_buckets FROM \"{{name}}\"; REVOKE USAGE ON SCHEMA security FROM \"{{name}}\"; REVOKE ALL ON ALL TABLES IN SCHEMA public FROM \"{{name}}\"; REVOKE USAGE ON SCHEMA public FROM \"{{name}}\"; DROP ROLE IF EXISTS \"{{name}}\";" \
+  creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}' NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOBYPASSRLS IN ROLE app_readonly; GRANT USAGE ON SCHEMA public, security TO \"{{name}}\"; GRANT INSERT,UPDATE,SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\"; REVOKE ALL ON security.api_rate_limit_state, security.api_rate_limit_buckets FROM \"{{name}}\"; GRANT EXECUTE ON FUNCTION security.consume_api_rate_limit(TEXT,TEXT,INTEGER) TO \"{{name}}\";" \
+  revocation_statements="REVOKE ALL ON FUNCTION security.consume_api_rate_limit(TEXT,TEXT,INTEGER) FROM \"{{name}}\"; REVOKE ALL ON security.api_rate_limit_state, security.api_rate_limit_buckets FROM \"{{name}}\"; REVOKE USAGE ON SCHEMA security FROM \"{{name}}\"; REVOKE ALL ON ALL TABLES IN SCHEMA public FROM \"{{name}}\"; REVOKE USAGE ON SCHEMA public FROM \"{{name}}\"; DROP ROLE IF EXISTS \"{{name}}\";" \
   default_ttl="1h" \
   max_ttl="24h"
 


### PR DESCRIPTION
## Суть

Узкий production-deployment delta поверх уже объединённого PR #2302. Runtime rate-limit, bounded PostgreSQL state и pre-auth shield не переписываются.

Закрыты оставшиеся разрывы:

- production отклоняет trust-all proxy CIDRs `0.0.0.0/0` и `::/0`;
- Vault dynamic PostgreSQL role получает только `USAGE` + `EXECUTE security.consume_api_rate_limit(...)`;
- Vault role не получает direct CRUD на `security.api_rate_limit_state` или legacy bucket table;
- Kubernetes deployment явно получает отдельный `RATE_LIMIT_KEY_PEPPER` из Secret;
- `.env.example` фиксирует независимый 32+ pepper и explicit proxy mode.

## Exact-head evidence: `9c7bb0f6a7fefdffecf76dc4d13d972b8ae9fd3a`

- API typecheck — success;
- API unit tests — success;
- API build — success;
- trusted proxy IPv4/IPv6 trust-all negative tests — success;
- forward-only migration gate — success;
- persistent auth exploitation — success;
- 12 roles · 19 commands · PostgreSQL RLS — success;
- backup and restore DR rehearsal — success;
- web unit — success;
- production web build — success;
- Dependency Review — success;
- Security Scan — success;
- Security Quality Gate — success.

## Граница

Production secret не создаётся в репозитории: он должен быть выдан Vault/Kubernetes secret-management контуром. Live deployment, Redis/edge DDoS и production load capacity не заявляются.

Closes #2300