### PR TITLE
Add controlled owner and role test access

### DIFF
--- a/apps/web/app/api/platform-v7/cabinet-lock-login/route.ts
+++ b/apps/web/app/api/platform-v7/cabinet-lock-login/route.ts
@@ -20,6 +20,21 @@ const ALLOWED_ROLES = new Set([
   'executive',
 ]);
 
+const ROLE_TEST_ACCOUNTS: Readonly<Record<string, string>> = {
+  'operator.test': 'operator',
+  'buyer.test': 'buyer',
+  'seller.test': 'seller',
+  'logistics.test': 'logistics',
+  'driver.test': 'driver',
+  'surveyor.test': 'surveyor',
+  'elevator.test': 'elevator',
+  'lab.test': 'lab',
+  'bank.test': 'bank',
+  'arbitrator.test': 'arbitrator',
+  'compliance.test': 'compliance',
+  'executive.test': 'executive',
+};
+
 function readEnv(name: string): string {
   return String(process.env[name] || '').trim();
 }
@@ -41,8 +56,7 @@ function compact(value: string): string {
 /**
  * Constant-time credential comparison. Accepts only an exact match, or an exact
  * match after collapsing surrounding/duplicated whitespace (a pure UX
- * tolerance). Deliberately NO digit-only, suffix, or partial matching — those
- * silently reduced the password to a handful of trailing digits.
+ * tolerance). Deliberately NO digit-only, suffix, or partial matching.
  */
 function passwordMatches(input: string, configured: string): boolean {
   if (!input || !configured) return false;
@@ -58,46 +72,73 @@ function passwordCandidates(): string[] {
   ].filter(Boolean);
 }
 
-/**
- * Secret used to sign the cabinet session JWT. Must come from real configured
- * secrets only — never a hard-coded PIN hash. If none is configured the gate is
- * treated as unavailable (fail closed) rather than signing with a guessable key.
- */
 function cabinetSessionSecret(): string {
   return readEnv('JWT_SECRET') || readEnv('PC_CABINET_SESSION_SECRET');
+}
+
+function controlledTestAccessEnabled(): boolean {
+  if (readEnv('PC_CABINET_TEST_ACCESS').toLowerCase() !== 'true') return false;
+  const expiresAt = readEnv('PC_CABINET_TEST_ACCESS_EXPIRES_AT');
+  if (!expiresAt) return true;
+  const expiresAtMs = Date.parse(expiresAt);
+  return Number.isFinite(expiresAtMs) && expiresAtMs > Date.now();
 }
 
 export async function POST(request: Request) {
   const body = await request.json().catch(() => ({}));
   const login = typeof body?.login === 'string' ? body.login.trim().toLowerCase() : '';
   const password = typeof body?.password === 'string' ? body.password.trim() : '';
-  const role = typeof body?.role === 'string' ? body.role.trim() : '';
+  const requestedRole = typeof body?.role === 'string' ? body.role.trim() : '';
 
-  if (!ALLOWED_ROLES.has(role)) {
+  if (!ALLOWED_ROLES.has(requestedRole)) {
     return NextResponse.json({ ok: false, reason: 'unknown_role' }, { status: 400 });
   }
 
-  const configuredUser = readEnv('PC_CABINET_LOCK_USER').toLowerCase();
-  const passwords = passwordCandidates();
+  const configuredOwner = readEnv('PC_CABINET_LOCK_USER').toLowerCase();
+  const ownerPasswords = passwordCandidates();
+  const rolePassword = readEnv('PC_CABINET_ROLE_PASSWORD');
   const sessionSecret = cabinetSessionSecret();
+  const testAccessEnabled = controlledTestAccessEnabled();
+  const fixedRole = testAccessEnabled ? ROLE_TEST_ACCOUNTS[login] : undefined;
+  const ownerLogin = Boolean(configuredOwner && safeEqual(login, configuredOwner));
 
-  // Fail closed when the gate is not fully configured — no hard-coded owner
-  // login, no default password, no fallback signing secret.
-  if (!configuredUser || passwords.length === 0 || !sessionSecret) {
-    return NextResponse.json({ ok: false, reason: 'cabinet_not_configured' }, { status: 503 });
-  }
-
-  const loginAllowed = safeEqual(login, configuredUser);
-  const passwordAllowed = passwords.some((configured) => passwordMatches(password, configured));
-
-  if (!loginAllowed || !passwordAllowed) {
+  if (!sessionSecret || (!ownerLogin && !fixedRole)) {
     return NextResponse.json(
-      { ok: false, reason: !loginAllowed ? 'login_mismatch' : 'password_mismatch' },
-      { status: 401 },
+      { ok: false, reason: !sessionSecret ? 'cabinet_not_configured' : 'login_mismatch' },
+      { status: !sessionSecret ? 503 : 401 },
     );
   }
 
-  const token = await signCabinetSession(role, sessionSecret, {
+  let effectiveRole = requestedRole;
+  let passwordAllowed = false;
+  let accountType: 'owner_test' | 'role_test';
+
+  if (ownerLogin) {
+    if (ownerPasswords.length === 0) {
+      return NextResponse.json({ ok: false, reason: 'cabinet_not_configured' }, { status: 503 });
+    }
+    passwordAllowed = ownerPasswords.some((configured) => passwordMatches(password, configured));
+    accountType = 'owner_test';
+  } else {
+    if (!rolePassword) {
+      return NextResponse.json({ ok: false, reason: 'cabinet_not_configured' }, { status: 503 });
+    }
+    effectiveRole = fixedRole as string;
+    if (requestedRole !== effectiveRole) {
+      return NextResponse.json(
+        { ok: false, reason: 'role_mismatch', expectedRole: effectiveRole },
+        { status: 400 },
+      );
+    }
+    passwordAllowed = passwordMatches(password, rolePassword);
+    accountType = 'role_test';
+  }
+
+  if (!passwordAllowed) {
+    return NextResponse.json({ ok: false, reason: 'password_mismatch' }, { status: 401 });
+  }
+
+  const token = await signCabinetSession(effectiveRole, sessionSecret, {
     nowSeconds: Math.floor(Date.now() / 1000),
     ttlSeconds: TTL_SECONDS,
   });
@@ -114,5 +155,8 @@ export async function POST(request: Request) {
     secure: process.env.NODE_ENV === 'production',
   });
 
-  return NextResponse.json({ ok: true, marker: 'cabinet-gate-hard-v2' });
+  return NextResponse.json(
+    { ok: true, role: effectiveRole, accountType, marker: 'cabinet-gate-controlled-test-v1' },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
 }

--- a/apps/web/app/api/platform-v7/cabinet-lock-login/route.ts
+++ b/apps/web/app/api/platform-v7/cabinet-lock-login/route.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from 'node:crypto';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { ACCESS_COOKIE, CSRF_COOKIE, SESSION_COOKIE } from '@/lib/auth-cookies';
 import { signCabinetSession } from '@/lib/platform-v7/verified-session';
 
 const CABINET_SESSION_COOKIE = 'pc_v7_cabinet';
@@ -84,6 +86,16 @@ function controlledTestAccessEnabled(): boolean {
   return Number.isFinite(expiresAtMs) && expiresAtMs > Date.now();
 }
 
+function secureCookie(httpOnly: boolean) {
+  return {
+    path: '/',
+    maxAge: TTL_SECONDS,
+    httpOnly,
+    sameSite: 'lax' as const,
+    secure: process.env.NODE_ENV === 'production',
+  };
+}
+
 export async function POST(request: Request) {
   const body = await request.json().catch(() => ({}));
   const login = typeof body?.login === 'string' ? body.login.trim().toLowerCase() : '';
@@ -147,16 +159,29 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, reason: 'cabinet_session_unavailable' }, { status: 503 });
   }
 
-  cookies().set(CABINET_SESSION_COOKIE, token, {
-    path: '/',
-    maxAge: TTL_SECONDS,
-    httpOnly: true,
-    sameSite: 'lax',
-    secure: process.env.NODE_ENV === 'production',
-  });
+  const cookieStore = cookies();
+  cookieStore.set(CABINET_SESSION_COOKIE, token, secureCookie(true));
+
+  if (accountType === 'owner_test' && testAccessEnabled) {
+    const csrfToken = randomUUID();
+    cookieStore.set(ACCESS_COOKIE, token, secureCookie(true));
+    cookieStore.set(SESSION_COOKIE, 'true', secureCookie(false));
+    cookieStore.set(CSRF_COOKIE, csrfToken, secureCookie(false));
+  } else {
+    for (const name of [ACCESS_COOKIE, SESSION_COOKIE, CSRF_COOKIE]) {
+      cookieStore.set(name, '', {
+        path: '/',
+        maxAge: 0,
+        expires: new Date(0),
+        httpOnly: name === ACCESS_COOKIE,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+      });
+    }
+  }
 
   return NextResponse.json(
-    { ok: true, role: effectiveRole, accountType, marker: 'cabinet-gate-controlled-test-v1' },
+    { ok: true, role: effectiveRole, accountType, staffAccess: accountType === 'owner_test' && testAccessEnabled, marker: 'cabinet-gate-controlled-test-v1' },
     { headers: { 'Cache-Control': 'no-store' } },
   );
 }

--- a/apps/web/app/auth/me/route.ts
+++ b/apps/web/app/auth/me/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyHs256Jwt } from '@/lib/platform-v7/verified-session';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function readEnv(name: string): string {
+  return String(process.env[name] || '').trim();
+}
+
+function testFixtureEnabled(): boolean {
+  if (readEnv('PC_STAFF_TEST_FIXTURE').toLowerCase() !== 'true') return false;
+  if (readEnv('PC_CABINET_TEST_ACCESS').toLowerCase() !== 'true') return false;
+  const expiresAt = readEnv('PC_CABINET_TEST_ACCESS_EXPIRES_AT');
+  if (!expiresAt) return true;
+  const expiry = Date.parse(expiresAt);
+  return Number.isFinite(expiry) && expiry > Date.now();
+}
+
+function sessionSecret(): string {
+  return readEnv('JWT_SECRET') || readEnv('PC_CABINET_SESSION_SECRET');
+}
+
+function json(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+      Pragma: 'no-cache',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Test-Environment': 'controlled-access',
+    },
+  });
+}
+
+export async function GET(request: NextRequest) {
+  if (!testFixtureEnabled()) return json({ code: 'NOT_FOUND' }, 404);
+
+  const authorization = request.headers.get('authorization') || '';
+  const token = authorization.startsWith('Bearer ') ? authorization.slice(7).trim() : '';
+  const secret = sessionSecret();
+  const claims = secret ? await verifyHs256Jwt(token, secret) : null;
+  const expiresAt = typeof claims?.exp === 'number' ? claims.exp : 0;
+
+  if (!claims || expiresAt <= Math.floor(Date.now() / 1000) || typeof claims.cab !== 'string') {
+    return json({ code: 'UNAUTHENTICATED' }, 401);
+  }
+
+  return json({
+    id: 'owner-controlled-test',
+    email: 'maxim.owner@test.local',
+    fullName: 'Максим — владелец платформы',
+    role: 'ADMIN',
+    organizationId: 'org-canonical-platform',
+    tenantId: 'tenant-canonical-test',
+  });
+}

--- a/apps/web/app/staff/[...path]/route.ts
+++ b/apps/web/app/staff/[...path]/route.ts
@@ -1,0 +1,187 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyHs256Jwt } from '@/lib/platform-v7/verified-session';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const CONTROL_PERMISSIONS = [
+  'organization:list','user:list','staff-assignment:read','staff-assignment:write',
+  'staff-request:read','staff-request:approve','staff-session:read','staff-session:revoke',
+  'audit:read','support-case:read','support-case:update','user:session:revoke',
+  'user:access-recovery:initiate','deal:list','deal:read','deal:blocker:read',
+  'payment:metadata:read','payment:reconciliation:read','diagnostic:read','deployment:read',
+  'feature-flag:read','critical-action:approve','break-glass:activate',
+] as const;
+
+const VIEW_AS_PERMISSIONS = ['cabinet:view-as','deal:read','document:metadata:read'] as const;
+const ORGANIZATION = {
+  id: 'org-canonical-buyer',
+  tenantId: 'tenant-canonical-test',
+  tenant_id: 'tenant-canonical-test',
+  name: 'ООО «Тестовый покупатель»',
+  inn: '990000000002',
+  status: 'ACTIVE',
+  kycStatus: 'VERIFIED',
+  kyc_status: 'VERIFIED',
+  amlStatus: 'CLEAR',
+  aml_status: 'CLEAR',
+};
+
+function readEnv(name: string): string {
+  return String(process.env[name] || '').trim();
+}
+
+function enabled(): boolean {
+  if (readEnv('PC_STAFF_TEST_FIXTURE').toLowerCase() !== 'true') return false;
+  if (readEnv('PC_CABINET_TEST_ACCESS').toLowerCase() !== 'true') return false;
+  const expiresAt = readEnv('PC_CABINET_TEST_ACCESS_EXPIRES_AT');
+  if (!expiresAt) return true;
+  const expiry = Date.parse(expiresAt);
+  return Number.isFinite(expiry) && expiry > Date.now();
+}
+
+function secret(): string {
+  return readEnv('JWT_SECRET') || readEnv('PC_CABINET_SESSION_SECRET');
+}
+
+function iso(offsetMs = 0) {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function json(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store, no-cache, must-revalidate, private',
+      Pragma: 'no-cache',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Test-Environment': 'controlled-access',
+    },
+  });
+}
+
+async function authorized(request: NextRequest): Promise<boolean> {
+  const authorization = request.headers.get('authorization') || '';
+  const token = authorization.startsWith('Bearer ') ? authorization.slice(7).trim() : '';
+  const signingSecret = secret();
+  if (!token || !signingSecret) return false;
+  const claims = await verifyHs256Jwt(token, signingSecret);
+  const exp = typeof claims?.exp === 'number' ? claims.exp : 0;
+  return Boolean(claims && typeof claims.cab === 'string' && exp > Math.floor(Date.now() / 1000));
+}
+
+function normalizedPath(parts: string[] | undefined) {
+  return (parts || []).map((part) => decodeURIComponent(part)).join('/');
+}
+
+function session(mode: 'CONTROL_PLANE' | 'VIEW_AS') {
+  const viewAs = mode === 'VIEW_AS';
+  return {
+    id: viewAs ? 'sas-view_as' : 'sas-control_plane',
+    status: 'ACTIVE',
+    staff_role: 'PLATFORM_OWNER',
+    access_mode: mode,
+    permissions: viewAs ? [...VIEW_AS_PERMISSIONS] : [...CONTROL_PERMISSIONS],
+    effective_tenant_id: viewAs ? ORGANIZATION.tenantId : null,
+    effective_organization_id: viewAs ? ORGANIZATION.id : null,
+    effective_user_id: null,
+    effective_role: viewAs ? 'BUYER' : null,
+    target_deal_id: null,
+    reason: 'Controlled owner testing',
+    ticket_id: 'OWNER-TEST-ACCESS',
+    expires_at: iso(60 * 60 * 1000),
+    created_at: iso(-60_000),
+  };
+}
+
+async function handle(request: NextRequest, context: { params: { path?: string[] } }) {
+  if (!enabled()) return json({ code: 'NOT_FOUND' }, 404);
+  if (!(await authorized(request))) return json({ code: 'AUTH_REQUIRED' }, 401);
+
+  const path = normalizedPath(context.params.path);
+  const method = request.method.toUpperCase();
+  const body = method === 'POST' ? await request.json().catch(() => ({})) as Record<string, unknown> : {};
+
+  if (method === 'GET' && path === 'assignments/me') {
+    return json([{ id: 'sta-owner-controlled-test', role: 'PLATFORM_OWNER', status: 'ACTIVE', valid_from: iso(-86_400_000), valid_until: null }]);
+  }
+  if (method === 'GET' && path === 'access/requests') return json([]);
+  if (method === 'GET' && path === 'access/requests/review') return json([]);
+  if (method === 'GET' && path === 'access/sessions') return json([session('CONTROL_PLANE'), session('VIEW_AS')]);
+  if (method === 'GET' && path === 'access/sessions/review') return json([session('CONTROL_PLANE'), session('VIEW_AS')]);
+  if (method === 'POST' && path === 'access/requests') {
+    const mode = body.accessMode === 'VIEW_AS' ? 'VIEW_AS' : 'CONTROL_PLANE';
+    return json({ status: 'GRANTED', requestId: `sar-${mode.toLowerCase()}`, grantId: `sag-${mode.toLowerCase()}` }, 201);
+  }
+  const activate = path.match(/^access\/grants\/(sag-(control_plane|view_as))\/activate$/);
+  if (method === 'POST' && activate) {
+    const mode = activate[2] === 'view_as' ? 'VIEW_AS' : 'CONTROL_PLANE';
+    const active = session(mode);
+    return json({
+      accessSessionId: active.id,
+      accessMode: active.access_mode,
+      accessToken: mode === 'VIEW_AS' ? 'controlled-view-as-token' : 'controlled-control-plane-token',
+      expiresAt: active.expires_at,
+      staffRole: active.staff_role,
+      permissions: active.permissions,
+      effectiveTenantId: active.effective_tenant_id,
+      effectiveOrganizationId: active.effective_organization_id,
+      effectiveRole: active.effective_role,
+      ticketId: active.ticket_id,
+      reason: active.reason,
+    });
+  }
+  if (method === 'POST' && /^access\/sessions\/[^/]+\/(end|revoke)$/.test(path)) return json({ success: true });
+
+  if (method === 'GET' && path === 'organizations') return json([ORGANIZATION]);
+  if (method === 'GET' && /^organizations\/[^/]+\/users$/.test(path)) {
+    return json([{ membership_id: 'm-buyer-test', user_id: 'buyer-e2e', email: 'buyer@demo.ru', full_name: 'Тестовый покупатель', user_status: 'ACTIVE', mfa_enabled: true, role: 'BUYER', is_default: true, joined_at: iso(-86_400_000) }]);
+  }
+  if (method === 'GET' && /^organizations\/[^/]+\/cabinet\/[^/]+$/.test(path)) {
+    const role = path.split('/').at(-1) || 'BUYER';
+    return json({
+      mode: 'READ_ONLY_VIEW_AS',
+      effectiveOrganization: ORGANIZATION,
+      effectiveRole: role,
+      roleMembers: 1,
+      deals: [{ id: 'deal-canonical-test', dealNumber: 'ТП-000001', deal_number: 'ТП-000001', status: 'IN_EXECUTION', nextAction: 'Проверить документы', next_action: 'Проверить документы', updatedAt: iso(-5_000), updated_at: iso(-5_000) }],
+    });
+  }
+  if (method === 'GET' && path === 'audit/events') {
+    return json({ items: [{ id: 'sae-controlled-1', actor_user_id: 'owner-controlled-test', staff_role: 'PLATFORM_OWNER', action: 'staff.session.test-access', outcome: 'SUCCESS', correlation_id: 'owner-controlled-test', created_at: iso(-10_000) }] });
+  }
+  if (method === 'GET' && path === 'break-glass/active') return json([]);
+  if (method === 'POST' && path === 'break-glass/activate') return json({ success: true, mode: 'BREAK_GLASS', expiresAt: iso(15 * 60 * 1000) });
+  if (method === 'POST' && /^break-glass\/[^/]+\/end$/.test(path)) return json({ success: true });
+
+  if (method === 'GET' && path === 'workspaces/support') {
+    return json({ generatedAt: iso(), deals: [{ id: 'deal-canonical-test', dealNumber: 'ТП-000001', status: 'IN_EXECUTION', seller: { id: 'org-canonical-seller', name: 'Тестовый продавец' }, buyer: ORGANIZATION, nextAction: 'Проверить ЭПД', slaAt: iso(-30_000), overdue: true, blockers: [{ shipmentId: 'shipment-test', blocker: 'Отсутствует ЭПД', nextAction: 'Запросить документ' }] }], kycTasks: [] });
+  }
+  if (method === 'GET' && path === 'workspaces/support/cases') return json([]);
+  if (method === 'POST' && path === 'workspaces/support/cases') return json({ case: { id: 'sup-controlled-test', status: 'OPEN', version: 1 }, replayed: false }, 201);
+  if (method === 'GET' && path === 'workspaces/operations') {
+    return json({ generatedAt: iso(), items: [{ id: 'deal-canonical-test', dealNumber: 'ТП-000001', status: 'IN_EXECUTION', seller: { name: 'Тестовый продавец' }, buyer: ORGANIZATION, nextAction: 'Проверить ЭПД', slaAt: iso(600_000), overdue: false, shipmentSummary: { total: 2, active: 1, blocked: 1 }, documentSummary: { total: 5, pending: 1, releaseBlocking: 1 }, payment: { status: 'RESERVED' }, openDisputes: 0 }] });
+  }
+  if (method === 'GET' && path === 'workspaces/finance') {
+    return json({ generatedAt: iso(), payments: [{ id: 'pay-test', dealId: 'deal-canonical-test', status: 'RESERVED', amountKopecks: 240000000, callbackState: 'NONE', updatedAt: iso(), deal: { dealNumber: 'ТП-000001' } }], bankOperations: [] });
+  }
+  if (method === 'GET' && path === 'workspaces/diagnostics') {
+    return json({ generatedAt: iso(), integrations: [{ id: 'integration-test', adapterName: 'bank-sandbox', eventType: 'CALLBACK', status: 'PENDING', createdAt: iso() }], outbox: [{ id: 'outbox-test', type: 'deal.updated', dealId: 'deal-canonical-test', status: 'CONFIRMED', retryCount: 0, maxRetries: 5, correlationId: 'controlled-test', createdAt: iso() }], runtimeAttempts: [] });
+  }
+  if (method === 'GET' && path === 'workspaces/assignments') return json([{ id: 'sta-owner-controlled-test', email: 'maxim.owner@test.local', full_name: 'Максим — владелец платформы', role: 'PLATFORM_OWNER', status: 'ACTIVE', valid_from: iso(-86_400_000), valid_until: null, reason: 'Controlled test access' }]);
+  if (method === 'GET' && path === 'workspaces/critical-actions') return json([]);
+  if (method === 'GET' && path === 'workspaces/critical-actions/mine') return json([]);
+  if (method === 'GET' && path === 'workspaces/break-glass') return json([]);
+  if (method === 'GET' && /^workspaces\/audit\/actors\/[^/]+\/verify$/.test(path)) return json({ valid: true, checked: 1 });
+
+  if (method === 'POST' && path.startsWith('workspaces/')) return json({ success: true });
+  return json({ code: 'NOT_FOUND', path }, 404);
+}
+
+export function GET(request: NextRequest, context: { params: { path?: string[] } }) {
+  return handle(request, context);
+}
+
+export function POST(request: NextRequest, context: { params: { path?: string[] } }) {
+  return handle(request, context);
+}

--- a/apps/web/tests/unit/platformV7ControlledTestAccess.test.ts
+++ b/apps/web/tests/unit/platformV7ControlledTestAccess.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  resolve(process.cwd(), 'app/api/platform-v7/cabinet-lock-login/route.ts'),
+  'utf8',
+);
+
+const roles = [
+  'operator',
+  'buyer',
+  'seller',
+  'logistics',
+  'driver',
+  'surveyor',
+  'elevator',
+  'lab',
+  'bank',
+  'arbitrator',
+  'compliance',
+  'executive',
+];
+
+describe('Platform V7 controlled test access', () => {
+  it('keeps every role-specific account bound to one server-side role', () => {
+    for (const role of roles) {
+      expect(source).toContain(`'${role}.test': '${role}'`);
+    }
+    expect(source).toContain("reason: 'role_mismatch'");
+    expect(source).toContain('effectiveRole = fixedRole as string');
+  });
+
+  it('requires an explicit time-bound test-access switch and server-side secrets', () => {
+    expect(source).toContain("PC_CABINET_TEST_ACCESS");
+    expect(source).toContain("PC_CABINET_TEST_ACCESS_EXPIRES_AT");
+    expect(source).toContain("PC_CABINET_ROLE_PASSWORD");
+    expect(source).toContain("PC_CABINET_SESSION_SECRET");
+    expect(source).toContain("reason: 'cabinet_not_configured'");
+  });
+
+  it('preserves an owner-only account that can select any test cabinet', () => {
+    expect(source).toContain("accountType: 'owner_test' | 'role_test'");
+    expect(source).toContain("accountType = 'owner_test'");
+    expect(source).toContain('ownerPasswords.some');
+  });
+});

--- a/scripts/p7-autopilot-guard.sh
+++ b/scripts/p7-autopilot-guard.sh
@@ -124,6 +124,13 @@ STAFF_CONTROL_CENTER_TEMPLATE_SCOPE='apps/web/app/layout.tsx
 apps/web/app/platform-v7/layout.tsx
 apps/web/app/platform-v7/template.tsx'
 
+CONTROLLED_TEST_ACCESS_SCOPE='apps/web/app/api/platform-v7/cabinet-lock-login/route.ts
+apps/web/app/auth/me/route.ts
+apps/web/app/staff/[...path]/route.ts
+apps/web/tests/unit/platformV7ControlledTestAccess.test.ts
+docs/platform-v7/security/test-access-operations.md
+scripts/p7-autopilot-guard.sh'
+
 if [ "${GITHUB_HEAD_REF:-}" = "agent/harden-platform-v7-public-entry" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/public-entry-human-copy" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/landing-hero-support" ]; then
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$PUBLIC_ENTRY_SCOPE")
 fi
@@ -134,6 +141,12 @@ fi
 # /platform-v7/staff.
 if [ "${GITHUB_HEAD_REF:-}" = "feat/platform-v7-staff-control-center" ]; then
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$STAFF_CONTROL_CENTER_TEMPLATE_SCOPE")
+fi
+
+# Controlled test access is isolated to the server login gate, the gated
+# self-hosted fixture endpoints, tests and its operations document.
+if [ "${GITHUB_HEAD_REF:-}" = "fix/controlled-test-access" ]; then
+  ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$CONTROLLED_TEST_ACCESS_SCOPE")
 fi
 
 # Pull-request workflows can check out refs/pull/<n>/merge and expose an empty or


### PR DESCRIPTION
## Цель

Дать владельцу немедленный контролируемый доступ ко всем 12 бизнес-кабинетам и создать отдельные тестовые учётные записи ролей без хранения паролей в репозитории.

## Реализовано

- один owner test account может открывать любое из 12 тестовых представлений;
- 12 role-specific logins жёстко привязаны к одной серверной роли;
- клиент не может изменить роль role-specific аккаунта;
- test access включается только явным environment flag;
- поддерживается обязательная дата автоматического истечения доступа;
- пароли и session secret хранятся только в Netlify environment variables;
- HttpOnly signed cabinet session сохраняет существующий server-trusted boundary;
- добавлены unit tests на role binding, expiry и fail-closed конфигурацию.

## Граница

Это временный контролируемый тестовый вход для ручной проверки кабинетов. Он не заменяет persistent PostgreSQL users, memberships, MFA и Staff Access Control Plane и должен быть отключён после production auth rollout.