### PR TITLE
Restore owner cabinet role handoff

### DIFF
--- a/apps/web/app/platform-v7/staff/cabinet-handoff/page.tsx
+++ b/apps/web/app/platform-v7/staff/cabinet-handoff/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { OwnerCabinetHandoff } from '@/components/platform-v7/staff/OwnerCabinetHandoff';
+import { CABINET_SESSION_COOKIE } from '@/lib/server/auth-session-response';
+import { readVerifiedCabinetSessionRole } from '@/lib/platform-v7/verified-session';
+import type { PlatformRole } from '@/stores/usePlatformV7RStore';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export const metadata: Metadata = {
+  title: 'Открываем кабинет — Прозрачная Цена',
+  robots: { index: false, follow: false, nocache: true },
+};
+
+const TARGETS: Readonly<Record<PlatformRole, string>> = {
+  operator: '/platform-v7/control-tower',
+  buyer: '/platform-v7/buyer',
+  seller: '/platform-v7/seller',
+  logistics: '/platform-v7/logistics',
+  driver: '/platform-v7/driver/field',
+  surveyor: '/platform-v7/surveyor',
+  elevator: '/platform-v7/elevator',
+  lab: '/platform-v7/lab',
+  bank: '/platform-v7/bank',
+  arbitrator: '/platform-v7/arbitrator',
+  compliance: '/platform-v7/compliance',
+  executive: '/platform-v7/executive',
+};
+
+const LABELS: Readonly<Record<PlatformRole, string>> = {
+  operator: 'Оператор',
+  buyer: 'Покупатель',
+  seller: 'Продавец',
+  logistics: 'Логистика',
+  driver: 'Водитель',
+  surveyor: 'Сюрвейер',
+  elevator: 'Элеватор',
+  lab: 'Лаборатория',
+  bank: 'Банк',
+  arbitrator: 'Арбитр',
+  compliance: 'Комплаенс',
+  executive: 'Руководитель',
+};
+
+function signingSecret(): string {
+  return String(process.env.JWT_SECRET || process.env.PC_CABINET_SESSION_SECRET || '').trim();
+}
+
+export default async function OwnerCabinetHandoffPage() {
+  const secret = signingSecret();
+  const token = cookies().get(CABINET_SESSION_COOKIE)?.value;
+  const role = secret
+    ? await readVerifiedCabinetSessionRole(token, secret, Math.floor(Date.now() / 1000))
+    : null;
+
+  if (!role) redirect('/platform-v7/staff?cabinetError=CABINET_SESSION_UNAVAILABLE');
+
+  return <OwnerCabinetHandoff role={role} target={TARGETS[role]} label={LABELS[role]} />;
+}

--- a/apps/web/app/platform-v7/staff/open-cabinet/submit/route.ts
+++ b/apps/web/app/platform-v7/staff/open-cabinet/submit/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { POST as issueCabinetSession } from '../route';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 12;
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const response = await issueCabinetSession(request);
+  const location = response.headers.get('location');
+
+  if (response.status === 303 && location) {
+    const target = new URL(location, request.url);
+    const failedBackToOwnerCenter = target.pathname === '/platform-v7/staff';
+    if (!failedBackToOwnerCenter) {
+      response.headers.set(
+        'Location',
+        new URL('/platform-v7/staff/cabinet-handoff', request.url).toString(),
+      );
+    }
+  }
+
+  return response;
+}

--- a/apps/web/components/platform-v7/PlatformV7SingleEntryGuard.tsx
+++ b/apps/web/components/platform-v7/PlatformV7SingleEntryGuard.tsx
@@ -7,7 +7,16 @@ import { usePlatformV7RStore, type PlatformRole } from '@/stores/usePlatformV7RS
 
 export const PLATFORM_V7_ACTIVE_ROLE_KEY = 'pc-v7-active-role';
 
-const PUBLIC_PATHS = new Set(['/platform-v7', '/platform-v7/open', '/platform-v7/login', '/platform-v7/register', '/platform-v7/demo', '/platform-v7/contact', '/platform-v7/request']);
+const PUBLIC_PATHS = new Set([
+  '/platform-v7',
+  '/platform-v7/open',
+  '/platform-v7/login',
+  '/platform-v7/register',
+  '/platform-v7/demo',
+  '/platform-v7/contact',
+  '/platform-v7/request',
+  '/platform-v7/staff/cabinet-handoff',
+]);
 
 const PLATFORM_ROLES: readonly PlatformRole[] = [
   'operator',

--- a/apps/web/components/platform-v7/PlatformV7SingleEntryGuard.tsx
+++ b/apps/web/components/platform-v7/PlatformV7SingleEntryGuard.tsx
@@ -7,16 +7,7 @@ import { usePlatformV7RStore, type PlatformRole } from '@/stores/usePlatformV7RS
 
 export const PLATFORM_V7_ACTIVE_ROLE_KEY = 'pc-v7-active-role';
 
-const PUBLIC_PATHS = new Set([
-  '/platform-v7',
-  '/platform-v7/open',
-  '/platform-v7/login',
-  '/platform-v7/register',
-  '/platform-v7/demo',
-  '/platform-v7/contact',
-  '/platform-v7/request',
-  '/platform-v7/staff/cabinet-handoff',
-]);
+const PUBLIC_PATHS = new Set(['/platform-v7', '/platform-v7/open', '/platform-v7/login', '/platform-v7/register', '/platform-v7/demo', '/platform-v7/contact', '/platform-v7/request']);
 
 const PLATFORM_ROLES: readonly PlatformRole[] = [
   'operator',

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx
@@ -1,3 +1,4 @@
 // Owner-only cabinet selector. Role authority remains server-verified.
-// Cabinet navigation is a native server POST and must not depend on client submit state.
+// Cabinet navigation is a native server POST and must not depend on React submit state.
+// The client role handoff only prevents a legacy guard bounce; it never grants authority.
 export { OwnerAccessCenter } from './OwnerAccessCenterV3';

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
@@ -76,14 +76,6 @@ const OWNER_COPY = {
   },
 } as const;
 
-function handoffActiveRole(role: SurfaceRole) {
-  try {
-    window.sessionStorage.setItem('pc-v7-active-role', role);
-  } catch {
-    // The server-signed cabinet session remains authoritative; this marker only prevents a client guard bounce.
-  }
-}
-
 export function OwnerAccessCenter(props: Props) {
   const { csrfToken, ...baseProps } = props;
   const { locale, copy, identity, apiAvailable } = baseProps;
@@ -162,11 +154,7 @@ export function OwnerAccessCenter(props: Props) {
           <article key={item.role} className={styles.cabinetCard}>
             <span className={styles.number} aria-hidden="true">{item.icon}</span>
             <h2>{item.label}</h2>
-            <form
-              method="post"
-              action="/platform-v7/staff/open-cabinet"
-              onSubmit={() => handoffActiveRole(item.role)}
-            >
+            <form method="post" action="/platform-v7/staff/open-cabinet">
               <input type="hidden" name="_csrf" value={csrfToken} />
               <button type="submit" name="role" value={item.role} disabled={!csrfToken}>
                 {text.open}

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
@@ -154,7 +154,7 @@ export function OwnerAccessCenter(props: Props) {
           <article key={item.role} className={styles.cabinetCard}>
             <span className={styles.number} aria-hidden="true">{item.icon}</span>
             <h2>{item.label}</h2>
-            <form method="post" action="/platform-v7/staff/open-cabinet">
+            <form method="post" action="/platform-v7/staff/open-cabinet/submit">
               <input type="hidden" name="_csrf" value={csrfToken} />
               <button type="submit" name="role" value={item.role} disabled={!csrfToken}>
                 {text.open}

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
@@ -76,6 +76,14 @@ const OWNER_COPY = {
   },
 } as const;
 
+function handoffActiveRole(role: SurfaceRole) {
+  try {
+    window.sessionStorage.setItem('pc-v7-active-role', role);
+  } catch {
+    // The server-signed cabinet session remains authoritative; this marker only prevents a client guard bounce.
+  }
+}
+
 export function OwnerAccessCenter(props: Props) {
   const { csrfToken, ...baseProps } = props;
   const { locale, copy, identity, apiAvailable } = baseProps;
@@ -154,7 +162,11 @@ export function OwnerAccessCenter(props: Props) {
           <article key={item.role} className={styles.cabinetCard}>
             <span className={styles.number} aria-hidden="true">{item.icon}</span>
             <h2>{item.label}</h2>
-            <form method="post" action="/platform-v7/staff/open-cabinet">
+            <form
+              method="post"
+              action="/platform-v7/staff/open-cabinet"
+              onSubmit={() => handoffActiveRole(item.role)}
+            >
               <input type="hidden" name="_csrf" value={csrfToken} />
               <button type="submit" name="role" value={item.role} disabled={!csrfToken}>
                 {text.open}

--- a/apps/web/components/platform-v7/staff/OwnerCabinetHandoff.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerCabinetHandoff.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+import { PLATFORM_V7_ACTIVE_ROLE_KEY } from '@/components/platform-v7/PlatformV7SingleEntryGuard';
+import type { PlatformRole } from '@/stores/usePlatformV7RStore';
+
+type Props = {
+  role: PlatformRole;
+  target: string;
+  label: string;
+};
+
+export function OwnerCabinetHandoff({ role, target, label }: Props) {
+  useEffect(() => {
+    window.sessionStorage.setItem(PLATFORM_V7_ACTIVE_ROLE_KEY, role);
+    window.location.replace(target);
+  }, [role, target]);
+
+  return (
+    <main
+      aria-live="polite"
+      style={{
+        minHeight: '100dvh',
+        display: 'grid',
+        placeItems: 'center',
+        padding: '24px',
+        background: '#f3f8f5',
+        color: '#10231d',
+        fontFamily: 'Inter, ui-sans-serif, system-ui, sans-serif',
+      }}
+    >
+      <section
+        style={{
+          width: 'min(100%, 520px)',
+          padding: '28px',
+          border: '1px solid rgba(19,75,55,.16)',
+          borderRadius: '24px',
+          background: '#fff',
+          textAlign: 'center',
+          boxShadow: '0 18px 48px rgba(15,51,39,.09)',
+        }}
+      >
+        <strong style={{ display: 'block', fontSize: '24px', lineHeight: 1.2 }}>Открываем кабинет</strong>
+        <p style={{ margin: '12px 0 0', color: '#5a7067', lineHeight: 1.5 }}>{label}</p>
+        <noscript>
+          <a href={target}>Продолжить</a>
+        </noscript>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/components/platform-v7/staff/OwnerCabinetHandoff.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerCabinetHandoff.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import { PLATFORM_V7_ACTIVE_ROLE_KEY } from '@/components/platform-v7/PlatformV7SingleEntryGuard';
 import type { PlatformRole } from '@/stores/usePlatformV7RStore';
 
@@ -11,7 +11,7 @@ type Props = {
 };
 
 export function OwnerCabinetHandoff({ role, target, label }: Props) {
-  useEffect(() => {
+  useLayoutEffect(() => {
     window.sessionStorage.setItem(PLATFORM_V7_ACTIVE_ROLE_KEY, role);
     window.location.replace(target);
   }, [role, target]);

--- a/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
+++ b/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
@@ -16,6 +16,10 @@ const page = read('apps/web/app/platform-v7/staff/page.tsx');
 const entry = read('apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx');
 const directCenter = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx');
 const directRoute = read('apps/web/app/platform-v7/staff/open-cabinet/route.ts');
+const submitRoute = read('apps/web/app/platform-v7/staff/open-cabinet/submit/route.ts');
+const handoffPage = read('apps/web/app/platform-v7/staff/cabinet-handoff/page.tsx');
+const handoffClient = read('apps/web/components/platform-v7/staff/OwnerCabinetHandoff.tsx');
+const singleEntryGuard = read('apps/web/components/platform-v7/PlatformV7SingleEntryGuard.tsx');
 const directCss = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV3.module.css');
 const center = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV2.tsx');
 const catalog = read('apps/web/lib/platform-v7/staff-access-task-catalog.ts');
@@ -33,26 +37,39 @@ describe('platform-v7 owner access center task UX', () => {
       expect(directCenter).toContain(`role: '${role}'`);
     }
     expect(directCenter).toContain('method="post"');
-    expect(directCenter).toContain('action="/platform-v7/staff/open-cabinet"');
+    expect(directCenter).toContain('action="/platform-v7/staff/open-cabinet/submit"');
     expect(directCenter).toContain('name="_csrf"');
     expect(directCenter).toContain('name="role"');
     expect(page).toContain('csrfToken={csrfToken}');
-    expect(directCenter).toContain("window.sessionStorage.setItem('pc-v7-active-role', role)");
+    expect(directCenter).not.toContain('sessionStorage');
     expect(directCenter).not.toContain("fetch('/platform-v7/staff/open-cabinet'");
     expect(directCenter).not.toContain('Рабочий тикет');
     expect(directCenter).not.toContain('Причина доступа');
   });
 
-  it('uses native POST while handing off the role without React state mutation', () => {
+  it('uses native POST and performs the client role handoff only after server success', () => {
     expect(directRoute).toContain("contentType.includes('application/x-www-form-urlencoded')");
     expect(directRoute).toContain('request.formData()');
     expect(directRoute).toContain('formCsrfValid(request');
-    expect(directRoute).toContain('NextResponse.redirect(new URL(OWNER_CABINETS[parsed.role], request.url), 303)');
-    expect(directRoute).toContain("transport: parsed.formSubmission ? 'native-form' : 'json-fetch'");
-    expect(directCenter).toContain('onSubmit={() => handoffActiveRole(item.role)}');
+    expect(submitRoute).toContain("import { POST as issueCabinetSession } from '../route'");
+    expect(submitRoute).toContain("target.pathname === '/platform-v7/staff'");
+    expect(submitRoute).toContain("new URL('/platform-v7/staff/cabinet-handoff', request.url)");
+    expect(handoffPage).toContain('readVerifiedCabinetSessionRole');
+    expect(handoffPage).toContain('CABINET_SESSION_COOKIE');
+    expect(handoffPage).toContain('<OwnerCabinetHandoff');
+    expect(handoffClient).toContain('window.sessionStorage.setItem(PLATFORM_V7_ACTIVE_ROLE_KEY, role)');
+    expect(handoffClient).toContain('window.location.replace(target)');
+    expect(singleEntryGuard).toContain("'/platform-v7/staff/cabinet-handoff'");
+    expect(directCenter).not.toContain('onSubmit=');
     expect(directCenter).not.toContain('busyRole');
     expect(directCenter).not.toContain('setBusyRole');
-    expect(directCenter).toContain('<button type="submit" name="role" value={item.role} disabled={!csrfToken}>');
+  });
+
+  it('does not create a client role marker when the server rejects cabinet opening', () => {
+    expect(directRoute).toContain("redirectBack(request, code)");
+    expect(submitRoute).toContain('if (!failedBackToOwnerCenter)');
+    expect(directCenter).not.toContain('PLATFORM_V7_ACTIVE_ROLE_KEY');
+    expect(handoffPage).toContain("redirect('/platform-v7/staff?cabinetError=CABINET_SESSION_UNAVAILABLE')");
   });
 
   it('requires controlled-owner claims or an active API-backed PLATFORM_OWNER assignment', () => {

--- a/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
+++ b/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
@@ -37,19 +37,19 @@ describe('platform-v7 owner access center task UX', () => {
     expect(directCenter).toContain('name="_csrf"');
     expect(directCenter).toContain('name="role"');
     expect(page).toContain('csrfToken={csrfToken}');
-    expect(directCenter).not.toContain("window.sessionStorage.setItem('pc-v7-active-role'");
+    expect(directCenter).toContain("window.sessionStorage.setItem('pc-v7-active-role', role)");
     expect(directCenter).not.toContain("fetch('/platform-v7/staff/open-cabinet'");
     expect(directCenter).not.toContain('Рабочий тикет');
     expect(directCenter).not.toContain('Причина доступа');
   });
 
-  it('uses a pure native POST redirect so Safari cannot cancel submission after a React state update', () => {
+  it('uses native POST while handing off the role without React state mutation', () => {
     expect(directRoute).toContain("contentType.includes('application/x-www-form-urlencoded')");
     expect(directRoute).toContain('request.formData()');
     expect(directRoute).toContain('formCsrfValid(request');
     expect(directRoute).toContain('NextResponse.redirect(new URL(OWNER_CABINETS[parsed.role], request.url), 303)');
     expect(directRoute).toContain("transport: parsed.formSubmission ? 'native-form' : 'json-fetch'");
-    expect(directCenter).not.toContain('onSubmit=');
+    expect(directCenter).toContain('onSubmit={() => handoffActiveRole(item.role)}');
     expect(directCenter).not.toContain('busyRole');
     expect(directCenter).not.toContain('setBusyRole');
     expect(directCenter).toContain('<button type="submit" name="role" value={item.role} disabled={!csrfToken}>');

--- a/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
+++ b/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
@@ -19,7 +19,6 @@ const directRoute = read('apps/web/app/platform-v7/staff/open-cabinet/route.ts')
 const submitRoute = read('apps/web/app/platform-v7/staff/open-cabinet/submit/route.ts');
 const handoffPage = read('apps/web/app/platform-v7/staff/cabinet-handoff/page.tsx');
 const handoffClient = read('apps/web/components/platform-v7/staff/OwnerCabinetHandoff.tsx');
-const singleEntryGuard = read('apps/web/components/platform-v7/PlatformV7SingleEntryGuard.tsx');
 const directCss = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV3.module.css');
 const center = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV2.tsx');
 const catalog = read('apps/web/lib/platform-v7/staff-access-task-catalog.ts');
@@ -57,9 +56,9 @@ describe('platform-v7 owner access center task UX', () => {
     expect(handoffPage).toContain('readVerifiedCabinetSessionRole');
     expect(handoffPage).toContain('CABINET_SESSION_COOKIE');
     expect(handoffPage).toContain('<OwnerCabinetHandoff');
+    expect(handoffClient).toContain('useLayoutEffect(() =>');
     expect(handoffClient).toContain('window.sessionStorage.setItem(PLATFORM_V7_ACTIVE_ROLE_KEY, role)');
     expect(handoffClient).toContain('window.location.replace(target)');
-    expect(singleEntryGuard).toContain("'/platform-v7/staff/cabinet-handoff'");
     expect(directCenter).not.toContain('onSubmit=');
     expect(directCenter).not.toContain('busyRole');
     expect(directCenter).not.toContain('setBusyRole');


### PR DESCRIPTION
Fix the remaining owner-cabinet navigation failure without trusting a pre-submit client role marker.

The cabinet button performs a native POST. The server verifies PLATFORM_OWNER, validates CSRF, signs the cabinet session and sets the protected cookies. Failed requests return to the owner center and do not write any client role state. Successful requests alone are routed through a server-verified handoff page; it cryptographically verifies the signed cabinet cookie, writes the legacy navigation marker in useLayoutEffect, and immediately opens the selected cabinet.

No React busy state is used, so iOS Safari cannot disable or cancel the native form submission. The sessionStorage marker remains navigation-only; server authorization, the role allowlist and protected financial/legal boundaries remain authoritative.