### PR TITLE
Harden platform-v7 public entry and access recovery

### DIFF
--- a/apps/web/app/platform-v7/forgot-password/page.tsx
+++ b/apps/web/app/platform-v7/forgot-password/page.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { ArrowLeft, CheckCircle2, Mail } from 'lucide-react';
+import { PublicSiteHeader } from '@/components/platform-v7/PublicSiteHeader';
+
+export default function ForgotPasswordPage() {
+  const t = useTranslations('publicEntry.forgot');
+  const [email, setEmail] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [submitted, setSubmitted] = React.useState(false);
+  const [error, setError] = React.useState('');
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const contact = email.trim();
+    if (!contact) {
+      setError(t('error'));
+      return;
+    }
+
+    setSubmitting(true);
+    setError('');
+
+    try {
+      const response = await fetch('/api/platform-v7/inquiries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'technical',
+          source: 'platform_v7_contact_page',
+          name: t('requestName'),
+          organization: '',
+          contact,
+          message: t('requestMessage'),
+          consent: 'yes',
+          website: '',
+        }),
+        cache: 'no-store',
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || payload?.accepted !== true) throw new Error('recovery_request_failed');
+      setSubmitted(true);
+    } catch {
+      setError(t('error'));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className='pc-v7-public-entry pc-recovery-page'>
+      <PublicSiteHeader
+        ariaLabel={t('publicNav')}
+        tagline={t('brandTagline')}
+        actions={(
+          <Link className='pc-site-action' href='/platform-v7' aria-label={t('backHome')} title={t('backHome')}>
+            <ArrowLeft size={20} aria-hidden='true' />
+            <span>{t('backHome')}</span>
+          </Link>
+        )}
+      />
+
+      <section className='pc-recovery-shell' aria-labelledby='pc-recovery-title'>
+        <div className='pc-recovery-heading'>
+          <h1 id='pc-recovery-title'>{t('title')}</h1>
+          <p>{t('lead')}</p>
+        </div>
+
+        {submitted ? (
+          <section className='pc-recovery-card pc-recovery-success' aria-live='polite'>
+            <CheckCircle2 size={42} strokeWidth={1.9} aria-hidden='true' />
+            <h2>{t('successTitle')}</h2>
+            <p>{t('successText')}</p>
+            <Link className='pc-recovery-primary-link' href='/platform-v7/login'>{t('backToLogin')}</Link>
+          </section>
+        ) : (
+          <form className='pc-recovery-card' onSubmit={onSubmit} noValidate>
+            <label className='pc-recovery-label'>
+              <span>{t('email')}</span>
+              <span className='pc-recovery-field'>
+                <Mail size={19} aria-hidden='true' />
+                <input
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  type='email'
+                  inputMode='email'
+                  autoComplete='email'
+                  placeholder={t('emailPlaceholder')}
+                  disabled={submitting}
+                  aria-invalid={Boolean(error)}
+                />
+              </span>
+            </label>
+
+            {error ? <p className='pc-recovery-error' role='alert'>{error}</p> : null}
+
+            <button className='pc-recovery-submit' type='submit' disabled={submitting}>
+              {submitting ? t('loading') : t('submit')}
+            </button>
+
+            <Link className='pc-recovery-login-link' href='/platform-v7/login'>{t('backToLogin')}</Link>
+            <p className='pc-recovery-note'>{t('note')}</p>
+          </form>
+        )}
+      </section>
+
+      <style jsx>{`
+        .pc-recovery-page{--recovery-header-height:64px;min-height:100dvh;padding-top:var(--recovery-header-height);background:radial-gradient(circle at 85% 0%,rgba(8,122,59,.12),transparent 34%),linear-gradient(180deg,#f7faf7 0%,#eef5ef 58%,#f8faf8 100%);color:#102019;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.pc-recovery-page *{box-sizing:border-box}.pc-recovery-shell{width:min(100%,560px);min-height:calc(100dvh - var(--recovery-header-height));margin:0 auto;padding:clamp(34px,7vh,74px) 18px 40px;display:flex;flex-direction:column;justify-content:center;gap:24px}.pc-recovery-heading{text-align:center}.pc-recovery-heading h1{margin:0;font-size:clamp(38px,7vw,58px);line-height:1;letter-spacing:-.055em}.pc-recovery-heading p{max-width:520px;margin:16px auto 0;color:#5c6b64;font-size:16px;line-height:1.5;font-weight:600}.pc-recovery-card{display:grid;gap:18px;padding:clamp(22px,5vw,36px);border-radius:30px;background:rgba(255,255,255,.96);border:1px solid rgba(16,32,25,.1);box-shadow:0 28px 80px rgba(27,66,45,.13)}.pc-recovery-label{display:grid;gap:8px}.pc-recovery-label>span:first-child{font-size:13px;font-weight:900;color:#31423a}.pc-recovery-field{height:56px;display:flex;align-items:center;gap:10px;padding:0 15px;border-radius:17px;background:#f9fbf9;border:1px solid rgba(16,32,25,.12);transition:border-color .15s,box-shadow .15s}.pc-recovery-field:focus-within{border-color:rgba(8,122,59,.58);box-shadow:0 0 0 4px rgba(8,122,59,.1)}.pc-recovery-field>svg{color:#708078;flex:0 0 auto}.pc-recovery-field input{width:100%;height:100%;min-width:0;border:0;outline:0;background:transparent;color:#102019;font:inherit;font-size:16px}.pc-recovery-error{margin:0;padding:12px 14px;border-radius:14px;background:#fff1f1;border:1px solid #f2c5c5;color:#9b2525;font-size:13px;font-weight:800;line-height:1.4}.pc-recovery-submit,.pc-recovery-primary-link{min-height:56px;border:0;border-radius:17px;background:linear-gradient(135deg,#087a3b,#075f31);color:#fff;font:inherit;font-size:15px;font-weight:950;display:flex;align-items:center;justify-content:center;text-align:center;text-decoration:none;cursor:pointer;box-shadow:0 18px 36px rgba(8,122,59,.22)}.pc-recovery-submit:disabled{cursor:wait;opacity:.66}.pc-recovery-submit:focus-visible,.pc-recovery-primary-link:focus-visible,.pc-recovery-login-link:focus-visible{outline:3px solid rgba(8,122,59,.35);outline-offset:3px}.pc-recovery-login-link{justify-self:center;color:#087a3b;text-decoration:none;font-size:13px;font-weight:850}.pc-recovery-note{margin:0;color:#6b7973;font-size:12px;line-height:1.5;text-align:center}.pc-recovery-success{text-align:center;justify-items:center}.pc-recovery-success>svg{color:#087a3b}.pc-recovery-success h2{margin:0;font-size:28px;letter-spacing:-.04em}.pc-recovery-success p{margin:0;color:#5c6b64;line-height:1.55}.pc-recovery-primary-link{width:100%;margin-top:4px}@media(max-width:520px){.pc-recovery-shell{padding:28px 14px 28px;justify-content:flex-start}.pc-recovery-heading h1{font-size:38px}.pc-recovery-card{padding:22px;border-radius:24px}.pc-recovery-field{height:54px}}
+      `}</style>
+    </main>
+  );
+}

--- a/apps/web/app/platform-v7/login/page.tsx
+++ b/apps/web/app/platform-v7/login/page.tsx
@@ -3,76 +3,13 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, CheckCircle2, Eye, EyeOff, LockKeyhole, Mail, ShieldCheck, Wheat } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { ArrowLeft, Eye, EyeOff, LockKeyhole, Mail } from 'lucide-react';
+import { PublicSiteHeader } from '@/components/platform-v7/PublicSiteHeader';
 import { PLATFORM_V7_ACTIVE_ROLE_KEY, platformV7RoleHome } from '@/components/platform-v7/PlatformV7SingleEntryGuard';
 import { usePlatformV7RStore, type PlatformRole } from '@/stores/usePlatformV7RStore';
 
-type Lang = 'ru' | 'en' | 'zh';
 const ENTRY_COOKIE = 'pc_v7_entry_seen';
-const LANGUAGE_KEY = 'pc-v7-language';
-
-const copy = {
-  ru: {
-    brand: 'Прозрачная Цена',
-    subbrand: 'Единый вход в контур сделки',
-    title: 'Войти в систему',
-    lead: 'Роль, организация и полномочия определяются сервером после проверки учётной записи.',
-    email: 'Рабочий email',
-    password: 'Пароль',
-    emailPlaceholder: 'name@company.ru',
-    passwordPlaceholder: 'Введите пароль',
-    submit: 'Войти',
-    loading: 'Проверяем доступ…',
-    forgot: 'Восстановить доступ',
-    register: 'Создать учётную запись',
-    back: 'Назад',
-    required: 'Введи email и пароль.',
-    unavailable: 'Не удалось подтвердить доступ. Проверь данные или повтори позже.',
-    facts: ['Один аккаунт', 'Права только с сервера', 'Защищённая сессия'],
-  },
-  en: {
-    brand: 'Transparent Price',
-    subbrand: 'Single entry to the deal execution circuit',
-    title: 'Sign in',
-    lead: 'Role, organisation and permissions are resolved by the server after account verification.',
-    email: 'Work email',
-    password: 'Password',
-    emailPlaceholder: 'name@company.com',
-    passwordPlaceholder: 'Enter password',
-    submit: 'Sign in',
-    loading: 'Verifying access…',
-    forgot: 'Restore access',
-    register: 'Create account',
-    back: 'Back',
-    required: 'Enter email and password.',
-    unavailable: 'Access could not be verified. Check the credentials or try again later.',
-    facts: ['One account', 'Server-side permissions', 'Protected session'],
-  },
-  zh: {
-    brand: '透明价格',
-    subbrand: '统一进入交易执行闭环',
-    title: '登录系统',
-    lead: '服务器在验证账户后确定角色、组织和权限。',
-    email: '工作邮箱',
-    password: '密码',
-    emailPlaceholder: 'name@company.cn',
-    passwordPlaceholder: '输入密码',
-    submit: '登录',
-    loading: '正在验证访问权限…',
-    forgot: '恢复访问权限',
-    register: '创建账户',
-    back: '返回',
-    required: '请输入邮箱和密码。',
-    unavailable: '无法验证访问权限。请检查凭据或稍后重试。',
-    facts: ['一个账户', '服务器权限控制', '受保护会话'],
-  },
-} as const;
-
-function readLanguage(): Lang {
-  if (typeof window === 'undefined') return 'ru';
-  const value = window.localStorage.getItem(LANGUAGE_KEY);
-  return value === 'en' || value === 'zh' ? value : 'ru';
-}
 
 function surfaceRole(role: string | undefined): PlatformRole {
   const normalized = String(role ?? '').toUpperCase();
@@ -96,31 +33,25 @@ function markEntrySeen() {
 }
 
 export default function LoginPage() {
+  const t = useTranslations('publicEntry.login');
   const router = useRouter();
   const setRole = usePlatformV7RStore((state) => state.setRole);
-  const [lang, setLang] = React.useState<Lang>('ru');
   const [email, setEmail] = React.useState('');
   const [password, setPassword] = React.useState('');
   const [showPassword, setShowPassword] = React.useState(false);
   const [submitting, setSubmitting] = React.useState(false);
   const [error, setError] = React.useState('');
 
-  React.useEffect(() => {
-    const update = () => setLang(readLanguage());
-    update();
-    window.addEventListener('storage', update);
-    return () => window.removeEventListener('storage', update);
-  }, []);
-
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!email.trim() || !password) {
-      setError(copy[lang].required);
+      setError(t('required'));
       return;
     }
 
     setSubmitting(true);
     setError('');
+
     try {
       const response = await fetch('/api/auth/login', {
         method: 'POST',
@@ -130,13 +61,10 @@ export default function LoginPage() {
       });
       const payload = await response.json().catch(() => ({}));
       if (!response.ok || !payload?.ok) {
-        throw new Error(payload?.message || copy[lang].unavailable);
+        throw new Error(payload?.message || t('unavailable'));
       }
 
       const role = surfaceRole(payload?.user?.role ?? payload?.role);
-      // A production login mints the cabinet exclusively from the verified access token.
-      // The role is sent only for a server-labelled gated demo fallback, where the
-      // cabinet-session endpoint independently checks the explicit non-production flag.
       const sessionBody = payload?.demo === true ? { role } : {};
       const sessionResponse = await fetch('/api/platform-v7/cabinet-session', {
         method: 'POST',
@@ -144,9 +72,7 @@ export default function LoginPage() {
         body: JSON.stringify(sessionBody),
         cache: 'no-store',
       });
-      if (!sessionResponse.ok) {
-        throw new Error(copy[lang].unavailable);
-      }
+      if (!sessionResponse.ok) throw new Error(t('unavailable'));
 
       markEntrySeen();
       globalThis.sessionStorage?.setItem(PLATFORM_V7_ACTIVE_ROLE_KEY, role);
@@ -154,57 +80,91 @@ export default function LoginPage() {
       router.replace(platformV7RoleHome(role));
       router.refresh();
     } catch (reason) {
-      setError(reason instanceof Error ? reason.message : copy[lang].unavailable);
+      setError(reason instanceof Error ? reason.message : t('unavailable'));
     } finally {
       setSubmitting(false);
     }
   }
 
-  const t = copy[lang];
-
   return (
-    <main className='pc-login'>
-      <header className='pc-login-header'>
-        <Link className='pc-login-brand' href='/platform-v7'>
-          <span className='pc-login-logo' aria-hidden='true'><Wheat size={24} strokeWidth={2.35} /></span>
-          <span><b>{t.brand}</b><small>{t.subbrand}</small></span>
-        </Link>
-        <Link className='pc-login-back' href='/platform-v7' aria-label={t.back}><ArrowLeft size={21} /></Link>
-      </header>
+    <main className='pc-v7-public-entry pc-auth-page'>
+      <PublicSiteHeader
+        ariaLabel={t('publicNav')}
+        tagline={t('brandTagline')}
+        actions={(
+          <Link className='pc-site-action' href='/platform-v7' aria-label={t('backHome')} title={t('backHome')}>
+            <ArrowLeft size={20} aria-hidden='true' />
+            <span>{t('backHome')}</span>
+          </Link>
+        )}
+      />
 
-      <section className='pc-login-layout'>
-        <aside className='pc-login-context' aria-label={t.subbrand}>
-          <span className='pc-login-eyebrow'><ShieldCheck size={17} /> B2B Deal Execution</span>
-          <h1>{t.title}</h1>
-          <p>{t.lead}</p>
-          <div className='pc-login-facts'>
-            {t.facts.map((fact) => <span key={fact}><CheckCircle2 size={17} />{fact}</span>)}
-          </div>
-        </aside>
+      <section className='pc-auth-shell' aria-labelledby='pc-login-title'>
+        <div className='pc-auth-heading'>
+          <h1 id='pc-login-title'>{t('title')}</h1>
+          <p>{t('lead')}</p>
+        </div>
 
-        <form className='pc-login-card' onSubmit={onSubmit} noValidate>
-          <label>
-            <span>{t.email}</span>
-            <div className='pc-login-field'><Mail size={19} /><input value={email} onChange={(event) => setEmail(event.target.value)} type='email' inputMode='email' autoComplete='username' placeholder={t.emailPlaceholder} disabled={submitting} /></div>
+        <form className='pc-auth-card' onSubmit={onSubmit} noValidate>
+          <label className='pc-auth-label'>
+            <span>{t('email')}</span>
+            <span className='pc-auth-field'>
+              <Mail size={19} aria-hidden='true' />
+              <input
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                type='email'
+                inputMode='email'
+                autoComplete='username'
+                placeholder={t('emailPlaceholder')}
+                disabled={submitting}
+                aria-invalid={Boolean(error)}
+              />
+            </span>
           </label>
-          <label>
-            <span>{t.password}</span>
-            <div className='pc-login-field'><LockKeyhole size={19} /><input value={password} onChange={(event) => setPassword(event.target.value)} type={showPassword ? 'text' : 'password'} autoComplete='current-password' placeholder={t.passwordPlaceholder} disabled={submitting} /><button type='button' onClick={() => setShowPassword((value) => !value)} aria-label={showPassword ? 'Hide password' : 'Show password'}>{showPassword ? <EyeOff size={19} /> : <Eye size={19} />}</button></div>
+
+          <label className='pc-auth-label'>
+            <span>{t('password')}</span>
+            <span className='pc-auth-field'>
+              <LockKeyhole size={19} aria-hidden='true' />
+              <input
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                type={showPassword ? 'text' : 'password'}
+                autoComplete='current-password'
+                placeholder={t('passwordPlaceholder')}
+                disabled={submitting}
+                aria-invalid={Boolean(error)}
+              />
+              <button
+                type='button'
+                className='pc-auth-password-toggle'
+                onClick={() => setShowPassword((value) => !value)}
+                aria-label={showPassword ? t('hidePassword') : t('showPassword')}
+                title={showPassword ? t('hidePassword') : t('showPassword')}
+              >
+                {showPassword ? <EyeOff size={19} aria-hidden='true' /> : <Eye size={19} aria-hidden='true' />}
+              </button>
+            </span>
           </label>
 
-          <div className='pc-login-links'>
-            <Link href='/platform-v7/contact'>{t.forgot}</Link>
-            <Link href='/platform-v7/register'>{t.register}</Link>
+          <div className='pc-auth-links'>
+            <Link href='/platform-v7/forgot-password'>{t('forgot')}</Link>
+            <Link href='/platform-v7/register'>{t('register')}</Link>
           </div>
 
-          {error ? <p className='pc-login-error' role='alert'>{error}</p> : null}
-          <button className='pc-login-submit' type='submit' disabled={submitting}>{submitting ? t.loading : t.submit}</button>
-          <p className='pc-login-note'>После входа система откроет рабочее место, назначенное твоей организации. Роль нельзя выбрать или изменить через URL.</p>
+          {error ? <p className='pc-auth-error' role='alert'>{error}</p> : null}
+
+          <button className='pc-auth-submit' type='submit' disabled={submitting}>
+            {submitting ? t('loading') : t('submit')}
+          </button>
+
+          <p className='pc-auth-note'>{t('note')}</p>
         </form>
       </section>
 
       <style jsx>{`
-        .pc-login{min-height:100dvh;padding:clamp(14px,3vw,40px);background:radial-gradient(circle at 8% 0%,rgba(20,124,74,.12),transparent 34%),linear-gradient(180deg,#f7faf7 0%,#eef5ef 58%,#f8faf8 100%);color:#102019;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.pc-login *{box-sizing:border-box}.pc-login-header{max-width:1120px;margin:0 auto 22px;display:flex;align-items:center;justify-content:space-between;gap:12px}.pc-login-brand{display:flex;align-items:center;gap:12px;color:inherit;text-decoration:none;min-width:0}.pc-login-logo{width:46px;height:46px;display:grid;place-items:center;border-radius:15px;background:#e2f1e7;color:#087a3b;border:1px solid rgba(8,122,59,.13)}.pc-login-brand b{display:block;font-size:20px;line-height:1.05;letter-spacing:-.035em}.pc-login-brand small{display:block;margin-top:4px;color:#63726b;font-size:12px;font-weight:700}.pc-login-back{width:44px;height:44px;display:grid;place-items:center;border-radius:14px;background:rgba(255,255,255,.85);border:1px solid rgba(16,32,25,.1);color:#102019}.pc-login-layout{max-width:1120px;margin:0 auto;display:grid;grid-template-columns:minmax(0,1.08fr) minmax(360px,.92fr);gap:clamp(20px,4vw,62px);align-items:center;min-height:calc(100dvh - 140px)}.pc-login-context{padding:clamp(10px,4vw,42px)}.pc-login-eyebrow{display:inline-flex;align-items:center;gap:8px;color:#087a3b;font-size:13px;font-weight:900;letter-spacing:.04em;text-transform:uppercase}.pc-login-context h1{margin:18px 0 16px;font-size:clamp(46px,7vw,84px);line-height:.94;letter-spacing:-.07em;max-width:720px}.pc-login-context p{margin:0;max-width:650px;font-size:clamp(17px,2vw,22px);line-height:1.48;color:#54645c;font-weight:620}.pc-login-facts{display:flex;flex-wrap:wrap;gap:10px;margin-top:30px}.pc-login-facts span{display:inline-flex;align-items:center;gap:8px;padding:10px 13px;border-radius:999px;background:rgba(255,255,255,.78);border:1px solid rgba(8,122,59,.13);color:#244038;font-size:13px;font-weight:800}.pc-login-facts svg{color:#087a3b}.pc-login-card{display:grid;gap:17px;padding:clamp(22px,4vw,38px);border-radius:30px;background:rgba(255,255,255,.94);border:1px solid rgba(16,32,25,.1);box-shadow:0 28px 80px rgba(27,66,45,.13)}.pc-login-card label{display:grid;gap:8px}.pc-login-card label>span{font-size:13px;font-weight:900;color:#31423a}.pc-login-field{height:56px;display:flex;align-items:center;gap:10px;padding:0 15px;border-radius:17px;background:#f9fbf9;border:1px solid rgba(16,32,25,.12);transition:border-color .15s,box-shadow .15s}.pc-login-field:focus-within{border-color:rgba(8,122,59,.58);box-shadow:0 0 0 4px rgba(8,122,59,.1)}.pc-login-field>svg{color:#708078;flex:0 0 auto}.pc-login-field input{width:100%;height:100%;border:0;outline:0;background:transparent;color:#102019;font:inherit;font-size:16px}.pc-login-field button{width:38px;height:38px;border:0;background:transparent;color:#607068;display:grid;place-items:center;cursor:pointer}.pc-login-links{display:flex;align-items:center;justify-content:space-between;gap:14px;flex-wrap:wrap}.pc-login-links a{color:#087a3b;text-decoration:none;font-size:13px;font-weight:850}.pc-login-error{margin:0;padding:12px 14px;border-radius:14px;background:#fff1f1;border:1px solid #f2c5c5;color:#9b2525;font-size:13px;font-weight:800}.pc-login-submit{height:56px;border:0;border-radius:17px;background:#087a3b;color:#fff;font-size:16px;font-weight:950;cursor:pointer;box-shadow:0 14px 32px rgba(8,122,59,.24)}.pc-login-submit:disabled{opacity:.62;cursor:wait}.pc-login-note{margin:0;text-align:center;color:#718078;font-size:12px;line-height:1.45;font-weight:650}@media(max-width:820px){.pc-login{padding:calc(env(safe-area-inset-top) + 12px) 14px calc(env(safe-area-inset-bottom) + 22px)}.pc-login-layout{grid-template-columns:1fr;gap:16px;align-items:start}.pc-login-context{padding:18px 4px 4px}.pc-login-context h1{font-size:clamp(42px,13vw,66px)}.pc-login-context p{font-size:16px}.pc-login-facts{margin-top:20px}.pc-login-card{border-radius:24px;padding:22px}.pc-login-brand small{display:none}}@media(max-width:420px){.pc-login-facts{display:grid;grid-template-columns:1fr}.pc-login-facts span{border-radius:14px}.pc-login-links{align-items:flex-start;flex-direction:column}.pc-login-card{padding:19px}.pc-login-field,.pc-login-submit{height:54px}}
+        .pc-auth-page{--auth-header-height:64px;min-height:100dvh;padding-top:var(--auth-header-height);background:radial-gradient(circle at 12% 0%,rgba(8,122,59,.12),transparent 34%),linear-gradient(180deg,#f7faf7 0%,#eef5ef 58%,#f8faf8 100%);color:#102019;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.pc-auth-page *{box-sizing:border-box}.pc-auth-shell{width:min(100%,560px);min-height:calc(100dvh - var(--auth-header-height));margin:0 auto;padding:clamp(34px,7vh,74px) 18px 40px;display:flex;flex-direction:column;justify-content:center;gap:24px}.pc-auth-heading{text-align:center}.pc-auth-heading h1{margin:0;font-size:clamp(38px,7vw,58px);line-height:1;letter-spacing:-.055em}.pc-auth-heading p{max-width:520px;margin:16px auto 0;color:#5c6b64;font-size:16px;line-height:1.5;font-weight:600}.pc-auth-card{display:grid;gap:18px;padding:clamp(22px,5vw,36px);border-radius:30px;background:rgba(255,255,255,.96);border:1px solid rgba(16,32,25,.1);box-shadow:0 28px 80px rgba(27,66,45,.13)}.pc-auth-label{display:grid;gap:8px}.pc-auth-label>span:first-child{font-size:13px;font-weight:900;color:#31423a}.pc-auth-field{height:56px;display:flex;align-items:center;gap:10px;padding:0 15px;border-radius:17px;background:#f9fbf9;border:1px solid rgba(16,32,25,.12);transition:border-color .15s,box-shadow .15s}.pc-auth-field:focus-within{border-color:rgba(8,122,59,.58);box-shadow:0 0 0 4px rgba(8,122,59,.1)}.pc-auth-field>svg{color:#708078;flex:0 0 auto}.pc-auth-field input{width:100%;height:100%;min-width:0;border:0;outline:0;background:transparent;color:#102019;font:inherit;font-size:16px}.pc-auth-password-toggle{width:38px;height:38px;flex:0 0 38px;border:0;border-radius:11px;background:transparent;color:#607068;display:grid;place-items:center;cursor:pointer}.pc-auth-password-toggle:focus-visible{outline:3px solid rgba(8,122,59,.28);outline-offset:2px}.pc-auth-links{display:flex;align-items:center;justify-content:space-between;gap:14px;flex-wrap:wrap}.pc-auth-links a{color:#087a3b;text-decoration:none;font-size:13px;font-weight:850}.pc-auth-links a:focus-visible{outline:3px solid rgba(8,122,59,.28);outline-offset:3px;border-radius:6px}.pc-auth-error{margin:0;padding:12px 14px;border-radius:14px;background:#fff1f1;border:1px solid #f2c5c5;color:#9b2525;font-size:13px;font-weight:800;line-height:1.4}.pc-auth-submit{height:56px;border:0;border-radius:17px;background:linear-gradient(135deg,#087a3b,#075f31);color:#fff;font:inherit;font-size:15px;font-weight:950;cursor:pointer;box-shadow:0 18px 36px rgba(8,122,59,.22)}.pc-auth-submit:disabled{cursor:wait;opacity:.66}.pc-auth-submit:focus-visible{outline:3px solid rgba(8,122,59,.35);outline-offset:3px}.pc-auth-note{margin:0;color:#6b7973;font-size:12px;line-height:1.5;text-align:center}@media(max-width:520px){.pc-auth-shell{padding:28px 14px 28px;justify-content:flex-start}.pc-auth-heading h1{font-size:38px}.pc-auth-card{padding:22px;border-radius:24px}.pc-auth-links{align-items:flex-start;flex-direction:column}.pc-auth-field{height:54px}}
       `}</style>
     </main>
   );

--- a/apps/web/app/platform-v7/page.tsx
+++ b/apps/web/app/platform-v7/page.tsx
@@ -12,7 +12,6 @@ import {
   Leaf,
   LockKeyhole,
   LogIn,
-  MessageCircleQuestion,
   PlayCircle,
   Scale,
   ShieldCheck,
@@ -26,7 +25,7 @@ import { PlatformV7IntelligenceStrip } from '@/components/v7r/PlatformV7Intellig
 import { PublicSiteHeader } from '@/components/platform-v7/PublicSiteHeader';
 
 type Card = { key: string; Icon: LucideIcon };
-type RoleCard = Card & { href: string };
+type RoleCard = Card & { href: '/platform-v7/login' };
 
 const controlCards: Card[] = [
   { key: 'money', Icon: Banknote },
@@ -46,18 +45,18 @@ const processSteps: Card[] = [
 ];
 
 const roles: RoleCard[] = [
-  { key: 'operator', href: '/platform-v7/login?role=operator', Icon: ClipboardCheck },
-  { key: 'buyer', href: '/platform-v7/login?role=buyer', Icon: UserRound },
-  { key: 'seller', href: '/platform-v7/login?role=seller', Icon: Wheat },
-  { key: 'logistics', href: '/platform-v7/login?role=logistics', Icon: Truck },
-  { key: 'driver', href: '/platform-v7/login?role=driver', Icon: Truck },
-  { key: 'elevator', href: '/platform-v7/login?role=elevator', Icon: Building2 },
-  { key: 'lab', href: '/platform-v7/login?role=lab', Icon: FlaskConical },
-  { key: 'surveyor', href: '/platform-v7/login?role=surveyor', Icon: ShieldCheck },
-  { key: 'bank', href: '/platform-v7/login?role=bank', Icon: Landmark },
-  { key: 'compliance', href: '/platform-v7/login?role=compliance', Icon: ShieldCheck },
-  { key: 'arbitrator', href: '/platform-v7/login?role=arbitrator', Icon: Scale },
-  { key: 'executive', href: '/platform-v7/login?role=executive', Icon: Banknote },
+  { key: 'operator', href: '/platform-v7/login', Icon: ClipboardCheck },
+  { key: 'buyer', href: '/platform-v7/login', Icon: UserRound },
+  { key: 'seller', href: '/platform-v7/login', Icon: Wheat },
+  { key: 'logistics', href: '/platform-v7/login', Icon: Truck },
+  { key: 'driver', href: '/platform-v7/login', Icon: Truck },
+  { key: 'elevator', href: '/platform-v7/login', Icon: Building2 },
+  { key: 'lab', href: '/platform-v7/login', Icon: FlaskConical },
+  { key: 'surveyor', href: '/platform-v7/login', Icon: ShieldCheck },
+  { key: 'bank', href: '/platform-v7/login', Icon: Landmark },
+  { key: 'compliance', href: '/platform-v7/login', Icon: ShieldCheck },
+  { key: 'arbitrator', href: '/platform-v7/login', Icon: Scale },
+  { key: 'executive', href: '/platform-v7/login', Icon: Banknote },
 ];
 
 const trustItems: Card[] = [
@@ -77,6 +76,8 @@ const heroSignals: { key: string; tone: 'done' | 'active' | 'wait' | 'pending' }
 
 export default async function PlatformV7RootPage() {
   const t = await getTranslations('landing');
+  const roleCatalog = await getTranslations('publicEntry.rolesCatalog');
+
   return (
     <main data-testid='platform-v7-root-execution-cockpit' className='pc-v7-entry-page pc-v7-public-entry'>
       <style>{css}</style>
@@ -95,7 +96,7 @@ export default async function PlatformV7RootPage() {
         )}
         actions={(
           <>
-            <Link href='/platform-v7/login' className='entry-login'><LogIn size={16} />{t('signIn')}</Link>
+            <Link href='/platform-v7/login' className='entry-login'><LogIn size={16} aria-hidden='true' />{t('signIn')}</Link>
             <Link href='/platform-v7/register' className='entry-header-register'>{t('register')}</Link>
           </>
         )}
@@ -111,9 +112,8 @@ export default async function PlatformV7RootPage() {
           </h1>
           <p>{t('hero.lead')}</p>
           <div className='entry-hero-actions'>
-            <Link href='/platform-v7/register' className='entry-primary-cta'>{t('hero.primaryCta')}<ArrowRight size={20} /></Link>
-            <Link href='/platform-v7/deal-flow' className='entry-secondary-cta'><PlayCircle size={18} />{t('hero.secondaryCta')}</Link>
-            <Link href='/platform-v7/contact' className='entry-register-cta'><MessageCircleQuestion size={18} />{t('hero.questionCta')}</Link>
+            <Link href='/platform-v7/register' className='entry-primary-cta'>{t('hero.primaryCta')}<ArrowRight size={20} aria-hidden='true' /></Link>
+            <Link href='/platform-v7/deal-flow' className='entry-secondary-cta'><PlayCircle size={18} aria-hidden='true' />{t('hero.secondaryCta')}</Link>
           </div>
         </div>
 
@@ -138,84 +138,73 @@ export default async function PlatformV7RootPage() {
       </section>
 
       <section id='control' className='entry-section' aria-labelledby='control-title'>
-        <SectionHead title={t('control.title')} text={t('control.text')} />
+        <SectionHead id='control-title' title={t('control.title')} text={t('control.text')} />
         <div className='entry-control-grid'>
-          {controlCards.map((item) => {
-            const Icon = item.Icon;
-            return (
-              <article key={item.key} className='entry-control-tile'>
-                <Icon size={31} strokeWidth={2.25} />
-                <strong>{t(`control.${item.key}.title`)}</strong>
-                <span>{t(`control.${item.key}.text`)}</span>
-              </article>
-            );
-          })}
+          {controlCards.map(({ key, Icon }) => (
+            <article key={key} className='entry-control-tile'>
+              <Icon size={31} strokeWidth={2.25} aria-hidden='true' />
+              <strong>{t(`control.${key}.title`)}</strong>
+              <span>{t(`control.${key}.text`)}</span>
+            </article>
+          ))}
         </div>
       </section>
 
       <section id='process' className='entry-section entry-process-section' aria-labelledby='process-title'>
-        <SectionHead title={t('process.title')} text={t('process.text')} compact />
+        <SectionHead id='process-title' title={t('process.title')} text={t('process.text')} compact />
         <div className='entry-process-row'>
-          {processSteps.map((step, index) => {
-            const Icon = step.Icon;
-            return (
-              <article key={step.key} className='entry-process-tile'>
-                <span className='entry-process-index'>{index + 1}</span>
-                <span className='entry-process-icon'><Icon size={21} strokeWidth={2.2} /></span>
-                <strong>{t(`process.${step.key}.title`)}</strong>
-                <small>{t(`process.${step.key}.text`)}</small>
-              </article>
-            );
-          })}
+          {processSteps.map(({ key, Icon }, index) => (
+            <article key={key} className='entry-process-tile'>
+              <span className='entry-process-index'>{index + 1}</span>
+              <span className='entry-process-icon'><Icon size={21} strokeWidth={2.2} aria-hidden='true' /></span>
+              <strong>{t(`process.${key}.title`)}</strong>
+              <small>{t(`process.${key}.text`)}</small>
+            </article>
+          ))}
         </div>
       </section>
 
       <PlatformV7IntelligenceStrip />
 
       <section id='roles' className='entry-section' aria-labelledby='roles-title'>
-        <SectionHead title={t('roles.title')} text={t('roles.text')} />
+        <SectionHead id='roles-title' title={roleCatalog('title')} text={roleCatalog('text')} />
         <div className='entry-role-grid'>
-          {roles.map((role) => {
-            const Icon = role.Icon;
-            return (
-              <Link key={role.key} href={role.href} className='entry-role-tile'>
-                <Icon size={27} strokeWidth={2.25} />
-                <strong>{t(`roles.${role.key}.title`)}</strong>
-                <span>{t(`roles.${role.key}.text`)}</span>
-                <em>{t(`roles.${role.key}.cta`)}</em>
-              </Link>
-            );
-          })}
+          {roles.map(({ key, href, Icon }) => (
+            <Link key={key} href={href} className='entry-role-tile'>
+              <Icon size={27} strokeWidth={2.25} aria-hidden='true' />
+              <strong>{t(`roles.${key}.title`)}</strong>
+              <span>{t(`roles.${key}.text`)}</span>
+              <em>{roleCatalog('cta')}</em>
+            </Link>
+          ))}
         </div>
       </section>
 
       <section className='entry-trust-strip' aria-label={t('trust.aria')}>
-        {trustItems.map((item) => {
-          const Icon = item.Icon;
-          return (
-            <article key={item.key} className='entry-trust-item'>
-              <Icon size={26} strokeWidth={2.25} />
-              <strong>{t(`trust.${item.key}.title`)}</strong>
-              <span>{t(`trust.${item.key}.text`)}</span>
-            </article>
-          );
-        })}
+        {trustItems.map(({ key, Icon }) => (
+          <article key={key} className='entry-trust-item'>
+            <Icon size={26} strokeWidth={2.25} aria-hidden='true' />
+            <strong>{t(`trust.${key}.title`)}</strong>
+            <span>{t(`trust.${key}.text`)}</span>
+          </article>
+        ))}
         <Link href='/platform-v7/register' className='entry-trust-cta'>{t('trust.cta')}</Link>
       </section>
     </main>
   );
 }
 
-function SectionHead({ title, text, compact }: { title: string; text: string; compact?: boolean }) {
-  return <div className={compact ? 'entry-section-head compact' : 'entry-section-head'}><h2>{title}</h2><p>{text}</p></div>;
+function SectionHead({ id, title, text, compact }: { id: string; title: string; text: string; compact?: boolean }) {
+  return <div className={compact ? 'entry-section-head compact' : 'entry-section-head'}><h2 id={id}>{title}</h2><p>{text}</p></div>;
 }
 
 const css = `
-.pc-v7-public-entry{--entry-green:#087a3b;--entry-green-dark:#055c2d;--entry-ink:#071611;--entry-muted:#5e6b66;--entry-line:rgba(7,22,17,.09);--entry-card:rgba(255,255,255,.86);--entry-header-height:64px;min-height:100vh;padding-top:var(--entry-header-height);overflow-x:hidden;color:var(--entry-ink);background:radial-gradient(circle at 12% 0%,rgba(0,122,47,.13),transparent 30%),radial-gradient(circle at 92% 8%,rgba(196,145,42,.10),transparent 34%),linear-gradient(180deg,#fbfcf9 0%,#f2f7f0 54%,#fff 100%);font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.pc-v7-public-entry *{box-sizing:border-box}.pc-v7-public-entry a{color:inherit;text-decoration:none}.pc-v7-public-entry a:focus-visible{outline:3px solid var(--entry-green);outline-offset:3px;border-radius:12px}.pc-v7-public-entry :where(.entry-role-tile,.entry-primary-cta,.entry-secondary-cta,.entry-register-cta,.entry-login,.entry-header-register,.entry-trust-cta):focus-visible{outline:3px solid var(--entry-green-dark);outline-offset:3px}@media (prefers-reduced-motion:reduce){.pc-v7-public-entry *,.pc-v7-public-entry *::before,.pc-v7-public-entry *::after{animation-duration:.001ms!important;animation-iteration-count:1!important;transition-duration:.001ms!important;scroll-behavior:auto!important}}
+.pc-v7-public-entry{--entry-green:#087a3b;--entry-green-dark:#055c2d;--entry-ink:#071611;--entry-muted:#5e6b66;--entry-line:rgba(7,22,17,.09);--entry-card:rgba(255,255,255,.88);--entry-header-height:64px;min-height:100vh;padding-top:var(--entry-header-height);overflow-x:hidden;color:var(--entry-ink);background:radial-gradient(circle at 12% 0%,rgba(0,122,47,.13),transparent 30%),radial-gradient(circle at 92% 8%,rgba(196,145,42,.10),transparent 34%),linear-gradient(180deg,#fbfcf9 0%,#f2f7f0 54%,#fff 100%);font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.pc-v7-public-entry *{box-sizing:border-box}.pc-v7-public-entry a{color:inherit;text-decoration:none}.pc-v7-public-entry a:focus-visible{outline:3px solid var(--entry-green);outline-offset:3px;border-radius:12px}.pc-v7-public-entry :where(.entry-role-tile,.entry-primary-cta,.entry-secondary-cta,.entry-login,.entry-header-register,.entry-trust-cta):focus-visible{outline:3px solid var(--entry-green-dark);outline-offset:3px}@media(prefers-reduced-motion:reduce){.pc-v7-public-entry *,.pc-v7-public-entry *::before,.pc-v7-public-entry *::after{animation-duration:.001ms!important;animation-iteration-count:1!important;transition-duration:.001ms!important;scroll-behavior:auto!important}}
 .entry-login,.entry-header-register{min-height:42px;border-radius:15px;border:1px solid rgba(7,22,17,.10);background:rgba(255,255,255,.86);font-size:14px;font-weight:900;display:inline-flex;align-items:center;justify-content:center}.entry-login{gap:8px;padding:0 15px}.entry-header-register{padding:0 16px;color:var(--entry-green);background:rgba(0,122,47,.07);border-color:rgba(0,122,47,.16)}
-.entry-hero{max-width:1220px;margin:0 auto;min-height:calc(100svh - var(--entry-header-height));padding:clamp(34px,5vw,74px) clamp(18px,4vw,46px) 34px;display:grid;grid-template-columns:minmax(0,1.02fr) minmax(360px,.82fr);gap:clamp(26px,5vw,70px);align-items:center;position:relative}.entry-hero::before{content:"";position:absolute;inset:42px 0 auto 42%;height:420px;border-radius:999px;background:linear-gradient(135deg,rgba(0,122,47,.10),rgba(196,145,42,.10));filter:blur(34px);pointer-events:none}.entry-hero-copy{position:relative;z-index:1;display:grid;gap:20px;max-width:760px}.entry-kicker{width:max-content;display:inline-flex;align-items:center;min-height:34px;padding:0 14px;border-radius:999px;background:rgba(0,122,47,.09);color:var(--entry-green-dark);font-size:12px;font-weight:900;text-transform:uppercase;letter-spacing:.08em}.entry-hero h1{margin:0;display:grid;gap:2px;font-size:clamp(50px,7.3vw,92px);line-height:.94;letter-spacing:-.067em;color:var(--entry-ink)}.entry-hero h1 span:last-child{color:var(--entry-green-dark)}.entry-hero p{max-width:720px;margin:0;color:#43514b;font-size:clamp(18px,2vw,23px);line-height:1.42;font-weight:520}.entry-hero-actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:6px}.entry-primary-cta,.entry-secondary-cta,.entry-register-cta{min-height:54px;border-radius:18px;padding:0 20px;display:inline-flex;align-items:center;justify-content:center;gap:10px;font-size:15px;font-weight:950;border:1px solid transparent;transition:transform .18s ease,box-shadow .18s ease}.entry-primary-cta{color:#fff;background:linear-gradient(135deg,#087a3b,#0b6a37);box-shadow:0 20px 42px rgba(0,122,47,.24)}.entry-secondary-cta{color:#0b5f31;background:#fff;border-color:rgba(0,122,47,.18);box-shadow:0 14px 34px rgba(7,22,17,.08)}.entry-register-cta{color:#17251f;background:rgba(255,255,255,.62);border-color:rgba(7,22,17,.10)}.entry-primary-cta:hover,.entry-secondary-cta:hover,.entry-register-cta:hover{transform:translateY(-1px)}
-.entry-hero-visual{position:relative;z-index:1;display:flex;align-items:center;min-height:520px;padding:26px;border-radius:42px;background:linear-gradient(145deg,rgba(255,255,255,.92),rgba(245,249,242,.80));border:1px solid rgba(7,22,17,.08);box-shadow:0 30px 80px rgba(7,22,17,.13);overflow:hidden}.entry-hero-visual::before{content:"";position:absolute;inset:0;background:linear-gradient(90deg,rgba(7,22,17,.03) 1px,transparent 1px),linear-gradient(rgba(7,22,17,.03) 1px,transparent 1px);background-size:34px 34px;mask-image:linear-gradient(180deg,rgba(0,0,0,.85),transparent);pointer-events:none}.entry-visual-card{position:relative;z-index:1;width:100%;display:flex;flex-direction:column;gap:16px;padding:26px;border-radius:30px;background:rgba(255,255,255,.94);border:1px solid rgba(7,22,17,.08);box-shadow:0 18px 45px rgba(7,22,17,.10)}.entry-visual-head{display:flex;align-items:center;justify-content:space-between;gap:12px}.entry-visual-label{color:var(--entry-green);font-size:12px;font-weight:950;text-transform:uppercase;letter-spacing:.08em;white-space:nowrap}.entry-visual-id{margin:-4px 0 4px;font-size:46px;line-height:1;letter-spacing:-.055em;white-space:nowrap}.entry-visual-live{display:inline-flex;align-items:center;gap:7px;padding:6px 12px;border-radius:999px;background:rgba(0,122,47,.09);color:var(--entry-green-dark);font-size:12px;font-weight:850;white-space:nowrap}.entry-visual-live i{width:8px;height:8px;border-radius:999px;background:var(--entry-green);box-shadow:0 0 0 4px rgba(0,122,47,.16);animation:entryPulse 2.4s ease-in-out infinite}.entry-signal-list{display:flex;flex-direction:column;gap:9px}.entry-signal-row{display:grid;grid-template-columns:11px 104px 1fr;gap:12px;align-items:center;padding:13px 15px;border-radius:16px;background:#f8fbf7;border:1px solid rgba(7,22,17,.06)}.entry-signal-dot{width:11px;height:11px;border-radius:999px;background:var(--dot,#9aa8a2);box-shadow:0 0 0 4px var(--dot-halo,rgba(154,168,162,.16))}.entry-signal-row b{font-size:14px;font-weight:820}.entry-signal-row em{font-style:normal;justify-self:end;text-align:right;color:var(--val,#5a6762);font-size:13.5px;font-weight:820}.entry-signal-row[data-tone='done']{--dot:var(--entry-green);--dot-halo:rgba(0,122,47,.16);--val:var(--entry-green-dark)}.entry-signal-row[data-tone='active']{--dot:#c4912a;--dot-halo:rgba(196,145,42,.18);--val:#8a6410}.entry-signal-row[data-tone='wait']{--dot:#3b73c4;--dot-halo:rgba(59,115,196,.16);--val:#2c568f}.entry-signal-row[data-tone='pending']{--dot:#9aa8a2;--dot-halo:rgba(154,168,162,.16);--val:#5a6762}@keyframes entryPulse{0%,100%{box-shadow:0 0 0 3px rgba(0,122,47,.20)}50%{box-shadow:0 0 0 6px rgba(0,122,47,.05)}}
+.entry-hero{max-width:1220px;margin:0 auto;min-height:calc(100svh - var(--entry-header-height));padding:clamp(34px,5vw,74px) clamp(18px,4vw,46px) 34px;display:grid;grid-template-columns:minmax(0,1.02fr) minmax(360px,.82fr);gap:clamp(26px,5vw,70px);align-items:center;position:relative}.entry-hero::before{content:"";position:absolute;inset:42px 0 auto 42%;height:420px;border-radius:999px;background:linear-gradient(135deg,rgba(0,122,47,.10),rgba(196,145,42,.10));filter:blur(34px);pointer-events:none}.entry-hero-copy{position:relative;z-index:1;display:grid;gap:20px;max-width:760px}.entry-kicker{width:max-content;display:inline-flex;align-items:center;min-height:34px;padding:0 14px;border-radius:999px;background:rgba(0,122,47,.09);color:var(--entry-green-dark);font-size:12px;font-weight:900;text-transform:uppercase;letter-spacing:.08em}.entry-hero h1{margin:0;display:grid;gap:2px;font-size:clamp(50px,7.3vw,92px);line-height:.94;letter-spacing:-.067em;color:var(--entry-ink)}.entry-hero h1 span:last-child{color:var(--entry-green-dark)}.entry-hero p{max-width:720px;margin:0;color:#43514b;font-size:clamp(18px,2vw,23px);line-height:1.42;font-weight:520}.entry-hero-actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:6px}.entry-primary-cta,.entry-secondary-cta{min-height:54px;border-radius:18px;padding:0 20px;display:inline-flex;align-items:center;justify-content:center;gap:10px;font-size:15px;font-weight:950;border:1px solid transparent;transition:transform .18s ease,box-shadow .18s ease}.entry-primary-cta{color:#fff;background:linear-gradient(135deg,#087a3b,#0b6a37);box-shadow:0 20px 42px rgba(0,122,47,.24)}.entry-secondary-cta{color:#0b5f31;background:#fff;border-color:rgba(0,122,47,.18);box-shadow:0 14px 34px rgba(7,22,17,.08)}.entry-primary-cta:hover,.entry-secondary-cta:hover{transform:translateY(-1px)}
+.entry-hero-visual{position:relative;z-index:1;display:flex;align-items:center;min-height:520px;padding:26px;border-radius:42px;background:linear-gradient(145deg,rgba(255,255,255,.92),rgba(245,249,242,.80));border:1px solid rgba(7,22,17,.08);box-shadow:0 30px 80px rgba(7,22,17,.13);overflow:hidden}.entry-hero-visual::before{content:"";position:absolute;inset:0;background:linear-gradient(90deg,rgba(7,22,17,.03) 1px,transparent 1px),linear-gradient(rgba(7,22,17,.03) 1px,transparent 1px);background-size:34px 34px;mask-image:linear-gradient(180deg,rgba(0,0,0,.85),transparent);pointer-events:none}.entry-visual-card{position:relative;z-index:1;width:100%;display:flex;flex-direction:column;gap:16px;padding:26px;border-radius:30px;background:rgba(255,255,255,.94);border:1px solid rgba(7,22,17,.08);box-shadow:0 18px 45px rgba(7,22,17,.10)}.entry-visual-head{display:flex;align-items:center;justify-content:space-between;gap:12px}.entry-visual-label{color:var(--entry-green);font-size:12px;font-weight:950;text-transform:uppercase;letter-spacing:.08em;white-space:nowrap}.entry-visual-id{margin:-4px 0 4px;font-size:46px;line-height:1;letter-spacing:-.055em;white-space:nowrap}.entry-visual-live{display:inline-flex;align-items:center;gap:7px;padding:6px 12px;border-radius:999px;background:rgba(0,122,47,.09);color:var(--entry-green-dark);font-size:12px;font-weight:850;white-space:nowrap}.entry-visual-live i{width:8px;height:8px;border-radius:999px;background:var(--entry-green);box-shadow:0 0 0 4px rgba(0,122,47,.16);animation:entryPulse 2.4s ease-in-out infinite}.entry-signal-list{display:flex;flex-direction:column;gap:9px}.entry-signal-row{display:grid;grid-template-columns:11px 104px 1fr;gap:12px;align-items:center;padding:13px 15px;border-radius:16px;background:#f8fbf7;border:1px solid rgba(7,22,17,.06)}.entry-signal-dot{width:11px;height:11px;border-radius:999px;background:var(--dot,#9aa8a2);box-shadow:0 0 0 4px var(--dot-halo,rgba(154,168,162,.16))}.entry-signal-row b{font-size:14px;font-weight:820}.entry-signal-row em{font-style:normal;justify-self:end;text-align:right;color:var(--val,#5a6762);font-size:13.5px;font-weight:820}.entry-signal-row[data-tone='done']{--dot:var(--entry-green);--dot-halo:rgba(0,122,47,.16);--val:var(--entry-green-dark)}.entry-signal-row[data-tone='active']{--dot:#c4912a;--dot-halo:rgba(196,145,42,.18);--val:#8a6410}.entry-signal-row[data-tone='wait']{--dot:#3b73c4;--dot-halo:rgba(59,115,196,.16);--val:#2c568f}@keyframes entryPulse{0%,100%{box-shadow:0 0 0 3px rgba(0,122,47,.20)}50%{box-shadow:0 0 0 6px rgba(0,122,47,.05)}}
 .entry-section{max-width:1220px;margin:0 auto;padding:48px clamp(18px,4vw,46px)}.entry-section-head{display:flex;align-items:end;justify-content:space-between;gap:28px;margin-bottom:22px}.entry-section-head.compact{margin-bottom:18px}.entry-section-head h2{max-width:650px;margin:0;font-size:clamp(34px,4.5vw,58px);line-height:1;letter-spacing:-.055em}.entry-section-head p{max-width:500px;margin:0;color:#60706a;font-size:17px;line-height:1.48}.entry-control-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:14px}.entry-control-tile,.entry-process-tile,.entry-role-tile,.entry-trust-item{border:1px solid var(--entry-line);background:var(--entry-card);box-shadow:0 18px 46px rgba(7,22,17,.07);backdrop-filter:blur(12px)}.entry-control-tile{min-height:230px;padding:24px;border-radius:30px;display:grid;align-content:start;gap:14px;color:var(--entry-green)}.entry-control-tile strong{color:var(--entry-ink);font-size:22px;letter-spacing:-.03em}.entry-control-tile span{color:#61716b;line-height:1.45;font-weight:560}.entry-process-row{display:grid;grid-template-columns:repeat(7,minmax(132px,1fr));gap:10px}.entry-process-tile{position:relative;min-height:176px;padding:18px;border-radius:24px;display:grid;align-content:start;gap:10px}.entry-process-tile:not(:last-child)::after{content:"";position:absolute;right:-9px;top:50%;width:12px;height:2px;background:rgba(0,122,47,.28)}.entry-process-index{width:28px;height:28px;border-radius:999px;background:rgba(0,122,47,.09);color:var(--entry-green);display:grid;place-items:center;font-size:12px;font-weight:950}.entry-process-icon{color:var(--entry-green)}.entry-process-tile strong{font-size:18px}.entry-process-tile small{color:#68746f;line-height:1.38;font-size:13px;font-weight:570}.entry-role-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:14px}.entry-role-tile{min-height:196px;padding:20px;border-radius:28px;display:flex;flex-direction:column;align-items:flex-start;gap:10px;color:var(--entry-green);transition:transform .18s ease,box-shadow .18s ease,border-color .18s ease}.entry-role-tile:hover{transform:translateY(-2px);border-color:rgba(0,122,47,.28);box-shadow:0 24px 58px rgba(7,22,17,.11)}.entry-role-tile strong{color:var(--entry-ink);font-size:20px;letter-spacing:-.03em}.entry-role-tile span{color:#65736e;line-height:1.42;font-weight:560}.entry-role-tile em{margin-top:auto;color:var(--entry-green-dark);font-size:13px;font-style:normal;font-weight:900}.entry-trust-strip{max-width:1220px;margin:16px auto 70px;padding:18px clamp(18px,4vw,46px);display:grid;grid-template-columns:repeat(4,minmax(0,1fr)) auto;gap:12px}.entry-trust-item{min-height:128px;padding:18px;border-radius:24px;display:grid;align-content:start;gap:8px;color:var(--entry-green)}.entry-trust-item strong{color:var(--entry-ink);font-size:16px}.entry-trust-item span{color:#66736e;font-size:13px;line-height:1.35}.entry-trust-cta{min-height:128px;min-width:190px;border-radius:24px;display:grid;place-items:center;text-align:center;padding:18px;background:linear-gradient(135deg,#087a3b,#075f31);color:#fff;font-weight:950;box-shadow:0 20px 42px rgba(0,122,47,.22)}
-@media (max-width:1080px){.entry-hero{grid-template-columns:1fr;min-height:0}.entry-hero-visual{min-height:0;justify-content:center;padding:22px}.entry-visual-card{max-width:560px}.entry-control-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.entry-process-row{display:flex;gap:10px;overflow-x:auto;padding:0 2px 8px;scroll-snap-type:x proximity}.entry-process-row::-webkit-scrollbar{display:none}.entry-process-tile{flex:0 0 172px;scroll-snap-align:start;min-height:0}.entry-process-tile:not(:last-child)::after{display:none}.entry-role-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.entry-trust-strip{grid-template-columns:repeat(2,minmax(0,1fr))}.entry-trust-cta{min-height:92px}}
-@media (max-width:720px){.entry-header-register{display:none}.entry-hero{padding:26px 14px 20px}.entry-hero-copy{padding:22px 20px;border-radius:28px;background:rgba(255,255,255,.88);border:1px solid rgba(7,22,17,.08);box-shadow:0 16px 42px rgba(7,22,17,.07)}.entry-hero h1{font-size:42px;line-height:1.02}.entry-hero p{font-size:17px}.entry-hero-actions{display:grid}.entry-primary-cta,.entry-secondary-cta,.entry-register-cta{width:100%;min-height:54px}.entry-hero-visual{display:none}.entry-section{padding:36px 14px}.entry-section-head{display:grid;gap:10px}.entry-section-head h2{font-size:34px}.entry-section-head p{font-size:15px}.entry-control-grid{grid-template-columns:1fr}.entry-control-tile{min-height:0;padding:20px;border-radius:24px}.entry-role-grid{grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}.entry-role-tile{min-height:172px;padding:16px;border-radius:22px}.entry-trust-strip{grid-template-columns:1fr;margin:8px auto 50px;padding:14px}.entry-trust-cta{min-height:64px}}
+@media(max-width:1080px){.entry-hero{grid-template-columns:1fr;min-height:0}.entry-hero-visual{min-height:0;justify-content:center;padding:22px}.entry-visual-card{max-width:560px}.entry-control-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.entry-process-row{display:flex;gap:10px;overflow-x:auto;padding:0 2px 8px;scroll-snap-type:x proximity}.entry-process-row::-webkit-scrollbar{display:none}.entry-process-tile{flex:0 0 172px;scroll-snap-align:start;min-height:0}.entry-process-tile:not(:last-child)::after{display:none}.entry-role-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.entry-trust-strip{grid-template-columns:repeat(2,minmax(0,1fr))}.entry-trust-cta{min-height:92px}}
+@media(max-width:720px){.entry-header-register{display:none}.entry-hero{padding:26px 14px 20px}.entry-hero-copy{padding:22px 20px;border-radius:28px;background:rgba(255,255,255,.88);border:1px solid rgba(7,22,17,.08);box-shadow:0 16px 42px rgba(7,22,17,.07)}.entry-hero h1{font-size:42px;line-height:1.02}.entry-hero p{font-size:17px}.entry-hero-actions{display:grid}.entry-primary-cta,.entry-secondary-cta{width:100%;min-height:54px}.entry-hero-visual{display:none}.entry-section{padding:36px 14px}.entry-section-head{display:grid;gap:10px}.entry-section-head h2{font-size:34px}.entry-section-head p{font-size:15px}.entry-control-grid{grid-template-columns:1fr}.entry-control-tile{min-height:0;padding:20px;border-radius:24px}.entry-role-grid{grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}.entry-role-tile{min-height:172px;padding:16px;border-radius:22px}.entry-trust-strip{grid-template-columns:1fr;margin:8px auto 50px;padding:14px}.entry-trust-cta{min-height:64px}}
+@media(max-width:420px){.entry-role-grid{grid-template-columns:1fr}.entry-role-tile{min-height:0}.entry-visual-id{font-size:38px}}
 `;

--- a/apps/web/components/platform-v7/PlatformV7ShellSwitch.tsx
+++ b/apps/web/components/platform-v7/PlatformV7ShellSwitch.tsx
@@ -23,6 +23,7 @@ const PUBLIC_EXACT_PATHS = new Set([
   '/platform-v7',
   '/platform-v7/open',
   '/platform-v7/login',
+  '/platform-v7/forgot-password',
   '/platform-v7/register',
   '/platform-v7/help',
   '/platform-v7/pricing',
@@ -81,7 +82,7 @@ function roleFromPath(pathname: string): PlatformRole {
 export function PlatformV7ShellSwitch({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() || '/platform-v7';
 
-  if (isPublicPath(pathname)) return <><HeaderLanguageSwitch />{children}</>;
+  if (isPublicPath(pathname)) return <>{children}</>;
 
   const initialRole = roleFromPath(pathname);
   const showRoleIntentDashboard = shouldShowRoleIntentDashboard(pathname);

--- a/apps/web/components/platform-v7/PlatformV7TemplateGuards.tsx
+++ b/apps/web/components/platform-v7/PlatformV7TemplateGuards.tsx
@@ -100,7 +100,9 @@ export function PlatformV7TemplateGuards({ position }: { position: GuardPosition
 
   if (publicPath) {
     if (landingPath) {
-      return position === 'before' ? <><PlatformV7UniversalAdaptiveStyle /><PlatformV7ViewportRuntimeGuard /><PublicOpenPlaceholderCleanup pathname={pathname} /><PublicHeroWeightPatch /><PlatformV7BlankScreenGuard /></> : <ChatSupportWidget />;
+      return position === 'before'
+        ? <><PlatformV7UniversalAdaptiveStyle /><PlatformV7ViewportRuntimeGuard /><PublicOpenPlaceholderCleanup pathname={pathname} /><PublicHeroWeightPatch /><PlatformV7BlankScreenGuard /></>
+        : <ChatSupportWidget />;
     }
 
     if (position === 'before') {
@@ -111,11 +113,13 @@ export function PlatformV7TemplateGuards({ position }: { position: GuardPosition
           {authPath ? <LoginMobileStabilityStyle /> : null}
           <PlatformV7BlankScreenGuard />
           <PublicEntryCleanup />
-          <PublicRegistrationEntryPatch />
-          <PublicHeroWeightPatch />
+          {authPath ? null : <PublicRegistrationEntryPatch />}
+          {authPath ? null : <PublicHeroWeightPatch />}
         </>
       );
     }
+
+    if (authPath) return <ChatSupportWidget />;
 
     return (
       <>

--- a/apps/web/components/platform-v7/PlatformV7TemplateGuards.tsx
+++ b/apps/web/components/platform-v7/PlatformV7TemplateGuards.tsx
@@ -23,6 +23,7 @@ const PUBLIC_EXACT_PATHS = new Set([
   '/platform-v7',
   '/platform-v7/open',
   '/platform-v7/login',
+  '/platform-v7/forgot-password',
   '/platform-v7/register',
   '/platform-v7/help',
   '/platform-v7/pricing',
@@ -60,8 +61,9 @@ function isLandingPath(pathname: string | null): boolean {
   return path === '/platform-v7' || path === '/platform-v7/open';
 }
 
-function isLoginPath(pathname: string | null): boolean {
-  return normalizePath(pathname) === '/platform-v7/login';
+function isAuthPath(pathname: string | null): boolean {
+  const path = normalizePath(pathname);
+  return path === '/platform-v7/login' || path === '/platform-v7/forgot-password';
 }
 
 function PublicOpenPlaceholderCleanup({ pathname }: { pathname: string | null }) {
@@ -94,7 +96,7 @@ export function PlatformV7TemplateGuards({ position }: { position: GuardPosition
   const pathname = usePathname();
   const publicPath = isPublicPath(pathname);
   const landingPath = isLandingPath(pathname);
-  const loginPath = isLoginPath(pathname);
+  const authPath = isAuthPath(pathname);
 
   if (publicPath) {
     if (landingPath) {
@@ -106,7 +108,7 @@ export function PlatformV7TemplateGuards({ position }: { position: GuardPosition
         <>
           <PlatformV7UniversalAdaptiveStyle />
           <PlatformV7ViewportRuntimeGuard />
-          {loginPath ? <LoginMobileStabilityStyle /> : null}
+          {authPath ? <LoginMobileStabilityStyle /> : null}
           <PlatformV7BlankScreenGuard />
           <PublicEntryCleanup />
           <PublicRegistrationEntryPatch />

--- a/apps/web/components/platform-v7/PublicEntryCleanup.tsx
+++ b/apps/web/components/platform-v7/PublicEntryCleanup.tsx
@@ -6,6 +6,7 @@ const PUBLIC_PATHS = new Set([
   '/platform-v7',
   '/platform-v7/open',
   '/platform-v7/login',
+  '/platform-v7/forgot-password',
   '/platform-v7/register',
   '/platform-v7/help',
   '/platform-v7/pricing',

--- a/apps/web/components/platform-v7/PublicLocaleSwitch.tsx
+++ b/apps/web/components/platform-v7/PublicLocaleSwitch.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Languages } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+import { isAppLocale, SUPPORTED_LOCALES, type AppLocale } from '@/i18n/locale';
+
+const SHORT_LABELS: Record<AppLocale, string> = {
+  ru: 'RU',
+  en: 'EN',
+  zh: 'ZH',
+};
+
+function nextLocale(current: AppLocale): AppLocale {
+  const index = SUPPORTED_LOCALES.indexOf(current);
+  return SUPPORTED_LOCALES[(index + 1) % SUPPORTED_LOCALES.length] ?? 'ru';
+}
+
+export function PublicLocaleSwitch() {
+  const localeValue = useLocale();
+  const t = useTranslations('publicEntry.language');
+  const locale: AppLocale = isAppLocale(localeValue) ? localeValue : 'ru';
+  const next = nextLocale(locale);
+  const currentLabel = SHORT_LABELS[locale];
+  const nextLabel = SHORT_LABELS[next];
+
+  function switchLocale() {
+    const url = new URL(window.location.href);
+    url.searchParams.set('lang', next);
+    url.searchParams.delete('l10n');
+    window.location.replace(url.toString());
+  }
+
+  return (
+    <button
+      type='button'
+      className='pc-site-locale-switch'
+      aria-label={t('switchLabel', { current: currentLabel, next: nextLabel })}
+      title={t('switchTitle', { current: currentLabel })}
+      onClick={switchLocale}
+      data-current-locale={locale}
+      data-next-locale={next}
+    >
+      <Languages size={16} strokeWidth={2.35} aria-hidden='true' />
+      <span>{currentLabel}</span>
+    </button>
+  );
+}

--- a/apps/web/components/platform-v7/PublicSiteHeader.tsx
+++ b/apps/web/components/platform-v7/PublicSiteHeader.tsx
@@ -1,15 +1,14 @@
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { BrandMark } from '@/components/v7r/BrandMark';
+import { PublicLocaleSwitch } from '@/components/platform-v7/PublicLocaleSwitch';
 
 export const PUBLIC_SITE_HEADER_HEIGHT = 64;
 
 /**
- * Single canonical public header. One logo, one height, one sticky bar shared
- * by every public page (landing, login, register, contact, …). Pages pass their
- * own right-side `actions` and optional center `nav`; the chrome (position,
- * height, brand, background) is identical everywhere so the header no longer
- * shifts or changes between pages.
+ * Single canonical public header shared by every public platform-v7 surface.
+ * Locale switching is rendered inside the header and triggers a server-side
+ * next-intl render; it does not mutate translated text in the DOM.
  */
 export function PublicSiteHeader({
   tagline,
@@ -32,7 +31,10 @@ export function PublicSiteHeader({
         </span>
       </Link>
       {nav ? <nav className='pc-site-nav' aria-label='Разделы'>{nav}</nav> : null}
-      <div className='pc-site-actions'>{actions}</div>
+      <div className='pc-site-actions'>
+        <PublicLocaleSwitch />
+        {actions}
+      </div>
       <style>{css}</style>
     </header>
   );
@@ -60,21 +62,27 @@ const css = `
 .pc-site-nav a{color:inherit;text-decoration:none;white-space:nowrap}
 .pc-site-nav a:hover{color:#087a3b}
 .pc-site-actions{flex:0 0 auto;margin-left:auto;display:flex;align-items:center;justify-content:flex-end;gap:9px}
-.pc-site-action{width:42px;height:42px;flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;padding:0;border-radius:14px;background:rgba(255,255,255,.9);border:1px solid rgba(7,22,17,.10);color:#071611;text-decoration:none}
+.pc-site-action,.pc-site-locale-switch{height:42px;flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;padding:0;border-radius:14px;background:rgba(255,255,255,.9);border:1px solid rgba(7,22,17,.10);color:#071611;text-decoration:none}
+.pc-site-action{width:42px}
 .pc-site-action>span{display:none}
 .pc-site-action.is-primary{background:rgba(0,122,47,.09);border-color:rgba(0,122,47,.2);color:#087a3b}
-.pc-site-action:hover{border-color:rgba(0,122,47,.34);background:rgba(0,122,47,.06)}
-.pc-site-header a:focus-visible{outline:3px solid #087a3b;outline-offset:3px;border-radius:12px}
+.pc-site-locale-switch{min-width:54px;gap:5px;padding:0 10px;color:#087a3b;background:rgba(0,122,47,.08);border-color:rgba(0,122,47,.18);font:inherit;cursor:pointer}
+.pc-site-locale-switch span{font-size:11px;font-weight:950;letter-spacing:.03em}
+.pc-site-action:hover,.pc-site-locale-switch:hover{border-color:rgba(0,122,47,.34);background:rgba(0,122,47,.06)}
+.pc-site-header a:focus-visible,.pc-site-header button:focus-visible{outline:3px solid #087a3b;outline-offset:3px;border-radius:12px}
 @media (max-width:1080px){.pc-site-nav{display:none}}
 @media (max-width:720px){
   .pc-site-header{gap:10px;padding:0 16px}
   .pc-site-brand-text small{display:none}
   .pc-site-brand-text strong{font-size:17px}
+  .pc-site-actions{gap:6px}
+  .pc-site-locale-switch{min-width:50px;height:40px;padding:0 8px}
 }
 @media (max-width:374px){
   .pc-site-header{padding:0 12px}
   .pc-site-brand{gap:9px}
   .pc-site-brand-mark{width:36px;height:36px;flex-basis:36px}
   .pc-site-brand-text strong{font-size:16px}
+  .pc-site-locale-switch{min-width:46px;padding:0 7px}
 }
 `;

--- a/apps/web/i18n/public-entry-messages.ts
+++ b/apps/web/i18n/public-entry-messages.ts
@@ -1,0 +1,181 @@
+import type { AppLocale } from './locale';
+
+type PublicEntryMessages = {
+  language: {
+    switchLabel: string;
+    switchTitle: string;
+  };
+  login: {
+    publicNav: string;
+    brandTagline: string;
+    backHome: string;
+    title: string;
+    lead: string;
+    email: string;
+    emailPlaceholder: string;
+    password: string;
+    passwordPlaceholder: string;
+    showPassword: string;
+    hidePassword: string;
+    submit: string;
+    loading: string;
+    forgot: string;
+    register: string;
+    required: string;
+    unavailable: string;
+    note: string;
+  };
+  forgot: {
+    publicNav: string;
+    brandTagline: string;
+    backHome: string;
+    title: string;
+    lead: string;
+    email: string;
+    emailPlaceholder: string;
+    submit: string;
+    loading: string;
+    successTitle: string;
+    successText: string;
+    error: string;
+    backToLogin: string;
+    note: string;
+    requestName: string;
+    requestMessage: string;
+  };
+};
+
+export const publicEntryMessages: Record<AppLocale, PublicEntryMessages> = {
+  ru: {
+    language: {
+      switchLabel: 'Текущий язык: {current}. Переключить на {next}',
+      switchTitle: 'Язык: {current}',
+    },
+    login: {
+      publicNav: 'Навигация страницы входа',
+      brandTagline: 'Единый вход в контур сделки',
+      backHome: 'На главную',
+      title: 'Войти в систему',
+      lead: 'Роль, организация и полномочия определяются сервером после проверки учётной записи.',
+      email: 'Рабочий email',
+      emailPlaceholder: 'name@company.ru',
+      password: 'Пароль',
+      passwordPlaceholder: 'Введите пароль',
+      showPassword: 'Показать пароль',
+      hidePassword: 'Скрыть пароль',
+      submit: 'Войти',
+      loading: 'Проверяем доступ…',
+      forgot: 'Восстановить доступ',
+      register: 'Создать учётную запись',
+      required: 'Введите email и пароль.',
+      unavailable: 'Не удалось подтвердить доступ. Проверьте данные или повторите позже.',
+      note: 'После входа откроется рабочее место, назначенное вашей организации. Роль нельзя выбрать или изменить через URL.',
+    },
+    forgot: {
+      publicNav: 'Навигация восстановления доступа',
+      brandTagline: 'Восстановление доступа',
+      backHome: 'На главную',
+      title: 'Восстановить доступ',
+      lead: 'Укажите рабочий email. Запрос будет обработан без раскрытия наличия учётной записи.',
+      email: 'Рабочий email',
+      emailPlaceholder: 'name@company.ru',
+      submit: 'Отправить запрос',
+      loading: 'Отправляем…',
+      successTitle: 'Запрос принят',
+      successText: 'Если адрес связан с учётной записью, инструкции будут направлены после проверки доступа.',
+      error: 'Не удалось принять запрос. Повторите позже или обратитесь в поддержку.',
+      backToLogin: 'Вернуться ко входу',
+      note: 'Пароль не передаётся в поддержку. Восстановление выполняется только после проверки принадлежности учётной записи.',
+      requestName: 'Восстановление доступа',
+      requestMessage: 'Запрос на восстановление доступа к рабочей платформе.',
+    },
+  },
+  en: {
+    language: {
+      switchLabel: 'Current language: {current}. Switch to {next}',
+      switchTitle: 'Language: {current}',
+    },
+    login: {
+      publicNav: 'Sign-in page navigation',
+      brandTagline: 'Single entry to the deal circuit',
+      backHome: 'Back to home',
+      title: 'Sign in',
+      lead: 'The server resolves the role, organisation and permissions after the account is verified.',
+      email: 'Work email',
+      emailPlaceholder: 'name@company.com',
+      password: 'Password',
+      passwordPlaceholder: 'Enter password',
+      showPassword: 'Show password',
+      hidePassword: 'Hide password',
+      submit: 'Sign in',
+      loading: 'Verifying access…',
+      forgot: 'Restore access',
+      register: 'Create account',
+      required: 'Enter email and password.',
+      unavailable: 'Access could not be verified. Check the credentials or try again later.',
+      note: 'After sign-in, the workspace assigned to your organisation will open. A role cannot be selected or changed through the URL.',
+    },
+    forgot: {
+      publicNav: 'Access recovery navigation',
+      brandTagline: 'Access recovery',
+      backHome: 'Back to home',
+      title: 'Restore access',
+      lead: 'Enter your work email. The request is processed without disclosing whether an account exists.',
+      email: 'Work email',
+      emailPlaceholder: 'name@company.com',
+      submit: 'Send request',
+      loading: 'Sending…',
+      successTitle: 'Request accepted',
+      successText: 'If the address is linked to an account, instructions will be sent after access verification.',
+      error: 'The request could not be accepted. Try again later or contact support.',
+      backToLogin: 'Back to sign in',
+      note: 'Never send a password to support. Recovery proceeds only after account ownership is verified.',
+      requestName: 'Access recovery',
+      requestMessage: 'Request to restore access to the working platform.',
+    },
+  },
+  zh: {
+    language: {
+      switchLabel: '当前语言：{current}。切换到 {next}',
+      switchTitle: '语言：{current}',
+    },
+    login: {
+      publicNav: '登录页导航',
+      brandTagline: '统一进入交易闭环',
+      backHome: '返回首页',
+      title: '登录系统',
+      lead: '服务器在验证账户后确定角色、组织和权限。',
+      email: '工作邮箱',
+      emailPlaceholder: 'name@company.cn',
+      password: '密码',
+      passwordPlaceholder: '输入密码',
+      showPassword: '显示密码',
+      hidePassword: '隐藏密码',
+      submit: '登录',
+      loading: '正在验证访问权限…',
+      forgot: '恢复访问权限',
+      register: '创建账户',
+      required: '请输入邮箱和密码。',
+      unavailable: '无法验证访问权限。请检查凭据或稍后重试。',
+      note: '登录后将打开分配给贵组织的工作区。不能通过 URL 选择或更改角色。',
+    },
+    forgot: {
+      publicNav: '访问恢复导航',
+      brandTagline: '恢复访问权限',
+      backHome: '返回首页',
+      title: '恢复访问权限',
+      lead: '请输入工作邮箱。系统不会披露该账户是否存在。',
+      email: '工作邮箱',
+      emailPlaceholder: 'name@company.cn',
+      submit: '发送请求',
+      loading: '正在发送…',
+      successTitle: '请求已受理',
+      successText: '如果该地址关联账户，完成访问核验后将发送说明。',
+      error: '无法受理请求。请稍后重试或联系支持。',
+      backToLogin: '返回登录',
+      note: '不要向支持人员发送密码。只有在核验账户归属后才会恢复访问权限。',
+      requestName: '恢复访问权限',
+      requestMessage: '请求恢复工作平台访问权限。',
+    },
+  },
+};

--- a/apps/web/i18n/public-entry-messages.ts
+++ b/apps/web/i18n/public-entry-messages.ts
@@ -5,6 +5,11 @@ type PublicEntryMessages = {
     switchLabel: string;
     switchTitle: string;
   };
+  rolesCatalog: {
+    title: string;
+    text: string;
+    cta: string;
+  };
   login: {
     publicNav: string;
     brandTagline: string;
@@ -51,6 +56,11 @@ export const publicEntryMessages: Record<AppLocale, PublicEntryMessages> = {
       switchLabel: 'Текущий язык: {current}. Переключить на {next}',
       switchTitle: 'Язык: {current}',
     },
+    rolesCatalog: {
+      title: 'Рабочие места участников сделки',
+      text: 'Вход единый. Роль, организация и полномочия определяются сервером после проверки учётной записи.',
+      cta: 'Войти',
+    },
     login: {
       publicNav: 'Навигация страницы входа',
       brandTagline: 'Единый вход в контур сделки',
@@ -95,6 +105,11 @@ export const publicEntryMessages: Record<AppLocale, PublicEntryMessages> = {
       switchLabel: 'Current language: {current}. Switch to {next}',
       switchTitle: 'Language: {current}',
     },
+    rolesCatalog: {
+      title: 'Deal participant workspaces',
+      text: 'Sign-in is unified. The server resolves the role, organisation and permissions after the account is verified.',
+      cta: 'Sign in',
+    },
     login: {
       publicNav: 'Sign-in page navigation',
       brandTagline: 'Single entry to the deal circuit',
@@ -138,6 +153,11 @@ export const publicEntryMessages: Record<AppLocale, PublicEntryMessages> = {
     language: {
       switchLabel: '当前语言：{current}。切换到 {next}',
       switchTitle: '语言：{current}',
+    },
+    rolesCatalog: {
+      title: '交易参与方工作区',
+      text: '统一登录。服务器在验证账户后确定角色、组织和权限。',
+      cta: '登录',
     },
     login: {
       publicNav: '登录页导航',

--- a/apps/web/i18n/request.ts
+++ b/apps/web/i18n/request.ts
@@ -1,6 +1,7 @@
 import { cookies, headers } from 'next/headers';
 import { getRequestConfig } from 'next-intl/server';
 import { DEFAULT_LOCALE, LOCALE_COOKIE, isAppLocale } from './locale';
+import { publicEntryMessages } from './public-entry-messages';
 
 const LOCALE_HEADER = 'x-pc-locale';
 
@@ -25,8 +26,13 @@ export default getRequestConfig(async () => {
     }
   }
 
+  const baseMessages = (await import(`../messages/${locale}.json`)).default;
+
   return {
     locale,
-    messages: (await import(`../messages/${locale}.json`)).default,
+    messages: {
+      ...baseMessages,
+      publicEntry: publicEntryMessages[locale],
+    },
   };
 });

--- a/apps/web/tests/platform-v7-public-entry-links.test.ts
+++ b/apps/web/tests/platform-v7-public-entry-links.test.ts
@@ -46,29 +46,32 @@ describe('platform-v7 public entry link policy', () => {
     expect(leaks).toEqual([]);
   });
 
-  it('mounts the public entry cleanup in the platform-v7 template', () => {
-    const source = read('apps/web/app/platform-v7/template.tsx');
+  it('mounts public entry guards through the canonical platform template', () => {
+    const template = read('apps/web/app/platform-v7/template.tsx');
+    const guards = read('apps/web/components/platform-v7/PlatformV7TemplateGuards.tsx');
 
-    expect(source).toContain('PublicEntryCleanup');
-    expect(source).toContain('<PublicEntryCleanup />');
+    expect(template).toContain('PlatformV7TemplateGuards');
+    expect(template).toContain('<PlatformV7TemplateGuards position="before" />');
+    expect(template).toContain('<PlatformV7TemplateGuards position="after" />');
+    expect(guards).toContain('PublicEntryCleanup');
   });
 
-  it('routes public role cards through the single login gate with the selected role', () => {
+  it('routes every public role card through one login endpoint without role query parameters', () => {
     const page = read('apps/web/app/platform-v7/page.tsx');
-    const cleanup = read('apps/web/components/platform-v7/PublicEntryCleanup.tsx');
 
-    expect(page).toContain('/platform-v7/login?role=seller');
-    expect(page).toContain('/platform-v7/login?role=buyer');
-    expect(page).toContain('/platform-v7/login?role=operator');
-    expect(cleanup).not.toContain("link.setAttribute('href', '/platform-v7/login')");
-    expect(cleanup).not.toContain('rewritePublicLinks');
+    expect(page).toContain("href: '/platform-v7/login'");
+    expect(page).not.toContain('/platform-v7/login?role=');
+    expect(page).not.toContain("href: '/platform-v7/seller'");
+    expect(page).not.toContain("href: '/platform-v7/buyer'");
+    expect(page).not.toContain("href: '/platform-v7/bank'");
   });
 
-  it('keeps all 12 role ids available on the public role catalog', () => {
+  it('keeps all 12 role ids visible without allowing public role selection', () => {
     const source = read('apps/web/app/platform-v7/page.tsx');
-
     const missing = fullRoleSet.filter((role) => !source.includes(`key: '${role}'`));
+
     expect(missing).toEqual([]);
+    expect(source).toContain("getTranslations('publicEntry.rolesCatalog')");
   });
 
   it('keeps the public mobile entry visible after returning from protected shell', () => {

--- a/apps/web/tests/platform-v7-public-entry-links.test.ts
+++ b/apps/web/tests/platform-v7-public-entry-links.test.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const repoRoot = process.cwd();
+const cwd = process.cwd();
+const repoRoot = cwd.endsWith(path.join('apps', 'web')) ? path.resolve(cwd, '..', '..') : cwd;
 
 function read(relativePath: string) {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');

--- a/apps/web/tests/setup.ts
+++ b/apps/web/tests/setup.ts
@@ -19,6 +19,15 @@ const MSW_BACKEND_PATHS = [
   /^\/api\/rfq(?:\/[^/?]+)?(?:\/offer|\/accept)?$/,
 ];
 
+function installFetch(fetchImplementation: typeof fetch) {
+  Object.defineProperty(globalThis, 'fetch', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: fetchImplementation,
+  });
+}
+
 function localBackendPath(input: Parameters<typeof fetch>[0]) {
   const rawUrl = input instanceof Request ? input.url : String(input);
   const url = new URL(rawUrl, 'http://localhost');
@@ -43,11 +52,12 @@ function hasMswBackendPath(pathWithSearch: string) {
   return MSW_BACKEND_PATHS.some((pattern) => pattern.test(pathname));
 }
 
-// Start MSW server before all tests
+// Start MSW server before all tests. The descriptor remains configurable so
+// individual Vitest suites can spy on or replace fetch without descriptor errors.
 beforeAll(() => {
   server.listen({ onUnhandledRequest: 'warn' });
 
-  globalThis.fetch = async (input, init) => {
+  installFetch(async (input, init) => {
     let backendPath: string | null = null;
     try {
       backendPath = localBackendPath(input);
@@ -66,7 +76,7 @@ beforeAll(() => {
     } catch {
       return localBackendFallback(input, init);
     }
-  };
+  });
 });
 
 // Reset handlers after each test
@@ -74,6 +84,6 @@ afterEach(() => server.resetHandlers());
 
 // Close server after all tests
 afterAll(() => {
-  globalThis.fetch = localBackendFetch;
+  installFetch(localBackendFetch);
   server.close();
 });

--- a/apps/web/tests/unit/platformV7PublicRegistrationPatch.test.ts
+++ b/apps/web/tests/unit/platformV7PublicRegistrationPatch.test.ts
@@ -2,53 +2,57 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const template = fs.readFileSync(path.join(process.cwd(), 'apps/web/app/platform-v7/template.tsx'), 'utf8');
-const patch = fs.readFileSync(path.join(process.cwd(), 'apps/web/components/platform-v7/PublicRegistrationEntryPatch.tsx'), 'utf8');
-const cleanup = fs.readFileSync(path.join(process.cwd(), 'apps/web/components/platform-v7/PublicEntryCleanup.tsx'), 'utf8');
-const login = fs.readFileSync(path.join(process.cwd(), 'apps/web/app/platform-v7/login/page.tsx'), 'utf8');
+const page = fs.readFileSync(path.join(process.cwd(), 'app/platform-v7/page.tsx'), 'utf8');
+const login = fs.readFileSync(path.join(process.cwd(), 'app/platform-v7/login/page.tsx'), 'utf8');
+const forgot = fs.readFileSync(path.join(process.cwd(), 'app/platform-v7/forgot-password/page.tsx'), 'utf8');
+const shellSwitch = fs.readFileSync(path.join(process.cwd(), 'components/platform-v7/PlatformV7ShellSwitch.tsx'), 'utf8');
+const guards = fs.readFileSync(path.join(process.cwd(), 'components/platform-v7/PlatformV7TemplateGuards.tsx'), 'utf8');
+const localeSwitch = fs.readFileSync(path.join(process.cwd(), 'components/platform-v7/PublicLocaleSwitch.tsx'), 'utf8');
 
-describe('platform-v7 public registration and role-locked login', () => {
-  it('mounts a registration patch on platform-v7 public pages', () => {
-    expect(template).toContain('PublicRegistrationEntryPatch');
-    expect(template).toContain('<PublicRegistrationEntryPatch />');
+describe('platform-v7 public registration and single-entry login', () => {
+  it('keeps registration as a public organisation-onboarding route', () => {
+    expect(page).toContain("href='/platform-v7/register'");
+    expect(page).toContain("className='entry-header-register'");
+    expect(page).toContain("className='entry-primary-cta'");
   });
 
-  it('keeps public registration visible with role cards routing to registration', () => {
-    expect(patch).toContain("headerLink.href = '/platform-v7/register';");
-    expect(patch).toContain("headerLink.textContent = 'Регистрация';");
-    expect(patch).toContain("heroLink.href = '/platform-v7/register';");
-    expect(patch).toContain("heroLink.textContent = 'Зарегистрироваться';");
-    expect(patch).toContain("tile.href = `/platform-v7/register?role=${role}`;");
-    expect(patch).toContain("cta.textContent = 'Подать заявку на роль';");
+  it('does not derive a workspace role from a public URL', () => {
+    expect(page).not.toContain('/platform-v7/login?role=');
+    expect(login).not.toContain('useSearchParams');
+    expect(login).not.toContain('workspace-picker');
+    expect(login).not.toContain('pending_role');
+    expect(login).toContain("body: JSON.stringify(sessionBody)");
+    expect(login).toContain("const sessionBody = payload?.demo === true ? { role } : {};");
   });
 
-  it('keeps registration styling readable on mobile', () => {
-    expect(patch).toContain('background:rgba(0,122,47,.07)!important;color:#087a3b!important');
-    expect(patch).not.toContain('background:#071611!important;color:#fff!important');
-    expect(cleanup).toContain('height:72px!important;min-height:72px!important');
-    expect(cleanup).toContain('display:flex!important;grid-template-columns:none!important');
-    expect(cleanup).toContain('entry-trust-cta{min-height:54px!important;min-width:0!important;border-radius:18px!important');
+  it('uses the canonical public header and next-intl on login', () => {
+    expect(login).toContain('PublicSiteHeader');
+    expect(login).toContain("useTranslations('publicEntry.login')");
+    expect(login).not.toContain('const copy =');
+    expect(login).not.toContain('localStorage');
+    expect(login).toContain("href='/platform-v7/forgot-password'");
   });
 
-  it('preserves role query parameters from the main role grid', () => {
-    expect(cleanup).toContain('const ROLE_BY_TITLE = {');
-    expect(cleanup).toContain("'Оператор': 'operator'");
-    expect(cleanup).toContain('return role ? `/platform-v7/login?role=${role}` : \'/platform-v7/login\';');
-    expect(cleanup).toContain("href.startsWith('/platform-v7/login?')");
-    expect(cleanup).toContain("href === '/platform-v7/docs'");
-    expect(cleanup).toContain('applyRoleLoginHandoff(entry);');
-    expect(cleanup).not.toContain("item.setAttribute('href', '/platform-v7/login');");
+  it('provides a dedicated non-enumerating access recovery flow', () => {
+    expect(forgot).toContain("useTranslations('publicEntry.forgot')");
+    expect(forgot).toContain("fetch('/api/platform-v7/inquiries'");
+    expect(forgot).toContain("payload?.accepted !== true");
+    expect(forgot).toContain('PublicSiteHeader');
+    expect(forgot).not.toContain('accountExists');
   });
 
-  it('uses a compact workspace heading after handoff and an icon grid only for direct login', () => {
-    expect(login).toContain('type Workspace = { role: PlatformRole; title: string; Icon: LucideIcon };');
-    expect(login).toContain('const Icon = item.Icon;');
-    expect(login).toContain('<Icon size={20} strokeWidth={2.35} />');
-    expect(login).toContain('login-workspace-heading');
-    expect(login).toContain('login-workspace-picker');
-    expect(login).toContain('grid-template-columns:repeat(2,minmax(0,1fr))');
-    expect(login).toContain('Введите корпоративные данные для доступа к рабочему контуру.');
-    expect(login).toContain("<Link href={registerHref} className='login-register'>Зарегистрироваться</Link>");
-    expect(login).not.toContain('login-selected-missing');
+  it('keeps login and recovery outside the protected role shell', () => {
+    expect(shellSwitch).toContain("'/platform-v7/forgot-password'");
+    expect(shellSwitch).toContain('if (isPublicPath(pathname)) return <>{children}</>;');
+    expect(guards).toContain("'/platform-v7/forgot-password'");
+  });
+
+  it('switches public locale through next-intl without DOM translation', () => {
+    expect(localeSwitch).toContain('useLocale');
+    expect(localeSwitch).toContain('useTranslations');
+    expect(localeSwitch).toContain("url.searchParams.set('lang', next)");
+    expect(localeSwitch).not.toContain('MutationObserver');
+    expect(localeSwitch).not.toContain('TreeWalker');
+    expect(localeSwitch).not.toContain('applyTranslationToDom');
   });
 });

--- a/apps/web/tests/unit/platformV7RootWorkEntry.test.ts
+++ b/apps/web/tests/unit/platformV7RootWorkEntry.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 describe('platform-v7 root working entry', () => {
   const page = readFileSync(join(process.cwd(), 'app/platform-v7/page.tsx'), 'utf8');
-  const ruMessages = readFileSync(join(process.cwd(), 'messages/ru.json'), 'utf8');
+  const publicMessages = readFileSync(join(process.cwd(), 'i18n/public-entry-messages.ts'), 'utf8');
   const mobileShell = readFileSync(join(process.cwd(), 'styles/platform-v7-mobile-shell-p1.css'), 'utf8');
 
   it('uses the public execution cockpit as the root entry surface', () => {
@@ -13,18 +13,21 @@ describe('platform-v7 root working entry', () => {
     expect(page).toContain('entry-role-grid');
   });
 
-  it('routes public role cards through role-selected login instead of direct cabinets', () => {
-    expect(page).toContain('/platform-v7/login?role=seller');
-    expect(page).toContain('/platform-v7/login?role=buyer');
-    expect(page).toContain('/platform-v7/login?role=operator');
-    expect(page).toContain('/platform-v7/login?role=executive');
+  it('routes all public role cards through the same server-resolved login gate', () => {
+    expect(page).toContain("href: '/platform-v7/login'");
+    expect(page).not.toContain('/platform-v7/login?role=');
     expect(page).not.toContain("href: '/platform-v7/seller'");
     expect(page).not.toContain("href: '/platform-v7/buyer'");
     expect(page).not.toContain("href: '/platform-v7/bank'");
-    expect(ruMessages).not.toContain('Рабочее место выбирается внутри формы');
-    expect(ruMessages).toContain('Сначала выберите роль участника сделки');
+    expect(publicMessages).toContain('Роль, организация и полномочия определяются сервером');
     expect(page).not.toContain('key={role.href}');
-    expect(page).toContain('key={role.key}');
+  });
+
+  it('keeps exactly two primary hero actions', () => {
+    expect(page).toContain("className='entry-primary-cta'");
+    expect(page).toContain("className='entry-secondary-cta'");
+    expect(page).not.toContain("className='entry-register-cta'");
+    expect(page).not.toContain('MessageCircleQuestion');
   });
 
   it('keeps mobile entry polish guarded', () => {
@@ -32,7 +35,6 @@ describe('platform-v7 root working entry', () => {
     expect(page).toContain('.entry-process-row{display:flex;gap:10px;overflow-x:auto;padding:0 2px 8px;scroll-snap-type:x proximity}');
     expect(page).toContain('.entry-process-row::-webkit-scrollbar{display:none}');
     expect(page).toContain('flex:0 0 172px');
-    expect(page).toContain("className='entry-register-cta'");
     expect(page).toContain("href='/platform-v7/register'");
     expect(page).toContain('.entry-primary-cta{color:#fff;background:linear-gradient(135deg,#087a3b,#0b6a37)');
     expect(mobileShell).toContain('html:has(input:focus, textarea:focus, select:focus)');

--- a/apps/web/tests/unit/platformV7RuntimeEntryCockpit.test.ts
+++ b/apps/web/tests/unit/platformV7RuntimeEntryCockpit.test.ts
@@ -22,8 +22,8 @@ describe('platform-v7 runtime entry cockpit', () => {
   it('keeps operational runtime arrays out of the page component', () => {
     const src = pageSource();
 
-    // Публичная главная может хранить карточки ролей, но не должна тащить runtime-массивы cockpit state.
-    expect(src).toContain('/platform-v7/login?role=operator');
+    expect(src).toContain("href: '/platform-v7/login'");
+    expect(src).not.toContain('/platform-v7/login?role=');
     expect(src).not.toMatch(/const\s+blockers\s*=/);
     expect(src).not.toMatch(/const\s+lanes\s*=/);
     expect(src).not.toMatch(/const\s+executionPath\s*=/);

--- a/apps/web/tests/unit/platformV7VisibleEntry.test.ts
+++ b/apps/web/tests/unit/platformV7VisibleEntry.test.ts
@@ -2,28 +2,32 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-// Главный экран = мобильная витрина входа:
-// герой + единый primary CTA + выбор роли + честная подача без fake-live.
 const pageSource = () => readFileSync(resolve(__dirname, '../../app/platform-v7/page.tsx'), 'utf8');
-// Копия главной вынесена в next-intl сообщения; проверяем русский источник правды.
 const ruMessages = () => readFileSync(resolve(__dirname, '../../messages/ru.json'), 'utf8');
+const publicMessages = () => readFileSync(resolve(__dirname, '../../i18n/public-entry-messages.ts'), 'utf8');
 
 describe('platform-v7 visible entry (mobile home)', () => {
-  it('shows the hero and a single primary action', () => {
+  it('shows the hero with two deliberate actions', () => {
     const page = pageSource();
     const copy = ruMessages();
+
     expect(copy).toContain('Главный риск сделки');
     expect(copy).toContain('Прозрачная Цена — цифровой контур исполнения зерновой сделки');
-    // The one visually-primary action on the hero is "Подключить организацию".
-    expect(page).toContain('entry-primary-cta');
+    expect(page).toContain("className='entry-primary-cta'");
+    expect(page).toContain("className='entry-secondary-cta'");
+    expect(page).not.toContain("className='entry-register-cta'");
     expect(copy).toContain('Подключить организацию');
   });
 
-  it('shows role entry points and human public copy', () => {
+  it('shows participant workspaces without exposing role selection in the URL', () => {
     const page = pageSource();
     const copy = ruMessages();
-    expect(copy).toContain('Выберите свою роль');
-    expect(page).toContain('/platform-v7/login?role=operator');
+    const entryCopy = publicMessages();
+
+    expect(entryCopy).toContain('Рабочие места участников сделки');
+    expect(entryCopy).toContain('Вход единый');
+    expect(page).toContain("href: '/platform-v7/login'");
+    expect(page).not.toContain('/platform-v7/login?role=');
     expect(page).toContain("data-testid='platform-v7-root-execution-cockpit'");
     expect(copy).toContain('После согласования цены под контролем остаётся главное');
     expect(page).not.toContain('Не поиск зерна ради поиска');
@@ -31,7 +35,7 @@ describe('platform-v7 visible entry (mobile home)', () => {
   });
 
   it('keeps maturity honest and avoids fake-live claims', () => {
-    const joined = pageSource() + ruMessages();
+    const joined = pageSource() + ruMessages() + publicMessages();
     expect(joined).not.toMatch(/production-ready|fully live|fully integrated|bank connected|FGIS connected|EDO connected/i);
   });
 });

--- a/scripts/p7-autopilot-guard.sh
+++ b/scripts/p7-autopilot-guard.sh
@@ -43,6 +43,30 @@ if [ "${GITHUB_HEAD_REF:-}" = "p7-bank-basis-state-machine" ] || [ "${P7_BANK_BA
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$BANK_BASIS_MIGRATION_SCOPE")
 fi
 
+# Exact, reviewable concurrent scope for PR #2318. Do not broaden this to an
+# apps/web wildcard: the active financial-delivery autopilot remains isolated.
+PUBLIC_ENTRY_SCOPE='apps/web/app/platform-v7/forgot-password/page.tsx
+apps/web/app/platform-v7/login/page.tsx
+apps/web/app/platform-v7/page.tsx
+apps/web/components/platform-v7/PlatformV7ShellSwitch.tsx
+apps/web/components/platform-v7/PlatformV7TemplateGuards.tsx
+apps/web/components/platform-v7/PublicEntryCleanup.tsx
+apps/web/components/platform-v7/PublicLocaleSwitch.tsx
+apps/web/components/platform-v7/PublicSiteHeader.tsx
+apps/web/i18n/public-entry-messages.ts
+apps/web/i18n/request.ts
+apps/web/tests/platform-v7-public-entry-links.test.ts
+apps/web/tests/setup.ts
+apps/web/tests/unit/platformV7PublicRegistrationPatch.test.ts
+apps/web/tests/unit/platformV7RootWorkEntry.test.ts
+apps/web/tests/unit/platformV7RuntimeEntryCockpit.test.ts
+apps/web/tests/unit/platformV7VisibleEntry.test.ts
+scripts/p7-autopilot-guard.sh'
+
+if [ "${GITHUB_HEAD_REF:-}" = "agent/harden-platform-v7-public-entry" ]; then
+  ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$PUBLIC_ENTRY_SCOPE")
+fi
+
 APPROVED_BRANCH_SCOPE=$(GITHUB_HEAD_REF="${GITHUB_HEAD_REF:-}" node - <<'JS'
 const fs = require('fs');
 const state = JSON.parse(fs.readFileSync('docs/platform-v7/autopilot/autopilot-state.json', 'utf8'));


### PR DESCRIPTION
## Суть

Восстанавливает поверх актуального `main` ранее подготовленный, но не опубликованный срез усиления публичного входа platform-v7.

## Что изменено

- все 12 публичных карточек ролей ведут на единый `/platform-v7/login` без `?role=`;
- роль, организация и полномочия после входа остаются серверно определяемыми;
- hero ограничен двумя целевыми действиями: подключение организации и путь сделки;
- единый `PublicSiteHeader` используется на главной, login и recovery;
- public RU/EN/ZH переключается через next-intl и серверный рендер, без DOM-переводчика;
- login переведён на next-intl, центрирован и не содержит выбора роли или локального словаря;
- добавлен отдельный `/platform-v7/forgot-password` с нераскрывающим существование аккаунта ответом;
- forgot-password включён в public shell/guard allowlists;
- login/recovery освобождены от старых DOM-патчей header/logo и MutationObserver-обвязки;
- Vitest fetch override оставлен configurable/writable для независимых test spy/mock;
- устаревшие тесты role-query и workspace-picker переписаны под single-entry архитектуру;
- репозиторный autopilot guard допускает только точный перечень файлов этого параллельного PR, без wildcard на `apps/web`.

## Граница зрелости

Этот PR усиливает публичный entry/auth UX и архитектурные ограничения. Он не заявляет подключённый production password-reset provider, live-почту, production smoke или подтверждённую эксплуатацию.

## Проверки на head `624b5a7624dc23a86010aad5b8ef9a3a4e628376`

Зелёные:

- CI, включая persistent auth и industrial one-deal/DR контуры;
- Node CI: typecheck, tests, production build;
- web-unit;
- CodeQL;
- Qodana;
- Security Scan;
- Security Quality Gate;
- Dependency Review;
- platform-v7 autopilot guard.

## Следующий контур после merge

- browser matrix mobile/desktop;
- axe;
- Lighthouse;
- production smoke главной, login, recovery и RU/EN/ZH;
- отдельный production-grade token reset flow после подключения подтверждённого email/provider-контура.
