### PR TITLE
Enforce server-authoritative public login and MFA session issuance

### DIFF
--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import {
   applyAuthenticatedSession,
+  normalizeSurfaceRole,
+  platformHome,
   type AuthenticatedSessionPayload,
 } from '../../../../lib/server/auth-session-response';
 import {
@@ -129,16 +131,20 @@ export async function POST(request: Request) {
       return json({ ok: false, code: 'AUTH_SERVICE_INVALID_RESPONSE', message: UNIVERSAL_ERROR, correlationId }, 502);
     }
 
-    const response = json({ ok: true, mfaRequired: false, correlationId });
+    const role = normalizeSurfaceRole(payload.user.role, payload.user.surfaceRole);
+    const response = json({
+      ok: true,
+      mfaRequired: false,
+      redirectTo: platformHome(role),
+      correlationId,
+    });
     const session = await applyAuthenticatedSession(response, payload as AuthenticatedSessionPayload);
     if (!session) {
       console.error('cabinet_session_signing_failed', JSON.stringify({ correlationId }));
       return json({ ok: false, code: 'SESSION_CONFIGURATION_ERROR', message: UNIVERSAL_ERROR, correlationId }, 503);
     }
     response.cookies.set(MFA_PENDING_COOKIE, '', clearMfaPendingCookieOptions());
-    const bodyResponse = json({ ok: true, mfaRequired: false, redirectTo: session.redirectTo, correlationId });
-    for (const cookie of response.cookies.getAll()) bodyResponse.cookies.set(cookie);
-    return bodyResponse;
+    return response;
   } catch (error) {
     console.error('auth_login_transport_failure', JSON.stringify({
       correlationId,

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -1,98 +1,149 @@
-import { cookies } from 'next/headers';
+import { randomUUID } from 'node:crypto';
 import { NextResponse } from 'next/server';
-import { ACCESS_COOKIE, REFRESH_COOKIE, SESSION_COOKIE, CSRF_COOKIE, cookieSecurity, sessionMarkerCookie, csrfCookieSecurity } from '../../../../lib/auth-cookies';
-import { generateCsrfToken } from '../../../../lib/server-request-security';
-import { demoLoginAllowed } from '../../../../lib/platform-v7/demo-login-policy';
+import {
+  applyAuthenticatedSession,
+  type AuthenticatedSessionPayload,
+} from '../../../../lib/server/auth-session-response';
+import {
+  MFA_PENDING_COOKIE,
+  clearMfaPendingCookieOptions,
+  mfaPendingCookieOptions,
+  sealMfaLoginTicket,
+} from '../../../../lib/server/mfa-login-ticket';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 10;
 
-function detectDemoRole(email: string): string {
-  const local = email.toLowerCase().split('@')[0] ?? '';
-  if (local.startsWith('admin')) return 'ADMIN';
-  if (local.startsWith('operator') || local.startsWith('ops') || local.startsWith('support')) return 'SUPPORT_MANAGER';
-  if (local.startsWith('executive') || local.startsWith('ceo') || local.startsWith('director')) return 'EXECUTIVE';
-  if (local.startsWith('accounting') || local.startsWith('finance') || local.startsWith('buh') || local.startsWith('bank')) return 'ACCOUNTING';
-  if (local.startsWith('compliance')) return 'COMPLIANCE_OFFICER';
-  if (local.startsWith('arbitrator')) return 'ARBITRATOR';
-  if (local.startsWith('lab') || local.startsWith('quality')) return 'LAB';
-  if (local.startsWith('elevator') || local.startsWith('receiving') || local.startsWith('elev')) return 'ELEVATOR';
-  if (local.startsWith('driver') || local.startsWith('водитель')) return 'DRIVER';
-  if (local.startsWith('logistic') || local.startsWith('logistics') || local.startsWith('dispatch')) return 'LOGISTICIAN';
-  if (local.startsWith('buyer') || local.startsWith('покупатель')) return 'BUYER';
-  return 'FARMER';
+const API_URL = String(process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || '').replace(/\/$/, '');
+const UNIVERSAL_ERROR = 'Не удалось войти. Проверь данные или восстанови доступ.';
+
+type ApiLoginPayload = Partial<AuthenticatedSessionPayload> & {
+  mfaRequired?: boolean;
+  challengeToken?: string;
+  challengeExpiresAt?: string;
+  setupSecret?: string;
+  otpAuthUri?: string;
+  user?: AuthenticatedSessionPayload['user'];
+};
+
+function json(body: Record<string, unknown>, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store, no-cache, must-revalidate',
+      Pragma: 'no-cache',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
 }
 
-function setDemoSession(jar: ReturnType<typeof cookies>, role: string, email: string) {
-  const exp = Math.floor(Date.now() / 1000) + 8 * 3600;
-  const sessionValue = encodeURIComponent(JSON.stringify({ role, exp, email }));
-  jar.set(ACCESS_COOKIE, `demo.${Buffer.from(JSON.stringify({ role, exp })).toString('base64')}`, cookieSecurity());
-  jar.set(REFRESH_COOKIE, `demo-refresh.${role}`, cookieSecurity());
-  jar.set(SESSION_COOKIE, sessionValue, sessionMarkerCookie());
-  jar.set(CSRF_COOKIE, generateCsrfToken(), csrfCookieSecurity());
+function requestIp(request: Request) {
+  return (
+    request.headers.get('x-nf-client-connection-ip') ||
+    request.headers.get('cf-connecting-ip') ||
+    request.headers.get('x-real-ip') ||
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    ''
+  );
+}
+
+function forwardedHeaders(request: Request, correlationId: string) {
+  const ip = requestIp(request);
+  const userAgent = request.headers.get('user-agent');
+  return {
+    'Content-Type': 'application/json',
+    'x-correlation-id': correlationId,
+    ...(ip ? { 'x-forwarded-for': ip } : {}),
+    ...(userAgent ? { 'user-agent': userAgent } : {}),
+  };
 }
 
 export async function POST(request: Request) {
-  const body = await request.json().catch(() => ({}));
-  const { email = '', password = '', redirectTo = '' } = body;
+  const correlationId = request.headers.get('x-correlation-id') || randomUUID();
+  const body = await request.json().catch(() => ({} as Record<string, unknown>));
+  const email = String(body.email || '').trim().toLowerCase();
+  const password = String(body.password || '');
 
-  if (!email || !password) {
-    return NextResponse.json({ ok: false, message: 'Введите email и пароль.' }, { status: 400 });
+  if (!email || !password || email.length > 254 || password.length > 256) {
+    return json({ ok: false, code: 'INVALID_CREDENTIALS', message: UNIVERSAL_ERROR, correlationId }, 400);
+  }
+  if (!API_URL) {
+    console.error('auth_service_not_configured', JSON.stringify({ correlationId }));
+    return json({ ok: false, code: 'AUTH_SERVICE_UNAVAILABLE', message: UNIVERSAL_ERROR, correlationId }, 503);
   }
 
-  // The real identity service always has priority, including explicitly seeded
-  // test accounts. An email suffix must never force a fake browser session.
-  if (API_URL) {
-    try {
-      const response = await fetch(`${API_URL}/auth/login`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
-        cache: 'no-store',
-        signal: AbortSignal.timeout(4000),
-      });
-      const payload = await response.json().catch(() => ({}));
-      if (!response.ok) return NextResponse.json(payload, { status: response.status });
+  try {
+    const apiResponse = await fetch(`${API_URL}/auth/login`, {
+      method: 'POST',
+      headers: forwardedHeaders(request, correlationId),
+      body: JSON.stringify({ email, password }),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(5_000),
+    });
+    const payload = await apiResponse.json().catch(() => ({} as ApiLoginPayload)) as ApiLoginPayload;
 
-      const jar = cookies();
-      const role = payload.user?.role || payload.role || 'FARMER';
-      if (!payload.accessToken || !payload.refreshToken) {
-        return NextResponse.json({ ok: false, message: 'Сервис аутентификации вернул неполную сессию.' }, { status: 502 });
-      }
-      jar.set(ACCESS_COOKIE, payload.accessToken, cookieSecurity());
-      jar.set(REFRESH_COOKIE, payload.refreshToken, cookieSecurity());
-      const exp = Math.floor(Date.now() / 1000) + 8 * 3600;
-      jar.set(SESSION_COOKIE, encodeURIComponent(JSON.stringify({ role, exp, email: payload.user?.email || email })), sessionMarkerCookie());
-      jar.set(CSRF_COOKIE, generateCsrfToken(), csrfCookieSecurity());
-      return NextResponse.json({ ok: true, user: payload.user || null });
-    } catch {
-      // Network/timeout only. Demo fallback below remains explicitly gated.
+    if (!apiResponse.ok) {
+      const rateLimited = apiResponse.status === 429;
+      return json({
+        ok: false,
+        code: rateLimited ? 'RATE_LIMITED' : 'INVALID_CREDENTIALS',
+        message: UNIVERSAL_ERROR,
+        correlationId,
+      }, rateLimited ? 429 : 401);
     }
+
+    if (payload.mfaRequired) {
+      if (!payload.challengeToken || !payload.user?.email || !payload.user?.role) {
+        console.error('auth_service_incomplete_mfa_challenge', JSON.stringify({ correlationId }));
+        return json({ ok: false, code: 'AUTH_SERVICE_INVALID_RESPONSE', message: UNIVERSAL_ERROR, correlationId }, 502);
+      }
+
+      let ticket: string;
+      try {
+        ticket = sealMfaLoginTicket({
+          challengeToken: payload.challengeToken,
+          user: payload.user,
+        });
+      } catch {
+        console.error('mfa_ticket_secret_not_configured', JSON.stringify({ correlationId }));
+        return json({ ok: false, code: 'MFA_UNAVAILABLE', message: UNIVERSAL_ERROR, correlationId }, 503);
+      }
+
+      const response = json({
+        ok: true,
+        mfaRequired: true,
+        methods: ['totp', 'backup_code'],
+        enrollmentRequired: Boolean(payload.setupSecret),
+        setupSecret: payload.setupSecret || null,
+        otpAuthUri: payload.otpAuthUri || null,
+        expiresAt: payload.challengeExpiresAt || null,
+        correlationId,
+      });
+      response.cookies.set(MFA_PENDING_COOKIE, ticket, mfaPendingCookieOptions());
+      return response;
+    }
+
+    if (!payload.accessToken || !payload.refreshToken || !payload.user?.email || !payload.user?.role) {
+      console.error('auth_service_incomplete_session', JSON.stringify({ correlationId }));
+      return json({ ok: false, code: 'AUTH_SERVICE_INVALID_RESPONSE', message: UNIVERSAL_ERROR, correlationId }, 502);
+    }
+
+    const response = json({ ok: true, mfaRequired: false, correlationId });
+    const session = await applyAuthenticatedSession(response, payload as AuthenticatedSessionPayload);
+    if (!session) {
+      console.error('cabinet_session_signing_failed', JSON.stringify({ correlationId }));
+      return json({ ok: false, code: 'SESSION_CONFIGURATION_ERROR', message: UNIVERSAL_ERROR, correlationId }, 503);
+    }
+    response.cookies.set(MFA_PENDING_COOKIE, '', clearMfaPendingCookieOptions());
+    const bodyResponse = json({ ok: true, mfaRequired: false, redirectTo: session.redirectTo, correlationId });
+    for (const cookie of response.cookies.getAll()) bodyResponse.cookies.set(cookie);
+    return bodyResponse;
+  } catch (error) {
+    console.error('auth_login_transport_failure', JSON.stringify({
+      correlationId,
+      reason: error instanceof Error ? error.name : 'unknown',
+    }));
+    return json({ ok: false, code: 'AUTH_SERVICE_UNAVAILABLE', message: UNIVERSAL_ERROR, correlationId }, 503);
   }
-
-  if (!demoLoginAllowed()) {
-    return NextResponse.json(
-      { ok: false, message: 'Сервис аутентификации недоступен. Демо-вход отключён.' },
-      { status: 503 },
-    );
-  }
-
-  const role = detectDemoRole(email);
-  const jar = cookies();
-  setDemoSession(jar, role, email);
-
-  if (redirectTo && redirectTo.startsWith('/')) {
-    const res = NextResponse.redirect(new URL(redirectTo, request.url));
-    const exp = Math.floor(Date.now() / 1000) + 8 * 3600;
-    const sessionValue = encodeURIComponent(JSON.stringify({ role, exp, email }));
-    res.cookies.set(SESSION_COOKIE, sessionValue, sessionMarkerCookie());
-    res.cookies.set(ACCESS_COOKIE, `demo.${Buffer.from(JSON.stringify({ role, exp })).toString('base64')}`, cookieSecurity());
-    res.cookies.set(REFRESH_COOKIE, `demo-refresh.${role}`, cookieSecurity());
-    return res;
-  }
-
-  return NextResponse.json({
-    ok: true,
-    demo: true,
-    user: { email, role, orgName: 'Demo Org', fullName: email.split('@')[0] },
-  });
 }

--- a/apps/web/app/api/auth/mfa-login/cancel/route.ts
+++ b/apps/web/app/api/auth/mfa-login/cancel/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import {
+  MFA_PENDING_COOKIE,
+  clearMfaPendingCookieOptions,
+} from '../../../../../../lib/server/mfa-login-ticket';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  const response = NextResponse.json(
+    { ok: true },
+    { headers: { 'Cache-Control': 'no-store', Pragma: 'no-cache' } },
+  );
+  response.cookies.set(MFA_PENDING_COOKIE, '', clearMfaPendingCookieOptions());
+  return response;
+}

--- a/apps/web/app/api/auth/mfa-login/cancel/route.ts
+++ b/apps/web/app/api/auth/mfa-login/cancel/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import {
   MFA_PENDING_COOKIE,
   clearMfaPendingCookieOptions,
-} from '../../../../../../lib/server/mfa-login-ticket';
+} from '../../../../../lib/server/mfa-login-ticket';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/apps/web/app/api/auth/mfa-login/route.ts
+++ b/apps/web/app/api/auth/mfa-login/route.ts
@@ -6,12 +6,12 @@ import {
   normalizeSurfaceRole,
   platformHome,
   type AuthenticatedSessionPayload,
-} from '../../../../../lib/server/auth-session-response';
+} from '../../../../lib/server/auth-session-response';
 import {
   MFA_PENDING_COOKIE,
   clearMfaPendingCookieOptions,
   openMfaLoginTicket,
-} from '../../../../../lib/server/mfa-login-ticket';
+} from '../../../../lib/server/mfa-login-ticket';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/apps/web/app/api/auth/mfa-login/route.ts
+++ b/apps/web/app/api/auth/mfa-login/route.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from 'node:crypto';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import {
+  applyAuthenticatedSession,
+  normalizeSurfaceRole,
+  platformHome,
+  type AuthenticatedSessionPayload,
+} from '../../../../../lib/server/auth-session-response';
+import {
+  MFA_PENDING_COOKIE,
+  clearMfaPendingCookieOptions,
+  openMfaLoginTicket,
+} from '../../../../../lib/server/mfa-login-ticket';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 10;
+
+const API_URL = String(process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || '').replace(/\/$/, '');
+const UNIVERSAL_ERROR = 'Не удалось подтвердить второй фактор. Проверь код или начни вход заново.';
+
+function json(body: Record<string, unknown>, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store, no-cache, must-revalidate',
+      Pragma: 'no-cache',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}
+
+function requestIp(request: Request) {
+  return (
+    request.headers.get('x-nf-client-connection-ip') ||
+    request.headers.get('cf-connecting-ip') ||
+    request.headers.get('x-real-ip') ||
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    ''
+  );
+}
+
+export async function POST(request: Request) {
+  const correlationId = request.headers.get('x-correlation-id') || randomUUID();
+  const body = await request.json().catch(() => ({} as Record<string, unknown>));
+  const code = String(body.code || '').trim();
+  const jar = cookies();
+  const ticket = openMfaLoginTicket(jar.get(MFA_PENDING_COOKIE)?.value || '');
+
+  if (!ticket || !code || code.length > 128) {
+    const response = json({ ok: false, code: 'MFA_INVALID', message: UNIVERSAL_ERROR, correlationId }, 401);
+    if (!ticket) response.cookies.set(MFA_PENDING_COOKIE, '', clearMfaPendingCookieOptions());
+    return response;
+  }
+  if (!API_URL) {
+    return json({ ok: false, code: 'AUTH_SERVICE_UNAVAILABLE', message: UNIVERSAL_ERROR, correlationId }, 503);
+  }
+
+  const ip = requestIp(request);
+  try {
+    const apiResponse = await fetch(`${API_URL}/auth/mfa/verify`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-correlation-id': correlationId,
+        ...(ip ? { 'x-forwarded-for': ip } : {}),
+        ...(request.headers.get('user-agent') ? { 'user-agent': request.headers.get('user-agent') as string } : {}),
+      },
+      body: JSON.stringify({ challengeToken: ticket.challengeToken, code }),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(5_000),
+    });
+    const payload = await apiResponse.json().catch(() => ({} as AuthenticatedSessionPayload)) as AuthenticatedSessionPayload & {
+      backupCodes?: string[];
+    };
+
+    if (!apiResponse.ok || !payload.accessToken || !payload.refreshToken || !payload.user?.email || !payload.user?.role) {
+      const terminal = apiResponse.status === 401 || apiResponse.status === 403 || apiResponse.status === 410;
+      const response = json({
+        ok: false,
+        code: apiResponse.status === 429 ? 'RATE_LIMITED' : 'MFA_INVALID',
+        message: UNIVERSAL_ERROR,
+        correlationId,
+      }, apiResponse.status === 429 ? 429 : 401);
+      if (terminal) response.cookies.set(MFA_PENDING_COOKIE, '', clearMfaPendingCookieOptions());
+      return response;
+    }
+
+    const role = normalizeSurfaceRole(payload.user.role, payload.user.surfaceRole);
+    const response = json({
+      ok: true,
+      redirectTo: platformHome(role),
+      backupCodes: Array.isArray(payload.backupCodes) ? payload.backupCodes : undefined,
+      correlationId,
+    });
+    const session = await applyAuthenticatedSession(response, payload);
+    if (!session) {
+      return json({ ok: false, code: 'SESSION_CONFIGURATION_ERROR', message: UNIVERSAL_ERROR, correlationId }, 503);
+    }
+    response.cookies.set(MFA_PENDING_COOKIE, '', clearMfaPendingCookieOptions());
+    return response;
+  } catch (error) {
+    console.error('auth_mfa_transport_failure', JSON.stringify({
+      correlationId,
+      reason: error instanceof Error ? error.name : 'unknown',
+    }));
+    return json({ ok: false, code: 'AUTH_SERVICE_UNAVAILABLE', message: UNIVERSAL_ERROR, correlationId }, 503);
+  }
+}

--- a/apps/web/app/platform-v7/login/page.tsx
+++ b/apps/web/app/platform-v7/login/page.tsx
@@ -2,87 +2,149 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { ArrowLeft, Eye, EyeOff, LockKeyhole, Mail } from 'lucide-react';
+import { ArrowLeft, Eye, EyeOff, KeyRound, LockKeyhole, Mail, ShieldCheck } from 'lucide-react';
 import { PublicSiteHeader } from '@/components/platform-v7/PublicSiteHeader';
-import { PLATFORM_V7_ACTIVE_ROLE_KEY, platformV7RoleHome } from '@/components/platform-v7/PlatformV7SingleEntryGuard';
-import { usePlatformV7RStore, type PlatformRole } from '@/stores/usePlatformV7RStore';
 
-const ENTRY_COOKIE = 'pc_v7_entry_seen';
+type LoginStep = 'password' | 'mfa' | 'backup-codes';
+type MfaMethod = 'totp' | 'backup_code';
 
-function surfaceRole(role: string | undefined): PlatformRole {
-  const normalized = String(role ?? '').toUpperCase();
-  if (normalized === 'BUYER') return 'buyer';
-  if (normalized === 'FARMER' || normalized === 'SELLER') return 'seller';
-  if (normalized === 'LOGISTICIAN' || normalized === 'LOGISTICS') return 'logistics';
-  if (normalized === 'DRIVER') return 'driver';
-  if (normalized === 'ELEVATOR') return 'elevator';
-  if (normalized === 'LAB') return 'lab';
-  if (normalized === 'SURVEYOR') return 'surveyor';
-  if (normalized === 'ACCOUNTING' || normalized === 'BANK') return 'bank';
-  if (normalized === 'COMPLIANCE_OFFICER' || normalized === 'COMPLIANCE') return 'compliance';
-  if (normalized === 'ARBITRATOR') return 'arbitrator';
-  if (normalized === 'EXECUTIVE') return 'executive';
-  return 'operator';
-}
+type LoginResponse = {
+  ok?: boolean;
+  mfaRequired?: boolean;
+  redirectTo?: string;
+  methods?: MfaMethod[];
+  enrollmentRequired?: boolean;
+  setupSecret?: string | null;
+  otpAuthUri?: string | null;
+  backupCodes?: string[];
+  message?: string;
+};
 
-function markEntrySeen() {
-  const secure = globalThis.location?.protocol === 'https:' ? '; Secure' : '';
-  document.cookie = `${ENTRY_COOKIE}=true; Path=/; Max-Age=14400; SameSite=Lax${secure}`;
+async function requestJson(url: string, init: RequestInit) {
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal, cache: 'no-store' });
+    const payload = await response.json().catch(() => ({})) as LoginResponse;
+    return { response, payload };
+  } finally {
+    window.clearTimeout(timer);
+  }
 }
 
 export default function LoginPage() {
   const t = useTranslations('publicEntry.login');
-  const router = useRouter();
-  const setRole = usePlatformV7RStore((state) => state.setRole);
+  const [step, setStep] = React.useState<LoginStep>('password');
+  const [method, setMethod] = React.useState<MfaMethod>('totp');
   const [email, setEmail] = React.useState('');
   const [password, setPassword] = React.useState('');
+  const [code, setCode] = React.useState('');
   const [showPassword, setShowPassword] = React.useState(false);
   const [submitting, setSubmitting] = React.useState(false);
   const [error, setError] = React.useState('');
+  const [setupSecret, setSetupSecret] = React.useState('');
+  const [backupCodes, setBackupCodes] = React.useState<string[]>([]);
+  const [redirectTo, setRedirectTo] = React.useState('');
+  const emailRef = React.useRef<HTMLInputElement>(null);
+  const codeRef = React.useRef<HTMLInputElement>(null);
+  const errorRef = React.useRef<HTMLParagraphElement>(null);
 
-  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+  React.useEffect(() => {
+    if (error) errorRef.current?.focus();
+  }, [error]);
+
+  React.useEffect(() => {
+    if (step === 'mfa') codeRef.current?.focus();
+  }, [step, method]);
+
+  async function submitPassword(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!email.trim() || !password) {
+    if (submitting) return;
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail || !password) {
       setError(t('required'));
+      emailRef.current?.focus();
       return;
     }
 
     setSubmitting(true);
     setError('');
-
     try {
-      const response = await fetch('/api/auth/login', {
+      const { response, payload } = await requestJson('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email.trim(), password }),
-        cache: 'no-store',
+        body: JSON.stringify({ email: normalizedEmail, password }),
       });
-      const payload = await response.json().catch(() => ({}));
-      if (!response.ok || !payload?.ok) {
-        throw new Error(payload?.message || t('unavailable'));
+      if (!response.ok || !payload.ok) throw new Error(t('unavailable'));
+
+      if (payload.mfaRequired) {
+        setSetupSecret(payload.enrollmentRequired ? String(payload.setupSecret || '') : '');
+        setMethod('totp');
+        setCode('');
+        setPassword('');
+        setStep('mfa');
+        return;
       }
 
-      const role = surfaceRole(payload?.user?.role ?? payload?.role);
-      const sessionBody = payload?.demo === true ? { role } : {};
-      const sessionResponse = await fetch('/api/platform-v7/cabinet-session', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(sessionBody),
-        cache: 'no-store',
-      });
-      if (!sessionResponse.ok) throw new Error(t('unavailable'));
-
-      markEntrySeen();
-      globalThis.sessionStorage?.setItem(PLATFORM_V7_ACTIVE_ROLE_KEY, role);
-      setRole(role);
-      router.replace(platformV7RoleHome(role));
-      router.refresh();
-    } catch (reason) {
-      setError(reason instanceof Error ? reason.message : t('unavailable'));
+      if (!payload.redirectTo?.startsWith('/platform-v7/')) throw new Error(t('unavailable'));
+      globalThis.location.assign(payload.redirectTo);
+    } catch {
+      setError(t('unavailable'));
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  async function submitMfa(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitting) return;
+    const normalizedCode = code.trim();
+    if (!normalizedCode) {
+      setError(t('mfaError'));
+      codeRef.current?.focus();
+      return;
+    }
+
+    setSubmitting(true);
+    setError('');
+    try {
+      const { response, payload } = await requestJson('/api/auth/mfa-login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: normalizedCode, method }),
+      });
+      if (!response.ok || !payload.ok || !payload.redirectTo?.startsWith('/platform-v7/')) {
+        throw new Error(t('mfaError'));
+      }
+
+      if (Array.isArray(payload.backupCodes) && payload.backupCodes.length > 0) {
+        setBackupCodes(payload.backupCodes);
+        setRedirectTo(payload.redirectTo);
+        setStep('backup-codes');
+        return;
+      }
+      globalThis.location.assign(payload.redirectTo);
+    } catch {
+      setError(t('mfaError'));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function returnToPassword() {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await fetch('/api/auth/mfa-login/cancel', { method: 'POST', cache: 'no-store' });
+    } finally {
+      setStep('password');
+      setMethod('totp');
+      setCode('');
+      setSetupSecret('');
+      setError('');
+      setSubmitting(false);
+      window.setTimeout(() => emailRef.current?.focus(), 0);
     }
   }
 
@@ -101,70 +163,139 @@ export default function LoginPage() {
 
       <section className='pc-auth-shell' aria-labelledby='pc-login-title'>
         <div className='pc-auth-heading'>
-          <h1 id='pc-login-title'>{t('title')}</h1>
-          <p>{t('lead')}</p>
+          <h1 id='pc-login-title'>{step === 'password' ? t('title') : step === 'mfa' ? t('mfaTitle') : t('backupCodesTitle')}</h1>
+          <p>{step === 'password' ? t('lead') : step === 'mfa' ? t('mfaLead') : t('backupCodesLead')}</p>
         </div>
 
-        <form className='pc-auth-card' onSubmit={onSubmit} noValidate>
-          <label className='pc-auth-label'>
-            <span>{t('email')}</span>
-            <span className='pc-auth-field'>
-              <Mail size={19} aria-hidden='true' />
-              <input
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                type='email'
-                inputMode='email'
-                autoComplete='username'
-                placeholder={t('emailPlaceholder')}
-                disabled={submitting}
-                aria-invalid={Boolean(error)}
-              />
-            </span>
-          </label>
+        {step === 'password' ? (
+          <form className='pc-auth-card' onSubmit={submitPassword} noValidate>
+            <label className='pc-auth-label'>
+              <span>{t('email')}</span>
+              <span className='pc-auth-field'>
+                <Mail size={19} aria-hidden='true' />
+                <input
+                  ref={emailRef}
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  type='email'
+                  inputMode='email'
+                  autoComplete='username'
+                  autoCapitalize='none'
+                  spellCheck={false}
+                  placeholder={t('emailPlaceholder')}
+                  disabled={submitting}
+                  aria-invalid={Boolean(error)}
+                  aria-describedby={error ? 'pc-auth-error' : undefined}
+                />
+              </span>
+            </label>
 
-          <label className='pc-auth-label'>
-            <span>{t('password')}</span>
-            <span className='pc-auth-field'>
-              <LockKeyhole size={19} aria-hidden='true' />
-              <input
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                type={showPassword ? 'text' : 'password'}
-                autoComplete='current-password'
-                placeholder={t('passwordPlaceholder')}
-                disabled={submitting}
-                aria-invalid={Boolean(error)}
-              />
-              <button
-                type='button'
-                className='pc-auth-password-toggle'
-                onClick={() => setShowPassword((value) => !value)}
-                aria-label={showPassword ? t('hidePassword') : t('showPassword')}
-                title={showPassword ? t('hidePassword') : t('showPassword')}
-              >
-                {showPassword ? <EyeOff size={19} aria-hidden='true' /> : <Eye size={19} aria-hidden='true' />}
+            <label className='pc-auth-label'>
+              <span>{t('password')}</span>
+              <span className='pc-auth-field'>
+                <LockKeyhole size={19} aria-hidden='true' />
+                <input
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete='current-password'
+                  autoCapitalize='none'
+                  spellCheck={false}
+                  placeholder={t('passwordPlaceholder')}
+                  disabled={submitting}
+                  aria-invalid={Boolean(error)}
+                  aria-describedby={error ? 'pc-auth-error' : undefined}
+                />
+                <button
+                  type='button'
+                  className='pc-auth-password-toggle'
+                  onClick={() => setShowPassword((value) => !value)}
+                  aria-label={showPassword ? t('hidePassword') : t('showPassword')}
+                  title={showPassword ? t('hidePassword') : t('showPassword')}
+                >
+                  {showPassword ? <EyeOff size={19} aria-hidden='true' /> : <Eye size={19} aria-hidden='true' />}
+                </button>
+              </span>
+            </label>
+
+            <div className='pc-auth-links'>
+              <Link href='/platform-v7/forgot-password'>{t('forgot')}</Link>
+              <Link href='/platform-v7/register'>{t('register')}</Link>
+            </div>
+
+            {error ? <p ref={errorRef} id='pc-auth-error' className='pc-auth-error' role='alert' tabIndex={-1}>{error}</p> : null}
+
+            <button className='pc-auth-submit' type='submit' disabled={submitting} aria-busy={submitting}>
+              {submitting ? t('loading') : t('submit')}
+            </button>
+            <p className='pc-auth-note'>{t('note')}</p>
+          </form>
+        ) : null}
+
+        {step === 'mfa' ? (
+          <form className='pc-auth-card' onSubmit={submitMfa} noValidate>
+            {setupSecret ? (
+              <section className='pc-auth-enrollment' aria-labelledby='pc-auth-enrollment-title'>
+                <ShieldCheck size={24} aria-hidden='true' />
+                <div>
+                  <h2 id='pc-auth-enrollment-title'>{t('enrollmentTitle')}</h2>
+                  <p>{t('enrollmentLead')}</p>
+                  <span>{t('setupSecretLabel')}</span>
+                  <code>{setupSecret}</code>
+                </div>
+              </section>
+            ) : null}
+
+            <div className='pc-auth-methods' role='group' aria-label={t('mfaCode')}>
+              <button type='button' aria-pressed={method === 'totp'} onClick={() => { setMethod('totp'); setCode(''); setError(''); }}>
+                <ShieldCheck size={18} aria-hidden='true' />{t('totpMethod')}
               </button>
-            </span>
-          </label>
+              <button type='button' aria-pressed={method === 'backup_code'} onClick={() => { setMethod('backup_code'); setCode(''); setError(''); }}>
+                <KeyRound size={18} aria-hidden='true' />{t('backupMethod')}
+              </button>
+            </div>
 
-          <div className='pc-auth-links'>
-            <Link href='/platform-v7/forgot-password'>{t('forgot')}</Link>
-            <Link href='/platform-v7/register'>{t('register')}</Link>
-          </div>
+            <label className='pc-auth-label'>
+              <span>{t('mfaCode')}</span>
+              <span className='pc-auth-field'>
+                <KeyRound size={19} aria-hidden='true' />
+                <input
+                  ref={codeRef}
+                  value={code}
+                  onChange={(event) => setCode(event.target.value)}
+                  type='text'
+                  inputMode={method === 'totp' ? 'numeric' : 'text'}
+                  autoComplete={method === 'totp' ? 'one-time-code' : 'off'}
+                  autoCapitalize='characters'
+                  spellCheck={false}
+                  placeholder={method === 'totp' ? t('mfaCodePlaceholder') : t('backupCodePlaceholder')}
+                  disabled={submitting}
+                  aria-invalid={Boolean(error)}
+                  aria-describedby={error ? 'pc-auth-error' : undefined}
+                />
+              </span>
+            </label>
 
-          {error ? <p className='pc-auth-error' role='alert'>{error}</p> : null}
+            {error ? <p ref={errorRef} id='pc-auth-error' className='pc-auth-error' role='alert' tabIndex={-1}>{error}</p> : null}
 
-          <button className='pc-auth-submit' type='submit' disabled={submitting}>
-            {submitting ? t('loading') : t('submit')}
-          </button>
+            <button className='pc-auth-submit' type='submit' disabled={submitting} aria-busy={submitting}>
+              {submitting ? t('mfaLoading') : t('mfaSubmit')}
+            </button>
+            <button className='pc-auth-secondary' type='button' onClick={returnToPassword} disabled={submitting}>{t('mfaBack')}</button>
+          </form>
+        ) : null}
 
-          <p className='pc-auth-note'>{t('note')}</p>
-        </form>
+        {step === 'backup-codes' ? (
+          <section className='pc-auth-card pc-auth-backup-codes' aria-live='polite'>
+            <ShieldCheck size={36} aria-hidden='true' />
+            <div className='pc-auth-code-grid'>{backupCodes.map((item) => <code key={item}>{item}</code>)}</div>
+            <button className='pc-auth-submit' type='button' onClick={() => globalThis.location.assign(redirectTo)}>{t('submit')}</button>
+          </section>
+        ) : null}
       </section>
 
       <style jsx>{`
-        .pc-auth-page{--auth-header-height:64px;min-height:100dvh;padding-top:var(--auth-header-height);background:radial-gradient(circle at 12% 0%,rgba(8,122,59,.12),transparent 34%),linear-gradient(180deg,#f7faf7 0%,#eef5ef 58%,#f8faf8 100%);color:#102019;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.pc-auth-page *{box-sizing:border-box}.pc-auth-shell{width:min(100%,560px);min-height:calc(100dvh - var(--auth-header-height));margin:0 auto;padding:clamp(34px,7vh,74px) 18px 40px;display:flex;flex-direction:column;justify-content:center;gap:24px}.pc-auth-heading{text-align:center}.pc-auth-heading h1{margin:0;font-size:clamp(38px,7vw,58px);line-height:1;letter-spacing:-.055em}.pc-auth-heading p{max-width:520px;margin:16px auto 0;color:#5c6b64;font-size:16px;line-height:1.5;font-weight:600}.pc-auth-card{display:grid;gap:18px;padding:clamp(22px,5vw,36px);border-radius:30px;background:rgba(255,255,255,.96);border:1px solid rgba(16,32,25,.1);box-shadow:0 28px 80px rgba(27,66,45,.13)}.pc-auth-label{display:grid;gap:8px}.pc-auth-label>span:first-child{font-size:13px;font-weight:900;color:#31423a}.pc-auth-field{height:56px;display:flex;align-items:center;gap:10px;padding:0 15px;border-radius:17px;background:#f9fbf9;border:1px solid rgba(16,32,25,.12);transition:border-color .15s,box-shadow .15s}.pc-auth-field:focus-within{border-color:rgba(8,122,59,.58);box-shadow:0 0 0 4px rgba(8,122,59,.1)}.pc-auth-field>svg{color:#708078;flex:0 0 auto}.pc-auth-field input{width:100%;height:100%;min-width:0;border:0;outline:0;background:transparent;color:#102019;font:inherit;font-size:16px}.pc-auth-password-toggle{width:38px;height:38px;flex:0 0 38px;border:0;border-radius:11px;background:transparent;color:#607068;display:grid;place-items:center;cursor:pointer}.pc-auth-password-toggle:focus-visible{outline:3px solid rgba(8,122,59,.28);outline-offset:2px}.pc-auth-links{display:flex;align-items:center;justify-content:space-between;gap:14px;flex-wrap:wrap}.pc-auth-links a{color:#087a3b;text-decoration:none;font-size:13px;font-weight:850}.pc-auth-links a:focus-visible{outline:3px solid rgba(8,122,59,.28);outline-offset:3px;border-radius:6px}.pc-auth-error{margin:0;padding:12px 14px;border-radius:14px;background:#fff1f1;border:1px solid #f2c5c5;color:#9b2525;font-size:13px;font-weight:800;line-height:1.4}.pc-auth-submit{height:56px;border:0;border-radius:17px;background:linear-gradient(135deg,#087a3b,#075f31);color:#fff;font:inherit;font-size:15px;font-weight:950;cursor:pointer;box-shadow:0 18px 36px rgba(8,122,59,.22)}.pc-auth-submit:disabled{cursor:wait;opacity:.66}.pc-auth-submit:focus-visible{outline:3px solid rgba(8,122,59,.35);outline-offset:3px}.pc-auth-note{margin:0;color:#6b7973;font-size:12px;line-height:1.5;text-align:center}@media(max-width:520px){.pc-auth-shell{padding:28px 14px 28px;justify-content:flex-start}.pc-auth-heading h1{font-size:38px}.pc-auth-card{padding:22px;border-radius:24px}.pc-auth-links{align-items:flex-start;flex-direction:column}.pc-auth-field{height:54px}}
+        .pc-auth-page{--auth-header-height:64px;min-height:100dvh;padding-top:var(--auth-header-height);background:radial-gradient(circle at 12% 0%,rgba(8,122,59,.12),transparent 34%),linear-gradient(180deg,#f7faf7 0%,#eef5ef 58%,#f8faf8 100%);color:#102019;font-family:var(--font-inter),Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.pc-auth-page *{box-sizing:border-box}.pc-auth-shell{width:min(100%,560px);min-height:calc(100dvh - var(--auth-header-height));margin:0 auto;padding:clamp(34px,7vh,74px) 18px 40px;display:flex;flex-direction:column;justify-content:center;gap:24px}.pc-auth-heading{text-align:center}.pc-auth-heading h1{margin:0;font-size:clamp(38px,7vw,58px);line-height:1;letter-spacing:-.055em}.pc-auth-heading p{max-width:520px;margin:16px auto 0;color:#5c6b64;font-size:16px;line-height:1.5;font-weight:600}.pc-auth-card{display:grid;gap:18px;padding:clamp(22px,5vw,36px);border-radius:30px;background:rgba(255,255,255,.96);border:1px solid rgba(16,32,25,.1);box-shadow:0 28px 80px rgba(27,66,45,.13)}.pc-auth-label{display:grid;gap:8px}.pc-auth-label>span:first-child{font-size:13px;font-weight:900;color:#31423a}.pc-auth-field{height:56px;display:flex;align-items:center;gap:10px;padding:0 15px;border-radius:17px;background:#f9fbf9;border:1px solid rgba(16,32,25,.12);transition:border-color .15s,box-shadow .15s}.pc-auth-field:focus-within{border-color:rgba(8,122,59,.58);box-shadow:0 0 0 4px rgba(8,122,59,.1)}.pc-auth-field>svg{color:#708078;flex:0 0 auto}.pc-auth-field input{width:100%;height:100%;min-width:0;border:0;outline:0;background:transparent;color:#102019;font:inherit;font-size:16px}.pc-auth-password-toggle{width:38px;height:38px;flex:0 0 38px;border:0;border-radius:11px;background:transparent;color:#607068;display:grid;place-items:center;cursor:pointer}.pc-auth-password-toggle:focus-visible,.pc-auth-secondary:focus-visible,.pc-auth-methods button:focus-visible{outline:3px solid rgba(8,122,59,.28);outline-offset:2px}.pc-auth-links{display:flex;align-items:center;justify-content:space-between;gap:14px;flex-wrap:wrap}.pc-auth-links a{color:#087a3b;text-decoration:none;font-size:13px;font-weight:850}.pc-auth-links a:focus-visible{outline:3px solid rgba(8,122,59,.28);outline-offset:3px;border-radius:6px}.pc-auth-error{margin:0;padding:12px 14px;border-radius:14px;background:#fff1f1;border:1px solid #f2c5c5;color:#9b2525;font-size:13px;font-weight:800;line-height:1.4}.pc-auth-submit,.pc-auth-secondary{min-height:56px;border-radius:17px;font:inherit;font-size:15px;font-weight:950;cursor:pointer}.pc-auth-submit{border:0;background:linear-gradient(135deg,#087a3b,#075f31);color:#fff;box-shadow:0 18px 36px rgba(8,122,59,.22)}.pc-auth-secondary{border:1px solid rgba(8,122,59,.18);background:#fff;color:#087a3b}.pc-auth-submit:disabled,.pc-auth-secondary:disabled{cursor:wait;opacity:.66}.pc-auth-submit:focus-visible{outline:3px solid rgba(8,122,59,.35);outline-offset:3px}.pc-auth-note{margin:0;color:#6b7973;font-size:12px;line-height:1.5;text-align:center}.pc-auth-methods{display:grid;grid-template-columns:1fr 1fr;gap:8px}.pc-auth-methods button{min-height:48px;border:1px solid rgba(16,32,25,.12);border-radius:14px;background:#f7faf7;color:#42524b;font:inherit;font-size:13px;font-weight:850;display:flex;align-items:center;justify-content:center;gap:7px;cursor:pointer}.pc-auth-methods button[aria-pressed='true']{border-color:rgba(8,122,59,.5);background:rgba(8,122,59,.08);color:#087a3b}.pc-auth-enrollment{display:flex;gap:12px;padding:14px;border-radius:16px;border:1px solid rgba(8,122,59,.18);background:rgba(8,122,59,.055)}.pc-auth-enrollment>svg{flex:0 0 auto;color:#087a3b}.pc-auth-enrollment h2{margin:0;font-size:16px}.pc-auth-enrollment p{margin:5px 0 10px;color:#5c6b64;font-size:13px;line-height:1.45}.pc-auth-enrollment span{display:block;color:#5c6b64;font-size:11px;font-weight:850}.pc-auth-enrollment code{display:block;margin-top:4px;overflow-wrap:anywhere;color:#17362a;font-size:13px}.pc-auth-backup-codes{text-align:center;justify-items:center}.pc-auth-code-grid{width:100%;display:grid;grid-template-columns:1fr 1fr;gap:8px}.pc-auth-code-grid code{padding:10px;border-radius:10px;background:#f1f5f2;color:#17362a;font-size:12px;font-weight:800}.pc-auth-backup-codes .pc-auth-submit{width:100%}@media(max-width:520px){.pc-auth-shell{padding:28px 14px 28px;justify-content:flex-start}.pc-auth-heading h1{font-size:38px}.pc-auth-card{padding:22px;border-radius:24px}.pc-auth-links{align-items:flex-start;flex-direction:column}.pc-auth-field{height:54px}.pc-auth-methods,.pc-auth-code-grid{grid-template-columns:1fr}}
       `}</style>
     </main>
   );

--- a/apps/web/i18n/public-entry-messages.ts
+++ b/apps/web/i18n/public-entry-messages.ts
@@ -29,6 +29,22 @@ type PublicEntryMessages = {
     required: string;
     unavailable: string;
     note: string;
+    mfaTitle: string;
+    mfaLead: string;
+    totpMethod: string;
+    backupMethod: string;
+    mfaCode: string;
+    mfaCodePlaceholder: string;
+    backupCodePlaceholder: string;
+    mfaSubmit: string;
+    mfaLoading: string;
+    mfaError: string;
+    mfaBack: string;
+    enrollmentTitle: string;
+    enrollmentLead: string;
+    setupSecretLabel: string;
+    backupCodesTitle: string;
+    backupCodesLead: string;
   };
   forgot: {
     publicNav: string;
@@ -78,8 +94,24 @@ export const publicEntryMessages: Record<AppLocale, PublicEntryMessages> = {
       forgot: 'Восстановить доступ',
       register: 'Создать учётную запись',
       required: 'Введите email и пароль.',
-      unavailable: 'Не удалось подтвердить доступ. Проверьте данные или повторите позже.',
+      unavailable: 'Не удалось войти. Проверьте данные или восстановите доступ.',
       note: 'После входа откроется рабочее место, назначенное вашей организации. Роль нельзя выбрать или изменить через URL.',
+      mfaTitle: 'Подтвердить вход',
+      mfaLead: 'Введите код второго фактора. Основная сессия будет создана только после успешной проверки.',
+      totpMethod: 'Код приложения',
+      backupMethod: 'Резервный код',
+      mfaCode: 'Код подтверждения',
+      mfaCodePlaceholder: '6 цифр',
+      backupCodePlaceholder: 'Резервный код',
+      mfaSubmit: 'Подтвердить',
+      mfaLoading: 'Проверяем код…',
+      mfaError: 'Не удалось подтвердить второй фактор. Проверьте код или начните вход заново.',
+      mfaBack: 'Вернуться к паролю',
+      enrollmentTitle: 'Подключение второго фактора',
+      enrollmentLead: 'Добавьте ключ в приложение-аутентификатор, затем введите текущий код.',
+      setupSecretLabel: 'Ключ настройки',
+      backupCodesTitle: 'Сохраните резервные коды',
+      backupCodesLead: 'Они показываются один раз. Храните их отдельно от пароля.',
     },
     forgot: {
       publicNav: 'Навигация восстановления доступа',
@@ -127,8 +159,24 @@ export const publicEntryMessages: Record<AppLocale, PublicEntryMessages> = {
       forgot: 'Restore access',
       register: 'Create account',
       required: 'Enter email and password.',
-      unavailable: 'Access could not be verified. Check the credentials or try again later.',
+      unavailable: 'Sign-in failed. Check the credentials or restore access.',
       note: 'After sign-in, the workspace assigned to your organisation will open. A role cannot be selected or changed through the URL.',
+      mfaTitle: 'Confirm sign-in',
+      mfaLead: 'Enter the second-factor code. The main session is created only after successful verification.',
+      totpMethod: 'Authenticator code',
+      backupMethod: 'Backup code',
+      mfaCode: 'Verification code',
+      mfaCodePlaceholder: '6 digits',
+      backupCodePlaceholder: 'Backup code',
+      mfaSubmit: 'Confirm',
+      mfaLoading: 'Verifying code…',
+      mfaError: 'The second factor could not be verified. Check the code or restart sign-in.',
+      mfaBack: 'Back to password',
+      enrollmentTitle: 'Set up a second factor',
+      enrollmentLead: 'Add the key to an authenticator app, then enter the current code.',
+      setupSecretLabel: 'Setup key',
+      backupCodesTitle: 'Save the backup codes',
+      backupCodesLead: 'They are displayed once. Store them separately from the password.',
     },
     forgot: {
       publicNav: 'Access recovery navigation',
@@ -176,8 +224,24 @@ export const publicEntryMessages: Record<AppLocale, PublicEntryMessages> = {
       forgot: '恢复访问权限',
       register: '创建账户',
       required: '请输入邮箱和密码。',
-      unavailable: '无法验证访问权限。请检查凭据或稍后重试。',
+      unavailable: '登录失败。请检查凭据或恢复访问权限。',
       note: '登录后将打开分配给贵组织的工作区。不能通过 URL 选择或更改角色。',
+      mfaTitle: '确认登录',
+      mfaLead: '请输入第二因素代码。只有验证成功后才会创建主会话。',
+      totpMethod: '身份验证器代码',
+      backupMethod: '备用代码',
+      mfaCode: '验证码',
+      mfaCodePlaceholder: '6 位数字',
+      backupCodePlaceholder: '备用代码',
+      mfaSubmit: '确认',
+      mfaLoading: '正在验证代码…',
+      mfaError: '无法验证第二因素。请检查代码或重新开始登录。',
+      mfaBack: '返回密码登录',
+      enrollmentTitle: '设置第二因素',
+      enrollmentLead: '将密钥添加到身份验证器应用，然后输入当前代码。',
+      setupSecretLabel: '设置密钥',
+      backupCodesTitle: '保存备用代码',
+      backupCodesLead: '备用代码仅显示一次。请与密码分开保存。',
     },
     forgot: {
       publicNav: '访问恢复导航',

--- a/apps/web/lib/server/auth-session-response.ts
+++ b/apps/web/lib/server/auth-session-response.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import {
+  ACCESS_COOKIE,
+  CSRF_COOKIE,
+  REFRESH_COOKIE,
+  SESSION_COOKIE,
+  cookieSecurity,
+  csrfCookieSecurity,
+  sessionMarkerCookie,
+} from '../auth-cookies';
+import { generateCsrfToken } from '../server-request-security';
+import { signCabinetSession } from '../platform-v7/verified-session';
+
+export const CABINET_SESSION_COOKIE = 'pc_v7_cabinet';
+
+export type AuthenticatedSessionPayload = {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn?: number;
+  user: {
+    email: string;
+    role: string;
+    surfaceRole?: string;
+  };
+};
+
+export type SurfaceRole =
+  | 'operator'
+  | 'buyer'
+  | 'seller'
+  | 'logistics'
+  | 'driver'
+  | 'elevator'
+  | 'lab'
+  | 'surveyor'
+  | 'bank'
+  | 'arbitrator'
+  | 'compliance'
+  | 'executive';
+
+export function normalizeSurfaceRole(apiRole: string | undefined, explicit?: string): SurfaceRole {
+  const normalized = String(explicit || apiRole || '').toUpperCase();
+  if (normalized === 'BUYER') return 'buyer';
+  if (normalized === 'FARMER' || normalized === 'SELLER') return 'seller';
+  if (normalized === 'LOGISTICIAN' || normalized === 'LOGISTICS') return 'logistics';
+  if (normalized === 'DRIVER') return 'driver';
+  if (normalized === 'ELEVATOR') return 'elevator';
+  if (normalized === 'LAB') return 'lab';
+  if (normalized === 'SURVEYOR') return 'surveyor';
+  if (normalized === 'ACCOUNTING' || normalized === 'BANK') return 'bank';
+  if (normalized === 'ARBITRATOR') return 'arbitrator';
+  if (normalized === 'COMPLIANCE_OFFICER' || normalized === 'COMPLIANCE') return 'compliance';
+  if (normalized === 'EXECUTIVE') return 'executive';
+  return 'operator';
+}
+
+export function platformHome(role: SurfaceRole) {
+  const routes: Record<SurfaceRole, string> = {
+    operator: '/platform-v7/control-tower',
+    buyer: '/platform-v7/buyer',
+    seller: '/platform-v7/seller',
+    logistics: '/platform-v7/logistics',
+    driver: '/platform-v7/driver',
+    elevator: '/platform-v7/elevator',
+    lab: '/platform-v7/lab',
+    surveyor: '/platform-v7/surveyor',
+    bank: '/platform-v7/bank',
+    arbitrator: '/platform-v7/arbitrator',
+    compliance: '/platform-v7/compliance',
+    executive: '/platform-v7/executive',
+  };
+  return routes[role];
+}
+
+export async function applyAuthenticatedSession(
+  response: NextResponse,
+  payload: AuthenticatedSessionPayload,
+): Promise<{ role: SurfaceRole; redirectTo: string } | null> {
+  const role = normalizeSurfaceRole(payload.user.role, payload.user.surfaceRole);
+  const expiresIn = Math.max(60, Math.min(Number(payload.expiresIn || 900), 24 * 60 * 60));
+  const exp = Math.floor(Date.now() / 1000) + expiresIn;
+  const secret = String(process.env.JWT_SECRET || '').trim();
+  const cabinetToken = await signCabinetSession(role, secret, {
+    nowSeconds: Math.floor(Date.now() / 1000),
+    ttlSeconds: expiresIn,
+  });
+  if (!cabinetToken) return null;
+
+  response.cookies.set(ACCESS_COOKIE, payload.accessToken, cookieSecurity());
+  response.cookies.set(REFRESH_COOKIE, payload.refreshToken, cookieSecurity());
+  response.cookies.set(
+    SESSION_COOKIE,
+    encodeURIComponent(JSON.stringify({ role, exp, email: payload.user.email })),
+    sessionMarkerCookie(),
+  );
+  response.cookies.set(CSRF_COOKIE, generateCsrfToken(), csrfCookieSecurity());
+  response.cookies.set(CABINET_SESSION_COOKIE, cabinetToken, {
+    path: '/',
+    maxAge: expiresIn,
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  });
+
+  return { role, redirectTo: platformHome(role) };
+}
+
+export function clearAuthenticatedSession(response: NextResponse) {
+  for (const name of [ACCESS_COOKIE, REFRESH_COOKIE, SESSION_COOKIE, CSRF_COOKIE, CABINET_SESSION_COOKIE]) {
+    response.cookies.set(name, '', { path: '/', expires: new Date(0), maxAge: 0 });
+  }
+}

--- a/apps/web/lib/server/mfa-login-ticket.ts
+++ b/apps/web/lib/server/mfa-login-ticket.ts
@@ -1,0 +1,92 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+
+export const MFA_PENDING_COOKIE = 'pc_mfa_pending';
+export const MFA_PENDING_TTL_SECONDS = 10 * 60;
+
+export type MfaLoginTicket = {
+  v: 1;
+  challengeToken: string;
+  user: {
+    email: string;
+    role: string;
+    surfaceRole?: string;
+  };
+  exp: number;
+};
+
+function key(env: NodeJS.ProcessEnv = process.env) {
+  const secret = String(env.MFA_LOGIN_TICKET_SECRET || '').trim();
+  if (secret.length < 32) throw new Error('MFA_LOGIN_TICKET_SECRET must contain at least 32 characters');
+  return createHash('sha256').update(secret, 'utf8').digest();
+}
+
+export function sealMfaLoginTicket(
+  input: Omit<MfaLoginTicket, 'v' | 'exp'>,
+  nowSeconds = Math.floor(Date.now() / 1000),
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  const payload: MfaLoginTicket = {
+    v: 1,
+    ...input,
+    exp: nowSeconds + MFA_PENDING_TTL_SECONDS,
+  };
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key(env), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(payload), 'utf8'),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return ['v1', iv.toString('base64url'), tag.toString('base64url'), ciphertext.toString('base64url')].join('.');
+}
+
+export function openMfaLoginTicket(
+  value: string,
+  nowSeconds = Math.floor(Date.now() / 1000),
+  env: NodeJS.ProcessEnv = process.env,
+): MfaLoginTicket | null {
+  try {
+    const [version, ivRaw, tagRaw, payloadRaw, extra] = String(value || '').split('.');
+    if (version !== 'v1' || !ivRaw || !tagRaw || !payloadRaw || extra) return null;
+    const decipher = createDecipheriv('aes-256-gcm', key(env), Buffer.from(ivRaw, 'base64url'));
+    decipher.setAuthTag(Buffer.from(tagRaw, 'base64url'));
+    const payload = JSON.parse(Buffer.concat([
+      decipher.update(Buffer.from(payloadRaw, 'base64url')),
+      decipher.final(),
+    ]).toString('utf8')) as Partial<MfaLoginTicket>;
+
+    if (
+      payload.v !== 1 ||
+      typeof payload.challengeToken !== 'string' || !payload.challengeToken ||
+      !payload.user || typeof payload.user.email !== 'string' || typeof payload.user.role !== 'string' ||
+      typeof payload.exp !== 'number' || payload.exp <= nowSeconds ||
+      payload.exp - nowSeconds > MFA_PENDING_TTL_SECONDS
+    ) {
+      return null;
+    }
+    return payload as MfaLoginTicket;
+  } catch {
+    return null;
+  }
+}
+
+export function mfaPendingCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict' as const,
+    path: '/api/auth',
+    maxAge: MFA_PENDING_TTL_SECONDS,
+  };
+}
+
+export function clearMfaPendingCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict' as const,
+    path: '/api/auth',
+    expires: new Date(0),
+    maxAge: 0,
+  };
+}

--- a/apps/web/tests/unit/mfaPendingLoginTicket.test.ts
+++ b/apps/web/tests/unit/mfaPendingLoginTicket.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MFA_PENDING_TTL_SECONDS,
+  mfaPendingCookieOptions,
+  openMfaLoginTicket,
+  sealMfaLoginTicket,
+} from '../../lib/server/mfa-login-ticket';
+
+const env = {
+  MFA_LOGIN_TICKET_SECRET: 'mfa-login-ticket-secret-with-more-than-thirty-two-characters',
+  NODE_ENV: 'production',
+} as NodeJS.ProcessEnv;
+
+const pending = {
+  challengeToken: 'mc_challenge-token',
+  user: { email: 'user@example.com', role: 'BUYER', surfaceRole: 'buyer' },
+};
+
+describe('MFA pending login ticket', () => {
+  it('encrypts and opens a bounded challenge without session tokens', () => {
+    const sealed = sealMfaLoginTicket(pending, 1_000, env);
+    const opened = openMfaLoginTicket(sealed, 1_001, env);
+
+    expect(sealed).not.toContain('mc_challenge-token');
+    expect(sealed).not.toContain('user@example.com');
+    expect(opened).toMatchObject({
+      v: 1,
+      ...pending,
+      exp: 1_000 + MFA_PENDING_TTL_SECONDS,
+    });
+    expect(opened).not.toHaveProperty('accessToken');
+    expect(opened).not.toHaveProperty('refreshToken');
+  });
+
+  it('rejects tampering, expiry and a different secret', () => {
+    const sealed = sealMfaLoginTicket(pending, 1_000, env);
+    const tampered = `${sealed.slice(0, -1)}A`;
+
+    expect(openMfaLoginTicket(tampered, 1_001, env)).toBeNull();
+    expect(openMfaLoginTicket(sealed, 1_000 + MFA_PENDING_TTL_SECONDS, env)).toBeNull();
+    expect(openMfaLoginTicket(sealed, 1_001, {
+      ...env,
+      MFA_LOGIN_TICKET_SECRET: 'different-ticket-secret-with-more-than-thirty-two-characters',
+    })).toBeNull();
+  });
+
+  it('fails closed when the encryption secret is absent', () => {
+    expect(() => sealMfaLoginTicket(pending, 1_000, {})).toThrow();
+    expect(openMfaLoginTicket('invalid', 1_001, {})).toBeNull();
+  });
+
+  it('uses a short-lived HttpOnly strict cookie', () => {
+    const options = mfaPendingCookieOptions();
+    expect(options).toMatchObject({
+      httpOnly: true,
+      secure: true,
+      sameSite: 'strict',
+      path: '/api/auth',
+      maxAge: MFA_PENDING_TTL_SECONDS,
+    });
+  });
+});

--- a/apps/web/tests/unit/platformV7FinalShellStaticGate.test.ts
+++ b/apps/web/tests/unit/platformV7FinalShellStaticGate.test.ts
@@ -5,13 +5,15 @@ import { describe, expect, it } from 'vitest';
 const read = (file: string) => fs.readFileSync(path.join(process.cwd(), file), 'utf8');
 
 const appLayout = read('apps/web/app/platform-v7/layout.tsx');
-const clientLayout = read('apps/web/components/platform-v7/PlatformV7LayoutClient.tsx');
+const protectedRuntime = read('apps/web/components/platform-v7/PlatformV7ProtectedRuntime.tsx');
+const shellSwitch = read('apps/web/components/platform-v7/PlatformV7ShellSwitch.tsx');
 const shellUx = read('apps/web/components/platform-v7/PlatformV7ShellUxController.tsx');
 const supportHeader = read('apps/web/components/platform-v7/SupportHeaderIcon.tsx');
 const entryFixCss = read('apps/web/styles/platform-v7-entry-fix.css');
 const shellRoutes = read('apps/web/lib/platform-v7/shellRoutes.ts');
 const statusPage = read('apps/web/app/platform-v7/status/page.tsx');
 const loginPage = read('apps/web/app/platform-v7/login/page.tsx');
+const loginRoute = read('apps/web/app/api/auth/login/route.ts');
 
 function roleDockBlock() {
   const start = shellUx.indexOf('<nav className="pc-v7-role-dock"');
@@ -26,32 +28,35 @@ function protectedShellBlock(source: string) {
 }
 
 describe('platform-v7 final shell static gate', () => {
-  it('keeps protected layouts on the same shell contract', () => {
-    for (const source of [appLayout, clientLayout]) {
-      expect(source).toContain('<AppShellV4 initialRole=');
-      expect(source).toContain('<PlatformV7SingleEntryGuard />');
-      expect(source).toContain('<PlatformV7ShellUxController />');
-      expect(source).toContain('<RbacCabinetGuard />');
-      expect(source).toContain('<CalculatorHeaderWidget />');
-      expect(source).toContain('<NotepadHeaderWidget />');
-      expect(source).toContain('<SupportHeaderIcon />');
-      expect(source).toContain('<RoleAssistantWidget />');
-      expect(source).not.toContain('<CommandPalette />');
+  it('keeps public routes outside the protected client graph', () => {
+    expect(appLayout).toContain("headers().get('x-pc-pathname')");
+    expect(appLayout).toContain("await import('@/components/platform-v7/PlatformV7ProtectedRuntime')");
+    expect(appLayout).not.toContain("import { AppShellV4 }");
+    expect(protectedRuntime).toContain('<PlatformV7ShellSwitch>{children}</PlatformV7ShellSwitch>');
+  });
+
+  it('keeps the protected shell contract intact', () => {
+    const shell = protectedShellBlock(shellSwitch);
+    for (const snippet of [
+      '<PlatformV7SingleEntryGuard />',
+      '<PlatformV7ShellUxController />',
+      '<RbacCabinetGuard />',
+      '<CalculatorHeaderWidget />',
+      '<NotepadHeaderWidget />',
+      '<SupportHeaderIcon />',
+      '<RoleAssistantWidget />',
+    ]) {
+      expect(shell).toContain(snippet);
     }
+    expect(shellSwitch).not.toContain('<CommandPalette />');
   });
 
   it('keeps notepad and calculator inside protected shell only', () => {
-    for (const source of [appLayout, clientLayout]) {
-      const shell = protectedShellBlock(source);
-      const publicBlock = source.slice(source.indexOf('if (isPublicPath'), source.indexOf('<AppShellV4 initialRole='));
-
-      expect(shell).toContain('<CalculatorHeaderWidget />');
-      expect(shell).toContain('<NotepadHeaderWidget />');
-      expect(shell.indexOf('<CalculatorHeaderWidget />')).toBeLessThan(shell.indexOf('<NotepadHeaderWidget />'));
-      expect(shell.indexOf('<NotepadHeaderWidget />')).toBeLessThan(shell.indexOf('<SupportHeaderIcon />'));
-      expect(publicBlock).not.toContain('CalculatorHeaderWidget');
-      expect(publicBlock).not.toContain('NotepadHeaderWidget');
-    }
+    const shell = protectedShellBlock(shellSwitch);
+    expect(shell.indexOf('<CalculatorHeaderWidget />')).toBeLessThan(shell.indexOf('<NotepadHeaderWidget />'));
+    expect(shell.indexOf('<NotepadHeaderWidget />')).toBeLessThan(shell.indexOf('<SupportHeaderIcon />'));
+    expect(appLayout).not.toContain('CalculatorHeaderWidget');
+    expect(appLayout).not.toContain('NotepadHeaderWidget');
   });
 
   it('keeps the correct role dock visible and the legacy bottom navigation hidden', () => {
@@ -97,11 +102,8 @@ describe('platform-v7 final shell static gate', () => {
 
   it('keeps mobile entry copy inside the 390px viewport contract', () => {
     expect(entryFixCss).toContain('overflow-wrap:anywhere');
-    expect(entryFixCss).toContain('.entry-bg-field{position:absolute;z-index:0;top:54px;left:0;right:0;height:310px;opacity:.16;background:linear-gradient(90deg,rgba(0,139,46,.18),transparent 38%),radial-gradient(circle at 82% 24%,rgba(0,139,46,.18),transparent 28%),repeating-linear-gradient(108deg,rgba(0,139,46,.16) 0 8px,rgba(197,150,38,.1) 8px 18px,transparent 18px 34px)');
     expect(entryFixCss).toContain('.entry-role-tile-exact strong{max-width:100%;overflow:visible;text-overflow:clip;white-space:normal');
-    expect(entryFixCss).toContain('.entry-title span:last-child{color:var(--green);white-space:normal}');
     expect(entryFixCss).not.toContain('.entry-role-tile-exact strong{max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap');
-    expect(entryFixCss).not.toContain('rgba(197,150,38,.1) 8px 18px 34px');
   });
 
   it('keeps header help on an existing shared route', () => {
@@ -110,31 +112,19 @@ describe('platform-v7 final shell static gate', () => {
     expect(shellRoutes).toContain('PLATFORM_V7_STATUS_ROUTE');
   });
 
-  it('keeps status page wording aligned with pre-integration maturity', () => {
-    expect(statusPage).toContain('Controlled-pilot / pre-integration');
+  it('keeps status wording aligned with unconfirmed external integrations', () => {
     expect(statusPage).toContain('Требует проверки');
     expect(statusPage).not.toContain('99.4%');
     expect(statusPage).not.toContain('97.8%');
     expect(statusPage).not.toContain('проходят штатно');
-    expect(statusPage).not.toContain('Проверка партий и источников работает');
     expect(statusPage).not.toContain('уже встроены в платформу');
   });
 
-  it('marks the public entry cookie before replacing login with a role cabinet route', () => {
-    expect(loginPage).toContain("const PLATFORM_V7_ENTRY_COOKIE = 'pc_v7_entry_seen'");
-    expect(loginPage).toContain('function markEntrySeen()');
-    expect(loginPage).toContain('document.cookie = `${PLATFORM_V7_ENTRY_COOKIE}=true; Path=/; Max-Age=');
-    expect(loginPage).toContain('markEntrySeen();');
-    expect(loginPage.indexOf('markEntrySeen();')).toBeLessThan(loginPage.indexOf('router.replace(platformV7RoleHome(nextRole))'));
-  });
-
-  it('waits for the cabinet session request before route replacement to avoid middleware race redirects', () => {
-    expect(loginPage).toContain('async function openWorkspace(nextRole: PlatformRole)');
-    expect(loginPage).toContain("await fetch('/api/platform-v7/cabinet-session'");
-    expect(loginPage.indexOf("await fetch('/api/platform-v7/cabinet-session'")).toBeLessThan(loginPage.indexOf('router.replace(platformV7RoleHome(nextRole))'));
-  });
-
-  it('keeps in-shell style tags hidden so CSS is never shown as page text', () => {
-    expect(appLayout).toContain('html body .pc-shell-root-v4 style{display:none!important}');
+  it('uses server session issuance and redirect instead of client cabinet handoff', () => {
+    expect(loginPage).toContain('payload.redirectTo');
+    expect(loginPage).not.toContain('platformV7RoleHome');
+    expect(loginPage).not.toContain("fetch('/api/platform-v7/cabinet-session'");
+    expect(loginPage).not.toContain('document.cookie');
+    expect(loginRoute).toContain('applyAuthenticatedSession');
   });
 });

--- a/apps/web/tests/unit/platformV7LoginRoleHandoff.test.ts
+++ b/apps/web/tests/unit/platformV7LoginRoleHandoff.test.ts
@@ -3,19 +3,23 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const loginPage = fs.readFileSync(path.join(process.cwd(), 'apps/web/app/platform-v7/login/page.tsx'), 'utf8');
+const loginRoute = fs.readFileSync(path.join(process.cwd(), 'apps/web/app/api/auth/login/route.ts'), 'utf8');
 
-describe('platform-v7 login role handoff', () => {
-  it('reads a public role query without using a router search-param bailout', () => {
-    expect(loginPage).toContain('readRoleFromPublicEntry');
-    expect(loginPage).toContain("new URLSearchParams(window.location.search).get('role')");
+describe('platform-v7 server role handoff', () => {
+  it('does not read role from URL or expose a role picker', () => {
+    expect(loginPage).not.toContain("new URLSearchParams(window.location.search).get('role')");
     expect(loginPage).not.toContain('useSearchParams');
+    expect(loginPage).not.toContain('readRoleFromPublicEntry');
+    expect(loginPage).not.toContain('?role=');
   });
 
-  it('keeps the selected public role as form context only until login succeeds', () => {
-    expect(loginPage).toContain('setRole(publicEntryRole);');
-    expect(loginPage).toContain('setRoleFromEntry(true);');
-    expect(loginPage).toContain('роль фиксируется на сессию только после входа');
-    expect(loginPage).toContain('публичный выбор роли не открывает кабинет');
-    expect(loginPage).toContain('globalThis.sessionStorage?.setItem(PLATFORM_V7_ACTIVE_ROLE_KEY, nextRole);');
+  it('accepts only the server redirect after authentication', () => {
+    expect(loginPage).toContain('payload.redirectTo');
+    expect(loginPage).toContain("globalThis.location.assign(payload.redirectTo)");
+    expect(loginPage).not.toContain('setRole(');
+    expect(loginPage).not.toContain('sessionStorage');
+    expect(loginPage).not.toContain("fetch('/api/platform-v7/cabinet-session'");
+    expect(loginRoute).toContain('normalizeSurfaceRole(payload.user.role');
+    expect(loginRoute).toContain('applyAuthenticatedSession');
   });
 });

--- a/apps/web/tests/unit/platformV7LoginSecurityBoundary.test.ts
+++ b/apps/web/tests/unit/platformV7LoginSecurityBoundary.test.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const read = (relativePath: string) => fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+const loginPage = read('apps/web/app/platform-v7/login/page.tsx');
+const loginRoute = read('apps/web/app/api/auth/login/route.ts');
+const mfaRoute = read('apps/web/app/api/auth/mfa-login/route.ts');
+const cancelRoute = read('apps/web/app/api/auth/mfa-login/cancel/route.ts');
+const session = read('apps/web/lib/server/auth-session-response.ts');
+const ticket = read('apps/web/lib/server/mfa-login-ticket.ts');
+const messages = read('apps/web/i18n/public-entry-messages.ts');
+
+describe('platform-v7 server-authoritative login boundary', () => {
+  it('removes all client role authority and direct cabinet-session calls', () => {
+    for (const forbidden of [
+      'surfaceRole(',
+      'usePlatformV7RStore',
+      'PLATFORM_V7_ACTIVE_ROLE_KEY',
+      'sessionStorage',
+      "fetch('/api/platform-v7/cabinet-session'",
+      'platformV7RoleHome',
+    ]) {
+      expect(loginPage).not.toContain(forbidden);
+    }
+    expect(loginPage).toContain('payload.redirectTo');
+    expect(loginPage).toContain("globalThis.location.assign(payload.redirectTo)");
+  });
+
+  it('removes production demo fallback and email-derived role detection', () => {
+    for (const forbidden of [
+      'demoLoginAllowed',
+      'detectDemoRole',
+      'setDemoSession',
+      'demo-refresh',
+      'Demo Org',
+      "payload?.demo",
+    ]) {
+      expect(loginRoute).not.toContain(forbidden);
+    }
+    expect(loginRoute).toContain("fetch(`${API_URL}/auth/login`");
+    expect(loginRoute).toContain('UNIVERSAL_ERROR');
+  });
+
+  it('withholds access refresh and cabinet cookies until MFA succeeds', () => {
+    expect(loginRoute).toContain('payload.mfaRequired');
+    expect(loginRoute).toContain('sealMfaLoginTicket');
+    expect(loginRoute).not.toMatch(/payload\.mfaRequired[\s\S]{0,1400}applyAuthenticatedSession/);
+    expect(mfaRoute).toContain("fetch(`${API_URL}/auth/mfa/verify`");
+    expect(mfaRoute).toContain('applyAuthenticatedSession');
+    expect(session).toContain('signCabinetSession');
+    expect(session).toContain('CABINET_SESSION_COOKIE');
+  });
+
+  it('stores only the encrypted challenge in a bounded HttpOnly ticket', () => {
+    expect(ticket).toContain("createCipheriv('aes-256-gcm'");
+    expect(ticket).toContain('challengeToken: string');
+    expect(ticket).not.toContain('accessToken: string');
+    expect(ticket).not.toContain('refreshToken: string');
+    expect(ticket).toContain('httpOnly: true');
+    expect(ticket).toContain("sameSite: 'strict'");
+    expect(ticket).toContain("path: '/api/auth'");
+    expect(ticket).toContain('MFA_PENDING_TTL_SECONDS = 10 * 60');
+    expect(cancelRoute).toContain('clearMfaPendingCookieOptions');
+  });
+
+  it('keeps password, MFA and one-time backup-code disclosure as separate UI states', () => {
+    expect(loginPage).toContain("type LoginStep = 'password' | 'mfa' | 'backup-codes'");
+    expect(loginPage).toContain("type MfaMethod = 'totp' | 'backup_code'");
+    expect(loginPage).toContain("requestJson('/api/auth/mfa-login'");
+    expect(loginPage).toContain("autoComplete={method === 'totp' ? 'one-time-code' : 'off'}");
+    expect(loginPage).toContain("step === 'backup-codes'");
+    expect(messages).toContain('mfaTitle: string');
+    expect(messages).toContain('backupCodesTitle: string');
+  });
+});

--- a/apps/web/tests/unit/platformV7SingleEntryLogin.test.ts
+++ b/apps/web/tests/unit/platformV7SingleEntryLogin.test.ts
@@ -4,12 +4,15 @@ import { describe, expect, it } from 'vitest';
 
 const source = readFileSync(resolve(process.cwd(), 'apps/web/app/platform-v7/login/page.tsx'), 'utf8');
 
-describe('platform-v7 single role login', () => {
-  it('contains the fixed single entry copy and key roles', () => {
-    expect(source).toContain('Единый вход');
-    expect(source).toContain('Выберите один рабочий кабинет');
-    expect(source).toContain('Водитель');
-    expect(source).toContain('Комплаенс');
-    expect(source).toContain('Руководитель');
+describe('platform-v7 single entry login', () => {
+  it('keeps one credential form without role selection or client authority', () => {
+    expect(source).toContain("useTranslations('publicEntry.login')");
+    expect(source).toContain("type LoginStep = 'password' | 'mfa' | 'backup-codes'");
+    expect(source).toContain("requestJson('/api/auth/login'");
+    expect(source).toContain('payload.redirectTo');
+    expect(source).not.toContain('Выберите один рабочий кабинет');
+    expect(source).not.toContain('usePlatformV7RStore');
+    expect(source).not.toContain('sessionStorage');
+    expect(source).not.toContain('?role=');
   });
 });

--- a/apps/web/tests/unit/productEntryM31.test.tsx
+++ b/apps/web/tests/unit/productEntryM31.test.tsx
@@ -12,10 +12,13 @@ describe('platform-v7 product entry', () => {
     expect(registerSrc).toContain('Допущен');
   });
 
-  it('keeps login source as single role entry', () => {
-    expect(loginSrc).toContain('Единый вход');
-    expect(loginSrc).toContain('Выберите один рабочий кабинет');
-    expect(loginSrc).toContain('Водитель');
-    expect(loginSrc).toContain('Комплаенс');
+  it('keeps login as one server-authoritative entry', () => {
+    expect(loginSrc).toContain("requestJson('/api/auth/login'");
+    expect(loginSrc).toContain('payload.redirectTo');
+    expect(loginSrc).toContain("type LoginStep = 'password' | 'mfa' | 'backup-codes'");
+    expect(loginSrc).not.toContain('Выберите один рабочий кабинет');
+    expect(loginSrc).not.toContain('Водитель');
+    expect(loginSrc).not.toContain('Комплаенс');
+    expect(loginSrc).not.toContain('sessionStorage');
   });
 });

--- a/scripts/p7-autopilot-guard.sh
+++ b/scripts/p7-autopilot-guard.sh
@@ -93,7 +93,7 @@ if [ "${GITHUB_HEAD_REF:-}" = "fix/public-entry-production-hydration-performance
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$PUBLIC_RUNTIME_FIX_SCOPE")
 fi
 
-if [ "${GITHUB_HEAD_REF:-}" = "fix/public-auth-server-authority" ]; then
+if [ "${GITHUB_HEAD_REF:-}" = "fix/public-auth-server-authority" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/public-auth-server-authority-final" ]; then
   ALLOWED_CURRENT=$(printf '%s\n%s\n%s\n' "$ALLOWED_CURRENT" "$PUBLIC_RUNTIME_FIX_SCOPE" "$PUBLIC_AUTH_FIX_SCOPE")
 fi
 

--- a/scripts/p7-autopilot-guard.sh
+++ b/scripts/p7-autopilot-guard.sh
@@ -43,8 +43,6 @@ if [ "${GITHUB_HEAD_REF:-}" = "p7-bank-basis-state-machine" ] || [ "${P7_BANK_BA
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$BANK_BASIS_MIGRATION_SCOPE")
 fi
 
-# Exact, reviewable concurrent scope for PR #2318. Do not broaden this to an
-# apps/web wildcard: the active financial-delivery autopilot remains isolated.
 PUBLIC_ENTRY_SCOPE='apps/web/app/platform-v7/forgot-password/page.tsx
 apps/web/app/platform-v7/login/page.tsx
 apps/web/app/platform-v7/page.tsx
@@ -72,12 +70,27 @@ apps/web/middleware.ts
 apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts
 scripts/p7-autopilot-guard.sh'
 
+PUBLIC_AUTH_FIX_SCOPE='apps/web/app/api/auth/login/route.ts
+apps/web/app/api/auth/mfa-login/route.ts
+apps/web/app/api/auth/mfa-login/cancel/route.ts
+apps/web/app/platform-v7/login/page.tsx
+apps/web/i18n/public-entry-messages.ts
+apps/web/lib/server/auth-session-response.ts
+apps/web/lib/server/mfa-login-ticket.ts
+apps/web/tests/unit/platformV7LoginSecurityBoundary.test.ts
+apps/web/tests/unit/mfaPendingLoginTicket.test.ts
+scripts/p7-autopilot-guard.sh'
+
 if [ "${GITHUB_HEAD_REF:-}" = "agent/harden-platform-v7-public-entry" ]; then
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$PUBLIC_ENTRY_SCOPE")
 fi
 
 if [ "${GITHUB_HEAD_REF:-}" = "fix/public-entry-production-hydration-performance" ]; then
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$PUBLIC_RUNTIME_FIX_SCOPE")
+fi
+
+if [ "${GITHUB_HEAD_REF:-}" = "fix/public-auth-server-authority" ]; then
+  ALLOWED_CURRENT=$(printf '%s\n%s\n%s\n' "$ALLOWED_CURRENT" "$PUBLIC_RUNTIME_FIX_SCOPE" "$PUBLIC_AUTH_FIX_SCOPE")
 fi
 
 APPROVED_BRANCH_SCOPE=$(GITHUB_HEAD_REF="${GITHUB_HEAD_REF:-}" node - <<'JS'

--- a/scripts/p7-autopilot-guard.sh
+++ b/scripts/p7-autopilot-guard.sh
@@ -77,8 +77,12 @@ apps/web/app/platform-v7/login/page.tsx
 apps/web/i18n/public-entry-messages.ts
 apps/web/lib/server/auth-session-response.ts
 apps/web/lib/server/mfa-login-ticket.ts
+apps/web/tests/unit/platformV7FinalShellStaticGate.test.ts
+apps/web/tests/unit/platformV7LoginRoleHandoff.test.ts
 apps/web/tests/unit/platformV7LoginSecurityBoundary.test.ts
+apps/web/tests/unit/platformV7SingleEntryLogin.test.ts
 apps/web/tests/unit/mfaPendingLoginTicket.test.ts
+apps/web/tests/unit/productEntryM31.test.tsx
 scripts/p7-autopilot-guard.sh'
 
 if [ "${GITHUB_HEAD_REF:-}" = "agent/harden-platform-v7-public-entry" ]; then


### PR DESCRIPTION
## P0-проблема

После merge persistent auth API публичный web-login всё ещё вычислял роль в браузере, писал её в Zustand/sessionStorage, самостоятельно создавал cabinet session и содержал production demo fallback.

## Реализовано

- login BFF работает только с реальным auth API;
- demo fallback и email-derived role удалены;
- browser принимает только серверный `redirectTo`;
- client role store, sessionStorage и прямой cabinet-session call удалены;
- password, TOTP, backup code и one-time backup-code disclosure разделены;
- pending MFA cookie содержит только AES-256-GCM encrypted challenge, без access/refresh tokens;
- access/refresh/session/CSRF и подписанный cabinet cookie выдаются только после успешного `/auth/mfa/verify`;
- отсутствие `JWT_SECRET`/`MFA_LOGIN_TICKET_SECRET` закрывает вход fail-closed;
- RU/EN/ZH для MFA/enrollment/backup-code flow;
- universal errors, timeout, duplicate-submit protection и focus management;
- старые tests, закреплявшие URL/client role handoff, заменены server-authority gates;
- добавлены crypto tests MFA pending ticket.

## Зависимость

Base — PR #2321. После его merge PR должен быть retargeted на `main`.

## Граница

До merge обязательны green CI/typecheck/build/security, preview smoke с mocked password→MFA paths и проверка production env. Durable API cancellation `MFA_PENDING` остаётся отдельным API follow-up: browser ticket очищается сразу, server challenge истекает через 10 минут и не содержит рабочей сессии.