### PR TITLE
Add durable one-time password reset and session revocation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,12 +22,18 @@ DB_PRINCIPAL_BOUNDARY_ENFORCED=false
 # fallback secret). Generate with: openssl rand -hex 32
 # =====================================================================
 JWT_SECRET=                       # signs/verifies access tokens (>= 32 chars)
-AUTH_TOKEN_PEPPER=                # HMAC pepper for refresh/challenge/backup-code hashes
+AUTH_TOKEN_PEPPER=                # HMAC pepper for refresh/challenge/reset/backup-code hashes
 MFA_ENCRYPTION_KEY=               # encrypts TOTP secrets with AES-256-GCM
 RATE_LIMIT_KEY_PEPPER=            # independent HMAC pepper for rate-limit subjects (>= 32 chars)
+PASSWORD_RESET_DELIVERY_KEY=      # trusted web BFF boundary; never expose to the browser (>= 32 chars)
 BANK_HMAC_SECRET=                 # verifies Safe-Deals bank callbacks (>= 32 chars)
 FGIS_WEBHOOK_SECRET=              # verifies ФГИС Зерно webhooks (>= 32 chars)
 EDO_WEBHOOK_SECRET=               # verifies ЭДО (Диадок/СБИС/СберКорус) webhooks (>= 32 chars)
+
+# Auth request throttles. Values are per-IP limits for the matching window.
+RATE_LIMIT_AUTH_PASSWORD_RESET=5
+RATE_LIMIT_AUTH_PASSWORD_RESET_CONFIRM=8
+RATE_LIMIT_AUTH_PASSWORD_RESET_WINDOW_SECONDS=900
 
 # Reverse proxy trust boundary.
 # Production requires explicit direct|cidr. Trust-all CIDRs 0.0.0.0/0 and ::/0 are forbidden.

--- a/apps/api/prisma/migrations/20260710230000_password_reset_challenges/migration.sql
+++ b/apps/api/prisma/migrations/20260710230000_password_reset_challenges/migration.sql
@@ -1,0 +1,33 @@
+-- Durable, single-use password reset state for the persistent auth boundary.
+-- Tokens are stored only as keyed hashes; raw reset tokens never enter PostgreSQL.
+
+CREATE TABLE auth.password_reset_challenges (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  requested_ip_hash TEXT,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT auth_password_reset_user_fkey
+    FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT auth_password_reset_status_check
+    CHECK (status IN ('PENDING', 'CONSUMED', 'EXPIRED'))
+);
+
+CREATE INDEX auth_password_reset_user_status_created_idx
+  ON auth.password_reset_challenges(user_id, status, created_at DESC);
+CREATE INDEX auth_password_reset_expires_idx
+  ON auth.password_reset_challenges(expires_at);
+
+REVOKE ALL ON auth.password_reset_challenges FROM PUBLIC;
+
+DO $grant_password_reset$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_service') THEN
+    GRANT SELECT, INSERT, UPDATE ON auth.password_reset_challenges TO app_service;
+  END IF;
+END
+$grant_password_reset$;

--- a/apps/api/src/common/prisma/database-principal-inspection.ts
+++ b/apps/api/src/common/prisma/database-principal-inspection.ts
@@ -139,6 +139,9 @@ async function inspectAuthPrincipal(
         AND has_table_privilege(current_user, 'auth.mfa_challenges', 'SELECT')
         AND has_table_privilege(current_user, 'auth.mfa_challenges', 'INSERT')
         AND has_table_privilege(current_user, 'auth.mfa_challenges', 'UPDATE')
+        AND has_table_privilege(current_user, 'auth.password_reset_challenges', 'SELECT')
+        AND has_table_privilege(current_user, 'auth.password_reset_challenges', 'INSERT')
+        AND has_table_privilege(current_user, 'auth.password_reset_challenges', 'UPDATE')
       ) AS auth_tables_read_write,
       (
         has_table_privilege(current_user, 'auth.audit_events', 'SELECT')

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -6,24 +6,49 @@ import { RateLimit } from '../../common/decorators/rate-limit.decorator';
 import { Public } from '../../common/decorators/public.decorator';
 import { RequestUser, Role } from '../../common/types/request-user';
 import { AuthService } from './auth.service';
+import { PasswordResetService } from './password-reset.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { RefreshDto } from './dto/refresh.dto';
 import { LogoutDto } from './dto/logout.dto';
 import { MfaVerifyDto } from './dto/mfa-verify.dto';
 import { RevokeUserSessionsDto } from './dto/revoke-user-sessions.dto';
+import { ConfirmPasswordResetDto, RequestPasswordResetDto } from './dto/password-reset.dto';
 
 @UseGuards(RolesGuard)
 @Roles('ANY_AUTHENTICATED')
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly passwordReset: PasswordResetService,
+  ) {}
 
   @Public()
   @RateLimit({ name: 'auth_login', scope: 'ip', limit: 8, windowSeconds: 60, limitEnv: 'RATE_LIMIT_AUTH_LOGIN', windowEnv: 'RATE_LIMIT_WINDOW_SECONDS' })
   @Post('login')
   login(@Body() dto: LoginDto, @Headers('user-agent') userAgent?: string, @Ip() ip?: string) {
     return this.authService.login(dto, userAgent, ip);
+  }
+
+  @Public()
+  @HttpCode(202)
+  @RateLimit({ name: 'auth_password_reset_request', scope: 'ip', limit: 5, windowSeconds: 900, limitEnv: 'RATE_LIMIT_AUTH_PASSWORD_RESET', windowEnv: 'RATE_LIMIT_AUTH_PASSWORD_RESET_WINDOW_SECONDS' })
+  @Post('password-reset/request')
+  requestPasswordReset(
+    @Body() dto: RequestPasswordResetDto,
+    @Headers('x-password-reset-delivery-key') deliveryKey?: string,
+    @Ip() ip?: string,
+  ) {
+    return this.passwordReset.request(dto.email, ip, deliveryKey);
+  }
+
+  @Public()
+  @HttpCode(200)
+  @RateLimit({ name: 'auth_password_reset_confirm', scope: 'ip', limit: 8, windowSeconds: 900, limitEnv: 'RATE_LIMIT_AUTH_PASSWORD_RESET_CONFIRM', windowEnv: 'RATE_LIMIT_AUTH_PASSWORD_RESET_WINDOW_SECONDS' })
+  @Post('password-reset/confirm')
+  confirmPasswordReset(@Body() dto: ConfirmPasswordResetDto, @Ip() ip?: string) {
+    return this.passwordReset.confirm(dto.token, dto.newPassword, ip);
   }
 
   @Public()

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -3,6 +3,8 @@ import { BusinessReputationModule } from '../business-reputation/business-reputa
 import { AuthController } from './auth.controller';
 import { AuthPrismaService } from './auth-prisma.service';
 import { AuthService } from './auth.service';
+import { PasswordResetRepository } from './password-reset.repository';
+import { PasswordResetService } from './password-reset.service';
 import { PersistentAuthRepository } from './persistent-auth.repository';
 
 @Module({
@@ -15,8 +17,15 @@ import { PersistentAuthRepository } from './persistent-auth.repository';
       inject: [AuthPrismaService],
       useFactory: (prisma: AuthPrismaService) => new PersistentAuthRepository(prisma),
     },
+    PasswordResetRepository,
+    PasswordResetService,
     AuthService,
   ],
-  exports: [AuthService, PersistentAuthRepository, AuthPrismaService],
+  exports: [
+    AuthService,
+    PasswordResetService,
+    PersistentAuthRepository,
+    AuthPrismaService,
+  ],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/dto/password-reset.dto.ts
+++ b/apps/api/src/modules/auth/dto/password-reset.dto.ts
@@ -1,0 +1,19 @@
+import { IsEmail, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class RequestPasswordResetDto {
+  @IsEmail()
+  @MaxLength(254)
+  email!: string;
+}
+
+export class ConfirmPasswordResetDto {
+  @IsString()
+  @MinLength(48)
+  @MaxLength(512)
+  token!: string;
+
+  @IsString()
+  @MinLength(12)
+  @MaxLength(128)
+  newPassword!: string;
+}

--- a/apps/api/src/modules/auth/password-reset-token.spec.ts
+++ b/apps/api/src/modules/auth/password-reset-token.spec.ts
@@ -1,0 +1,31 @@
+import {
+  issuePasswordResetToken,
+  parsePasswordResetToken,
+  passwordResetHashMatches,
+} from './password-reset-token';
+
+describe('password reset token', () => {
+  it('issues an opaque token and verifies only its keyed hash', () => {
+    const issued = issuePasswordResetToken();
+    const parsed = parsePasswordResetToken(issued.token);
+
+    expect(issued.token).toMatch(/^pr_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    expect(parsed?.id).toBe(issued.id);
+    expect(parsed?.hash).toBe(issued.hash);
+    expect(passwordResetHashMatches(issued.hash, parsed?.hash ?? '')).toBe(true);
+    expect(issued.hash).not.toContain(issued.token);
+  });
+
+  it('rejects malformed and tampered tokens', () => {
+    const issued = issuePasswordResetToken();
+    const [id, secret] = issued.token.split('.');
+
+    expect(parsePasswordResetToken('')).toBeNull();
+    expect(parsePasswordResetToken(`rt_${id}.${secret}`)).toBeNull();
+    expect(parsePasswordResetToken(`${id}.short`)).toBeNull();
+
+    const tampered = parsePasswordResetToken(`${id}.${secret}x`);
+    expect(tampered).not.toBeNull();
+    expect(passwordResetHashMatches(issued.hash, tampered?.hash ?? '')).toBe(false);
+  });
+});

--- a/apps/api/src/modules/auth/password-reset-token.ts
+++ b/apps/api/src/modules/auth/password-reset-token.ts
@@ -1,0 +1,28 @@
+import { randomBytes } from 'crypto';
+import { hashAuthMaterial, secureEqual } from './auth-crypto';
+
+export const PASSWORD_RESET_TTL_MS = 15 * 60 * 1000;
+export const PASSWORD_RESET_COOLDOWN_MS = 60 * 1000;
+
+export type PasswordResetToken = {
+  id: string;
+  token: string;
+  hash: string;
+};
+
+export function issuePasswordResetToken(): PasswordResetToken {
+  const id = `pr_${randomBytes(18).toString('base64url')}`;
+  const secret = randomBytes(32).toString('base64url');
+  const token = `${id}.${secret}`;
+  return { id, token, hash: hashAuthMaterial(token) };
+}
+
+export function parsePasswordResetToken(raw: string): { id: string; hash: string } | null {
+  const [id, secret, extra] = String(raw ?? '').split('.');
+  if (extra || !id || !secret || !id.startsWith('pr_') || secret.length < 40) return null;
+  return { id, hash: hashAuthMaterial(`${id}.${secret}`) };
+}
+
+export function passwordResetHashMatches(stored: string, candidate: string): boolean {
+  return secureEqual(stored, candidate);
+}

--- a/apps/api/src/modules/auth/password-reset.repository.ts
+++ b/apps/api/src/modules/auth/password-reset.repository.ts
@@ -1,0 +1,177 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import type { AuthSqlClient } from './persistent-auth.repository';
+import { PersistentAuthRepository } from './persistent-auth.repository';
+
+export type PasswordResetUserRow = {
+  id: string;
+  email: string;
+  status: string;
+  deleted_at: Date | null;
+};
+
+export type PasswordResetChallengeRow = {
+  id: string;
+  user_id: string;
+  token_hash: string;
+  status: string;
+  requested_ip_hash: string | null;
+  expires_at: Date;
+  consumed_at: Date | null;
+  created_at: Date;
+};
+
+@Injectable()
+export class PasswordResetRepository {
+  constructor(private readonly auth: PersistentAuthRepository) {}
+
+  get prisma() {
+    return this.auth.prisma;
+  }
+
+  transaction<T>(work: (tx: Prisma.TransactionClient) => Promise<T>): Promise<T> {
+    return this.auth.transaction(work);
+  }
+
+  async findUserByEmail(client: AuthSqlClient, email: string): Promise<PasswordResetUserRow | null> {
+    const rows = await client.$queryRaw<PasswordResetUserRow[]>(Prisma.sql`
+      SELECT
+        id,
+        email,
+        status,
+        "deletedAt" AS deleted_at
+      FROM public.users
+      WHERE LOWER(email) = LOWER(${email})
+      LIMIT 1
+    `);
+    return rows[0] ?? null;
+  }
+
+  async findRecentPending(
+    client: AuthSqlClient,
+    userId: string,
+    createdAfter: Date,
+    now: Date,
+  ): Promise<{ id: string; expires_at: Date } | null> {
+    const rows = await client.$queryRaw<Array<{ id: string; expires_at: Date }>>(Prisma.sql`
+      SELECT id, expires_at
+      FROM auth.password_reset_challenges
+      WHERE user_id = ${userId}
+        AND status = 'PENDING'
+        AND created_at > ${createdAfter}
+        AND expires_at > ${now}
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1
+    `);
+    return rows[0] ?? null;
+  }
+
+  async expirePending(client: AuthSqlClient, userId: string, exceptId?: string): Promise<void> {
+    const except = exceptId ? Prisma.sql` AND id <> ${exceptId}` : Prisma.empty;
+    await client.$executeRaw(Prisma.sql`
+      UPDATE auth.password_reset_challenges
+      SET status = 'EXPIRED', updated_at = NOW()
+      WHERE user_id = ${userId}
+        AND status = 'PENDING'${except}
+    `);
+  }
+
+  async createChallenge(
+    client: AuthSqlClient,
+    input: {
+      id: string;
+      userId: string;
+      tokenHash: string;
+      requestedIpHash?: string | null;
+      expiresAt: Date;
+    },
+  ): Promise<void> {
+    await client.$executeRaw(Prisma.sql`
+      INSERT INTO auth.password_reset_challenges (
+        id,
+        user_id,
+        token_hash,
+        requested_ip_hash,
+        expires_at
+      ) VALUES (
+        ${input.id},
+        ${input.userId},
+        ${input.tokenHash},
+        ${input.requestedIpHash ?? null},
+        ${input.expiresAt}
+      )
+    `);
+  }
+
+  async getChallengeForUpdate(
+    client: AuthSqlClient,
+    challengeId: string,
+  ): Promise<PasswordResetChallengeRow | null> {
+    const rows = await client.$queryRaw<PasswordResetChallengeRow[]>(Prisma.sql`
+      SELECT
+        id,
+        user_id,
+        token_hash,
+        status,
+        requested_ip_hash,
+        expires_at,
+        consumed_at,
+        created_at
+      FROM auth.password_reset_challenges
+      WHERE id = ${challengeId}
+      FOR UPDATE
+    `);
+    return rows[0] ?? null;
+  }
+
+  async consumeChallenge(client: AuthSqlClient, challengeId: string, now: Date): Promise<boolean> {
+    const changed = await client.$executeRaw(Prisma.sql`
+      UPDATE auth.password_reset_challenges
+      SET status = 'CONSUMED', consumed_at = ${now}, updated_at = NOW()
+      WHERE id = ${challengeId}
+        AND status = 'PENDING'
+        AND expires_at > ${now}
+    `);
+    return changed === 1;
+  }
+
+  async replacePassword(
+    client: AuthSqlClient,
+    userId: string,
+    passwordHash: string,
+    now: Date,
+  ): Promise<boolean> {
+    const updated = await client.$executeRaw(Prisma.sql`
+      UPDATE public.users
+      SET "passwordHash" = ${passwordHash}, "updatedAt" = ${now}
+      WHERE id = ${userId}
+        AND status = 'ACTIVE'
+        AND "deletedAt" IS NULL
+    `);
+    if (updated !== 1) return false;
+
+    await client.$executeRaw(Prisma.sql`
+      INSERT INTO auth.credential_states (user_id, password_changed_at)
+      VALUES (${userId}, ${now})
+      ON CONFLICT (user_id) DO UPDATE
+      SET credential_version = auth.credential_states.credential_version + 1,
+          password_changed_at = EXCLUDED.password_changed_at,
+          failed_login_count = 0,
+          locked_until = NULL,
+          updated_at = NOW()
+    `);
+    return true;
+  }
+
+  revokeAllUserSessions(client: AuthSqlClient, userId: string, reason: string): Promise<void> {
+    return this.auth.revokeAllUserSessions(client, userId, reason);
+  }
+
+  latestAuditHash(client: AuthSqlClient, userId?: string | null): Promise<string | null> {
+    return this.auth.latestAuditHash(client, userId, null);
+  }
+
+  insertAudit(client: AuthSqlClient, input: Parameters<PersistentAuthRepository['insertAudit']>[1]): Promise<void> {
+    return this.auth.insertAudit(client, input);
+  }
+}

--- a/apps/api/src/modules/auth/password-reset.service.spec.ts
+++ b/apps/api/src/modules/auth/password-reset.service.spec.ts
@@ -1,0 +1,153 @@
+import { BadRequestException } from '@nestjs/common';
+import { PasswordResetService } from './password-reset.service';
+import { issuePasswordResetToken } from './password-reset-token';
+
+function repositoryMock() {
+  const tx = {};
+  return {
+    tx,
+    prisma: {},
+    transaction: jest.fn(async (work: (client: unknown) => Promise<unknown>) => work(tx)),
+    findUserByEmail: jest.fn(),
+    findRecentPending: jest.fn(),
+    expirePending: jest.fn(),
+    createChallenge: jest.fn(),
+    getChallengeForUpdate: jest.fn(),
+    replacePassword: jest.fn(),
+    consumeChallenge: jest.fn(),
+    revokeAllUserSessions: jest.fn(),
+    latestAuditHash: jest.fn().mockResolvedValue(null),
+    insertAudit: jest.fn(),
+  };
+}
+
+describe('PasswordResetService', () => {
+  const deliveryKey = 'delivery-key-that-is-longer-than-thirty-two-characters';
+  const originalDeliveryKey = process.env.PASSWORD_RESET_DELIVERY_KEY;
+
+  beforeEach(() => {
+    process.env.PASSWORD_RESET_DELIVERY_KEY = deliveryKey;
+  });
+
+  afterAll(() => {
+    if (originalDeliveryKey === undefined) delete process.env.PASSWORD_RESET_DELIVERY_KEY;
+    else process.env.PASSWORD_RESET_DELIVERY_KEY = originalDeliveryKey;
+  });
+
+  it('returns the same universal response without issuing when the delivery boundary is absent', async () => {
+    const repository = repositoryMock();
+    const service = new PasswordResetService(repository as never);
+
+    const result = await service.request('known@example.com', '203.0.113.1');
+
+    expect(result).toEqual({
+      accepted: true,
+      message: 'If the account exists, password reset instructions will be sent.',
+    });
+    expect(repository.findUserByEmail).not.toHaveBeenCalled();
+    expect(repository.createChallenge).not.toHaveBeenCalled();
+  });
+
+  it('does not reveal whether an account exists', async () => {
+    const repository = repositoryMock();
+    repository.findUserByEmail.mockResolvedValue(null);
+    const service = new PasswordResetService(repository as never);
+
+    const result = await service.request('missing@example.com', '203.0.113.2', deliveryKey);
+
+    expect(result).toEqual({
+      accepted: true,
+      message: 'If the account exists, password reset instructions will be sent.',
+    });
+    expect(repository.createChallenge).not.toHaveBeenCalled();
+  });
+
+  it('issues a delivery token only after the durable challenge is created', async () => {
+    const repository = repositoryMock();
+    repository.findUserByEmail.mockResolvedValue({
+      id: 'user-1',
+      email: 'known@example.com',
+      status: 'ACTIVE',
+      deleted_at: null,
+    });
+    repository.findRecentPending.mockResolvedValue(null);
+    const service = new PasswordResetService(repository as never);
+
+    const result = await service.request(' Known@Example.com ', '203.0.113.3', deliveryKey);
+
+    expect(repository.createChallenge).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      accepted: true,
+      delivery: {
+        email: 'known@example.com',
+        expiresInSeconds: 900,
+      },
+    });
+    expect((result as { delivery: { token: string } }).delivery.token).toMatch(/^pr_/);
+  });
+
+  it('does not return an undeliverable token when a concurrent request wins the cooldown race', async () => {
+    const repository = repositoryMock();
+    repository.findUserByEmail.mockResolvedValue({
+      id: 'user-1',
+      email: 'known@example.com',
+      status: 'ACTIVE',
+      deleted_at: null,
+    });
+    repository.findRecentPending
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'existing', expires_at: new Date(Date.now() + 60_000) });
+    const service = new PasswordResetService(repository as never);
+
+    const result = await service.request('known@example.com', '203.0.113.4', deliveryKey);
+
+    expect(result).toEqual({
+      accepted: true,
+      message: 'If the account exists, password reset instructions will be sent.',
+    });
+    expect(repository.createChallenge).not.toHaveBeenCalled();
+  });
+
+  it('atomically replaces the password, consumes the token and revokes every active session', async () => {
+    const repository = repositoryMock();
+    const issued = issuePasswordResetToken();
+    repository.getChallengeForUpdate.mockResolvedValue({
+      id: issued.id,
+      user_id: 'user-1',
+      token_hash: issued.hash,
+      status: 'PENDING',
+      requested_ip_hash: null,
+      expires_at: new Date(Date.now() + 60_000),
+      consumed_at: null,
+      created_at: new Date(),
+    });
+    repository.replacePassword.mockResolvedValue(true);
+    repository.consumeChallenge.mockResolvedValue(true);
+    const service = new PasswordResetService(repository as never);
+
+    const result = await service.confirm(issued.token, 'New-Secure-Password-2026', '203.0.113.5');
+
+    expect(result).toEqual({ success: true, sessionsRevoked: true });
+    expect(repository.replacePassword).toHaveBeenCalledWith(repository.tx, 'user-1', expect.any(String), expect.any(Date));
+    expect(repository.consumeChallenge).toHaveBeenCalledWith(repository.tx, issued.id, expect.any(Date));
+    expect(repository.revokeAllUserSessions).toHaveBeenCalledWith(repository.tx, 'user-1', 'PASSWORD_RESET');
+    expect(repository.expirePending).toHaveBeenCalledWith(repository.tx, 'user-1', issued.id);
+  });
+
+  it('rejects a replayed or consumed reset token', async () => {
+    const repository = repositoryMock();
+    const issued = issuePasswordResetToken();
+    repository.getChallengeForUpdate.mockResolvedValue({
+      id: issued.id,
+      user_id: 'user-1',
+      token_hash: issued.hash,
+      status: 'CONSUMED',
+      expires_at: new Date(Date.now() + 60_000),
+    });
+    const service = new PasswordResetService(repository as never);
+
+    await expect(service.confirm(issued.token, 'New-Secure-Password-2026')).rejects.toBeInstanceOf(BadRequestException);
+    expect(repository.replacePassword).not.toHaveBeenCalled();
+    expect(repository.revokeAllUserSessions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/auth/password-reset.service.ts
+++ b/apps/api/src/modules/auth/password-reset.service.ts
@@ -1,0 +1,218 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import * as bcrypt from 'bcryptjs';
+import { randomUUID, timingSafeEqual } from 'crypto';
+import { hashAuthMaterial, hashClientValue, sha256, stableJson } from './auth-crypto';
+import type { AuthSqlClient } from './persistent-auth.repository';
+import { PasswordResetRepository } from './password-reset.repository';
+import {
+  issuePasswordResetToken,
+  parsePasswordResetToken,
+  PASSWORD_RESET_COOLDOWN_MS,
+  PASSWORD_RESET_TTL_MS,
+  passwordResetHashMatches,
+} from './password-reset-token';
+
+const UNIVERSAL_RESPONSE = {
+  accepted: true,
+  message: 'If the account exists, password reset instructions will be sent.',
+} as const;
+
+function safeEqual(leftValue: string, rightValue: string): boolean {
+  const left = Buffer.from(leftValue, 'utf8');
+  const right = Buffer.from(rightValue, 'utf8');
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+function deliveryAuthorized(provided?: string): boolean {
+  const expected = String(process.env.PASSWORD_RESET_DELIVERY_KEY ?? '').trim();
+  const candidate = String(provided ?? '').trim();
+  return expected.length >= 32 && candidate.length >= 32 && safeEqual(candidate, expected);
+}
+
+function assertPasswordPolicy(password: string): void {
+  const classes = [/[a-z]/, /[A-Z]/, /\d/, /[^A-Za-z0-9]/].filter((pattern) => pattern.test(password)).length;
+  if (password.length < 12 || password.length > 128 || classes < 3) {
+    throw new BadRequestException({
+      code: 'PASSWORD_POLICY_FAILED',
+      message: 'The password must be 12-128 characters and include at least three character classes.',
+    });
+  }
+}
+
+@Injectable()
+export class PasswordResetService {
+  private readonly logger = new Logger(PasswordResetService.name);
+
+  constructor(private readonly repository: PasswordResetRepository) {}
+
+  async request(emailInput: string, ip?: string, deliveryKey?: string) {
+    const email = String(emailInput ?? '').trim().toLowerCase();
+    const accountHash = hashAuthMaterial(`password-reset:${email}`);
+    const ipHash = hashClientValue(ip);
+
+    if (!deliveryAuthorized(deliveryKey)) {
+      await this.repository.transaction(async (tx) => {
+        await this.audit(tx, {
+          action: 'auth.password_reset.request',
+          outcome: 'DENIED',
+          reason: 'DELIVERY_BOUNDARY_REJECTED',
+          metadata: { accountHash, ipHash },
+        });
+      });
+      return UNIVERSAL_RESPONSE;
+    }
+
+    const user = await this.repository.findUserByEmail(this.repository.prisma, email);
+    if (!user || user.status !== 'ACTIVE' || user.deleted_at) {
+      await this.repository.transaction(async (tx) => {
+        await this.audit(tx, {
+          action: 'auth.password_reset.request',
+          outcome: 'SUCCESS',
+          reason: 'UNIVERSAL_NON_ELIGIBLE',
+          metadata: { accountHash, ipHash },
+        });
+      });
+      return UNIVERSAL_RESPONSE;
+    }
+
+    const now = new Date();
+    const recent = await this.repository.findRecentPending(
+      this.repository.prisma,
+      user.id,
+      new Date(now.getTime() - PASSWORD_RESET_COOLDOWN_MS),
+      now,
+    );
+    if (recent) {
+      await this.repository.transaction(async (tx) => {
+        await this.audit(tx, {
+          userId: user.id,
+          action: 'auth.password_reset.request',
+          outcome: 'SUCCESS',
+          reason: 'COOLDOWN_ACTIVE',
+          metadata: { ipHash },
+        });
+      });
+      return UNIVERSAL_RESPONSE;
+    }
+
+    const issued = issuePasswordResetToken();
+    const expiresAt = new Date(now.getTime() + PASSWORD_RESET_TTL_MS);
+
+    try {
+      await this.repository.transaction(async (tx) => {
+        const concurrentRecent = await this.repository.findRecentPending(
+          tx,
+          user.id,
+          new Date(now.getTime() - PASSWORD_RESET_COOLDOWN_MS),
+          now,
+        );
+        if (concurrentRecent) return;
+
+        await this.repository.expirePending(tx, user.id);
+        await this.repository.createChallenge(tx, {
+          id: issued.id,
+          userId: user.id,
+          tokenHash: issued.hash,
+          requestedIpHash: ipHash,
+          expiresAt,
+        });
+        await this.audit(tx, {
+          userId: user.id,
+          action: 'auth.password_reset.request',
+          outcome: 'SUCCESS',
+          reason: 'CHALLENGE_ISSUED',
+          metadata: { ipHash, expiresAt: expiresAt.toISOString() },
+        });
+      });
+    } catch (error) {
+      this.logger.error('Password reset challenge creation failed', error instanceof Error ? error.stack : undefined);
+      return UNIVERSAL_RESPONSE;
+    }
+
+    return {
+      ...UNIVERSAL_RESPONSE,
+      delivery: {
+        email: user.email,
+        token: issued.token,
+        expiresInSeconds: Math.floor(PASSWORD_RESET_TTL_MS / 1000),
+      },
+    };
+  }
+
+  async confirm(tokenInput: string, newPassword: string, ip?: string) {
+    assertPasswordPolicy(newPassword);
+    const parsed = parsePasswordResetToken(tokenInput);
+    if (!parsed) throw this.invalidReset();
+
+    const passwordHash = await bcrypt.hash(newPassword, 12);
+    const now = new Date();
+    const ipHash = hashClientValue(ip);
+
+    try {
+      return await this.repository.transaction(async (tx) => {
+        const challenge = await this.repository.getChallengeForUpdate(tx, parsed.id);
+        if (
+          !challenge
+          || challenge.status !== 'PENDING'
+          || challenge.expires_at <= now
+          || !passwordResetHashMatches(challenge.token_hash, parsed.hash)
+        ) {
+          throw this.invalidReset();
+        }
+
+        const passwordUpdated = await this.repository.replacePassword(tx, challenge.user_id, passwordHash, now);
+        if (!passwordUpdated) throw this.invalidReset();
+
+        const consumed = await this.repository.consumeChallenge(tx, challenge.id, now);
+        if (!consumed) throw this.invalidReset();
+
+        await this.repository.revokeAllUserSessions(tx, challenge.user_id, 'PASSWORD_RESET');
+        await this.repository.expirePending(tx, challenge.user_id, challenge.id);
+        await this.audit(tx, {
+          userId: challenge.user_id,
+          action: 'auth.password_reset.confirm',
+          outcome: 'SUCCESS',
+          reason: 'PASSWORD_REPLACED_SESSIONS_REVOKED',
+          metadata: { ipHash, challengeIdHash: hashAuthMaterial(challenge.id) },
+        });
+        return { success: true, sessionsRevoked: true };
+      });
+    } catch (error) {
+      if (error instanceof BadRequestException) throw error;
+      this.logger.error('Password reset confirmation failed', error instanceof Error ? error.stack : undefined);
+      throw this.invalidReset();
+    }
+  }
+
+  private invalidReset(): BadRequestException {
+    return new BadRequestException({
+      code: 'PASSWORD_RESET_INVALID',
+      message: 'The reset link is invalid, expired or already used.',
+    });
+  }
+
+  private async audit(
+    tx: AuthSqlClient,
+    input: {
+      userId?: string | null;
+      action: string;
+      outcome: 'SUCCESS' | 'FAILURE' | 'DENIED';
+      reason?: string | null;
+      metadata?: Record<string, unknown> | null;
+    },
+  ): Promise<void> {
+    const id = `auth_evt_${randomUUID()}`;
+    const prevHash = await this.repository.latestAuditHash(tx, input.userId);
+    const hash = sha256(stableJson({ id, ...input, prevHash }));
+    await this.repository.insertAudit(tx, {
+      id,
+      userId: input.userId,
+      action: input.action,
+      outcome: input.outcome,
+      reason: input.reason,
+      metadata: input.metadata,
+      hash,
+      prevHash,
+    });
+  }
+}

--- a/apps/api/src/modules/auth/password-reset.service.ts
+++ b/apps/api/src/modules/auth/password-reset.service.ts
@@ -97,16 +97,17 @@ export class PasswordResetService {
 
     const issued = issuePasswordResetToken();
     const expiresAt = new Date(now.getTime() + PASSWORD_RESET_TTL_MS);
+    let created = false;
 
     try {
-      await this.repository.transaction(async (tx) => {
+      created = await this.repository.transaction(async (tx) => {
         const concurrentRecent = await this.repository.findRecentPending(
           tx,
           user.id,
           new Date(now.getTime() - PASSWORD_RESET_COOLDOWN_MS),
           now,
         );
-        if (concurrentRecent) return;
+        if (concurrentRecent) return false;
 
         await this.repository.expirePending(tx, user.id);
         await this.repository.createChallenge(tx, {
@@ -123,12 +124,14 @@ export class PasswordResetService {
           reason: 'CHALLENGE_ISSUED',
           metadata: { ipHash, expiresAt: expiresAt.toISOString() },
         });
+        return true;
       });
     } catch (error) {
       this.logger.error('Password reset challenge creation failed', error instanceof Error ? error.stack : undefined);
       return UNIVERSAL_RESPONSE;
     }
 
+    if (!created) return UNIVERSAL_RESPONSE;
     return {
       ...UNIVERSAL_RESPONSE,
       delivery: {

--- a/scripts/platform-v7-database-dr-rehearsal.sh
+++ b/scripts/platform-v7-database-dr-rehearsal.sh
@@ -125,7 +125,8 @@ GRANT SELECT, INSERT, UPDATE ON
   auth.credential_states,
   auth.sessions,
   auth.refresh_tokens,
-  auth.mfa_challenges
+  auth.mfa_challenges,
+  auth.password_reset_challenges
 TO one_deal_auth;
 GRANT SELECT, INSERT ON auth.audit_events TO one_deal_auth;
 SQL

--- a/scripts/platform-v7-one-deal-e2e.sh
+++ b/scripts/platform-v7-one-deal-e2e.sh
@@ -123,7 +123,8 @@ GRANT SELECT, INSERT, UPDATE ON
   auth.credential_states,
   auth.sessions,
   auth.refresh_tokens,
-  auth.mfa_challenges
+  auth.mfa_challenges,
+  auth.password_reset_challenges
 TO one_deal_auth;
 GRANT SELECT, INSERT ON auth.audit_events TO one_deal_auth;
 SQL


### PR DESCRIPTION
Superseded by PR #2336, rebuilt on current `main` after merge #2323. The replacement preserves the same durable password-reset guarantees without the obsolete stacked conflict.