### PR TITLE
Add universal password recovery UI and secure reset BFF

### DIFF
--- a/apps/web/app/api/auth/forgot-password/route.ts
+++ b/apps/web/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,153 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { NextResponse } from 'next/server';
+import { sendTransactionalMail } from '../../../../../lib/server/transactional-mail';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 15;
+
+const UNIVERSAL_MESSAGE = 'If the account exists, password reset instructions will be sent.';
+const SUPPORTED_LOCALES = new Set(['ru', 'en', 'zh']);
+
+const mailCopy = {
+  ru: {
+    subject: 'Прозрачная Цена — восстановление доступа',
+    intro: 'Получен запрос на восстановление доступа к платформе «Прозрачная Цена».',
+    action: 'Чтобы установить новый пароль, открой ссылку:',
+    expiry: 'Ссылка действует 15 минут и может быть использована только один раз.',
+    ignore: 'Если запрос отправил не ты, ничего не делай. Действующие сессии не изменятся.',
+  },
+  en: {
+    subject: 'Transparent Price — restore access',
+    intro: 'A request was received to restore access to the Transparent Price platform.',
+    action: 'Open this link to set a new password:',
+    expiry: 'The link is valid for 15 minutes and can be used only once.',
+    ignore: 'If you did not make this request, no action is required. Existing sessions will remain unchanged.',
+  },
+  zh: {
+    subject: '透明价格 — 恢复访问权限',
+    intro: '我们收到了恢复“透明价格”平台访问权限的请求。',
+    action: '请打开以下链接设置新密码：',
+    expiry: '该链接有效期为15分钟且只能使用一次。',
+    ignore: '如果不是你发起的请求，无需操作。现有会话不会改变。',
+  },
+} as const;
+
+type Locale = keyof typeof mailCopy;
+type ApiPayload = {
+  accepted?: boolean;
+  delivery?: { email?: string; token?: string; expiresInSeconds?: number };
+};
+
+function json(body: Record<string, unknown>, status = 202) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store, no-cache, must-revalidate',
+      Pragma: 'no-cache',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}
+
+function emailHash(email: string) {
+  return createHash('sha256').update(email.trim().toLowerCase()).digest('hex').slice(0, 16);
+}
+
+function requestIp(request: Request) {
+  return request.headers.get('x-nf-client-connection-ip')
+    || request.headers.get('cf-connecting-ip')
+    || request.headers.get('x-real-ip')
+    || request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    || '';
+}
+
+function apiUrl() {
+  return String(process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || '').trim().replace(/\/$/, '');
+}
+
+function normalizeOrigin(request: Request) {
+  const configured = String(process.env.NEXT_PUBLIC_SITE_URL || '').trim().replace(/\/$/, '');
+  return configured || new URL(request.url).origin;
+}
+
+export async function POST(request: Request) {
+  const correlationId = request.headers.get('x-correlation-id') || randomUUID();
+  const body = await request.json().catch(() => ({} as Record<string, unknown>));
+  const email = String(body.email || '').trim().toLowerCase();
+  const locale = SUPPORTED_LOCALES.has(String(body.locale)) ? String(body.locale) as Locale : 'ru';
+
+  if (!/^\S+@\S+\.\S+$/.test(email) || email.length > 254) {
+    return json({ accepted: false, code: 'INVALID_EMAIL', correlationId }, 400);
+  }
+
+  const upstream = apiUrl();
+  const deliveryKey = String(process.env.PASSWORD_RESET_DELIVERY_KEY || '').trim();
+  if (!upstream || deliveryKey.length < 32) {
+    console.error('password_reset_request_configuration_error', JSON.stringify({
+      correlationId,
+      apiConfigured: Boolean(upstream),
+      deliveryBoundaryConfigured: deliveryKey.length >= 32,
+    }));
+    return json({ accepted: true, message: UNIVERSAL_MESSAGE, cooldownSeconds: 60, correlationId });
+  }
+
+  try {
+    const ip = requestIp(request);
+    const apiResponse = await fetch(`${upstream}/auth/password-reset/request`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-password-reset-delivery-key': deliveryKey,
+        'x-correlation-id': correlationId,
+        ...(ip ? { 'x-forwarded-for': ip } : {}),
+      },
+      body: JSON.stringify({ email }),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(5_000),
+    });
+    const payload = await apiResponse.json().catch(() => ({} as ApiPayload)) as ApiPayload;
+
+    if (!apiResponse.ok) {
+      console.error('password_reset_request_api_failure', JSON.stringify({
+        correlationId,
+        status: apiResponse.status,
+        accountHash: emailHash(email),
+      }));
+      return json({ accepted: true, message: UNIVERSAL_MESSAGE, cooldownSeconds: 60, correlationId });
+    }
+
+    const delivery = payload.delivery;
+    if (delivery?.email && delivery.token) {
+      const resetUrl = new URL('/platform-v7/reset-password', normalizeOrigin(request));
+      resetUrl.searchParams.set('token', delivery.token);
+      resetUrl.searchParams.set('lang', locale);
+      const copy = mailCopy[locale];
+      const result = await sendTransactionalMail({
+        to: delivery.email,
+        subject: copy.subject,
+        text: [copy.intro, '', copy.action, resetUrl.toString(), '', copy.expiry, copy.ignore].join('\n'),
+      });
+      console.info('password_reset_delivery_result', JSON.stringify({
+        correlationId,
+        accountHash: emailHash(email),
+        delivered: result.delivered,
+        provider: result.provider,
+        reason: result.reason,
+      }));
+    } else {
+      console.info('password_reset_request_accepted_without_delivery', JSON.stringify({
+        correlationId,
+        accountHash: emailHash(email),
+      }));
+    }
+  } catch (error) {
+    console.error('password_reset_request_transport_failure', JSON.stringify({
+      correlationId,
+      accountHash: emailHash(email),
+      reason: error instanceof Error ? error.name : 'unknown',
+    }));
+  }
+
+  return json({ accepted: true, message: UNIVERSAL_MESSAGE, cooldownSeconds: 60, correlationId });
+}

--- a/apps/web/app/api/auth/reset-password/route.ts
+++ b/apps/web/app/api/auth/reset-password/route.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from 'node:crypto';
+import { NextResponse } from 'next/server';
+import { clearAuthenticatedSession } from '../../../../../lib/server/auth-session-response';
+import { MFA_PENDING_COOKIE, clearMfaPendingCookieOptions } from '../../../../../lib/server/mfa-login-ticket';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 10;
+
+function json(body: Record<string, unknown>, status: number) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store, no-cache, must-revalidate',
+      Pragma: 'no-cache',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}
+
+function requestIp(request: Request) {
+  return request.headers.get('x-nf-client-connection-ip')
+    || request.headers.get('cf-connecting-ip')
+    || request.headers.get('x-real-ip')
+    || request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    || '';
+}
+
+function apiUrl() {
+  return String(process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || '').trim().replace(/\/$/, '');
+}
+
+export async function POST(request: Request) {
+  const correlationId = request.headers.get('x-correlation-id') || randomUUID();
+  const body = await request.json().catch(() => ({} as Record<string, unknown>));
+  const token = String(body.token || '').trim();
+  const newPassword = String(body.newPassword || '');
+
+  if (token.length < 48 || token.length > 512 || newPassword.length < 12 || newPassword.length > 128) {
+    return json({ ok: false, code: 'PASSWORD_RESET_INVALID', correlationId }, 400);
+  }
+
+  const upstream = apiUrl();
+  if (!upstream) {
+    console.error('password_reset_confirm_configuration_error', JSON.stringify({ correlationId, apiConfigured: false }));
+    return json({ ok: false, code: 'AUTH_SERVICE_UNAVAILABLE', correlationId }, 503);
+  }
+
+  try {
+    const ip = requestIp(request);
+    const apiResponse = await fetch(`${upstream}/auth/password-reset/confirm`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-correlation-id': correlationId,
+        ...(ip ? { 'x-forwarded-for': ip } : {}),
+      },
+      body: JSON.stringify({ token, newPassword }),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(5_000),
+    });
+    const payload = await apiResponse.json().catch(() => ({} as Record<string, unknown>));
+
+    if (!apiResponse.ok || payload.success !== true) {
+      const status = apiResponse.status === 429 ? 429 : apiResponse.status >= 500 ? 503 : 400;
+      return json({
+        ok: false,
+        code: status === 429 ? 'RATE_LIMITED' : status === 503 ? 'AUTH_SERVICE_UNAVAILABLE' : 'PASSWORD_RESET_INVALID',
+        correlationId,
+      }, status);
+    }
+
+    const response = json({ ok: true, sessionsRevoked: true, correlationId }, 200);
+    clearAuthenticatedSession(response);
+    response.cookies.set(MFA_PENDING_COOKIE, '', clearMfaPendingCookieOptions());
+    return response;
+  } catch (error) {
+    console.error('password_reset_confirm_transport_failure', JSON.stringify({
+      correlationId,
+      reason: error instanceof Error ? error.name : 'unknown',
+    }));
+    return json({ ok: false, code: 'AUTH_SERVICE_UNAVAILABLE', correlationId }, 503);
+  }
+}

--- a/apps/web/app/platform-v7/forgot-password/ForgotPasswordFormClient.tsx
+++ b/apps/web/app/platform-v7/forgot-password/ForgotPasswordFormClient.tsx
@@ -4,57 +4,61 @@ import * as React from 'react';
 import { CheckCircle2, Mail } from 'lucide-react';
 
 export type ForgotPasswordCopy = {
-  error: string;
-  requestName: string;
-  requestMessage: string;
-  successTitle: string;
-  successText: string;
-  backToLogin: string;
   email: string;
   emailPlaceholder: string;
-  loading: string;
   submit: string;
+  loading: string;
+  successTitle: string;
+  successText: string;
+  invalidEmail: string;
+  unavailable: string;
+  backToLogin: string;
   note: string;
 };
 
-export function ForgotPasswordFormClient({ copy }: { copy: ForgotPasswordCopy }) {
+export function ForgotPasswordFormClient({ copy, locale }: { copy: ForgotPasswordCopy; locale: 'ru' | 'en' | 'zh' }) {
   const [email, setEmail] = React.useState('');
   const [submitting, setSubmitting] = React.useState(false);
   const [submitted, setSubmitted] = React.useState(false);
   const [error, setError] = React.useState('');
+  const errorRef = React.useRef<HTMLParagraphElement>(null);
+
+  React.useEffect(() => {
+    if (error) errorRef.current?.focus();
+  }, [error]);
 
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const contact = email.trim();
-    if (!contact) {
-      setError(copy.error);
+    if (submitting) return;
+    const normalized = email.trim().toLowerCase();
+    if (!/^\S+@\S+\.\S+$/.test(normalized) || normalized.length > 254) {
+      setError(copy.invalidEmail);
       return;
     }
 
     setSubmitting(true);
     setError('');
-
     try {
-      const response = await fetch('/api/platform-v7/inquiries', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          type: 'technical',
-          source: 'platform_v7_contact_page',
-          name: copy.requestName,
-          organization: '',
-          contact,
-          message: copy.requestMessage,
-          consent: 'yes',
-          website: '',
-        }),
-        cache: 'no-store',
-      });
-      const payload = await response.json().catch(() => ({}));
-      if (!response.ok || payload?.accepted !== true) throw new Error('recovery_request_failed');
+      const controller = new AbortController();
+      const timer = window.setTimeout(() => controller.abort(), 10_000);
+      let response: Response;
+      try {
+        response = await fetch('/api/auth/forgot-password', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: normalized, locale }),
+          cache: 'no-store',
+          credentials: 'same-origin',
+          signal: controller.signal,
+        });
+      } finally {
+        window.clearTimeout(timer);
+      }
+      const payload = await response.json().catch(() => ({} as Record<string, unknown>));
+      if (!response.ok || payload.accepted !== true) throw new Error('recovery_request_failed');
       setSubmitted(true);
     } catch {
-      setError(copy.error);
+      setError(copy.unavailable);
     } finally {
       setSubmitting(false);
     }
@@ -83,14 +87,17 @@ export function ForgotPasswordFormClient({ copy }: { copy: ForgotPasswordCopy })
             type='email'
             inputMode='email'
             autoComplete='email'
+            autoCapitalize='none'
+            spellCheck={false}
             placeholder={copy.emailPlaceholder}
             disabled={submitting}
             aria-invalid={Boolean(error)}
+            aria-describedby={error ? 'pc-recovery-error' : undefined}
           />
         </span>
       </label>
 
-      {error ? <p className='pc-recovery-error' role='alert'>{error}</p> : null}
+      {error ? <p ref={errorRef} id='pc-recovery-error' className='pc-recovery-error' role='alert' tabIndex={-1}>{error}</p> : null}
 
       <button className='pc-recovery-submit' type='submit' disabled={submitting} aria-busy={submitting}>
         {submitting ? copy.loading : copy.submit}

--- a/apps/web/app/platform-v7/forgot-password/page.tsx
+++ b/apps/web/app/platform-v7/forgot-password/page.tsx
@@ -1,22 +1,24 @@
 import { ArrowLeft } from 'lucide-react';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { PublicLocaleLink } from '@/components/platform-v7/PublicLocaleLink';
 import { PublicSiteHeader } from '@/components/platform-v7/PublicSiteHeader';
+import { isAppLocale, type AppLocale } from '@/i18n/locale';
 import { ForgotPasswordFormClient, type ForgotPasswordCopy } from './ForgotPasswordFormClient';
 
 export default async function ForgotPasswordPage() {
   const t = await getTranslations('publicEntry.forgot');
+  const localeValue = await getLocale();
+  const locale: AppLocale = isAppLocale(localeValue) ? localeValue : 'ru';
   const copy = {
-    error: t('error'),
-    requestName: t('requestName'),
-    requestMessage: t('requestMessage'),
-    successTitle: t('successTitle'),
-    successText: t('successText'),
-    backToLogin: t('backToLogin'),
     email: t('email'),
     emailPlaceholder: t('emailPlaceholder'),
-    loading: t('loading'),
     submit: t('submit'),
+    loading: t('loading'),
+    successTitle: t('successTitle'),
+    successText: t('successText'),
+    invalidEmail: t('invalidEmail'),
+    unavailable: t('unavailable'),
+    backToLogin: t('backToLogin'),
     note: t('note'),
   } satisfies ForgotPasswordCopy;
 
@@ -39,7 +41,7 @@ export default async function ForgotPasswordPage() {
           <h1 id='pc-recovery-title'>{t('title')}</h1>
           <p>{t('lead')}</p>
         </div>
-        <ForgotPasswordFormClient copy={copy} />
+        <ForgotPasswordFormClient copy={copy} locale={locale} />
       </section>
     </main>
   );

--- a/apps/web/app/platform-v7/layout.tsx
+++ b/apps/web/app/platform-v7/layout.tsx
@@ -52,6 +52,7 @@ const PUBLIC_EXACT_PATHS = new Set([
   '/platform-v7/open',
   '/platform-v7/login',
   '/platform-v7/forgot-password',
+  '/platform-v7/reset-password',
   '/platform-v7/register',
   '/platform-v7/help',
   '/platform-v7/pricing',

--- a/apps/web/app/platform-v7/reset-password/ResetPasswordFormClient.tsx
+++ b/apps/web/app/platform-v7/reset-password/ResetPasswordFormClient.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import * as React from 'react';
+import { CheckCircle2, Eye, EyeOff, LockKeyhole } from 'lucide-react';
+
+export type ResetPasswordCopy = {
+  newPassword: string;
+  newPasswordPlaceholder: string;
+  confirmPassword: string;
+  confirmPasswordPlaceholder: string;
+  showPassword: string;
+  hidePassword: string;
+  policy: string;
+  mismatch: string;
+  invalid: string;
+  unavailable: string;
+  rateLimited: string;
+  submit: string;
+  loading: string;
+  successTitle: string;
+  successText: string;
+  sessionsRevoked: string;
+  backToLogin: string;
+};
+
+function meetsPolicy(password: string) {
+  const classes = [/[a-z]/, /[A-Z]/, /\d/, /[^A-Za-z0-9]/].filter((pattern) => pattern.test(password)).length;
+  return password.length >= 12 && password.length <= 128 && classes >= 3;
+}
+
+export function ResetPasswordFormClient({ token, copy }: { token: string; copy: ResetPasswordCopy }) {
+  const [password, setPassword] = React.useState('');
+  const [confirm, setConfirm] = React.useState('');
+  const [showPassword, setShowPassword] = React.useState(false);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [completed, setCompleted] = React.useState(false);
+  const [error, setError] = React.useState(token ? '' : copy.invalid);
+  const errorRef = React.useRef<HTMLParagraphElement>(null);
+
+  React.useEffect(() => {
+    if (error) errorRef.current?.focus();
+  }, [error]);
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitting || !token) return;
+    if (!meetsPolicy(password)) {
+      setError(copy.policy);
+      return;
+    }
+    if (password !== confirm) {
+      setError(copy.mismatch);
+      return;
+    }
+
+    setSubmitting(true);
+    setError('');
+    try {
+      const controller = new AbortController();
+      const timer = window.setTimeout(() => controller.abort(), 10_000);
+      let response: Response;
+      try {
+        response = await fetch('/api/auth/reset-password', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token, newPassword: password }),
+          cache: 'no-store',
+          credentials: 'same-origin',
+          signal: controller.signal,
+        });
+      } finally {
+        window.clearTimeout(timer);
+      }
+      const payload = await response.json().catch(() => ({} as Record<string, unknown>));
+      if (!response.ok || payload.ok !== true) {
+        if (payload.code === 'RATE_LIMITED') throw new Error('RATE_LIMITED');
+        if (payload.code === 'AUTH_SERVICE_UNAVAILABLE') throw new Error('UNAVAILABLE');
+        throw new Error('INVALID');
+      }
+      setPassword('');
+      setConfirm('');
+      setCompleted(true);
+    } catch (cause) {
+      const reason = cause instanceof Error ? cause.message : 'UNAVAILABLE';
+      setError(reason === 'RATE_LIMITED' ? copy.rateLimited : reason === 'INVALID' ? copy.invalid : copy.unavailable);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (completed) {
+    return (
+      <section className='pc-recovery-card pc-recovery-success' aria-live='polite'>
+        <CheckCircle2 size={42} strokeWidth={1.9} aria-hidden='true' />
+        <h2>{copy.successTitle}</h2>
+        <p>{copy.successText}</p>
+        <p>{copy.sessionsRevoked}</p>
+        <a className='pc-recovery-primary-link' href='/platform-v7/login'>{copy.backToLogin}</a>
+      </section>
+    );
+  }
+
+  return (
+    <form className='pc-recovery-card' onSubmit={onSubmit} noValidate>
+      <label className='pc-recovery-label'>
+        <span>{copy.newPassword}</span>
+        <span className='pc-recovery-field'>
+          <LockKeyhole size={19} aria-hidden='true' />
+          <input
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            type={showPassword ? 'text' : 'password'}
+            autoComplete='new-password'
+            autoCapitalize='none'
+            spellCheck={false}
+            placeholder={copy.newPasswordPlaceholder}
+            disabled={submitting || !token}
+            aria-invalid={Boolean(error)}
+            aria-describedby='pc-reset-policy pc-reset-error'
+          />
+          <button
+            type='button'
+            className='pc-auth-password-toggle'
+            onClick={() => setShowPassword((value) => !value)}
+            aria-label={showPassword ? copy.hidePassword : copy.showPassword}
+            title={showPassword ? copy.hidePassword : copy.showPassword}
+          >
+            {showPassword ? <EyeOff size={19} aria-hidden='true' /> : <Eye size={19} aria-hidden='true' />}
+          </button>
+        </span>
+      </label>
+
+      <label className='pc-recovery-label'>
+        <span>{copy.confirmPassword}</span>
+        <span className='pc-recovery-field'>
+          <LockKeyhole size={19} aria-hidden='true' />
+          <input
+            value={confirm}
+            onChange={(event) => setConfirm(event.target.value)}
+            type={showPassword ? 'text' : 'password'}
+            autoComplete='new-password'
+            autoCapitalize='none'
+            spellCheck={false}
+            placeholder={copy.confirmPasswordPlaceholder}
+            disabled={submitting || !token}
+            aria-invalid={Boolean(error)}
+            aria-describedby='pc-reset-policy pc-reset-error'
+          />
+        </span>
+      </label>
+
+      <p id='pc-reset-policy' className='pc-recovery-note'>{copy.policy}</p>
+      {error ? <p ref={errorRef} id='pc-reset-error' className='pc-recovery-error' role='alert' tabIndex={-1}>{error}</p> : null}
+
+      <button className='pc-recovery-submit' type='submit' disabled={submitting || !token} aria-busy={submitting}>
+        {submitting ? copy.loading : copy.submit}
+      </button>
+      <a className='pc-recovery-login-link' href='/platform-v7/login'>{copy.backToLogin}</a>
+    </form>
+  );
+}

--- a/apps/web/app/platform-v7/reset-password/ResetPasswordLocaleLink.tsx
+++ b/apps/web/app/platform-v7/reset-password/ResetPasswordLocaleLink.tsx
@@ -1,0 +1,35 @@
+import { Languages } from 'lucide-react';
+import { getLocale, getTranslations } from 'next-intl/server';
+import { isAppLocale, SUPPORTED_LOCALES, type AppLocale } from '@/i18n/locale';
+
+const SHORT_LABELS: Record<AppLocale, string> = { ru: 'RU', en: 'EN', zh: 'ZH' };
+
+function nextLocale(current: AppLocale): AppLocale {
+  const index = SUPPORTED_LOCALES.indexOf(current);
+  return SUPPORTED_LOCALES[(index + 1) % SUPPORTED_LOCALES.length] ?? 'ru';
+}
+
+export async function ResetPasswordLocaleLink({ token }: { token: string }) {
+  const localeValue = await getLocale();
+  const locale: AppLocale = isAppLocale(localeValue) ? localeValue : 'ru';
+  const next = nextLocale(locale);
+  const t = await getTranslations('publicEntry.language');
+  const currentLabel = SHORT_LABELS[locale];
+  const nextLabel = SHORT_LABELS[next];
+  const query = new URLSearchParams({ lang: next });
+  if (token) query.set('token', token);
+
+  return (
+    <a
+      className='pc-site-locale-switch'
+      href={`/platform-v7/reset-password?${query.toString()}`}
+      aria-label={t('switchLabel', { current: currentLabel, next: nextLabel })}
+      title={t('switchTitle', { current: currentLabel })}
+      data-current-locale={locale}
+      data-next-locale={next}
+    >
+      <Languages size={16} strokeWidth={2.35} aria-hidden='true' />
+      <span>{currentLabel}</span>
+    </a>
+  );
+}

--- a/apps/web/app/platform-v7/reset-password/page.tsx
+++ b/apps/web/app/platform-v7/reset-password/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next';
+import { ArrowLeft } from 'lucide-react';
+import { getTranslations } from 'next-intl/server';
+import { PublicLocaleLink } from '@/components/platform-v7/PublicLocaleLink';
+import { PublicSiteHeader } from '@/components/platform-v7/PublicSiteHeader';
+import { ResetPasswordFormClient, type ResetPasswordCopy } from './ResetPasswordFormClient';
+
+export const metadata: Metadata = {
+  title: 'Установить новый пароль',
+  robots: { index: false, follow: false, nocache: true },
+};
+
+export default async function ResetPasswordPage({ searchParams }: { searchParams?: { token?: string } }) {
+  const t = await getTranslations('publicEntry.reset');
+  const token = String(searchParams?.token || '').trim().slice(0, 512);
+  const copy = {
+    newPassword: t('newPassword'),
+    newPasswordPlaceholder: t('newPasswordPlaceholder'),
+    confirmPassword: t('confirmPassword'),
+    confirmPasswordPlaceholder: t('confirmPasswordPlaceholder'),
+    showPassword: t('showPassword'),
+    hidePassword: t('hidePassword'),
+    policy: t('policy'),
+    mismatch: t('mismatch'),
+    invalid: t('invalid'),
+    unavailable: t('unavailable'),
+    rateLimited: t('rateLimited'),
+    submit: t('submit'),
+    loading: t('loading'),
+    successTitle: t('successTitle'),
+    successText: t('successText'),
+    sessionsRevoked: t('sessionsRevoked'),
+    backToLogin: t('backToLogin'),
+  } satisfies ResetPasswordCopy;
+
+  return (
+    <main className='pc-v7-public-entry pc-recovery-page'>
+      <PublicSiteHeader
+        ariaLabel={t('publicNav')}
+        tagline={t('brandTagline')}
+        localeControl={<PublicLocaleLink />}
+        actions={(
+          <a className='pc-site-action' href='/platform-v7' aria-label={t('backHome')} title={t('backHome')}>
+            <ArrowLeft size={20} aria-hidden='true' />
+            <span>{t('backHome')}</span>
+          </a>
+        )}
+      />
+
+      <section className='pc-recovery-shell' aria-labelledby='pc-reset-title'>
+        <div className='pc-recovery-heading'>
+          <h1 id='pc-reset-title'>{t('title')}</h1>
+          <p>{t('lead')}</p>
+        </div>
+        <ResetPasswordFormClient token={token} copy={copy} />
+      </section>
+    </main>
+  );
+}

--- a/apps/web/components/platform-v7/PlatformV7TemplateSwitch.tsx
+++ b/apps/web/components/platform-v7/PlatformV7TemplateSwitch.tsx
@@ -14,6 +14,7 @@ const PUBLIC_EXACT_PATHS = new Set([
   '/platform-v7/open',
   '/platform-v7/login',
   '/platform-v7/forgot-password',
+  '/platform-v7/reset-password',
   '/platform-v7/register',
   '/platform-v7/help',
   '/platform-v7/pricing',

--- a/apps/web/i18n/public-entry-messages.ts
+++ b/apps/web/i18n/public-entry-messages.ts
@@ -1,68 +1,30 @@
 import type { AppLocale } from './locale';
 
 type PublicEntryMessages = {
-  language: {
-    switchLabel: string;
-    switchTitle: string;
-  };
-  rolesCatalog: {
-    title: string;
-    text: string;
-    cta: string;
-  };
+  language: { switchLabel: string; switchTitle: string };
+  rolesCatalog: { title: string; text: string; cta: string };
   login: {
-    publicNav: string;
-    brandTagline: string;
-    backHome: string;
-    title: string;
-    lead: string;
-    email: string;
-    emailPlaceholder: string;
-    password: string;
-    passwordPlaceholder: string;
-    showPassword: string;
-    hidePassword: string;
-    submit: string;
-    loading: string;
-    forgot: string;
-    register: string;
-    required: string;
-    unavailable: string;
-    note: string;
-    mfaTitle: string;
-    mfaLead: string;
-    totpMethod: string;
-    backupMethod: string;
-    mfaCode: string;
-    mfaCodePlaceholder: string;
-    backupCodePlaceholder: string;
-    mfaSubmit: string;
-    mfaLoading: string;
-    mfaBack: string;
-    mfaError: string;
-    enrollmentTitle: string;
-    enrollmentLead: string;
-    setupSecretLabel: string;
-    backupCodesTitle: string;
-    backupCodesLead: string;
+    publicNav: string; brandTagline: string; backHome: string; title: string; lead: string;
+    email: string; emailPlaceholder: string; password: string; passwordPlaceholder: string;
+    showPassword: string; hidePassword: string; submit: string; loading: string; forgot: string;
+    register: string; required: string; unavailable: string; note: string; mfaTitle: string;
+    mfaLead: string; totpMethod: string; backupMethod: string; mfaCode: string;
+    mfaCodePlaceholder: string; backupCodePlaceholder: string; mfaSubmit: string;
+    mfaLoading: string; mfaBack: string; mfaError: string; enrollmentTitle: string;
+    enrollmentLead: string; setupSecretLabel: string; backupCodesTitle: string; backupCodesLead: string;
   };
   forgot: {
-    publicNav: string;
-    brandTagline: string;
-    backHome: string;
-    title: string;
-    lead: string;
-    email: string;
-    emailPlaceholder: string;
-    submit: string;
-    loading: string;
-    successTitle: string;
-    successText: string;
-    error: string;
-    backToLogin: string;
-    note: string;
-    requestName: string;
-    requestMessage: string;
+    publicNav: string; brandTagline: string; backHome: string; title: string; lead: string;
+    email: string; emailPlaceholder: string; submit: string; loading: string; successTitle: string;
+    successText: string; invalidEmail: string; unavailable: string; backToLogin: string; note: string;
+  };
+  reset: {
+    publicNav: string; brandTagline: string; backHome: string; title: string; lead: string;
+    newPassword: string; newPasswordPlaceholder: string; confirmPassword: string;
+    confirmPasswordPlaceholder: string; showPassword: string; hidePassword: string;
+    policy: string; mismatch: string; invalid: string; unavailable: string; rateLimited: string;
+    submit: string; loading: string; successTitle: string; successText: string;
+    sessionsRevoked: string; backToLogin: string;
   };
 };
 
@@ -118,18 +80,41 @@ export const publicEntryMessages: Record<AppLocale, PublicEntryMessages> = {
       brandTagline: 'Восстановление доступа',
       backHome: 'На главную',
       title: 'Восстановить доступ',
-      lead: 'Укажите рабочий email. Запрос будет обработан без раскрытия наличия учётной записи.',
+      lead: 'Укажите рабочий email. Ответ одинаков для существующих и неизвестных адресов.',
       email: 'Рабочий email',
       emailPlaceholder: 'name@company.ru',
-      submit: 'Отправить запрос',
+      submit: 'Получить ссылку',
       loading: 'Отправляем…',
-      successTitle: 'Запрос принят',
-      successText: 'Если адрес связан с учётной записью, инструкции будут направлены после проверки доступа.',
-      error: 'Не удалось принять запрос. Повторите позже или обратитесь в поддержку.',
+      successTitle: 'Проверьте почту',
+      successText: 'Если адрес связан с учётной записью, письмо со ссылкой придёт в течение нескольких минут.',
+      invalidEmail: 'Введите корректный рабочий email.',
+      unavailable: 'Сервис временно недоступен. Повторите запрос позже.',
       backToLogin: 'Вернуться ко входу',
-      note: 'Пароль не передаётся в поддержку. Восстановление выполняется только после проверки принадлежности учётной записи.',
-      requestName: 'Восстановление доступа',
-      requestMessage: 'Запрос на восстановление доступа к рабочей платформе.',
+      note: 'Ссылка действует 15 минут и используется один раз. Наличие учётной записи не раскрывается.',
+    },
+    reset: {
+      publicNav: 'Навигация установки нового пароля',
+      brandTagline: 'Защищённое восстановление доступа',
+      backHome: 'На главную',
+      title: 'Установить новый пароль',
+      lead: 'После смены пароля все действующие сессии будут отозваны.',
+      newPassword: 'Новый пароль',
+      newPasswordPlaceholder: 'Не менее 12 символов',
+      confirmPassword: 'Повторите пароль',
+      confirmPasswordPlaceholder: 'Введите пароль ещё раз',
+      showPassword: 'Показать пароль',
+      hidePassword: 'Скрыть пароль',
+      policy: '12–128 символов и минимум три класса: строчные, прописные, цифры, специальные символы.',
+      mismatch: 'Пароли не совпадают.',
+      invalid: 'Ссылка недействительна, истекла или уже использована.',
+      unavailable: 'Сервис временно недоступен. Повторите позже.',
+      rateLimited: 'Слишком много попыток. Повторите позже.',
+      submit: 'Сохранить новый пароль',
+      loading: 'Сохраняем…',
+      successTitle: 'Пароль изменён',
+      successText: 'Новый пароль сохранён.',
+      sessionsRevoked: 'Все прежние сессии отозваны. Войдите заново.',
+      backToLogin: 'Перейти ко входу',
     },
   },
   en: {
@@ -183,18 +168,41 @@ export const publicEntryMessages: Record<AppLocale, PublicEntryMessages> = {
       brandTagline: 'Access recovery',
       backHome: 'Back to home',
       title: 'Restore access',
-      lead: 'Enter your work email. The request is processed without disclosing whether an account exists.',
+      lead: 'Enter your work email. The response is identical for known and unknown addresses.',
       email: 'Work email',
       emailPlaceholder: 'name@company.com',
-      submit: 'Send request',
+      submit: 'Send reset link',
       loading: 'Sending…',
-      successTitle: 'Request accepted',
-      successText: 'If the address is linked to an account, instructions will be sent after access verification.',
-      error: 'The request could not be accepted. Try again later or contact support.',
+      successTitle: 'Check your email',
+      successText: 'If the address is linked to an account, a reset link will arrive within a few minutes.',
+      invalidEmail: 'Enter a valid work email.',
+      unavailable: 'The service is temporarily unavailable. Try again later.',
       backToLogin: 'Back to sign in',
-      note: 'Never send a password to support. Recovery proceeds only after account ownership is verified.',
-      requestName: 'Access recovery',
-      requestMessage: 'Request to restore access to the working platform.',
+      note: 'The link is valid for 15 minutes and can be used once. Account existence is never disclosed.',
+    },
+    reset: {
+      publicNav: 'New password navigation',
+      brandTagline: 'Secure access recovery',
+      backHome: 'Back to home',
+      title: 'Set a new password',
+      lead: 'All active sessions will be revoked after the password is changed.',
+      newPassword: 'New password',
+      newPasswordPlaceholder: 'At least 12 characters',
+      confirmPassword: 'Confirm password',
+      confirmPasswordPlaceholder: 'Enter the password again',
+      showPassword: 'Show password',
+      hidePassword: 'Hide password',
+      policy: '12–128 characters and at least three classes: lowercase, uppercase, digits and symbols.',
+      mismatch: 'The passwords do not match.',
+      invalid: 'The link is invalid, expired or already used.',
+      unavailable: 'The service is temporarily unavailable. Try again later.',
+      rateLimited: 'Too many attempts. Try again later.',
+      submit: 'Save new password',
+      loading: 'Saving…',
+      successTitle: 'Password changed',
+      successText: 'Your new password has been saved.',
+      sessionsRevoked: 'All previous sessions were revoked. Sign in again.',
+      backToLogin: 'Go to sign in',
     },
   },
   zh: {
@@ -248,18 +256,41 @@ export const publicEntryMessages: Record<AppLocale, PublicEntryMessages> = {
       brandTagline: '恢复访问权限',
       backHome: '返回首页',
       title: '恢复访问权限',
-      lead: '请输入工作邮箱。系统不会披露该账户是否存在。',
+      lead: '请输入工作邮箱。已知和未知地址会收到相同响应。',
       email: '工作邮箱',
       emailPlaceholder: 'name@company.cn',
-      submit: '发送请求',
+      submit: '发送重置链接',
       loading: '正在发送…',
-      successTitle: '请求已受理',
-      successText: '如果该地址关联账户，完成访问核验后将发送说明。',
-      error: '无法受理请求。请稍后重试或联系支持。',
+      successTitle: '请检查邮箱',
+      successText: '如果该地址关联账户，重置链接将在几分钟内发送。',
+      invalidEmail: '请输入有效的工作邮箱。',
+      unavailable: '服务暂时不可用。请稍后重试。',
       backToLogin: '返回登录',
-      note: '不要向支持人员发送密码。只有在核验账户归属后才会恢复访问权限。',
-      requestName: '恢复访问权限',
-      requestMessage: '请求恢复工作平台访问权限。',
+      note: '链接有效期为15分钟且只能使用一次。系统不会披露账户是否存在。',
+    },
+    reset: {
+      publicNav: '新密码页面导航',
+      brandTagline: '安全恢复访问权限',
+      backHome: '返回首页',
+      title: '设置新密码',
+      lead: '密码修改后，所有当前会话都将被撤销。',
+      newPassword: '新密码',
+      newPasswordPlaceholder: '至少12个字符',
+      confirmPassword: '确认密码',
+      confirmPasswordPlaceholder: '再次输入密码',
+      showPassword: '显示密码',
+      hidePassword: '隐藏密码',
+      policy: '12–128个字符，并至少包含三类：小写字母、大写字母、数字和特殊符号。',
+      mismatch: '两次输入的密码不一致。',
+      invalid: '链接无效、已过期或已使用。',
+      unavailable: '服务暂时不可用。请稍后重试。',
+      rateLimited: '尝试次数过多。请稍后重试。',
+      submit: '保存新密码',
+      loading: '正在保存…',
+      successTitle: '密码已更改',
+      successText: '新密码已保存。',
+      sessionsRevoked: '所有旧会话已撤销。请重新登录。',
+      backToLogin: '前往登录',
     },
   },
 };

--- a/apps/web/lib/server/transactional-mail.ts
+++ b/apps/web/lib/server/transactional-mail.ts
@@ -1,0 +1,163 @@
+import { connect as tlsConnect, type TLSSocket } from 'node:tls';
+
+const MAIL_TIMEOUT_MS = 5_000;
+
+export type TransactionalMail = {
+  to: string;
+  subject: string;
+  text: string;
+};
+
+export type MailDeliveryResult = {
+  delivered: boolean;
+  provider: 'resend' | 'smtp' | 'none';
+  reason: string;
+};
+
+function safeReason(error: unknown) {
+  if (error instanceof Error) return `${error.name}:${error.message}`.slice(0, 180);
+  return String(error || 'unknown').slice(0, 180);
+}
+
+function encodeHeader(value: string) {
+  return `=?UTF-8?B?${Buffer.from(value, 'utf8').toString('base64')}?=`;
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), MAIL_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal, cache: 'no-store' });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function sendViaResend(mail: TransactionalMail): Promise<MailDeliveryResult> {
+  const apiKey = String(process.env.RESEND_API_KEY || '').trim();
+  if (!apiKey) return { delivered: false, provider: 'none', reason: 'resend_not_configured' };
+
+  const from = String(process.env.RESEND_FROM_EMAIL || process.env.PC_MAIL_FROM || '').trim();
+  if (!from) return { delivered: false, provider: 'none', reason: 'resend_from_not_configured' };
+
+  try {
+    const response = await fetchWithTimeout('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from, to: [mail.to], subject: mail.subject, text: mail.text }),
+    });
+    if (!response.ok) return { delivered: false, provider: 'resend', reason: `resend_${response.status}` };
+    return { delivered: true, provider: 'resend', reason: 'sent' };
+  } catch (error) {
+    return { delivered: false, provider: 'resend', reason: `resend_failed:${safeReason(error)}` };
+  }
+}
+
+function smtpConfigured() {
+  return Boolean(process.env.PC_SMTP_HOST && process.env.PC_SMTP_USER && process.env.PC_SMTP_PASS);
+}
+
+async function readResponse(socket: TLSSocket): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    const timeout = setTimeout(() => cleanup(new Error('smtp_timeout')), MAIL_TIMEOUT_MS);
+
+    function cleanup(error?: Error) {
+      clearTimeout(timeout);
+      socket.off('data', onData);
+      socket.off('error', onError);
+      if (error) reject(error);
+    }
+    function onError(error: Error) { cleanup(error); }
+    function onData(data: Buffer) {
+      buffer += data.toString('utf8');
+      const last = buffer.split(/\r?\n/).filter(Boolean).at(-1) || '';
+      if (/^\d{3}\s/.test(last)) {
+        cleanup();
+        resolve(buffer);
+      }
+    }
+
+    socket.on('data', onData);
+    socket.on('error', onError);
+  });
+}
+
+function assertCode(response: string, allowed: number[]) {
+  const code = Number(response.slice(0, 3));
+  if (!allowed.includes(code)) throw new Error(`smtp_${code || 'unknown'}`);
+}
+
+async function command(socket: TLSSocket, value: string, allowed: number[]) {
+  socket.write(`${value}\r\n`);
+  assertCode(await readResponse(socket), allowed);
+}
+
+async function sendViaSmtp(mail: TransactionalMail): Promise<MailDeliveryResult> {
+  if (!smtpConfigured()) return { delivered: false, provider: 'none', reason: 'smtp_not_configured' };
+
+  const host = process.env.PC_SMTP_HOST as string;
+  const port = Number(process.env.PC_SMTP_PORT || 465);
+  const user = process.env.PC_SMTP_USER as string;
+  const pass = process.env.PC_SMTP_PASS as string;
+  const from = String(process.env.PC_MAIL_FROM || user).trim();
+  const mime = [
+    `From: <${from}>`,
+    `To: ${mail.to}`,
+    `Subject: ${encodeHeader(mail.subject)}`,
+    'MIME-Version: 1.0',
+    'Content-Type: text/plain; charset=UTF-8',
+    'Content-Transfer-Encoding: 8bit',
+    '',
+    mail.text,
+  ].join('\r\n');
+
+  return new Promise((resolve) => {
+    const socket = tlsConnect({ host, port, servername: host, rejectUnauthorized: true });
+    const totalTimeout = setTimeout(() => {
+      socket.destroy();
+      resolve({ delivered: false, provider: 'smtp', reason: 'smtp_timeout' });
+    }, MAIL_TIMEOUT_MS + 2_500);
+
+    async function run() {
+      try {
+        assertCode(await readResponse(socket), [220]);
+        await command(socket, 'EHLO transparent-price.local', [250]);
+        await command(socket, `AUTH PLAIN ${Buffer.from(`\u0000${user}\u0000${pass}`, 'utf8').toString('base64')}`, [235]);
+        await command(socket, `MAIL FROM:<${from}>`, [250]);
+        await command(socket, `RCPT TO:<${mail.to}>`, [250, 251]);
+        await command(socket, 'DATA', [354]);
+        socket.write(`${mime}\r\n.\r\n`);
+        assertCode(await readResponse(socket), [250]);
+        socket.write('QUIT\r\n');
+        clearTimeout(totalTimeout);
+        socket.end();
+        resolve({ delivered: true, provider: 'smtp', reason: 'sent' });
+      } catch (error) {
+        clearTimeout(totalTimeout);
+        socket.destroy();
+        resolve({ delivered: false, provider: 'smtp', reason: `smtp_failed:${safeReason(error)}` });
+      }
+    }
+
+    socket.once('secureConnect', () => { void run(); });
+    socket.once('error', (error) => {
+      clearTimeout(totalTimeout);
+      resolve({ delivered: false, provider: 'smtp', reason: `smtp_failed:${safeReason(error)}` });
+    });
+  });
+}
+
+export async function sendTransactionalMail(mail: TransactionalMail): Promise<MailDeliveryResult> {
+  const resend = await sendViaResend(mail);
+  if (resend.delivered) return resend;
+
+  const smtp = await sendViaSmtp(mail);
+  if (smtp.delivered) return smtp;
+
+  return {
+    delivered: false,
+    provider: smtp.provider !== 'none' ? smtp.provider : resend.provider,
+    reason: `${resend.reason};${smtp.reason}`,
+  };
+}

--- a/apps/web/tests/unit/platformV7PasswordRecoveryBoundary.test.ts
+++ b/apps/web/tests/unit/platformV7PasswordRecoveryBoundary.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const read = (file: string) => fs.readFileSync(path.join(process.cwd(), file), 'utf8');
+
+const forgotRoute = read('apps/web/app/api/auth/forgot-password/route.ts');
+const resetRoute = read('apps/web/app/api/auth/reset-password/route.ts');
+const forgotClient = read('apps/web/app/platform-v7/forgot-password/ForgotPasswordFormClient.tsx');
+const resetPage = read('apps/web/app/platform-v7/reset-password/page.tsx');
+const resetClient = read('apps/web/app/platform-v7/reset-password/ResetPasswordFormClient.tsx');
+const layout = read('apps/web/app/platform-v7/layout.tsx');
+const templateSwitch = read('apps/web/components/platform-v7/PlatformV7TemplateSwitch.tsx');
+const messages = read('apps/web/i18n/public-entry-messages.ts');
+
+describe('platform-v7 password recovery boundary', () => {
+  it('uses a universal BFF response and never returns reset tokens to the browser', () => {
+    expect(forgotRoute).toContain("/auth/password-reset/request");
+    expect(forgotRoute).toContain("'x-password-reset-delivery-key': deliveryKey");
+    expect(forgotRoute).toContain('UNIVERSAL_MESSAGE');
+    expect(forgotRoute).toContain('sendTransactionalMail');
+    expect(forgotRoute).not.toContain('token: delivery.token');
+    expect(forgotRoute).not.toContain('email, token');
+  });
+
+  it('replaces the old support request with the dedicated recovery endpoint', () => {
+    expect(forgotClient).toContain("fetch('/api/auth/forgot-password'");
+    expect(forgotClient).not.toContain('/api/platform-v7/inquiries');
+    expect(forgotClient).not.toContain('requestName');
+    expect(forgotClient).not.toContain('requestMessage');
+  });
+
+  it('confirms through the auth API and clears all local auth state on success', () => {
+    expect(resetRoute).toContain('/auth/password-reset/confirm');
+    expect(resetRoute).toContain('clearAuthenticatedSession(response)');
+    expect(resetRoute).toContain('MFA_PENDING_COOKIE');
+    expect(resetRoute).not.toContain('localStorage');
+    expect(resetRoute).not.toContain('sessionStorage');
+  });
+
+  it('keeps the token in the server page contract and not in client URL parsing', () => {
+    expect(resetPage).toContain("searchParams?.token");
+    expect(resetPage).toContain('<ResetPasswordFormClient token={token} copy={copy} />');
+    expect(resetPage).toContain('index: false');
+    expect(resetClient).not.toContain('useSearchParams');
+    expect(resetClient).toContain("fetch('/api/auth/reset-password'");
+    expect(resetClient).toContain("autoComplete='new-password'");
+  });
+
+  it('keeps both recovery routes outside protected runtime guards', () => {
+    expect(layout).toContain("'/platform-v7/forgot-password'");
+    expect(layout).toContain("'/platform-v7/reset-password'");
+    expect(templateSwitch).toContain("'/platform-v7/forgot-password'");
+    expect(templateSwitch).toContain("'/platform-v7/reset-password'");
+  });
+
+  it('contains complete RU EN ZH reset copy and no legacy support fields', () => {
+    expect(messages.match(/reset:\s*\{/g)?.length).toBe(4); // type + ru + en + zh
+    expect(messages).toContain("sessionsRevoked: 'Все прежние сессии отозваны. Войдите заново.'");
+    expect(messages).toContain("sessionsRevoked: 'All previous sessions were revoked. Sign in again.'");
+    expect(messages).toContain("sessionsRevoked: '所有旧会话已撤销。请重新登录。'");
+    expect(messages).not.toContain('requestName');
+    expect(messages).not.toContain('requestMessage');
+  });
+});


### PR DESCRIPTION
## Реализовано

- `/platform-v7/forgot-password` больше не отправляет обращение в поддержку;
- universal response для известных и неизвестных email;
- web BFF вызывает persistent auth endpoint через отдельный `PASSWORD_RESET_DELIVERY_KEY`;
- reset token никогда не возвращается браузеру из request endpoint и не логируется;
- доставка через Resend с TLS SMTP fallback;
- отдельный `/platform-v7/reset-password` без client-side parsing URL;
- локальная password policy и серверная финальная проверка;
- после успешного reset очищаются access/refresh/session/CSRF, cabinet и MFA pending cookies;
- RU/EN/ZH, noindex, accessible alerts/focus/loading;
- reset/forgot остаются вне protected runtime и DOM guards;
- regression tests на enumeration, token exposure, session cleanup и отсутствие legacy support flow.

## Зависимости и честная граница

Backend-механика идёт в PR #2336. До развёртывания отдельного auth API, PostgreSQL principals и mail credentials контур fail-closed; production delivery не объявляется подтверждённой.