### PR TITLE
Ops: diagnose clean c520 SSR and hydration

### DIFF
--- a/.github/workflows/c520-clean-build-diagnostic.yml
+++ b/.github/workflows/c520-clean-build-diagnostic.yml
@@ -1,0 +1,79 @@
+name: c520 clean build diagnostic
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Remove all build caches
+        shell: bash
+        run: rm -rf apps/web/.next .netlify node_modules/.cache apps/web/node_modules/.cache
+
+      - name: Build exact source without Netlify cache
+        run: pnpm --filter @pc/web build
+
+      - name: Install Chromium
+        working-directory: apps/web
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Start production server and compare raw SSR with hydrated DOM
+        working-directory: apps/web
+        shell: bash
+        env:
+          DIAGNOSTIC_BASE_URL: http://127.0.0.1:3000
+          DIAGNOSTIC_OUT_DIR: ../../artifacts/c520-clean-build-diagnostic
+        run: |
+          set -euo pipefail
+          pnpm start > /tmp/c520-next-start.log 2>&1 &
+          SERVER_PID=$!
+          cleanup() { kill "$SERVER_PID" 2>/dev/null || true; }
+          trap cleanup EXIT
+          ready=0
+          for attempt in $(seq 1 90); do
+            if curl --silent --show-error --fail --max-time 5 'http://127.0.0.1:3000/platform-v7?lang=ru' >/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" -ne 1 ]; then
+            cat /tmp/c520-next-start.log
+            exit 1
+          fi
+          node scripts/c520-clean-build-diagnostic.mjs
+          cp /tmp/c520-next-start.log ../../artifacts/c520-clean-build-diagnostic/next-start.log
+          find .next/server/app/platform-v7 -maxdepth 4 -type f -printf '%p\n' | sort > ../../artifacts/c520-clean-build-diagnostic/next-route-files.txt
+
+      - name: Upload diagnostic evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: c520-clean-build-diagnostic
+          path: artifacts/c520-clean-build-diagnostic
+          if-no-files-found: error
+          retention-days: 3

--- a/apps/web/scripts/c520-clean-build-diagnostic.mjs
+++ b/apps/web/scripts/c520-clean-build-diagnostic.mjs
@@ -1,0 +1,97 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { chromium, request as playwrightRequest } from '@playwright/test';
+
+const BASE_URL = process.env.DIAGNOSTIC_BASE_URL || 'http://127.0.0.1:3000';
+const OUT_DIR = path.resolve(process.env.DIAGNOSTIC_OUT_DIR || '../../artifacts/c520-clean-build-diagnostic');
+const routes = [
+  { key: 'landing', path: '/platform-v7?lang=ru', expected: 'Главный риск сделки' },
+  { key: 'login', path: '/platform-v7/login?lang=ru', expected: 'Войти в систему' },
+  { key: 'forgot', path: '/platform-v7/forgot-password?lang=ru', expected: 'Восстановить доступ' },
+  { key: 'landing-en', path: '/platform-v7?lang=en', expected: 'The main transaction risk' },
+  { key: 'landing-zh', path: '/platform-v7?lang=zh', expected: '交易的主要风险' },
+];
+const staleLogin = 'Выберите один рабочий кабинет';
+
+await fs.mkdir(OUT_DIR, { recursive: true });
+const api = await playwrightRequest.newContext({ extraHTTPHeaders: { accept: 'text/html,application/xhtml+xml' } });
+const raw = [];
+for (const route of routes) {
+  const response = await api.get(`${BASE_URL}${route.path}`, { failOnStatusCode: false, timeout: 60_000 });
+  const html = await response.text();
+  await fs.writeFile(path.join(OUT_DIR, `${route.key}-raw.html`), html);
+  raw.push({
+    key: route.key,
+    status: response.status(),
+    headers: response.headers(),
+    expectedPresent: html.includes(route.expected),
+    staleLoginPresent: html.includes(staleLogin),
+    newLoginClassPresent: html.includes('pc-auth-page'),
+    oldLoginClassPresent: html.includes('pc-v7-login-single'),
+    byteLength: Buffer.byteLength(html),
+  });
+}
+await api.dispose();
+
+async function inspectBrowser(javaScriptEnabled) {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 }, javaScriptEnabled });
+  const results = [];
+  try {
+    for (const route of routes) {
+      const page = await context.newPage();
+      const consoleErrors = [];
+      const runtimeErrors = [];
+      page.on('console', (message) => {
+        if (message.type() === 'error') consoleErrors.push(message.text());
+      });
+      page.on('pageerror', (error) => runtimeErrors.push(String(error?.stack || error)));
+      const response = await page.goto(`${BASE_URL}${route.path}`, { waitUntil: javaScriptEnabled ? 'networkidle' : 'domcontentloaded', timeout: 90_000 });
+      if (javaScriptEnabled) await page.waitForTimeout(750);
+      const bodyText = await page.locator('body').innerText();
+      const html = await page.content();
+      results.push({
+        key: route.key,
+        status: response?.status() ?? null,
+        expectedPresent: bodyText.includes(route.expected),
+        staleLoginPresent: bodyText.includes(staleLogin),
+        newLoginClassPresent: html.includes('pc-auth-page'),
+        oldLoginClassPresent: html.includes('pc-v7-login-single'),
+        consoleErrors,
+        runtimeErrors,
+        title: await page.title(),
+      });
+      await page.screenshot({ path: path.join(OUT_DIR, `${route.key}-${javaScriptEnabled ? 'hydrated' : 'no-js'}.png`), fullPage: true });
+      await page.close();
+    }
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+  return results;
+}
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  baseUrl: BASE_URL,
+  raw,
+  noJs: await inspectBrowser(false),
+  hydrated: await inspectBrowser(true),
+};
+await fs.writeFile(path.join(OUT_DIR, 'report.json'), JSON.stringify(report, null, 2));
+console.log(JSON.stringify(report, null, 2));
+
+const failures = [];
+for (const item of report.raw) {
+  if (item.status !== 200) failures.push(`raw ${item.key}: HTTP ${item.status}`);
+  if (!item.expectedPresent) failures.push(`raw ${item.key}: expected text missing`);
+}
+for (const item of report.hydrated) {
+  if (!item.expectedPresent) failures.push(`hydrated ${item.key}: expected text missing`);
+  if (item.runtimeErrors.length) failures.push(`hydrated ${item.key}: ${item.runtimeErrors.length} runtime errors`);
+}
+if (report.raw.find((item) => item.key === 'login')?.staleLoginPresent) failures.push('raw login contains stale workspace picker');
+if (failures.length) {
+  console.error(JSON.stringify({ failures }, null, 2));
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Одноразовая диагностическая ветка, не предназначенная для merge.

Собирает `main` без `.next`/Netlify cache, запускает `next start` и сравнивает:
- сырой SSR HTML;
- Chromium с отключённым JavaScript;
- hydrated DOM;
- новую login-разметку против старого workspace-picker;
- runtime/console errors;
- RU/EN/ZH.

Цель — доказательно отделить ошибку исходного React-графа от несовместимого Netlify route/build cache. После получения артефакта workflow и script будут удалены, PR закрыт.