### PR TITLE
Fix owner cabinet buttons on mobile

### DIFF
--- a/apps/web/app/platform-v7/staff/open-cabinet/route.ts
+++ b/apps/web/app/platform-v7/staff/open-cabinet/route.ts
@@ -1,12 +1,13 @@
-import { randomUUID } from 'node:crypto';
+import { randomUUID, timingSafeEqual } from 'node:crypto';
 import { NextRequest, NextResponse } from 'next/server';
-import { ACCESS_COOKIE, SESSION_COOKIE, sessionMarkerCookie } from '@/lib/auth-cookies';
+import { ACCESS_COOKIE, CSRF_COOKIE, SESSION_COOKIE, sessionMarkerCookie } from '@/lib/auth-cookies';
 import { CABINET_SESSION_COOKIE } from '@/lib/server/auth-session-response';
-import { assertCsrf } from '@/lib/server-request-security';
+import { assertCsrf, assertSameOriginIfPresent } from '@/lib/server-request-security';
 import { signCabinetSession, verifyHs256Jwt } from '@/lib/platform-v7/verified-session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 12;
 
 const MAX_CONTROLLED_TTL_SECONDS = 8 * 60 * 60;
 const MAX_API_OWNER_TTL_SECONDS = 60 * 60;
@@ -37,16 +38,13 @@ type AuthorityResult =
   | { status: 'authorized'; authority: OwnerAuthority }
   | { status: 'denied' }
   | { status: 'unavailable' };
-
-type StaffIdentity = {
-  id?: string;
-  email?: string;
+type ParsedRequest = {
+  role: unknown;
+  formSubmission: boolean;
+  csrfOk: boolean;
 };
-
-type StaffAssignment = {
-  role?: string;
-  status?: string;
-};
+type StaffIdentity = { id?: string; email?: string };
+type StaffAssignment = { role?: string; status?: string };
 
 function readEnv(name: string): string {
   return String(process.env[name] || '').trim();
@@ -89,8 +87,46 @@ function json(body: Record<string, unknown>, status = 200) {
   });
 }
 
+function redirectBack(request: NextRequest, code: string) {
+  const url = new URL('/platform-v7/staff', request.url);
+  url.searchParams.set('cabinetError', code);
+  return NextResponse.redirect(url, 303);
+}
+
 function isOwnerCabinetRole(value: unknown): value is OwnerCabinetRole {
   return typeof value === 'string' && Object.prototype.hasOwnProperty.call(OWNER_CABINETS, value);
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+function formCsrfValid(request: NextRequest, token: unknown): boolean {
+  if (!assertSameOriginIfPresent(request).ok) return false;
+  const cookie = request.cookies.get(CSRF_COOKIE)?.value || '';
+  return typeof token === 'string' && constantTimeEqual(cookie, token);
+}
+
+async function parseRequest(request: NextRequest): Promise<ParsedRequest> {
+  const contentType = String(request.headers.get('content-type') || '').toLowerCase();
+  const formSubmission = contentType.includes('application/x-www-form-urlencoded') || contentType.includes('multipart/form-data');
+  if (formSubmission) {
+    const form = await request.formData().catch(() => null);
+    return {
+      role: form?.get('role'),
+      formSubmission: true,
+      csrfOk: formCsrfValid(request, form?.get('_csrf')),
+    };
+  }
+  const body = await request.json().catch(() => ({} as Record<string, unknown>));
+  return {
+    role: body.role,
+    formSubmission: false,
+    csrfOk: assertCsrf(request).ok,
+  };
 }
 
 async function controlledOwnerAuthority(accessToken: string, secret: string): Promise<AuthorityResult | null> {
@@ -128,42 +164,30 @@ async function apiOwnerAuthority(accessToken: string, correlationId: string): Pr
   if (!origin) return { status: 'unavailable' };
 
   try {
-    const headers = {
+    const commonHeaders = {
       Authorization: `Bearer ${accessToken}`,
       Accept: 'application/json',
       'x-correlation-id': correlationId,
     };
     const [identityResponse, assignmentsResponse] = await Promise.all([
       fetch(`${origin}/auth/me`, {
-        headers,
+        headers: commonHeaders,
         cache: 'no-store',
         redirect: 'manual',
-        signal: AbortSignal.timeout(6_000),
+        signal: AbortSignal.timeout(5_000),
       }),
       fetch(`${origin}/staff/assignments/me`, {
-        headers,
+        headers: commonHeaders,
         cache: 'no-store',
         redirect: 'manual',
-        signal: AbortSignal.timeout(6_000),
+        signal: AbortSignal.timeout(5_000),
       }),
     ]);
 
-    if (
-      identityResponse.status === 401
-      || identityResponse.status === 403
-      || assignmentsResponse.status === 401
-      || assignmentsResponse.status === 403
-    ) {
+    if ([identityResponse.status, assignmentsResponse.status].some((status) => status === 401 || status === 403)) {
       return { status: 'denied' };
     }
-    if (
-      !identityResponse.ok
-      || !assignmentsResponse.ok
-      || (identityResponse.status >= 300 && identityResponse.status < 400)
-      || (assignmentsResponse.status >= 300 && assignmentsResponse.status < 400)
-    ) {
-      return { status: 'unavailable' };
-    }
+    if (!identityResponse.ok || !assignmentsResponse.ok) return { status: 'unavailable' };
 
     const identity = await identityResponse.json().catch(() => null) as StaffIdentity | null;
     const assignments = await assignmentsResponse.json().catch(() => null) as StaffAssignment[] | null;
@@ -188,61 +212,18 @@ async function apiOwnerAuthority(accessToken: string, correlationId: string): Pr
   }
 }
 
-async function resolveOwnerAuthority(
-  accessToken: string,
-  secret: string,
-  correlationId: string,
-): Promise<AuthorityResult> {
+async function resolveOwnerAuthority(accessToken: string, secret: string, correlationId: string): Promise<AuthorityResult> {
   const controlled = await controlledOwnerAuthority(accessToken, secret);
   return controlled || apiOwnerAuthority(accessToken, correlationId);
 }
 
-export async function POST(request: NextRequest) {
-  const correlationId = request.headers.get('x-correlation-id')?.slice(0, 128) || randomUUID();
-  const csrf = assertCsrf(request);
-  if (!csrf.ok) {
-    return json({ ok: false, code: 'CSRF_REJECTED', message: 'Сессия формы устарела. Обнови страницу.', correlationId }, 403);
-  }
-
-  const secret = signingSecret();
-  const accessToken = request.cookies.get(ACCESS_COOKIE)?.value || '';
-  if (!secret || !accessToken) {
-    return json({ ok: false, code: 'OWNER_ACCESS_UNAVAILABLE', message: 'Требуется активный вход владельца платформы.', correlationId }, 401);
-  }
-
-  const authorityResult = await resolveOwnerAuthority(accessToken, secret, correlationId);
-  if (authorityResult.status === 'unavailable') {
-    return json({ ok: false, code: 'OWNER_AUTHORITY_UNAVAILABLE', message: 'Не удалось проверить полномочия владельца.', correlationId }, 503);
-  }
-  if (authorityResult.status === 'denied') {
-    return json({ ok: false, code: 'PLATFORM_OWNER_REQUIRED', message: 'Требуется активное назначение владельца платформы.', correlationId }, 403);
-  }
-
-  const body = await request.json().catch(() => ({} as Record<string, unknown>));
-  const role = body.role;
-  if (!isOwnerCabinetRole(role)) {
-    return json({ ok: false, code: 'INVALID_CABINET_ROLE', message: 'Неизвестный кабинет.', correlationId }, 400);
-  }
-
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const { authority } = authorityResult;
-  const cabinetToken = await signCabinetSession(role, secret, {
-    nowSeconds,
-    ttlSeconds: authority.ttlSeconds,
-  });
-  if (!cabinetToken) {
-    return json({ ok: false, code: 'CABINET_SESSION_UNAVAILABLE', message: 'Не удалось открыть кабинет.', correlationId }, 503);
-  }
-
-  const expiresAt = nowSeconds + authority.ttlSeconds;
-  const response = json({
-    ok: true,
-    role,
-    redirectTo: OWNER_CABINETS[role],
-    expiresAt: new Date(expiresAt * 1000).toISOString(),
-    correlationId,
-  });
-
+function setCabinetCookies(
+  response: NextResponse,
+  cabinetToken: string,
+  role: OwnerCabinetRole,
+  authority: OwnerAuthority,
+  expiresAt: number,
+) {
   response.cookies.set(CABINET_SESSION_COOKIE, cabinetToken, {
     path: '/',
     maxAge: authority.ttlSeconds,
@@ -263,12 +244,60 @@ export async function POST(request: NextRequest) {
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',
   });
+}
+
+export async function POST(request: NextRequest) {
+  const correlationId = request.headers.get('x-correlation-id')?.slice(0, 128) || randomUUID();
+  const parsed = await parseRequest(request);
+  const fail = (code: string, message: string, status: number) => parsed.formSubmission
+    ? redirectBack(request, code)
+    : json({ ok: false, code, message, correlationId }, status);
+
+  if (!parsed.csrfOk) return fail('CSRF_REJECTED', 'Сессия формы устарела. Обнови страницу.', 403);
+  if (!isOwnerCabinetRole(parsed.role)) return fail('INVALID_CABINET_ROLE', 'Неизвестный кабинет.', 400);
+
+  const secret = signingSecret();
+  const accessToken = request.cookies.get(ACCESS_COOKIE)?.value || '';
+  if (!secret || !accessToken) {
+    return fail('OWNER_ACCESS_UNAVAILABLE', 'Требуется активный вход владельца платформы.', 401);
+  }
+
+  const authorityResult = await resolveOwnerAuthority(accessToken, secret, correlationId);
+  if (authorityResult.status === 'unavailable') {
+    return fail('OWNER_AUTHORITY_UNAVAILABLE', 'Не удалось проверить полномочия владельца.', 503);
+  }
+  if (authorityResult.status === 'denied') {
+    return fail('PLATFORM_OWNER_REQUIRED', 'Требуется активное назначение владельца платформы.', 403);
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const { authority } = authorityResult;
+  const cabinetToken = await signCabinetSession(parsed.role, secret, {
+    nowSeconds,
+    ttlSeconds: authority.ttlSeconds,
+  });
+  if (!cabinetToken) return fail('CABINET_SESSION_UNAVAILABLE', 'Не удалось открыть кабинет.', 503);
+
+  const expiresAt = nowSeconds + authority.ttlSeconds;
+  const response = parsed.formSubmission
+    ? NextResponse.redirect(new URL(OWNER_CABINETS[parsed.role], request.url), 303)
+    : json({
+      ok: true,
+      role: parsed.role,
+      redirectTo: OWNER_CABINETS[parsed.role],
+      expiresAt: new Date(expiresAt * 1000).toISOString(),
+      correlationId,
+    });
+
+  response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
+  setCabinetCookies(response, cabinetToken, parsed.role, authority, expiresAt);
 
   console.info('owner_direct_cabinet_open', JSON.stringify({
     actor: authority.actorId,
     authoritySource: authority.source,
-    role,
+    role: parsed.role,
     correlationId,
+    transport: parsed.formSubmission ? 'native-form' : 'json-fetch',
   }));
 
   return response;

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx
@@ -1,1 +1,2 @@
+// Owner-only cabinet selector. Role authority remains server-verified.
 export { OwnerAccessCenter } from './OwnerAccessCenterV3';

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
@@ -95,7 +95,14 @@ export function OwnerAccessCenter(props: Props) {
   const [isOwner, setIsOwner] = useState(false);
   const [advanced, setAdvanced] = useState(false);
   const [busyRole, setBusyRole] = useState<SurfaceRole | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [csrf, setCsrf] = useState('');
+
+  useEffect(() => {
+    setCsrf(csrfToken());
+    const resetBusy = () => setBusyRole(null);
+    window.addEventListener('pageshow', resetBusy);
+    return () => window.removeEventListener('pageshow', resetBusy);
+  }, []);
 
   useEffect(() => {
     if (!apiAvailable) {
@@ -103,7 +110,11 @@ export function OwnerAccessCenter(props: Props) {
       return;
     }
     let cancelled = false;
-    fetch('/api/staff/assignments/me', { credentials: 'same-origin', cache: 'no-store' })
+    fetch('/api/staff/assignments/me', {
+      credentials: 'same-origin',
+      cache: 'no-store',
+      signal: AbortSignal.timeout(8_000),
+    })
       .then(async (response) => response.ok ? response.json() : [])
       .then((rows: StaffAssignment[]) => {
         if (!cancelled) setIsOwner(Array.isArray(rows) && rows.some((item) => item.role === 'PLATFORM_OWNER' && item.status === 'ACTIVE'));
@@ -122,31 +133,9 @@ export function OwnerAccessCenter(props: Props) {
     [copy],
   );
 
-  const openCabinet = async (role: SurfaceRole) => {
+  const prepareCabinetNavigation = (role: SurfaceRole) => {
     setBusyRole(role);
-    setError(null);
-    try {
-      const response = await fetch('/platform-v7/staff/open-cabinet', {
-        method: 'POST',
-        credentials: 'same-origin',
-        cache: 'no-store',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-          'x-csrf-token': csrfToken(),
-        },
-        body: JSON.stringify({ role }),
-      });
-      const payload = await response.json().catch(() => ({})) as { ok?: boolean; redirectTo?: string; role?: SurfaceRole; message?: string };
-      if (!response.ok || !payload.ok || !payload.redirectTo || !payload.role) {
-        throw new Error(payload.message || text.error);
-      }
-      window.sessionStorage.setItem('pc-v7-active-role', payload.role);
-      window.location.assign(payload.redirectTo);
-    } catch (value) {
-      setError(value instanceof Error && value.message ? value.message : text.error);
-      setBusyRole(null);
-    }
+    window.sessionStorage.setItem('pc-v7-active-role', role);
   };
 
   if (advanced || (!checking && !isOwner)) {
@@ -180,8 +169,6 @@ export function OwnerAccessCenter(props: Props) {
         </button>
       </header>
 
-      {error && <div className={styles.error} role="alert">{error}</div>}
-
       <section className={styles.accessSummary}>
         <strong>{text.access}</strong>
         <p>{text.accessBody}</p>
@@ -192,13 +179,17 @@ export function OwnerAccessCenter(props: Props) {
           <article key={item.role} className={styles.cabinetCard}>
             <span className={styles.number} aria-hidden="true">{item.icon}</span>
             <h2>{item.label}</h2>
-            <button
-              type="button"
-              onClick={() => void openCabinet(item.role)}
-              disabled={busyRole !== null}
+            <form
+              method="post"
+              action="/platform-v7/staff/open-cabinet"
+              onSubmit={() => prepareCabinetNavigation(item.role)}
             >
-              {busyRole === item.role ? text.opening : text.open}
-            </button>
+              <input type="hidden" name="_csrf" value={csrf} />
+              <input type="hidden" name="role" value={item.role} />
+              <button type="submit" disabled={!csrf || busyRole !== null}>
+                {busyRole === item.role ? text.opening : text.open}
+              </button>
+            </form>
           </article>
         ))}
       </section>

--- a/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
+++ b/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
@@ -32,22 +32,35 @@ describe('platform-v7 owner access center task UX', () => {
     ]) {
       expect(directCenter).toContain(`role: '${role}'`);
     }
-    expect(directCenter).toContain("fetch('/platform-v7/staff/open-cabinet'");
-    expect(directCenter).toContain("window.sessionStorage.setItem('pc-v7-active-role', payload.role)");
-    expect(directCenter).toContain('window.location.assign(payload.redirectTo)');
+    expect(directCenter).toContain('method="post"');
+    expect(directCenter).toContain('action="/platform-v7/staff/open-cabinet"');
+    expect(directCenter).toContain('name="_csrf"');
+    expect(directCenter).toContain('name="role"');
+    expect(directCenter).toContain("window.sessionStorage.setItem('pc-v7-active-role', role)");
+    expect(directCenter).not.toContain("fetch('/platform-v7/staff/open-cabinet'");
     expect(directCenter).not.toContain('Рабочий тикет');
     expect(directCenter).not.toContain('Причина доступа');
   });
 
+  it('uses a native POST redirect so mobile browsers do not remain stuck in the opening state', () => {
+    expect(directRoute).toContain("contentType.includes('application/x-www-form-urlencoded')");
+    expect(directRoute).toContain('request.formData()');
+    expect(directRoute).toContain('formCsrfValid(request');
+    expect(directRoute).toContain('NextResponse.redirect(new URL(OWNER_CABINETS[parsed.role], request.url), 303)');
+    expect(directRoute).toContain("transport: parsed.formSubmission ? 'native-form' : 'json-fetch'");
+    expect(directCenter).toContain("window.addEventListener('pageshow', resetBusy)");
+  });
+
   it('requires controlled-owner claims or an active API-backed PLATFORM_OWNER assignment', () => {
     expect(directRoute).toContain('assertCsrf(request)');
+    expect(directRoute).toContain('assertSameOriginIfPresent(request)');
     expect(directRoute).toContain('claims.owner !== true');
     expect(directRoute).toContain('claims.testAccess !== true');
     expect(directRoute).toContain("claims.tokenType !== 'access'");
     expect(directRoute).toContain("fetch(`${origin}/auth/me`");
     expect(directRoute).toContain("fetch(`${origin}/staff/assignments/me`");
     expect(directRoute).toContain("item.role === 'PLATFORM_OWNER' && item.status === 'ACTIVE'");
-    expect(directRoute).toContain('signCabinetSession(role, secret');
+    expect(directRoute).toContain('signCabinetSession(parsed.role, secret');
     expect(directRoute).toContain('response.cookies.set(CABINET_SESSION_COOKIE');
     expect(directRoute).toContain('response.cookies.set(SESSION_COOKIE');
     expect(directRoute).toContain("response.cookies.set('pc-role'");


### PR DESCRIPTION
Replace the hanging client fetch with a native POST form. The server verifies the platform owner, sets the signed cabinet session, and returns a 303 redirect to the selected cabinet. CSRF, owner checks, server allowlist, and protected financial/legal actions remain enforced.