### PR TITLE
Remove Safari-cancellable state from owner cabinet submit

### DIFF
--- a/apps/web/app/platform-v7/staff/page.tsx
+++ b/apps/web/app/platform-v7/staff/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from 'next/navigation';
 import { OwnerAccessCenter } from '@/components/platform-v7/staff/OwnerAccessCenter';
 import { StaffOperationalWorkspacesDeferred } from '@/components/platform-v7/staff/StaffOperationalWorkspacesDeferred';
 import { StaffPlatformShell } from '@/components/platform-v7/staff/StaffPlatformShell';
-import { ACCESS_COOKIE } from '@/lib/auth-cookies';
+import { ACCESS_COOKIE, CSRF_COOKIE } from '@/lib/auth-cookies';
 import { verifyHs256Jwt } from '@/lib/platform-v7/verified-session';
 import { staffAccessTaskCatalog } from '@/lib/platform-v7/staff-access-task-catalog';
 import { DEFAULT_LOCALE, isAppLocale, LOCALE_COOKIE, type AppLocale } from '@/i18n/locale';
@@ -136,7 +136,9 @@ async function verifyIdentity(accessToken: string): Promise<Verification> {
 
 export default async function StaffControlCenterPage() {
   const locale = resolveLocale();
-  const accessToken = cookies().get(ACCESS_COOKIE)?.value;
+  const cookieStore = cookies();
+  const accessToken = cookieStore.get(ACCESS_COOKIE)?.value;
+  const csrfToken = cookieStore.get(CSRF_COOKIE)?.value || '';
   if (!accessToken) redirect('/platform-v7/login?next=%2Fplatform-v7%2Fstaff');
 
   const verification = await verifyIdentity(accessToken);
@@ -152,6 +154,7 @@ export default async function StaffControlCenterPage() {
         identity={verification.status === 'verified' ? verification.identity : null}
         apiAvailable={verification.status === 'verified'}
         accessCatalog={staffAccessTaskCatalog()}
+        csrfToken={csrfToken}
       />
       {verification.status === 'verified' ? (
         <StaffOperationalWorkspacesDeferred

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx
@@ -1,2 +1,3 @@
 // Owner-only cabinet selector. Role authority remains server-verified.
+// Cabinet navigation is a native server POST and must not depend on client submit state.
 export { OwnerAccessCenter } from './OwnerAccessCenterV3';

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
@@ -6,7 +6,7 @@ import { OwnerAccessCenter as OwnerAccessCenterV2 } from './OwnerAccessCenterV2'
 import styles from './OwnerAccessCenterV3.module.css';
 
 type StaffAssignment = { id: string; role: string; status: string };
-type Props = ComponentProps<typeof OwnerAccessCenterV2>;
+type Props = ComponentProps<typeof OwnerAccessCenterV2> & { csrfToken: string };
 
 type SurfaceRole =
   | 'operator'
@@ -46,11 +46,9 @@ const OWNER_COPY = {
     accessBody: 'Доступны все 12 рабочих кабинетов и их интерфейсы. Переключение действует в пределах текущего входа владельца.',
     safety: 'Деньги, банковские подтверждения, подпись, лабораторная финализация и решение арбитра не подменяются владельцем и остаются под отдельными серверными правилами.',
     open: 'Открыть кабинет',
-    opening: 'Открываем…',
     advanced: 'Управление сотрудниками и доступами',
     back: 'Вернуться ко всем кабинетам',
     loading: 'Проверяем полномочия владельца…',
-    error: 'Не удалось открыть кабинет. Обнови страницу и повтори.',
   },
   en: {
     eyebrow: 'Platform owner',
@@ -60,11 +58,9 @@ const OWNER_COPY = {
     accessBody: 'All 12 working cabinets and their interfaces are available within the current owner sign-in.',
     safety: 'Money movement, bank confirmations, signatures, laboratory finalization and arbitration decisions remain protected by separate server rules.',
     open: 'Open cabinet',
-    opening: 'Opening…',
     advanced: 'Staff and access management',
     back: 'Back to all cabinets',
     loading: 'Checking owner authority…',
-    error: 'The cabinet could not be opened. Refresh and try again.',
   },
   zh: {
     eyebrow: '平台所有者',
@@ -74,35 +70,19 @@ const OWNER_COPY = {
     accessBody: '当前所有者登录期间可访问全部 12 个工作台及其界面。',
     safety: '资金操作、银行确认、签署、实验室终审和仲裁决定仍受独立服务器规则保护。',
     open: '打开工作台',
-    opening: '正在打开…',
     advanced: '员工与访问管理',
     back: '返回全部工作台',
     loading: '正在检查所有者权限…',
-    error: '无法打开工作台。请刷新后重试。',
   },
 } as const;
 
-function csrfToken() {
-  if (typeof document === 'undefined') return '';
-  const row = document.cookie.split('; ').find((entry) => entry.startsWith('pc_csrf_token='));
-  return row ? decodeURIComponent(row.slice(row.indexOf('=') + 1)) : '';
-}
-
 export function OwnerAccessCenter(props: Props) {
-  const { locale, copy, identity, apiAvailable } = props;
+  const { csrfToken, ...baseProps } = props;
+  const { locale, copy, identity, apiAvailable } = baseProps;
   const text = OWNER_COPY[locale];
   const [checking, setChecking] = useState(apiAvailable);
   const [isOwner, setIsOwner] = useState(false);
   const [advanced, setAdvanced] = useState(false);
-  const [busyRole, setBusyRole] = useState<SurfaceRole | null>(null);
-  const [csrf, setCsrf] = useState('');
-
-  useEffect(() => {
-    setCsrf(csrfToken());
-    const resetBusy = () => setBusyRole(null);
-    window.addEventListener('pageshow', resetBusy);
-    return () => window.removeEventListener('pageshow', resetBusy);
-  }, []);
 
   useEffect(() => {
     if (!apiAvailable) {
@@ -133,11 +113,6 @@ export function OwnerAccessCenter(props: Props) {
     [copy],
   );
 
-  const prepareCabinetNavigation = (role: SurfaceRole) => {
-    setBusyRole(role);
-    window.sessionStorage.setItem('pc-v7-active-role', role);
-  };
-
   if (advanced || (!checking && !isOwner)) {
     return (
       <div className={styles.advancedWrap}>
@@ -146,7 +121,7 @@ export function OwnerAccessCenter(props: Props) {
             ← {text.back}
           </button>
         )}
-        <OwnerAccessCenterV2 {...props} />
+        <OwnerAccessCenterV2 {...baseProps} />
       </div>
     );
   }
@@ -179,15 +154,10 @@ export function OwnerAccessCenter(props: Props) {
           <article key={item.role} className={styles.cabinetCard}>
             <span className={styles.number} aria-hidden="true">{item.icon}</span>
             <h2>{item.label}</h2>
-            <form
-              method="post"
-              action="/platform-v7/staff/open-cabinet"
-              onSubmit={() => prepareCabinetNavigation(item.role)}
-            >
-              <input type="hidden" name="_csrf" value={csrf} />
-              <input type="hidden" name="role" value={item.role} />
-              <button type="submit" disabled={!csrf || busyRole !== null}>
-                {busyRole === item.role ? text.opening : text.open}
+            <form method="post" action="/platform-v7/staff/open-cabinet">
+              <input type="hidden" name="_csrf" value={csrfToken} />
+              <button type="submit" name="role" value={item.role} disabled={!csrfToken}>
+                {text.open}
               </button>
             </form>
           </article>

--- a/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
+++ b/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
@@ -36,19 +36,23 @@ describe('platform-v7 owner access center task UX', () => {
     expect(directCenter).toContain('action="/platform-v7/staff/open-cabinet"');
     expect(directCenter).toContain('name="_csrf"');
     expect(directCenter).toContain('name="role"');
-    expect(directCenter).toContain("window.sessionStorage.setItem('pc-v7-active-role', role)");
+    expect(page).toContain('csrfToken={csrfToken}');
+    expect(directCenter).not.toContain("window.sessionStorage.setItem('pc-v7-active-role'");
     expect(directCenter).not.toContain("fetch('/platform-v7/staff/open-cabinet'");
     expect(directCenter).not.toContain('Рабочий тикет');
     expect(directCenter).not.toContain('Причина доступа');
   });
 
-  it('uses a native POST redirect so mobile browsers do not remain stuck in the opening state', () => {
+  it('uses a pure native POST redirect so Safari cannot cancel submission after a React state update', () => {
     expect(directRoute).toContain("contentType.includes('application/x-www-form-urlencoded')");
     expect(directRoute).toContain('request.formData()');
     expect(directRoute).toContain('formCsrfValid(request');
     expect(directRoute).toContain('NextResponse.redirect(new URL(OWNER_CABINETS[parsed.role], request.url), 303)');
     expect(directRoute).toContain("transport: parsed.formSubmission ? 'native-form' : 'json-fetch'");
-    expect(directCenter).toContain("window.addEventListener('pageshow', resetBusy)");
+    expect(directCenter).not.toContain('onSubmit=');
+    expect(directCenter).not.toContain('busyRole');
+    expect(directCenter).not.toContain('setBusyRole');
+    expect(directCenter).toContain('<button type="submit" name="role" value={item.role} disabled={!csrfToken}>');
   });
 
   it('requires controlled-owner claims or an active API-backed PLATFORM_OWNER assignment', () => {
@@ -68,7 +72,7 @@ describe('platform-v7 owner access center task UX', () => {
   });
 
   it('retains the task-first PAM surface for staff management and privileged operations', () => {
-    expect(directCenter).toContain('<OwnerAccessCenterV2 {...props} />');
+    expect(directCenter).toContain('<OwnerAccessCenterV2 {...baseProps} />');
     expect(directCenter).toContain('setAdvanced(true)');
     expect(directCenter).toContain('setAdvanced(false)');
     expect(page).toContain('accessCatalog={staffAccessTaskCatalog()}');


### PR DESCRIPTION
The owner cabinet form was still entering React state in onSubmit. On iOS Safari this could disable the submit control before the native POST completed, leaving the page stuck on «Открываем…». This change makes cabinet opening a pure HTML POST with server-rendered CSRF, no onSubmit handler, no busy state, and no client role authority. The existing server-side owner verification, signed cabinet session, role allowlist and 303 redirect remain unchanged.