### PR TITLE
PR-4C API: Rate-limit MFA enrollment and verification

### DIFF
--- a/apps/api/src/modules/mfa/mfa.controller.spec.ts
+++ b/apps/api/src/modules/mfa/mfa.controller.spec.ts
@@ -1,0 +1,32 @@
+import { RATE_LIMIT_OPTIONS, type RateLimitOptions } from '../../common/decorators/rate-limit.decorator';
+import { MfaController } from './mfa.controller';
+
+function options(method: keyof MfaController): RateLimitOptions | undefined {
+  const handler = MfaController.prototype[method];
+  return Reflect.getMetadata(RATE_LIMIT_OPTIONS, handler as object) as RateLimitOptions | undefined;
+}
+
+describe('MfaController rate limits', () => {
+  it('limits challenge creation per authenticated user', () => {
+    expect(options('initVerification')).toMatchObject({
+      name: 'mfa_verify_init',
+      scope: 'user',
+      limit: 5,
+      windowSeconds: 300,
+    });
+  });
+
+  it('limits TOTP and backup-code verification per authenticated user', () => {
+    expect(options('verify')).toMatchObject({
+      name: 'mfa_verify',
+      scope: 'user',
+      limit: 8,
+      windowSeconds: 300,
+    });
+  });
+
+  it('also protects MFA enrollment endpoints', () => {
+    expect(options('initSetup')).toMatchObject({ scope: 'user', limit: 3, windowSeconds: 300 });
+    expect(options('verifySetup')).toMatchObject({ scope: 'user', limit: 8, windowSeconds: 300 });
+  });
+});

--- a/apps/api/src/modules/mfa/mfa.controller.ts
+++ b/apps/api/src/modules/mfa/mfa.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, Post } from '@nestjs/common';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { RateLimit } from '../../common/decorators/rate-limit.decorator';
 import type { RequestUser } from '../../common/types/request-user';
 import { MfaService } from './mfa.service';
 
@@ -12,11 +13,13 @@ export class MfaController {
     return this.mfa.status(user);
   }
 
+  @RateLimit({ name: 'mfa_setup_init', scope: 'user', limit: 3, windowSeconds: 300, limitEnv: 'RATE_LIMIT_MFA_SETUP_INIT', windowEnv: 'RATE_LIMIT_MFA_WINDOW_SECONDS' })
   @Post('setup/init')
   initSetup(@CurrentUser() user: RequestUser) {
     return this.mfa.beginSetup(user);
   }
 
+  @RateLimit({ name: 'mfa_setup_verify', scope: 'user', limit: 8, windowSeconds: 300, limitEnv: 'RATE_LIMIT_MFA_SETUP_VERIFY', windowEnv: 'RATE_LIMIT_MFA_WINDOW_SECONDS' })
   @Post('setup/verify')
   verifySetup(
     @CurrentUser() user: RequestUser,
@@ -25,11 +28,13 @@ export class MfaController {
     return this.mfa.confirmSetup(user, body.challengeId, body.code);
   }
 
+  @RateLimit({ name: 'mfa_verify_init', scope: 'user', limit: 5, windowSeconds: 300, limitEnv: 'RATE_LIMIT_MFA_VERIFY_INIT', windowEnv: 'RATE_LIMIT_MFA_WINDOW_SECONDS' })
   @Post('verify/init')
   initVerification(@CurrentUser() user: RequestUser) {
     return this.mfa.beginStepUp(user);
   }
 
+  @RateLimit({ name: 'mfa_verify', scope: 'user', limit: 8, windowSeconds: 300, limitEnv: 'RATE_LIMIT_MFA_VERIFY', windowEnv: 'RATE_LIMIT_MFA_WINDOW_SECONDS' })
   @Post('verify')
   verify(
     @CurrentUser() user: RequestUser,


### PR DESCRIPTION
## Цель

Добавить обязательный серверный rate limiting для TOTP/backup-code verification и MFA enrollment поверх persistent auth/recovery ветки.

## Реализовано

- `setup/init`: 3 запроса на пользователя за 5 минут;
- `setup/verify`: 8 попыток на пользователя за 5 минут;
- `verify/init`: 5 challenge на пользователя за 5 минут;
- `verify`: 8 TOTP/backup-code попыток на пользователя за 5 минут;
- лимиты настраиваются env-переменными;
- unit test проверяет metadata всех четырёх endpoint.

## Зависимость

Base — PR #2310, который зависит от persistent auth PR #2275.

## Граница

Rate limiting снижает brute-force риск, но production acceptance дополнительно требует централизованных MFA failure metrics/alerts и подтверждённого поведения распределённого rate-limit store под горизонтальной нагрузкой.