### PR TITLE
Add test organizations for owner cabinets

### DIFF
--- a/apps/api/src/modules/deals/canonical-test-deal.seed.ts
+++ b/apps/api/src/modules/deals/canonical-test-deal.seed.ts
@@ -16,11 +16,11 @@ const identities = [
   { userId: 'logistician-e2e', email: 'logistician@demo.ru', fullName: 'Тестовый логист', role: Role.LOGISTICIAN, orgId: 'org-canonical-logistics', requireMfa: false },
   { userId: 'driver-e2e', email: 'driver@demo.ru', fullName: 'Тестовый водитель', role: Role.DRIVER, orgId: 'org-canonical-logistics', requireMfa: false },
   { userId: 'surveyor-e2e', email: 'surveyor@demo.ru', fullName: 'Тестовый сюрвейер', role: Role.SURVEYOR, orgId: 'org-canonical-surveyor', requireMfa: false },
-  { userId: 'elevator-e2e', email: 'elevator@demo.ru', fullName: 'Тестовый элеватор', role: Role.ELEVATOR, orgId: 'org-canonical-elevator', requireMfa: false },
-  { userId: 'lab-e2e', email: 'lab@demo.ru', fullName: 'Тестовая лаборатория', role: Role.LAB, orgId: 'org-canonical-lab', requireMfa: false },
+  { userId: 'elevator-e2e', email: 'elevator@demo.ru', fullName: 'Тестовый сотрудник элеватора', role: Role.ELEVATOR, orgId: 'org-canonical-elevator', requireMfa: false },
+  { userId: 'lab-e2e', email: 'lab@demo.ru', fullName: 'Тестовый лаборант', role: Role.LAB, orgId: 'org-canonical-lab', requireMfa: false },
   { userId: 'accounting-e2e', email: 'accounting@demo.ru', fullName: 'Тестовый банковский сотрудник', role: Role.ACCOUNTING, orgId: 'org-canonical-bank', requireMfa: true },
   { userId: 'compliance-e2e', email: 'compliance@demo.ru', fullName: 'Тестовый комплаенс', role: Role.COMPLIANCE_OFFICER, orgId: 'org-canonical-platform', requireMfa: false },
-  { userId: 'arbitrator-e2e', email: 'arbitrator@demo.ru', fullName: 'Тестовый арбитр', role: Role.ARBITRATOR, orgId: 'org-canonical-platform', requireMfa: false },
+  { userId: 'arbitrator-e2e', email: 'arbitrator@demo.ru', fullName: 'Тестовый арбитр', role: Role.ARBITRATOR, orgId: 'org-canonical-arbitrator', requireMfa: false },
   { userId: 'operator-e2e', email: 'operator@demo.ru', fullName: 'Тестовый оператор', role: Role.SUPPORT_MANAGER, orgId: 'org-canonical-platform', requireMfa: false },
   { userId: 'executive-e2e', email: 'executive@demo.ru', fullName: 'Тестовый руководитель', role: Role.EXECUTIVE, orgId: 'org-canonical-platform', requireMfa: false },
 ] as const;
@@ -60,14 +60,15 @@ export class CanonicalTestDealSeedService implements OnModuleInit {
 
   private async seed(): Promise<void> {
     const organizations = [
-      { id: 'org-canonical-seller', inn: '990000000001', name: 'Тестовый продавец', type: 'LEGAL' },
-      { id: 'org-canonical-buyer', inn: '990000000002', name: 'Тестовый покупатель', type: 'LEGAL' },
-      { id: 'org-canonical-logistics', inn: '990000000003', name: 'Тестовый перевозчик', type: 'LEGAL' },
-      { id: 'org-canonical-lab', inn: '990000000004', name: 'Тестовая лаборатория', type: 'LEGAL' },
-      { id: 'org-canonical-elevator', inn: '990000000005', name: 'Тестовый элеватор', type: 'LEGAL' },
-      { id: 'org-canonical-platform', inn: '990000000006', name: 'Оператор тестового контура', type: 'LEGAL' },
-      { id: 'org-canonical-bank', inn: '990000000007', name: 'Тестовый банковский контур', type: 'LEGAL' },
-      { id: 'org-canonical-surveyor', inn: '990000000008', name: 'Тестовый сюрвейер', type: 'LEGAL' },
+      { id: 'org-canonical-platform', inn: '990000000001', name: 'АО «Прозрачная Цена — тестовый контур»', type: 'LEGAL' },
+      { id: 'org-canonical-buyer', inn: '990000000002', name: 'ООО «АгроТрейд Тест»', type: 'LEGAL' },
+      { id: 'org-canonical-seller', inn: '990000000003', name: 'ООО «Золотое Поле Тест»', type: 'LEGAL' },
+      { id: 'org-canonical-logistics', inn: '990000000004', name: 'ООО «ТрансАгро Тест»', type: 'LEGAL' },
+      { id: 'org-canonical-surveyor', inn: '990000000005', name: 'ООО «АгроКонтроль Тест»', type: 'LEGAL' },
+      { id: 'org-canonical-elevator', inn: '990000000006', name: 'АО «Центральный Элеватор Тест»', type: 'LEGAL' },
+      { id: 'org-canonical-lab', inn: '990000000007', name: 'ООО «ЗерноЛаб Тест»', type: 'LEGAL' },
+      { id: 'org-canonical-bank', inn: '990000000008', name: 'АО «Банк-партнёр Тест»', type: 'LEGAL' },
+      { id: 'org-canonical-arbitrator', inn: '990000000009', name: 'АНО «АгроАрбитраж Тест»', type: 'LEGAL' },
     ] as const;
 
     await this.prisma.$transaction(async (tx) => {

--- a/apps/api/src/modules/deals/canonical-test-deal.seed.ts
+++ b/apps/api/src/modules/deals/canonical-test-deal.seed.ts
@@ -187,6 +187,14 @@ export class CanonicalTestDealSeedService implements OnModuleInit {
           WHERE user_id = ${user.id}
         `);
 
+        await tx.userOrg.updateMany({
+          where: {
+            userId: user.id,
+            NOT: { organizationId: identity.orgId },
+          },
+          data: { isDefault: false },
+        });
+
         const membership = await tx.userOrg.upsert({
           where: {
             userId_organizationId: {

--- a/apps/api/test/one-deal/persistent-auth-actors.ts
+++ b/apps/api/test/one-deal/persistent-auth-actors.ts
@@ -108,8 +108,21 @@ export async function createPersistentActorHarness(
       throw new Error(`Persistent auth harness connected as unexpected principal ${currentUser}`);
     }
 
+    const organizationRows = await primaryPrisma.organization.findMany({
+      where: { id: { in: [...organizationIds] } },
+      select: { tenantId: true },
+    });
+    const tenantIds = [...new Set(organizationRows.map((item) => item.tenantId).filter(Boolean))];
+    if (tenantIds.length === 0) {
+      throw new Error('Persistent auth harness could not resolve a canonical tenant');
+    }
+
     const memberships = (await primaryPrisma.userOrg.findMany({
-      where: { organizationId: { in: [...organizationIds] } },
+      where: {
+        isDefault: true,
+        organization: { tenantId: { in: tenantIds } },
+        user: { id: { endsWith: '-e2e' } },
+      },
       include: { user: true, organization: true },
       orderBy: { role: 'asc' },
     })) as MembershipRow[];

--- a/apps/web/app/platform-v7/staff/cabinet-handoff/page.tsx
+++ b/apps/web/app/platform-v7/staff/cabinet-handoff/page.tsx
@@ -2,8 +2,9 @@ import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { OwnerCabinetHandoff } from '@/components/platform-v7/staff/OwnerCabinetHandoff';
+import { controlledOrganizationById } from '@/lib/platform-v7/controlled-test-organizations';
 import { CABINET_SESSION_COOKIE } from '@/lib/server/auth-session-response';
-import { readVerifiedCabinetSessionRole } from '@/lib/platform-v7/verified-session';
+import { readVerifiedCabinetSessionContext } from '@/lib/platform-v7/verified-session';
 import type { PlatformRole } from '@/stores/usePlatformV7RStore';
 
 export const dynamic = 'force-dynamic';
@@ -51,11 +52,20 @@ function signingSecret(): string {
 export default async function OwnerCabinetHandoffPage() {
   const secret = signingSecret();
   const token = cookies().get(CABINET_SESSION_COOKIE)?.value;
-  const role = secret
-    ? await readVerifiedCabinetSessionRole(token, secret, Math.floor(Date.now() / 1000))
+  const context = secret
+    ? await readVerifiedCabinetSessionContext(token, secret, Math.floor(Date.now() / 1000))
     : null;
 
-  if (!role) redirect('/platform-v7/staff?cabinetError=CABINET_SESSION_UNAVAILABLE');
+  if (!context) redirect('/platform-v7/staff?cabinetError=CABINET_SESSION_UNAVAILABLE');
 
-  return <OwnerCabinetHandoff role={role} target={TARGETS[role]} label={LABELS[role]} />;
+  const organization = controlledOrganizationById(context.organizationId);
+  return (
+    <OwnerCabinetHandoff
+      role={context.role}
+      target={TARGETS[context.role]}
+      label={LABELS[context.role]}
+      organizationName={organization?.name || null}
+      testData={organization?.testData === true}
+    />
+  );
 }

--- a/apps/web/app/platform-v7/staff/open-cabinet/route.ts
+++ b/apps/web/app/platform-v7/staff/open-cabinet/route.ts
@@ -3,6 +3,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { ACCESS_COOKIE, CSRF_COOKIE, SESSION_COOKIE, sessionMarkerCookie } from '@/lib/auth-cookies';
 import { CABINET_SESSION_COOKIE } from '@/lib/server/auth-session-response';
 import { assertCsrf, assertSameOriginIfPresent } from '@/lib/server-request-security';
+import {
+  controlledCabinetContext,
+  type ControlledCabinetContext,
+} from '@/lib/platform-v7/controlled-test-organizations';
 import { signCabinetSession, verifyHs256Jwt } from '@/lib/platform-v7/verified-session';
 
 export const runtime = 'nodejs';
@@ -40,6 +44,7 @@ type AuthorityResult =
   | { status: 'unavailable' };
 type ParsedRequest = {
   role: unknown;
+  organizationId: unknown;
   formSubmission: boolean;
   csrfOk: boolean;
 };
@@ -117,6 +122,7 @@ async function parseRequest(request: NextRequest): Promise<ParsedRequest> {
     const form = await request.formData().catch(() => null);
     return {
       role: form?.get('role'),
+      organizationId: form?.get('organizationId'),
       formSubmission: true,
       csrfOk: formCsrfValid(request, form?.get('_csrf')),
     };
@@ -124,6 +130,7 @@ async function parseRequest(request: NextRequest): Promise<ParsedRequest> {
   const body = await request.json().catch(() => ({} as Record<string, unknown>));
   return {
     role: body.role,
+    organizationId: body.organizationId,
     formSubmission: false,
     csrfOk: assertCsrf(request).ok,
   };
@@ -217,12 +224,27 @@ async function resolveOwnerAuthority(accessToken: string, secret: string, correl
   return controlled || apiOwnerAuthority(accessToken, correlationId);
 }
 
+function resolveControlledOrganization(
+  role: OwnerCabinetRole,
+  submittedOrganizationId: unknown,
+  authority: OwnerAuthority,
+): ControlledCabinetContext | null | 'invalid' {
+  if (authority.source !== 'controlled') return null;
+  const context = controlledCabinetContext(role);
+  if (!context) return 'invalid';
+  if (typeof submittedOrganizationId !== 'string' || submittedOrganizationId !== context.organizationId) {
+    return 'invalid';
+  }
+  return context;
+}
+
 function setCabinetCookies(
   response: NextResponse,
   cabinetToken: string,
   role: OwnerCabinetRole,
   authority: OwnerAuthority,
   expiresAt: number,
+  organization: ControlledCabinetContext | null,
 ) {
   response.cookies.set(CABINET_SESSION_COOKIE, cabinetToken, {
     path: '/',
@@ -234,7 +256,14 @@ function setCabinetCookies(
   });
   response.cookies.set(
     SESSION_COOKIE,
-    encodeURIComponent(JSON.stringify({ role, exp: expiresAt, email: authority.email })),
+    encodeURIComponent(JSON.stringify({
+      role,
+      exp: expiresAt,
+      email: authority.email,
+      organizationId: organization?.organizationId || null,
+      tenantId: organization?.tenantId || null,
+      ownerAccess: true,
+    })),
     { ...sessionMarkerCookie(), maxAge: authority.ttlSeconds, priority: 'high' },
   );
   response.cookies.set('pc-role', role, {
@@ -270,11 +299,19 @@ export async function POST(request: NextRequest) {
     return fail('PLATFORM_OWNER_REQUIRED', 'Требуется активное назначение владельца платформы.', 403);
   }
 
-  const nowSeconds = Math.floor(Date.now() / 1000);
   const { authority } = authorityResult;
+  const organization = resolveControlledOrganization(parsed.role, parsed.organizationId, authority);
+  if (organization === 'invalid') {
+    return fail('INVALID_TEST_ORGANIZATION', 'Тестовая организация не соответствует выбранному кабинету.', 400);
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
   const cabinetToken = await signCabinetSession(parsed.role, secret, {
     nowSeconds,
     ttlSeconds: authority.ttlSeconds,
+    organizationId: organization?.organizationId || null,
+    tenantId: organization?.tenantId || null,
+    ownerAccess: true,
   });
   if (!cabinetToken) return fail('CABINET_SESSION_UNAVAILABLE', 'Не удалось открыть кабинет.', 503);
 
@@ -285,17 +322,24 @@ export async function POST(request: NextRequest) {
       ok: true,
       role: parsed.role,
       redirectTo: OWNER_CABINETS[parsed.role],
+      organization: organization ? {
+        id: organization.organizationId,
+        name: organization.organizationName,
+        tenantId: organization.tenantId,
+        testData: true,
+      } : null,
       expiresAt: new Date(expiresAt * 1000).toISOString(),
       correlationId,
     });
 
   response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
-  setCabinetCookies(response, cabinetToken, parsed.role, authority, expiresAt);
+  setCabinetCookies(response, cabinetToken, parsed.role, authority, expiresAt, organization);
 
   console.info('owner_direct_cabinet_open', JSON.stringify({
     actor: authority.actorId,
     authoritySource: authority.source,
     role: parsed.role,
+    organizationId: organization?.organizationId || null,
     correlationId,
     transport: parsed.formSubmission ? 'native-form' : 'json-fetch',
   }));

--- a/apps/web/app/staff/[...path]/route.ts
+++ b/apps/web/app/staff/[...path]/route.ts
@@ -1,4 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
+import {
+  CONTROLLED_CABINET_CONTEXTS,
+  CONTROLLED_TEST_ORGANIZATIONS,
+  controlledCabinetContext,
+  controlledOrganizationById,
+  controlledOrganizationForRole,
+  type ControlledCabinetRole,
+} from '@/lib/platform-v7/controlled-test-organizations';
 import { verifyHs256Jwt } from '@/lib/platform-v7/verified-session';
 
 export const runtime = 'nodejs';
@@ -14,18 +22,8 @@ const CONTROL_PERMISSIONS = [
 ] as const;
 
 const VIEW_AS_PERMISSIONS = ['cabinet:view-as','deal:read','document:metadata:read'] as const;
-const ORGANIZATION = {
-  id: 'org-canonical-buyer',
-  tenantId: 'tenant-canonical-test',
-  tenant_id: 'tenant-canonical-test',
-  name: 'ООО «Тестовый покупатель»',
-  inn: '990000000002',
-  status: 'ACTIVE',
-  kycStatus: 'VERIFIED',
-  kyc_status: 'VERIFIED',
-  amlStatus: 'CLEAR',
-  aml_status: 'CLEAR',
-};
+const DEFAULT_ORGANIZATION = controlledOrganizationForRole('buyer')!;
+const SELLER_ORGANIZATION = controlledOrganizationForRole('seller')!;
 
 type OwnerClaims = Record<string, unknown> & {
   sub: string;
@@ -98,8 +96,8 @@ function session(mode: 'CONTROL_PLANE' | 'VIEW_AS', claims: OwnerClaims) {
     staff_role: 'PLATFORM_OWNER',
     access_mode: mode,
     permissions: viewAs ? [...VIEW_AS_PERMISSIONS] : [...CONTROL_PERMISSIONS],
-    effective_tenant_id: viewAs ? ORGANIZATION.tenantId : null,
-    effective_organization_id: viewAs ? ORGANIZATION.id : null,
+    effective_tenant_id: viewAs ? DEFAULT_ORGANIZATION.tenantId : null,
+    effective_organization_id: viewAs ? DEFAULT_ORGANIZATION.id : null,
     effective_user_id: null,
     effective_role: viewAs ? 'BUYER' : null,
     target_deal_id: null,
@@ -108,6 +106,38 @@ function session(mode: 'CONTROL_PLANE' | 'VIEW_AS', claims: OwnerClaims) {
     expires_at: new Date(claims.exp * 1000).toISOString(),
     created_at: iso(-60_000),
   };
+}
+
+function organizationIdFromPath(path: string): string | null {
+  const match = path.match(/^organizations\/([^/]+)/);
+  return match ? match[1] : null;
+}
+
+function organizationMembers(organizationId: string) {
+  return Object.values(CONTROLLED_CABINET_CONTEXTS)
+    .filter((context) => context.organizationId === organizationId)
+    .map((context, index) => ({
+      membership_id: `m-${context.role}-test`,
+      user_id: `test:${context.role}`,
+      email: context.memberEmail,
+      full_name: context.memberName,
+      user_status: 'ACTIVE',
+      mfa_enabled: true,
+      role: context.apiRole,
+      is_default: index === 0,
+      joined_at: iso(-86_400_000),
+      test_data: true,
+    }));
+}
+
+function organizationCabinet(path: string) {
+  const match = path.match(/^organizations\/([^/]+)\/cabinet\/([^/]+)$/);
+  if (!match) return null;
+  const organization = controlledOrganizationById(match[1]);
+  const role = match[2] as ControlledCabinetRole;
+  const context = controlledCabinetContext(role);
+  if (!organization || !context || context.organizationId !== organization.id) return null;
+  return { organization, context };
 }
 
 async function handle(request: NextRequest, context: { params: { path?: string[] } }) {
@@ -150,18 +180,32 @@ async function handle(request: NextRequest, context: { params: { path?: string[]
   }
   if (method === 'POST' && /^access\/sessions\/[^/]+\/(end|revoke)$/.test(path)) return json({ success: true });
 
-  if (method === 'GET' && path === 'organizations') return json([ORGANIZATION]);
+  if (method === 'GET' && path === 'organizations') return json(CONTROLLED_TEST_ORGANIZATIONS);
   if (method === 'GET' && /^organizations\/[^/]+\/users$/.test(path)) {
-    return json([{ membership_id: 'm-buyer-test', user_id: 'buyer-e2e', email: 'buyer@demo.ru', full_name: 'Тестовый покупатель', user_status: 'ACTIVE', mfa_enabled: true, role: 'BUYER', is_default: true, joined_at: iso(-86_400_000) }]);
+    const organizationId = organizationIdFromPath(path);
+    const organization = controlledOrganizationById(organizationId);
+    if (!organization) return json({ code: 'ORGANIZATION_NOT_FOUND' }, 404);
+    return json(organizationMembers(organization.id));
   }
   if (method === 'GET' && /^organizations\/[^/]+\/cabinet\/[^/]+$/.test(path)) {
-    const role = path.split('/').at(-1) || 'BUYER';
+    const cabinet = organizationCabinet(path);
+    if (!cabinet) return json({ code: 'CABINET_CONTEXT_NOT_FOUND' }, 404);
     return json({
       mode: 'READ_ONLY_VIEW_AS',
-      effectiveOrganization: ORGANIZATION,
-      effectiveRole: role,
-      roleMembers: 1,
-      deals: [{ id: 'deal-canonical-test', dealNumber: 'ТП-000001', deal_number: 'ТП-000001', status: 'IN_EXECUTION', nextAction: 'Проверить документы', next_action: 'Проверить документы', updatedAt: iso(-5_000), updated_at: iso(-5_000) }],
+      effectiveOrganization: cabinet.organization,
+      effectiveRole: cabinet.context.apiRole,
+      roleMembers: organizationMembers(cabinet.organization.id).length,
+      deals: [{
+        id: 'deal-canonical-test',
+        dealNumber: 'ТП-000001',
+        deal_number: 'ТП-000001',
+        status: 'IN_EXECUTION',
+        nextAction: 'Продолжить каноническую тестовую сделку',
+        next_action: 'Продолжить каноническую тестовую сделку',
+        updatedAt: iso(-5_000),
+        updated_at: iso(-5_000),
+        testData: true,
+      }],
     });
   }
   if (method === 'GET' && path === 'audit/events') {
@@ -172,12 +216,12 @@ async function handle(request: NextRequest, context: { params: { path?: string[]
   if (method === 'POST' && /^break-glass\/[^/]+\/end$/.test(path)) return json({ success: true });
 
   if (method === 'GET' && path === 'workspaces/support') {
-    return json({ generatedAt: iso(), deals: [{ id: 'deal-canonical-test', dealNumber: 'ТП-000001', status: 'IN_EXECUTION', seller: { id: 'org-canonical-seller', name: 'Тестовый продавец' }, buyer: ORGANIZATION, nextAction: 'Проверить ЭПД', slaAt: iso(-30_000), overdue: true, blockers: [{ shipmentId: 'shipment-test', blocker: 'Отсутствует ЭПД', nextAction: 'Запросить документ' }] }], kycTasks: [] });
+    return json({ generatedAt: iso(), deals: [{ id: 'deal-canonical-test', dealNumber: 'ТП-000001', status: 'IN_EXECUTION', seller: SELLER_ORGANIZATION, buyer: DEFAULT_ORGANIZATION, nextAction: 'Проверить ЭПД', slaAt: iso(-30_000), overdue: true, blockers: [{ shipmentId: 'shipment-test', blocker: 'Отсутствует ЭПД', nextAction: 'Запросить документ' }] }], kycTasks: [] });
   }
   if (method === 'GET' && path === 'workspaces/support/cases') return json([]);
   if (method === 'POST' && path === 'workspaces/support/cases') return json({ case: { id: 'sup-controlled-test', status: 'OPEN', version: 1 }, replayed: false }, 201);
   if (method === 'GET' && path === 'workspaces/operations') {
-    return json({ generatedAt: iso(), items: [{ id: 'deal-canonical-test', dealNumber: 'ТП-000001', status: 'IN_EXECUTION', seller: { name: 'Тестовый продавец' }, buyer: ORGANIZATION, nextAction: 'Проверить ЭПД', slaAt: iso(600_000), overdue: false, shipmentSummary: { total: 2, active: 1, blocked: 1 }, documentSummary: { total: 5, pending: 1, releaseBlocking: 1 }, payment: { status: 'RESERVED' }, openDisputes: 0 }] });
+    return json({ generatedAt: iso(), items: [{ id: 'deal-canonical-test', dealNumber: 'ТП-000001', status: 'IN_EXECUTION', seller: SELLER_ORGANIZATION, buyer: DEFAULT_ORGANIZATION, nextAction: 'Проверить ЭПД', slaAt: iso(600_000), overdue: false, shipmentSummary: { total: 2, active: 1, blocked: 1 }, documentSummary: { total: 5, pending: 1, releaseBlocking: 1 }, payment: { status: 'RESERVED' }, openDisputes: 0 }] });
   }
   if (method === 'GET' && path === 'workspaces/finance') {
     return json({ generatedAt: iso(), payments: [{ id: 'pay-test', dealId: 'deal-canonical-test', status: 'RESERVED', amountKopecks: 240000000, callbackState: 'NONE', updatedAt: iso(), deal: { dealNumber: 'ТП-000001' } }], bankOperations: [] });
@@ -185,7 +229,24 @@ async function handle(request: NextRequest, context: { params: { path?: string[]
   if (method === 'GET' && path === 'workspaces/diagnostics') {
     return json({ generatedAt: iso(), integrations: [{ id: 'integration-test', adapterName: 'bank-sandbox', eventType: 'CALLBACK', status: 'PENDING', createdAt: iso() }], outbox: [{ id: 'outbox-test', type: 'deal.updated', dealId: 'deal-canonical-test', status: 'CONFIRMED', retryCount: 0, maxRetries: 5, correlationId: 'controlled-test', createdAt: iso() }], runtimeAttempts: [] });
   }
-  if (method === 'GET' && path === 'workspaces/assignments') return json([{ id: 'sta-owner-controlled-test', email: claims.email, full_name: 'Максим — владелец платформы', role: 'PLATFORM_OWNER', status: 'ACTIVE', valid_from: iso(-86_400_000), valid_until: null, reason: 'Controlled test access' }]);
+  if (method === 'GET' && path === 'workspaces/assignments') {
+    const organizationAssignments = Object.values(CONTROLLED_CABINET_CONTEXTS).map((item) => ({
+      id: `sta-${item.role}-controlled-test`,
+      email: item.memberEmail,
+      full_name: item.memberName,
+      role: item.apiRole,
+      status: 'ACTIVE',
+      organization_id: item.organizationId,
+      organization_name: item.organizationName,
+      valid_from: iso(-86_400_000),
+      valid_until: null,
+      reason: 'Controlled test organization access',
+    }));
+    return json([
+      { id: 'sta-owner-controlled-test', email: claims.email, full_name: 'Максим — владелец платформы', role: 'PLATFORM_OWNER', status: 'ACTIVE', valid_from: iso(-86_400_000), valid_until: null, reason: 'Controlled test access' },
+      ...organizationAssignments,
+    ]);
+  }
   if (method === 'GET' && path === 'workspaces/critical-actions') return json([]);
   if (method === 'GET' && path === 'workspaces/critical-actions/mine') return json([]);
   if (method === 'GET' && path === 'workspaces/break-glass') return json([]);

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.module.css
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.module.css
@@ -103,6 +103,43 @@
   line-height: 1.55;
 }
 
+.testNetwork {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  margin-top: 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(36, 112, 82, .2);
+  border-radius: 20px;
+  background: linear-gradient(145deg, #eff9f3, #ffffff);
+  box-shadow: 0 14px 42px rgba(18, 55, 43, .05);
+}
+
+.testNetwork > span {
+  display: inline-grid;
+  place-items: center;
+  min-width: 54px;
+  min-height: 32px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: #dff0e7;
+  color: #1f684c;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: .08em;
+}
+
+.testNetwork strong {
+  display: block;
+  font-size: 18px;
+}
+
+.testNetwork p {
+  margin: 6px 0 0;
+  color: #587066;
+  line-height: 1.5;
+}
+
 .cabinetGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -113,7 +150,7 @@
 .cabinetCard {
   display: grid;
   min-width: 0;
-  min-height: 190px;
+  min-height: 230px;
   padding: 18px;
   border: 1px solid rgba(20, 78, 57, .14);
   border-radius: 22px;
@@ -134,14 +171,43 @@
 }
 
 .cabinetCard h2 {
-  margin: 18px 0;
+  margin: 18px 0 8px;
   font-size: clamp(20px, 2vw, 25px);
   line-height: 1.15;
   overflow-wrap: anywhere;
 }
 
-.cabinetCard button {
+.organization {
+  margin: 0 0 16px;
+  color: #526a60;
+  line-height: 1.4;
+}
+
+.organization span,
+.organization strong {
+  display: block;
+}
+
+.organization span {
+  margin-bottom: 3px;
+  font-size: 12px;
+  font-weight: 760;
+  letter-spacing: .02em;
+  text-transform: uppercase;
+}
+
+.organization strong {
+  color: #183d30;
+  font-size: 14px;
+  overflow-wrap: anywhere;
+}
+
+.cabinetCard form {
   align-self: end;
+}
+
+.cabinetCard button {
+  width: 100%;
   min-height: 50px;
   padding: 12px 16px;
   border: 0;
@@ -204,9 +270,10 @@
   .page { padding: 12px; padding-bottom: calc(28px + env(safe-area-inset-bottom)); }
   .hero { padding: 22px 18px; border-radius: 24px; }
   .hero h1 { font-size: clamp(32px, 10vw, 44px); }
+  .testNetwork { align-items: flex-start; padding: 15px; }
   .cabinetGrid { grid-template-columns: 1fr; gap: 12px; }
-  .cabinetCard { min-height: 154px; padding: 16px; }
-  .cabinetCard h2 { margin: 14px 0; }
+  .cabinetCard { min-height: 198px; padding: 16px; }
+  .cabinetCard h2 { margin-top: 14px; }
   .cabinetCard button { min-height: 54px; }
   .backButton { margin-left: 10px; }
 }
@@ -218,6 +285,7 @@
 @media (forced-colors: active) {
   .hero,
   .accessSummary,
+  .testNetwork,
   .cabinetCard,
   .safetyNote,
   .loadingCard { border: 1px solid CanvasText; }

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
@@ -2,25 +2,16 @@
 
 import { useEffect, useMemo, useState, type ComponentProps } from 'react';
 import type { OwnerAccessCenterCopy } from '@/i18n/owner-access-center-messages';
+import {
+  CONTROLLED_CABINET_CONTEXTS,
+  type ControlledCabinetRole,
+} from '@/lib/platform-v7/controlled-test-organizations';
 import { OwnerAccessCenter as OwnerAccessCenterV2 } from './OwnerAccessCenterV2';
 import styles from './OwnerAccessCenterV3.module.css';
 
 type StaffAssignment = { id: string; role: string; status: string };
 type Props = ComponentProps<typeof OwnerAccessCenterV2> & { csrfToken: string };
-
-type SurfaceRole =
-  | 'operator'
-  | 'buyer'
-  | 'seller'
-  | 'logistics'
-  | 'driver'
-  | 'surveyor'
-  | 'elevator'
-  | 'lab'
-  | 'bank'
-  | 'arbitrator'
-  | 'compliance'
-  | 'executive';
+type SurfaceRole = ControlledCabinetRole;
 
 const CABINETS: ReadonlyArray<{ role: SurfaceRole; cabinetRole: keyof OwnerAccessCenterCopy['cabinetRoles']; icon: string }> = [
   { role: 'operator', cabinetRole: 'ADMIN', icon: '01' },
@@ -44,6 +35,8 @@ const OWNER_COPY = {
     description: 'Открывай любой рабочий кабинет одним нажатием. Повторный пароль, тикет, причина и отдельный запрос для просмотра не требуются.',
     access: 'Максимальный обзор',
     accessBody: 'Доступны все 12 рабочих кабинетов и их интерфейсы. Переключение действует в пределах текущего входа владельца.',
+    testNetwork: 'Тестовый контур компаний',
+    testNetworkBody: 'Для каждого кабинета назначена связанная тестовая организация. Все компании работают вокруг одной канонической тестовой сделки и помечены как тестовые данные.',
     safety: 'Деньги, банковские подтверждения, подпись, лабораторная финализация и решение арбитра не подменяются владельцем и остаются под отдельными серверными правилами.',
     open: 'Открыть кабинет',
     advanced: 'Управление сотрудниками и доступами',
@@ -56,6 +49,8 @@ const OWNER_COPY = {
     description: 'Open any working cabinet with one tap. No repeated password, ticket, reason or separate read-access request is required.',
     access: 'Maximum visibility',
     accessBody: 'All 12 working cabinets and their interfaces are available within the current owner sign-in.',
+    testNetwork: 'Test organization network',
+    testNetworkBody: 'Each cabinet is linked to a controlled test organization. All organizations participate in one canonical test deal and are explicitly marked as test data.',
     safety: 'Money movement, bank confirmations, signatures, laboratory finalization and arbitration decisions remain protected by separate server rules.',
     open: 'Open cabinet',
     advanced: 'Staff and access management',
@@ -68,6 +63,8 @@ const OWNER_COPY = {
     description: '一次点击即可打开任意工作台。只读访问无需再次输入密码、工单、原因或单独提交请求。',
     access: '最大可见范围',
     accessBody: '当前所有者登录期间可访问全部 12 个工作台及其界面。',
+    testNetwork: '测试组织网络',
+    testNetworkBody: '每个工作台都绑定到受控测试组织。所有组织围绕同一笔标准测试交易运行，并明确标记为测试数据。',
     safety: '资金操作、银行确认、签署、实验室终审和仲裁决定仍受独立服务器规则保护。',
     open: '打开工作台',
     advanced: '员工与访问管理',
@@ -83,6 +80,7 @@ export function OwnerAccessCenter(props: Props) {
   const [checking, setChecking] = useState(apiAvailable);
   const [isOwner, setIsOwner] = useState(false);
   const [advanced, setAdvanced] = useState(false);
+  const controlledOwner = identity?.id === 'owner-controlled-test';
 
   useEffect(() => {
     if (!apiAvailable) {
@@ -109,7 +107,11 @@ export function OwnerAccessCenter(props: Props) {
   }, [apiAvailable]);
 
   const cabinetLabels = useMemo(
-    () => CABINETS.map((item) => ({ ...item, label: copy.cabinetRoles[item.cabinetRole] })),
+    () => CABINETS.map((item) => ({
+      ...item,
+      label: copy.cabinetRoles[item.cabinetRole],
+      organization: CONTROLLED_CABINET_CONTEXTS[item.role],
+    })),
     [copy],
   );
 
@@ -149,13 +151,32 @@ export function OwnerAccessCenter(props: Props) {
         <p>{text.accessBody}</p>
       </section>
 
+      {controlledOwner && (
+        <section className={styles.testNetwork} aria-label={text.testNetwork}>
+          <span>TEST</span>
+          <div>
+            <strong>{text.testNetwork}</strong>
+            <p>{text.testNetworkBody}</p>
+          </div>
+        </section>
+      )}
+
       <section className={styles.cabinetGrid} aria-label={text.title}>
         {cabinetLabels.map((item) => (
           <article key={item.role} className={styles.cabinetCard}>
             <span className={styles.number} aria-hidden="true">{item.icon}</span>
             <h2>{item.label}</h2>
+            {controlledOwner && (
+              <p className={styles.organization}>
+                <span>Тестовая организация</span>
+                <strong>{item.organization.organizationName}</strong>
+              </p>
+            )}
             <form method="post" action="/platform-v7/staff/open-cabinet/submit">
               <input type="hidden" name="_csrf" value={csrfToken} />
+              {controlledOwner && (
+                <input type="hidden" name="organizationId" value={item.organization.organizationId} />
+              )}
               <button type="submit" name="role" value={item.role} disabled={!csrfToken}>
                 {text.open}
               </button>

--- a/apps/web/components/platform-v7/staff/OwnerCabinetHandoff.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerCabinetHandoff.tsx
@@ -8,9 +8,11 @@ type Props = {
   role: PlatformRole;
   target: string;
   label: string;
+  organizationName: string | null;
+  testData: boolean;
 };
 
-export function OwnerCabinetHandoff({ role, target, label }: Props) {
+export function OwnerCabinetHandoff({ role, target, label, organizationName, testData }: Props) {
   useLayoutEffect(() => {
     window.sessionStorage.setItem(PLATFORM_V7_ACTIVE_ROLE_KEY, role);
     window.location.replace(target);
@@ -40,8 +42,30 @@ export function OwnerCabinetHandoff({ role, target, label }: Props) {
           boxShadow: '0 18px 48px rgba(15,51,39,.09)',
         }}
       >
+        {testData && (
+          <span
+            style={{
+              display: 'inline-block',
+              marginBottom: '12px',
+              padding: '6px 10px',
+              borderRadius: '999px',
+              background: '#e3f2e9',
+              color: '#1f684c',
+              fontSize: '12px',
+              fontWeight: 900,
+              letterSpacing: '.08em',
+            }}
+          >
+            TEST
+          </span>
+        )}
         <strong style={{ display: 'block', fontSize: '24px', lineHeight: 1.2 }}>Открываем кабинет</strong>
         <p style={{ margin: '12px 0 0', color: '#5a7067', lineHeight: 1.5 }}>{label}</p>
+        {organizationName && (
+          <p style={{ margin: '6px 0 0', color: '#183d30', fontWeight: 750, lineHeight: 1.45 }}>
+            {organizationName}
+          </p>
+        )}
         <noscript>
           <a href={target}>Продолжить</a>
         </noscript>

--- a/apps/web/lib/platform-v7/controlled-test-organizations.ts
+++ b/apps/web/lib/platform-v7/controlled-test-organizations.ts
@@ -250,9 +250,11 @@ export function controlledOrganizationById(id: string | null | undefined): Contr
 }
 
 export function controlledCabinetContext(role: string | null | undefined): ControlledCabinetContext | null {
-  return role && Object.prototype.hasOwnProperty.call(CONTROLLED_CABINET_CONTEXTS, role)
-    ? CONTROLLED_CABINET_CONTEXTS[role as ControlledCabinetRole]
-    : null;
+  if (!role) return null;
+  if (Object.prototype.hasOwnProperty.call(CONTROLLED_CABINET_CONTEXTS, role)) {
+    return CONTROLLED_CABINET_CONTEXTS[role as ControlledCabinetRole];
+  }
+  return Object.values(CONTROLLED_CABINET_CONTEXTS).find((item) => item.apiRole === role) || null;
 }
 
 export function controlledOrganizationForRole(role: string | null | undefined): ControlledTestOrganization | null {

--- a/apps/web/lib/platform-v7/controlled-test-organizations.ts
+++ b/apps/web/lib/platform-v7/controlled-test-organizations.ts
@@ -1,0 +1,266 @@
+export type ControlledCabinetRole =
+  | 'operator'
+  | 'buyer'
+  | 'seller'
+  | 'logistics'
+  | 'driver'
+  | 'surveyor'
+  | 'elevator'
+  | 'lab'
+  | 'bank'
+  | 'arbitrator'
+  | 'compliance'
+  | 'executive';
+
+export type ControlledTestOrganization = {
+  id: string;
+  tenantId: string;
+  tenant_id: string;
+  name: string;
+  shortName: string;
+  inn: string;
+  status: 'ACTIVE';
+  kycStatus: 'VERIFIED';
+  kyc_status: 'VERIFIED';
+  amlStatus: 'CLEAR';
+  aml_status: 'CLEAR';
+  testData: true;
+  organizationType: 'PLATFORM' | 'BUYER' | 'SELLER' | 'LOGISTICS' | 'SURVEYOR' | 'ELEVATOR' | 'LAB' | 'BANK' | 'ARBITRATION';
+};
+
+export type ControlledCabinetContext = {
+  role: ControlledCabinetRole;
+  apiRole: string;
+  organizationId: string;
+  organizationName: string;
+  tenantId: string;
+  memberEmail: string;
+  memberName: string;
+};
+
+export const CONTROLLED_TEST_TENANT_ID = 'tenant-canonical-test';
+
+function organization(
+  id: string,
+  name: string,
+  shortName: string,
+  inn: string,
+  organizationType: ControlledTestOrganization['organizationType'],
+): ControlledTestOrganization {
+  return {
+    id,
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    tenant_id: CONTROLLED_TEST_TENANT_ID,
+    name,
+    shortName,
+    inn,
+    status: 'ACTIVE',
+    kycStatus: 'VERIFIED',
+    kyc_status: 'VERIFIED',
+    amlStatus: 'CLEAR',
+    aml_status: 'CLEAR',
+    testData: true,
+    organizationType,
+  };
+}
+
+export const CONTROLLED_TEST_ORGANIZATIONS: readonly ControlledTestOrganization[] = [
+  organization(
+    'org-canonical-platform',
+    'АО «Прозрачная Цена — тестовый контур»',
+    'Прозрачная Цена',
+    '990000000001',
+    'PLATFORM',
+  ),
+  organization(
+    'org-canonical-buyer',
+    'ООО «АгроТрейд Тест»',
+    'АгроТрейд Тест',
+    '990000000002',
+    'BUYER',
+  ),
+  organization(
+    'org-canonical-seller',
+    'ООО «Золотое Поле Тест»',
+    'Золотое Поле Тест',
+    '990000000003',
+    'SELLER',
+  ),
+  organization(
+    'org-canonical-logistics',
+    'ООО «ТрансАгро Тест»',
+    'ТрансАгро Тест',
+    '990000000004',
+    'LOGISTICS',
+  ),
+  organization(
+    'org-canonical-surveyor',
+    'ООО «АгроКонтроль Тест»',
+    'АгроКонтроль Тест',
+    '990000000005',
+    'SURVEYOR',
+  ),
+  organization(
+    'org-canonical-elevator',
+    'АО «Центральный Элеватор Тест»',
+    'Центральный Элеватор Тест',
+    '990000000006',
+    'ELEVATOR',
+  ),
+  organization(
+    'org-canonical-lab',
+    'ООО «ЗерноЛаб Тест»',
+    'ЗерноЛаб Тест',
+    '990000000007',
+    'LAB',
+  ),
+  organization(
+    'org-canonical-bank',
+    'АО «Банк-партнёр Тест»',
+    'Банк-партнёр Тест',
+    '990000000008',
+    'BANK',
+  ),
+  organization(
+    'org-canonical-arbitrator',
+    'АНО «АгроАрбитраж Тест»',
+    'АгроАрбитраж Тест',
+    '990000000009',
+    'ARBITRATION',
+  ),
+] as const;
+
+const ORGANIZATION_BY_ID = new Map(
+  CONTROLLED_TEST_ORGANIZATIONS.map((item) => [item.id, item] as const),
+);
+
+export const CONTROLLED_CABINET_CONTEXTS: Readonly<Record<ControlledCabinetRole, ControlledCabinetContext>> = {
+  operator: {
+    role: 'operator',
+    apiRole: 'SUPPORT_MANAGER',
+    organizationId: 'org-canonical-platform',
+    organizationName: 'АО «Прозрачная Цена — тестовый контур»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'operator.test@procent-agro.test',
+    memberName: 'Тестовый оператор',
+  },
+  buyer: {
+    role: 'buyer',
+    apiRole: 'BUYER',
+    organizationId: 'org-canonical-buyer',
+    organizationName: 'ООО «АгроТрейд Тест»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'buyer.test@procent-agro.test',
+    memberName: 'Тестовый покупатель',
+  },
+  seller: {
+    role: 'seller',
+    apiRole: 'FARMER',
+    organizationId: 'org-canonical-seller',
+    organizationName: 'ООО «Золотое Поле Тест»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'seller.test@procent-agro.test',
+    memberName: 'Тестовый продавец',
+  },
+  logistics: {
+    role: 'logistics',
+    apiRole: 'LOGISTICIAN',
+    organizationId: 'org-canonical-logistics',
+    organizationName: 'ООО «ТрансАгро Тест»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'logistics.test@procent-agro.test',
+    memberName: 'Тестовый логист',
+  },
+  driver: {
+    role: 'driver',
+    apiRole: 'DRIVER',
+    organizationId: 'org-canonical-logistics',
+    organizationName: 'ООО «ТрансАгро Тест»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'driver.test@procent-agro.test',
+    memberName: 'Тестовый водитель',
+  },
+  surveyor: {
+    role: 'surveyor',
+    apiRole: 'SURVEYOR',
+    organizationId: 'org-canonical-surveyor',
+    organizationName: 'ООО «АгроКонтроль Тест»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'surveyor.test@procent-agro.test',
+    memberName: 'Тестовый сюрвейер',
+  },
+  elevator: {
+    role: 'elevator',
+    apiRole: 'ELEVATOR',
+    organizationId: 'org-canonical-elevator',
+    organizationName: 'АО «Центральный Элеватор Тест»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'elevator.test@procent-agro.test',
+    memberName: 'Тестовый сотрудник элеватора',
+  },
+  lab: {
+    role: 'lab',
+    apiRole: 'LAB',
+    organizationId: 'org-canonical-lab',
+    organizationName: 'ООО «ЗерноЛаб Тест»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'lab.test@procent-agro.test',
+    memberName: 'Тестовый лаборант',
+  },
+  bank: {
+    role: 'bank',
+    apiRole: 'ACCOUNTING',
+    organizationId: 'org-canonical-bank',
+    organizationName: 'АО «Банк-партнёр Тест»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'bank.test@procent-agro.test',
+    memberName: 'Тестовый банковский сотрудник',
+  },
+  arbitrator: {
+    role: 'arbitrator',
+    apiRole: 'ARBITRATOR',
+    organizationId: 'org-canonical-arbitrator',
+    organizationName: 'АНО «АгроАрбитраж Тест»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'arbitrator.test@procent-agro.test',
+    memberName: 'Тестовый арбитр',
+  },
+  compliance: {
+    role: 'compliance',
+    apiRole: 'COMPLIANCE_OFFICER',
+    organizationId: 'org-canonical-platform',
+    organizationName: 'АО «Прозрачная Цена — тестовый контур»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'compliance.test@procent-agro.test',
+    memberName: 'Тестовый комплаенс-офицер',
+  },
+  executive: {
+    role: 'executive',
+    apiRole: 'EXECUTIVE',
+    organizationId: 'org-canonical-platform',
+    organizationName: 'АО «Прозрачная Цена — тестовый контур»',
+    tenantId: CONTROLLED_TEST_TENANT_ID,
+    memberEmail: 'executive.test@procent-agro.test',
+    memberName: 'Тестовый руководитель',
+  },
+};
+
+export function controlledOrganizationById(id: string | null | undefined): ControlledTestOrganization | null {
+  return id ? ORGANIZATION_BY_ID.get(id) || null : null;
+}
+
+export function controlledCabinetContext(role: string | null | undefined): ControlledCabinetContext | null {
+  return role && Object.prototype.hasOwnProperty.call(CONTROLLED_CABINET_CONTEXTS, role)
+    ? CONTROLLED_CABINET_CONTEXTS[role as ControlledCabinetRole]
+    : null;
+}
+
+export function controlledOrganizationForRole(role: string | null | undefined): ControlledTestOrganization | null {
+  const context = controlledCabinetContext(role);
+  return context ? controlledOrganizationById(context.organizationId) : null;
+}
+
+export function controlledRoleForOrganization(id: string): ControlledCabinetRole | null {
+  const match = Object.values(CONTROLLED_CABINET_CONTEXTS).find((item) => item.organizationId === id);
+  return match?.role || null;
+}

--- a/apps/web/lib/platform-v7/verified-session.ts
+++ b/apps/web/lib/platform-v7/verified-session.ts
@@ -30,6 +30,13 @@ const VALID_CABINET_ROLES: ReadonlySet<string> = new Set<PlatformRole>([
   'elevator', 'lab', 'bank', 'arbitrator', 'compliance', 'executive',
 ]);
 
+export type VerifiedCabinetSessionContext = {
+  role: PlatformRole;
+  organizationId: string | null;
+  tenantId: string | null;
+  ownerAccess: boolean;
+};
+
 export function mapApiRoleToCabinetRole(apiRole: unknown): PlatformRole | null {
   if (typeof apiRole !== 'string') return null;
   return API_ROLE_TO_CABINET[apiRole] ?? null;
@@ -112,14 +119,27 @@ function bytesToBase64Url(bytes: Uint8Array): string {
 export async function signCabinetSession(
   role: string,
   secret: string,
-  opts: { readonly nowSeconds: number; readonly ttlSeconds: number },
+  opts: {
+    readonly nowSeconds: number;
+    readonly ttlSeconds: number;
+    readonly organizationId?: string | null;
+    readonly tenantId?: string | null;
+    readonly ownerAccess?: boolean;
+  },
 ): Promise<string | null> {
   if (!secret || !VALID_CABINET_ROLES.has(role)) return null;
   try {
     const enc = new TextEncoder();
     const header = bytesToBase64Url(enc.encode(JSON.stringify({ alg: 'HS256', typ: 'JWT' })));
     const payload = bytesToBase64Url(
-      enc.encode(JSON.stringify({ cab: role, iat: opts.nowSeconds, exp: opts.nowSeconds + opts.ttlSeconds })),
+      enc.encode(JSON.stringify({
+        cab: role,
+        org: opts.organizationId || undefined,
+        tenant: opts.tenantId || undefined,
+        ownerAccess: opts.ownerAccess === true,
+        iat: opts.nowSeconds,
+        exp: opts.nowSeconds + opts.ttlSeconds,
+      })),
     );
     const key = await crypto.subtle.importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
     const signature = await crypto.subtle.sign('HMAC', key, enc.encode(`${header}.${payload}`));
@@ -129,16 +149,30 @@ export async function signCabinetSession(
   }
 }
 
-export async function readVerifiedCabinetSessionRole(
+export async function readVerifiedCabinetSessionContext(
   token: string | null | undefined,
   secret: string,
   nowSeconds: number,
-): Promise<PlatformRole | null> {
+): Promise<VerifiedCabinetSessionContext | null> {
   if (!token) return null;
   const claims = await verifyHs256Jwt(token, secret);
   if (!claims) return null;
   if (typeof claims.exp === 'number' && claims.exp <= nowSeconds) return null;
   if (typeof claims.nbf === 'number' && claims.nbf > nowSeconds) return null;
   const cab = claims.cab;
-  return typeof cab === 'string' && VALID_CABINET_ROLES.has(cab) ? (cab as PlatformRole) : null;
+  if (typeof cab !== 'string' || !VALID_CABINET_ROLES.has(cab)) return null;
+  return {
+    role: cab as PlatformRole,
+    organizationId: typeof claims.org === 'string' ? claims.org : null,
+    tenantId: typeof claims.tenant === 'string' ? claims.tenant : null,
+    ownerAccess: claims.ownerAccess === true,
+  };
+}
+
+export async function readVerifiedCabinetSessionRole(
+  token: string | null | undefined,
+  secret: string,
+  nowSeconds: number,
+): Promise<PlatformRole | null> {
+  return (await readVerifiedCabinetSessionContext(token, secret, nowSeconds))?.role || null;
 }

--- a/apps/web/tests/unit/platformV7ControlledTestOrganizationDocsMarker.test.ts
+++ b/apps/web/tests/unit/platformV7ControlledTestOrganizationDocsMarker.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { CONTROLLED_TEST_ORGANIZATIONS } from '../../lib/platform-v7/controlled-test-organizations';
+
+describe('controlled test organization markers', () => {
+  it('marks every controlled organization as test data', () => {
+    expect(CONTROLLED_TEST_ORGANIZATIONS.every((item) => item.testData)).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/platformV7ControlledTestOrganizations.test.ts
+++ b/apps/web/tests/unit/platformV7ControlledTestOrganizations.test.ts
@@ -14,6 +14,7 @@ const openCabinet = read('apps/web/app/platform-v7/staff/open-cabinet/route.ts')
 const staffFixture = read('apps/web/app/staff/[...path]/route.ts');
 const verifiedSession = read('apps/web/lib/platform-v7/verified-session.ts');
 const handoffPage = read('apps/web/app/platform-v7/staff/cabinet-handoff/page.tsx');
+const canonicalSeed = read('apps/api/src/modules/deals/canonical-test-deal.seed.ts');
 
 const roles = [
   'operator', 'buyer', 'seller', 'logistics', 'driver', 'surveyor',
@@ -50,7 +51,7 @@ describe('Platform V7 controlled test organization network', () => {
   it('binds the signed owner cabinet session to a server-approved organization', () => {
     expect(openCabinet).toContain('resolveControlledOrganization');
     expect(openCabinet).toContain("authority.source !== 'controlled'");
-    expect(openCabinet).toContain("submittedOrganizationId !== context.organizationId");
+    expect(openCabinet).toContain('submittedOrganizationId !== context.organizationId');
     expect(openCabinet).toContain('organizationId: organization?.organizationId || null');
     expect(openCabinet).toContain('tenantId: organization?.tenantId || null');
     expect(openCabinet).toContain('ownerAccess: true');
@@ -66,5 +67,14 @@ describe('Platform V7 controlled test organization network', () => {
     expect(staffFixture).toContain('organization_name: item.organizationName');
     expect(staffFixture).toContain("id: 'deal-canonical-test'");
     expect(staffFixture).toContain('testData: true');
+  });
+
+  it('demotes stale default memberships before moving a seeded user to another organization', () => {
+    expect(canonicalSeed).toContain('await tx.userOrg.updateMany({');
+    expect(canonicalSeed).toContain('NOT: { organizationId: identity.orgId }');
+    expect(canonicalSeed).toContain('data: { isDefault: false }');
+    expect(canonicalSeed.indexOf('await tx.userOrg.updateMany({')).toBeLessThan(
+      canonicalSeed.indexOf('const membership = await tx.userOrg.upsert({'),
+    );
   });
 });

--- a/apps/web/tests/unit/platformV7ControlledTestOrganizations.test.ts
+++ b/apps/web/tests/unit/platformV7ControlledTestOrganizations.test.ts
@@ -15,6 +15,7 @@ const staffFixture = read('apps/web/app/staff/[...path]/route.ts');
 const verifiedSession = read('apps/web/lib/platform-v7/verified-session.ts');
 const handoffPage = read('apps/web/app/platform-v7/staff/cabinet-handoff/page.tsx');
 const canonicalSeed = read('apps/api/src/modules/deals/canonical-test-deal.seed.ts');
+const persistentActors = read('apps/api/test/one-deal/persistent-auth-actors.ts');
 
 const roles = [
   'operator', 'buyer', 'seller', 'logistics', 'driver', 'surveyor',
@@ -76,5 +77,13 @@ describe('Platform V7 controlled test organization network', () => {
     expect(canonicalSeed.indexOf('await tx.userOrg.updateMany({')).toBeLessThan(
       canonicalSeed.indexOf('const membership = await tx.userOrg.upsert({'),
     );
+  });
+
+  it('discovers all canonical actors through the tenant after organizations are split by role', () => {
+    expect(persistentActors).toContain('primaryPrisma.organization.findMany');
+    expect(persistentActors).toContain('const tenantIds = [...new Set(');
+    expect(persistentActors).toContain('isDefault: true');
+    expect(persistentActors).toContain("user: { id: { endsWith: '-e2e' } }");
+    expect(persistentActors).toContain('organization: { tenantId: { in: tenantIds } }');
   });
 });

--- a/apps/web/tests/unit/platformV7ControlledTestOrganizations.test.ts
+++ b/apps/web/tests/unit/platformV7ControlledTestOrganizations.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  CONTROLLED_CABINET_CONTEXTS,
+  CONTROLLED_TEST_ORGANIZATIONS,
+  controlledCabinetContext,
+  controlledOrganizationById,
+} from '../../lib/platform-v7/controlled-test-organizations';
+
+const read = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const ownerCenter = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx');
+const openCabinet = read('apps/web/app/platform-v7/staff/open-cabinet/route.ts');
+const staffFixture = read('apps/web/app/staff/[...path]/route.ts');
+const verifiedSession = read('apps/web/lib/platform-v7/verified-session.ts');
+const handoffPage = read('apps/web/app/platform-v7/staff/cabinet-handoff/page.tsx');
+
+const roles = [
+  'operator', 'buyer', 'seller', 'logistics', 'driver', 'surveyor',
+  'elevator', 'lab', 'bank', 'arbitrator', 'compliance', 'executive',
+] as const;
+
+describe('Platform V7 controlled test organization network', () => {
+  it('creates a coherent test-company network for every cabinet', () => {
+    expect(CONTROLLED_TEST_ORGANIZATIONS).toHaveLength(9);
+    expect(new Set(CONTROLLED_TEST_ORGANIZATIONS.map((item) => item.id)).size).toBe(9);
+    expect(CONTROLLED_TEST_ORGANIZATIONS.every((item) => item.testData === true)).toBe(true);
+    expect(CONTROLLED_TEST_ORGANIZATIONS.every((item) => item.status === 'ACTIVE')).toBe(true);
+    expect(CONTROLLED_TEST_ORGANIZATIONS.every((item) => item.kycStatus === 'VERIFIED')).toBe(true);
+    expect(CONTROLLED_TEST_ORGANIZATIONS.every((item) => item.amlStatus === 'CLEAR')).toBe(true);
+
+    for (const role of roles) {
+      const context = CONTROLLED_CABINET_CONTEXTS[role];
+      expect(context.role).toBe(role);
+      expect(controlledOrganizationById(context.organizationId)?.name).toBe(context.organizationName);
+      expect(context.memberEmail).toBe(`${role}.test@procent-agro.test`);
+      expect(controlledCabinetContext(context.apiRole)?.role).toBe(role);
+    }
+  });
+
+  it('shows and submits the assigned organization on the owner cabinet selector', () => {
+    expect(ownerCenter).toContain('CONTROLLED_CABINET_CONTEXTS');
+    expect(ownerCenter).toContain('Тестовый контур компаний');
+    expect(ownerCenter).toContain('name="organizationId"');
+    expect(ownerCenter).toContain('item.organization.organizationId');
+    expect(ownerCenter).toContain('item.organization.organizationName');
+    expect(ownerCenter).toContain("identity?.id === 'owner-controlled-test'");
+  });
+
+  it('binds the signed owner cabinet session to a server-approved organization', () => {
+    expect(openCabinet).toContain('resolveControlledOrganization');
+    expect(openCabinet).toContain("authority.source !== 'controlled'");
+    expect(openCabinet).toContain("submittedOrganizationId !== context.organizationId");
+    expect(openCabinet).toContain('organizationId: organization?.organizationId || null');
+    expect(openCabinet).toContain('tenantId: organization?.tenantId || null');
+    expect(openCabinet).toContain('ownerAccess: true');
+    expect(verifiedSession).toContain('readVerifiedCabinetSessionContext');
+    expect(verifiedSession).toContain('organizationId: typeof claims.org');
+    expect(handoffPage).toContain('controlledOrganizationById(context.organizationId)');
+  });
+
+  it('exposes all test companies and role memberships through the controlled staff fixture', () => {
+    expect(staffFixture).toContain("path === 'organizations'");
+    expect(staffFixture).toContain('CONTROLLED_TEST_ORGANIZATIONS');
+    expect(staffFixture).toContain('organizationMembers(organization.id)');
+    expect(staffFixture).toContain('organization_name: item.organizationName');
+    expect(staffFixture).toContain("id: 'deal-canonical-test'");
+    expect(staffFixture).toContain('testData: true');
+  });
+});

--- a/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
+++ b/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
@@ -39,6 +39,7 @@ describe('platform-v7 owner access center task UX', () => {
     expect(directCenter).toContain('action="/platform-v7/staff/open-cabinet/submit"');
     expect(directCenter).toContain('name="_csrf"');
     expect(directCenter).toContain('name="role"');
+    expect(directCenter).toContain('name="organizationId"');
     expect(page).toContain('csrfToken={csrfToken}');
     expect(directCenter).not.toContain('sessionStorage');
     expect(directCenter).not.toContain("fetch('/platform-v7/staff/open-cabinet'");
@@ -53,8 +54,9 @@ describe('platform-v7 owner access center task UX', () => {
     expect(submitRoute).toContain("import { POST as issueCabinetSession } from '../route'");
     expect(submitRoute).toContain("target.pathname === '/platform-v7/staff'");
     expect(submitRoute).toContain("new URL('/platform-v7/staff/cabinet-handoff', request.url)");
-    expect(handoffPage).toContain('readVerifiedCabinetSessionRole');
+    expect(handoffPage).toContain('readVerifiedCabinetSessionContext');
     expect(handoffPage).toContain('CABINET_SESSION_COOKIE');
+    expect(handoffPage).toContain('controlledOrganizationById(context.organizationId)');
     expect(handoffPage).toContain('<OwnerCabinetHandoff');
     expect(handoffClient).toContain('useLayoutEffect(() =>');
     expect(handoffClient).toContain('window.sessionStorage.setItem(PLATFORM_V7_ACTIVE_ROLE_KEY, role)');
@@ -65,7 +67,7 @@ describe('platform-v7 owner access center task UX', () => {
   });
 
   it('does not create a client role marker when the server rejects cabinet opening', () => {
-    expect(directRoute).toContain("redirectBack(request, code)");
+    expect(directRoute).toContain('redirectBack(request, code)');
     expect(submitRoute).toContain('if (!failedBackToOwnerCenter)');
     expect(directCenter).not.toContain('PLATFORM_V7_ACTIVE_ROLE_KEY');
     expect(handoffPage).toContain("redirect('/platform-v7/staff?cabinetError=CABINET_SESSION_UNAVAILABLE')");

--- a/scripts/p7-autopilot-guard.sh
+++ b/scripts/p7-autopilot-guard.sh
@@ -146,6 +146,16 @@ apps/web/tests/unit/platformV7I18nRequestLocaleGuard.test.ts
 apps/web/tests/unit/platformV7LanguageReloadGuard.test.ts
 scripts/p7-autopilot-guard.sh'
 
+TEST_ORGANIZATIONS_SCOPE='apps/api/src/modules/deals/canonical-test-deal.seed.ts
+apps/web/app/platform-v7/staff/**
+apps/web/app/staff/[...path]/route.ts
+apps/web/components/platform-v7/staff/**
+apps/web/lib/platform-v7/controlled-test-organizations.ts
+apps/web/lib/platform-v7/verified-session.ts
+apps/web/tests/unit/platformV7ControlledTestOrganization*.test.ts
+apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
+scripts/p7-autopilot-guard.sh'
+
 if [ "${GITHUB_HEAD_REF:-}" = "agent/harden-platform-v7-public-entry" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/public-entry-human-copy" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/landing-hero-support" ]; then
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$PUBLIC_ENTRY_SCOPE")
 fi
@@ -168,6 +178,12 @@ fi
 # self-hosted fixture endpoints, tests and its operations document.
 if [ "${GITHUB_HEAD_REF:-}" = "fix/controlled-test-access" ]; then
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$CONTROLLED_TEST_ACCESS_SCOPE")
+fi
+
+# The controlled test organization network binds the twelve owner cabinets to
+# an explicit server-owned organization catalogue and one canonical test deal.
+if [ "${GITHUB_HEAD_REF:-}" = "fix/test-organizations-all-cabinets" ]; then
+  ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$TEST_ORGANIZATIONS_SCOPE")
 fi
 
 # A clean Platform V7 URL must always resolve to Russian; EN/ZH remain explicit


### PR DESCRIPTION
Adds nine clearly marked test organizations mapped to all twelve owner-access cabinets and the canonical test deal. Cabinet opening keeps server-side owner verification, CSRF validation, approved role-to-organization mapping, signed session context and regression tests.