### PR TITLE
PR-4A: Single-use password recovery security boundary

### DIFF
--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -7,21 +7,46 @@ import { RateLimit } from '../../common/decorators/rate-limit.decorator';
 import { Public } from '../../common/decorators/public.decorator';
 import { RequestUser } from '../../common/types/request-user';
 import { AuthService } from './auth.service';
+import { PasswordResetService } from './password-reset.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { RefreshDto } from './dto/refresh.dto';
+import { ConfirmPasswordResetDto, RequestPasswordResetDto } from './dto/password-reset.dto';
 
 @UseGuards(RolesGuard)
 @Roles('ANY_AUTHENTICATED')
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly passwordReset: PasswordResetService,
+  ) {}
 
   @Public()
   @RateLimit({ name: 'auth_login', scope: 'ip', limit: 8, windowSeconds: 60, limitEnv: 'RATE_LIMIT_AUTH_LOGIN', windowEnv: 'RATE_LIMIT_WINDOW_SECONDS' })
   @Post('login')
   login(@Body() dto: LoginDto, @Headers('user-agent') userAgent?: string, @Ip() ip?: string) {
     return this.authService.login(dto, userAgent, ip);
+  }
+
+  @Public()
+  @HttpCode(202)
+  @RateLimit({ name: 'auth_password_reset_request', scope: 'ip', limit: 5, windowSeconds: 900, limitEnv: 'RATE_LIMIT_AUTH_PASSWORD_RESET', windowEnv: 'RATE_LIMIT_AUTH_PASSWORD_RESET_WINDOW_SECONDS' })
+  @Post('password-reset/request')
+  requestPasswordReset(
+    @Body() dto: RequestPasswordResetDto,
+    @Headers('x-password-reset-delivery-key') deliveryKey?: string,
+    @Ip() ip?: string,
+  ) {
+    return this.passwordReset.request(dto.email, ip, deliveryKey);
+  }
+
+  @Public()
+  @HttpCode(200)
+  @RateLimit({ name: 'auth_password_reset_confirm', scope: 'ip', limit: 8, windowSeconds: 900, limitEnv: 'RATE_LIMIT_AUTH_PASSWORD_RESET_CONFIRM', windowEnv: 'RATE_LIMIT_AUTH_PASSWORD_RESET_WINDOW_SECONDS' })
+  @Post('password-reset/confirm')
+  confirmPasswordReset(@Body() dto: ConfirmPasswordResetDto, @Ip() ip?: string) {
+    return this.passwordReset.confirm(dto.token, dto.newPassword, ip);
   }
 
   @Public()

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -1,13 +1,15 @@
 import { Module } from '@nestjs/common';
 import { BusinessReputationModule } from '../business-reputation/business-reputation.module';
+import { AuditModule } from '../audit/audit.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { AuthSessionService } from './auth-session.service';
+import { PasswordResetService } from './password-reset.service';
 
 @Module({
-  imports: [BusinessReputationModule],
+  imports: [BusinessReputationModule, AuditModule],
   controllers: [AuthController],
-  providers: [AuthService, AuthSessionService],
-  exports: [AuthService, AuthSessionService],
+  providers: [AuthService, AuthSessionService, PasswordResetService],
+  exports: [AuthService, AuthSessionService, PasswordResetService],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/dto/password-reset.dto.ts
+++ b/apps/api/src/modules/auth/dto/password-reset.dto.ts
@@ -1,0 +1,19 @@
+import { IsEmail, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class RequestPasswordResetDto {
+  @IsEmail()
+  @MaxLength(254)
+  email!: string;
+}
+
+export class ConfirmPasswordResetDto {
+  @IsString()
+  @MinLength(32)
+  @MaxLength(2048)
+  token!: string;
+
+  @IsString()
+  @MinLength(12)
+  @MaxLength(128)
+  newPassword!: string;
+}

--- a/apps/api/src/modules/auth/password-reset-token.spec.ts
+++ b/apps/api/src/modules/auth/password-reset-token.spec.ts
@@ -1,0 +1,47 @@
+import {
+  issuePasswordResetToken,
+  PASSWORD_RESET_TTL_SECONDS,
+  verifyPasswordResetToken,
+} from './password-reset-token';
+
+const env = {
+  PASSWORD_RESET_TOKEN_SECRET: 'test-password-reset-secret-with-more-than-thirty-two-characters',
+} as NodeJS.ProcessEnv;
+
+describe('password reset token codec', () => {
+  it('issues a bounded signed token', () => {
+    const token = issuePasswordResetToken('challenge-1', 'user-1', 1_000, env);
+    const payload = verifyPasswordResetToken(token, 1_001, env);
+
+    expect(payload).toMatchObject({
+      v: 1,
+      cid: 'challenge-1',
+      sub: 'user-1',
+      iat: 1_000,
+      exp: 1_000 + PASSWORD_RESET_TTL_SECONDS,
+    });
+    expect(payload?.nonce.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it('rejects tampering', () => {
+    const token = issuePasswordResetToken('challenge-1', 'user-1', 1_000, env);
+    const [payload, signature] = token.split('.');
+    const tampered = `${payload.slice(0, -1)}A.${signature}`;
+
+    expect(verifyPasswordResetToken(tampered, 1_001, env)).toBeNull();
+  });
+
+  it('rejects expired and wrong-secret tokens', () => {
+    const token = issuePasswordResetToken('challenge-1', 'user-1', 1_000, env);
+
+    expect(verifyPasswordResetToken(token, 1_000 + PASSWORD_RESET_TTL_SECONDS, env)).toBeNull();
+    expect(verifyPasswordResetToken(token, 1_001, {
+      PASSWORD_RESET_TOKEN_SECRET: 'different-secret-with-more-than-thirty-two-characters',
+    } as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  it('fails closed when the secret is missing or weak', () => {
+    expect(() => issuePasswordResetToken('challenge-1', 'user-1', 1_000, {})).toThrow();
+    expect(verifyPasswordResetToken('invalid.token', 1_001, {})).toBeNull();
+  });
+});

--- a/apps/api/src/modules/auth/password-reset-token.ts
+++ b/apps/api/src/modules/auth/password-reset-token.ts
@@ -1,0 +1,80 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+
+export const PASSWORD_RESET_TTL_SECONDS = 15 * 60;
+
+export type PasswordResetTokenPayload = {
+  v: 1;
+  cid: string;
+  sub: string;
+  nonce: string;
+  iat: number;
+  exp: number;
+};
+
+function secret(env: NodeJS.ProcessEnv = process.env): string {
+  const value = String(env.PASSWORD_RESET_TOKEN_SECRET || env.JWT_SECRET || '').trim();
+  if (value.length < 32) throw new Error('PASSWORD_RESET_TOKEN_SECRET must contain at least 32 characters');
+  return value;
+}
+
+function signature(encodedPayload: string, env: NodeJS.ProcessEnv = process.env): string {
+  return createHmac('sha256', secret(env)).update(encodedPayload).digest('base64url');
+}
+
+export function issuePasswordResetToken(
+  challengeId: string,
+  userId: string,
+  nowSeconds = Math.floor(Date.now() / 1000),
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const payload: PasswordResetTokenPayload = {
+    v: 1,
+    cid: challengeId,
+    sub: userId,
+    nonce: randomBytes(24).toString('base64url'),
+    iat: nowSeconds,
+    exp: nowSeconds + PASSWORD_RESET_TTL_SECONDS,
+  };
+  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  return `${encoded}.${signature(encoded, env)}`;
+}
+
+export function verifyPasswordResetToken(
+  token: string,
+  nowSeconds = Math.floor(Date.now() / 1000),
+  env: NodeJS.ProcessEnv = process.env,
+): PasswordResetTokenPayload | null {
+  const [encoded, suppliedSignature, extra] = String(token || '').split('.');
+  if (!encoded || !suppliedSignature || extra) return null;
+
+  let expectedSignature: string;
+  try {
+    expectedSignature = signature(encoded, env);
+  } catch {
+    return null;
+  }
+
+  const supplied = Buffer.from(suppliedSignature, 'utf8');
+  const expected = Buffer.from(expectedSignature, 'utf8');
+  if (supplied.length !== expected.length || !timingSafeEqual(supplied, expected)) return null;
+
+  try {
+    const payload = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8')) as Partial<PasswordResetTokenPayload>;
+    if (
+      payload.v !== 1 ||
+      typeof payload.cid !== 'string' || !payload.cid ||
+      typeof payload.sub !== 'string' || !payload.sub ||
+      typeof payload.nonce !== 'string' || payload.nonce.length < 20 ||
+      typeof payload.iat !== 'number' ||
+      typeof payload.exp !== 'number' ||
+      payload.exp <= nowSeconds ||
+      payload.iat > nowSeconds + 60 ||
+      payload.exp - payload.iat > PASSWORD_RESET_TTL_SECONDS
+    ) {
+      return null;
+    }
+    return payload as PasswordResetTokenPayload;
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/modules/auth/password-reset.service.spec.ts
+++ b/apps/api/src/modules/auth/password-reset.service.spec.ts
@@ -1,0 +1,144 @@
+import { BadRequestException } from '@nestjs/common';
+import { PasswordResetService } from './password-reset.service';
+import { issuePasswordResetToken } from './password-reset-token';
+
+const DELIVERY_KEY = 'delivery-boundary-secret-with-more-than-thirty-two-characters';
+const TOKEN_SECRET = 'password-reset-token-secret-with-more-than-thirty-two-characters';
+
+describe('PasswordResetService', () => {
+  const previousEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.PASSWORD_RESET_DELIVERY_KEY = DELIVERY_KEY;
+    process.env.PASSWORD_RESET_TOKEN_SECRET = TOKEN_SECRET;
+  });
+
+  afterAll(() => {
+    process.env = previousEnv;
+  });
+
+  function setup(overrides: Record<string, unknown> = {}) {
+    const tx = {
+      mfaChallenge: {
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+        create: jest.fn().mockResolvedValue({ id: 'challenge-1', expiresAt: new Date(Date.now() + 900_000) }),
+      },
+      user: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      authSession: { updateMany: jest.fn().mockResolvedValue({ count: 2 }) },
+      authRefreshFamily: { updateMany: jest.fn().mockResolvedValue({ count: 2 }) },
+    };
+    const prisma = {
+      user: { findUnique: jest.fn().mockResolvedValue(null) },
+      mfaChallenge: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      $transaction: jest.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+      ...overrides,
+    };
+    const audit = { log: jest.fn() };
+    return { service: new PasswordResetService(prisma as never, audit as never), prisma, audit, tx };
+  }
+
+  it('returns the same public response when the trusted delivery boundary is missing', async () => {
+    const { service, prisma } = setup();
+
+    await expect(service.request('unknown@example.com', '127.0.0.1')).resolves.toEqual({
+      accepted: true,
+      message: 'If the account exists, password reset instructions will be sent.',
+    });
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('does not expose account existence to the trusted BFF for an unknown account', async () => {
+    const { service } = setup();
+
+    const result = await service.request('unknown@example.com', '127.0.0.1', DELIVERY_KEY);
+
+    expect(result).toEqual({
+      accepted: true,
+      message: 'If the account exists, password reset instructions will be sent.',
+    });
+    expect('delivery' in result).toBe(false);
+  });
+
+  it('issues a single short-lived delivery token for an eligible account', async () => {
+    const { service, prisma, tx } = setup({
+      user: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'user-1',
+          email: 'user@example.com',
+          status: 'ACTIVE',
+          deletedAt: null,
+        }),
+      },
+    });
+
+    const result = await service.request(' User@Example.com ', '127.0.0.1', DELIVERY_KEY);
+
+    expect(result).toMatchObject({
+      accepted: true,
+      delivery: {
+        email: 'user@example.com',
+        expiresInSeconds: 900,
+      },
+    });
+    expect((result as { delivery: { token: string } }).delivery.token).toContain('.');
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(tx.mfaChallenge.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ purpose: 'PASSWORD_RESET', status: 'PENDING' }),
+    }));
+  });
+
+  it('honours the per-account cooldown without issuing another token', async () => {
+    const { service, prisma } = setup({
+      user: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'user-1',
+          email: 'user@example.com',
+          status: 'ACTIVE',
+          deletedAt: null,
+        }),
+      },
+      mfaChallenge: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'challenge-existing', expiresAt: new Date(Date.now() + 600_000) }),
+        updateMany: jest.fn(),
+      },
+    });
+
+    const result = await service.request('user@example.com', '127.0.0.1', DELIVERY_KEY);
+
+    expect('delivery' in result).toBe(false);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('consumes the challenge and revokes active sessions in one transaction', async () => {
+    const { service, tx } = setup();
+    const token = issuePasswordResetToken('challenge-1', 'user-1');
+
+    await expect(service.confirm(token, 'New-Industrial-Passphrase-2026!', '127.0.0.1')).resolves.toEqual({
+      success: true,
+      sessionsRevoked: true,
+    });
+
+    expect(tx.mfaChallenge.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ id: 'challenge-1', status: 'PENDING' }),
+      data: expect.objectContaining({ status: 'CONSUMED' }),
+    }));
+    expect(tx.authSession.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: 'REVOKED', revokeReason: 'password_reset' }),
+    }));
+    expect(tx.authRefreshFamily.updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: 'REVOKED', revokeReason: 'password_reset' }),
+    }));
+  });
+
+  it('rejects replay after the challenge was already consumed', async () => {
+    const { service, tx } = setup();
+    tx.mfaChallenge.updateMany.mockResolvedValueOnce({ count: 0 });
+    const token = issuePasswordResetToken('challenge-1', 'user-1');
+
+    await expect(service.confirm(token, 'New-Industrial-Passphrase-2026!', '127.0.0.1'))
+      .rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/apps/api/src/modules/auth/password-reset.service.ts
+++ b/apps/api/src/modules/auth/password-reset.service.ts
@@ -1,0 +1,266 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+import { timingSafeEqual } from 'crypto';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { accountKeyHash, hmacFingerprint } from './auth-crypto';
+import {
+  issuePasswordResetToken,
+  PASSWORD_RESET_TTL_SECONDS,
+  verifyPasswordResetToken,
+} from './password-reset-token';
+
+const PURPOSE = 'PASSWORD_RESET';
+const COOLDOWN_MS = 60 * 1000;
+const UNIVERSAL_RESPONSE = {
+  accepted: true,
+  message: 'If the account exists, password reset instructions will be sent.',
+} as const;
+
+function safeEqual(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  const left = Buffer.from(a, 'utf8');
+  const right = Buffer.from(b, 'utf8');
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+function deliveryAuthorized(provided: string | undefined, env: NodeJS.ProcessEnv = process.env): boolean {
+  const expected = String(env.PASSWORD_RESET_DELIVERY_KEY || '').trim();
+  return expected.length >= 32 && safeEqual(String(provided || '').trim(), expected);
+}
+
+function assertPasswordPolicy(password: string) {
+  const classes = [/[a-z]/, /[A-Z]/, /\d/, /[^A-Za-z0-9]/].filter((pattern) => pattern.test(password)).length;
+  if (password.length < 12 || password.length > 128 || classes < 3) {
+    throw new BadRequestException({
+      code: 'PASSWORD_POLICY_FAILED',
+      message: 'The password must be 12-128 characters and include at least three character classes.',
+    });
+  }
+}
+
+@Injectable()
+export class PasswordResetService {
+  private readonly logger = new Logger(PasswordResetService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  async request(emailInput: string, ip?: string, deliveryKey?: string) {
+    const email = String(emailInput || '').trim().toLowerCase();
+    const accountHash = accountKeyHash(email);
+    const ipHash = hmacFingerprint(ip);
+
+    // Only the trusted web BFF may obtain a delivery token. Direct calls remain
+    // universal and do not create undeliverable challenges that could lock out a user.
+    if (!deliveryAuthorized(deliveryKey)) {
+      this.audit.log({
+        action: 'AUTH_PASSWORD_RESET_REQUEST_REJECTED_DELIVERY_BOUNDARY',
+        actorRole: 'PUBLIC',
+        objectType: 'ACCOUNT_HASH',
+        objectId: accountHash,
+        outcome: 'ACCEPTED_WITHOUT_ISSUANCE',
+        meta: { ipHash },
+      });
+      return UNIVERSAL_RESPONSE;
+    }
+
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+      select: { id: true, email: true, status: true, deletedAt: true },
+    });
+
+    if (!user || user.status !== 'ACTIVE' || user.deletedAt) {
+      this.audit.log({
+        action: 'AUTH_PASSWORD_RESET_REQUEST_ACCEPTED',
+        actorRole: 'PUBLIC',
+        objectType: 'ACCOUNT_HASH',
+        objectId: accountHash,
+        outcome: 'ACCEPTED',
+        meta: { eligible: false, ipHash },
+      });
+      return UNIVERSAL_RESPONSE;
+    }
+
+    const now = new Date();
+    const cooldownCutoff = new Date(now.getTime() - COOLDOWN_MS);
+    const recent = await this.prisma.mfaChallenge.findFirst({
+      where: {
+        userId: user.id,
+        purpose: PURPOSE,
+        status: 'PENDING',
+        createdAt: { gt: cooldownCutoff },
+        expiresAt: { gt: now },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, expiresAt: true },
+    });
+
+    if (recent) {
+      this.audit.log({
+        action: 'AUTH_PASSWORD_RESET_REQUEST_COOLDOWN',
+        actorUserId: user.id,
+        actorRole: 'PUBLIC',
+        objectType: 'MFA_CHALLENGE',
+        objectId: recent.id,
+        outcome: 'ACCEPTED_WITHOUT_ISSUANCE',
+        meta: { ipHash },
+      });
+      return UNIVERSAL_RESPONSE;
+    }
+
+    let challenge: { id: string; expiresAt: Date };
+    try {
+      challenge = await this.prisma.$transaction(
+        async (tx) => {
+          await tx.mfaChallenge.updateMany({
+            where: { userId: user.id, purpose: PURPOSE, status: 'PENDING' },
+            data: { status: 'EXPIRED' },
+          });
+          return tx.mfaChallenge.create({
+            data: {
+              userId: user.id,
+              purpose: PURPOSE,
+              status: 'PENDING',
+              expiresAt: new Date(now.getTime() + PASSWORD_RESET_TTL_SECONDS * 1000),
+            },
+            select: { id: true, expiresAt: true },
+          });
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+    } catch (error) {
+      this.logger.error('Failed to create password reset challenge', error instanceof Error ? error.stack : undefined);
+      this.audit.log({
+        action: 'AUTH_PASSWORD_RESET_REQUEST_FAILED',
+        actorUserId: user.id,
+        actorRole: 'SYSTEM',
+        objectType: 'USER',
+        objectId: user.id,
+        outcome: 'FAILURE',
+        reason: 'challenge_creation_failed',
+        meta: { ipHash },
+      });
+      return UNIVERSAL_RESPONSE;
+    }
+
+    let token: string;
+    try {
+      token = issuePasswordResetToken(challenge.id, user.id);
+    } catch (error) {
+      await this.prisma.mfaChallenge.updateMany({
+        where: { id: challenge.id, status: 'PENDING' },
+        data: { status: 'EXPIRED' },
+      });
+      this.logger.error('Password reset token secret is not configured', error instanceof Error ? error.stack : undefined);
+      this.audit.log({
+        action: 'AUTH_PASSWORD_RESET_REQUEST_FAILED',
+        actorUserId: user.id,
+        actorRole: 'SYSTEM',
+        objectType: 'MFA_CHALLENGE',
+        objectId: challenge.id,
+        outcome: 'FAILURE',
+        reason: 'token_secret_unavailable',
+        meta: { ipHash },
+      });
+      return UNIVERSAL_RESPONSE;
+    }
+
+    this.audit.log({
+      action: 'AUTH_PASSWORD_RESET_REQUEST_ISSUED',
+      actorUserId: user.id,
+      actorRole: 'PUBLIC',
+      objectType: 'MFA_CHALLENGE',
+      objectId: challenge.id,
+      outcome: 'SUCCESS',
+      meta: { ipHash, expiresAt: challenge.expiresAt.toISOString() },
+    });
+
+    return {
+      ...UNIVERSAL_RESPONSE,
+      delivery: {
+        email: user.email,
+        token,
+        expiresInSeconds: PASSWORD_RESET_TTL_SECONDS,
+      },
+    };
+  }
+
+  async confirm(token: string, newPassword: string, ip?: string) {
+    assertPasswordPolicy(newPassword);
+    const payload = verifyPasswordResetToken(token);
+    if (!payload) {
+      throw new BadRequestException({ code: 'PASSWORD_RESET_INVALID', message: 'The reset link is invalid or expired.' });
+    }
+
+    const passwordHash = await bcrypt.hash(newPassword, 12);
+    const now = new Date();
+    const ipHash = hmacFingerprint(ip);
+
+    try {
+      await this.prisma.$transaction(
+        async (tx) => {
+          const claimed = await tx.mfaChallenge.updateMany({
+            where: {
+              id: payload.cid,
+              userId: payload.sub,
+              purpose: PURPOSE,
+              status: 'PENDING',
+              expiresAt: { gt: now },
+            },
+            data: { status: 'CONSUMED', consumedAt: now, verifiedAt: now },
+          });
+          if (claimed.count !== 1) {
+            throw new BadRequestException({ code: 'PASSWORD_RESET_INVALID', message: 'The reset link is invalid or expired.' });
+          }
+
+          const updated = await tx.user.updateMany({
+            where: { id: payload.sub, status: 'ACTIVE', deletedAt: null },
+            data: { passwordHash },
+          });
+          if (updated.count !== 1) {
+            throw new BadRequestException({ code: 'PASSWORD_RESET_INVALID', message: 'The reset link is invalid or expired.' });
+          }
+
+          await tx.authSession.updateMany({
+            where: { userId: payload.sub, status: 'ACTIVE' },
+            data: { status: 'REVOKED', revokedAt: now, revokeReason: 'password_reset' },
+          });
+          await tx.authRefreshFamily.updateMany({
+            where: { userId: payload.sub, status: 'ACTIVE' },
+            data: { status: 'REVOKED', revokedAt: now, revokeReason: 'password_reset' },
+          });
+          await tx.mfaChallenge.updateMany({
+            where: {
+              userId: payload.sub,
+              purpose: PURPOSE,
+              status: 'PENDING',
+              id: { not: payload.cid },
+            },
+            data: { status: 'EXPIRED' },
+          });
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+    } catch (error) {
+      if (error instanceof BadRequestException) throw error;
+      this.logger.error('Password reset confirmation failed', error instanceof Error ? error.stack : undefined);
+      throw new BadRequestException({ code: 'PASSWORD_RESET_INVALID', message: 'The reset link is invalid or expired.' });
+    }
+
+    this.audit.log({
+      action: 'AUTH_PASSWORD_RESET_COMPLETED',
+      actorUserId: payload.sub,
+      actorRole: 'PUBLIC',
+      objectType: 'MFA_CHALLENGE',
+      objectId: payload.cid,
+      outcome: 'SUCCESS',
+      meta: { ipHash, sessionsRevoked: true },
+    });
+
+    return { success: true, sessionsRevoked: true };
+  }
+}


### PR DESCRIPTION
## Цель

Добавить промышленный backend password recovery поверх persistent identity/session/MFA foundation PR #2275, не смешивая security boundary с публичным UI.

## Реализовано

- `POST /auth/password-reset/request` с universal response и IP rate limiting;
- trusted delivery boundary: reset token возвращается только web BFF с отдельным 32+ char secret;
- прямой вызов API не создаёт недоставляемый challenge и не раскрывает существование аккаунта;
- 60-секундный per-account cooldown;
- signed HMAC token с nonce, 15-минутным TTL и fail-closed secret policy;
- persistent single-use challenge на существующей PostgreSQL `mfa_challenges` state machine;
- `POST /auth/password-reset/confirm` с password policy;
- Serializable transaction: consume challenge → update password → revoke active sessions → revoke refresh families → invalidate parallel reset challenges;
- security audit events без записи email, пароля, reset token или других секретов;
- unit tests на tampering, expiry, wrong secret, enumeration, cooldown, replay и session revocation.

## Архитектурное решение

Новая таблица не добавляется: используется существующая durable `MfaChallenge` state machine с purpose `PASSWORD_RESET`. Это снижает миграционный риск и сохраняет одноразовость/TTL в PostgreSQL.

## Обязательная конфигурация

- `PASSWORD_RESET_TOKEN_SECRET` — минимум 32 символа;
- `PASSWORD_RESET_DELIVERY_KEY` — минимум 32 символа, одинаковый в API и web BFF.

## Граница

Этот PR зависит от PR #2275. Email-доставка и публичные forgot/reset screens выполняются отдельным web PR. Production-ready не заявляется до миграции auth foundation, доставки, CI, preview и production smoke.