### PR TITLE
Make owner cabinet opening observable and direct

### DIFF
--- a/apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx
@@ -1,5 +1,5 @@
 // Owner-only cabinet selector. Role authority remains server-verified.
-// Cabinet navigation is a native server POST and must not depend on React submit state.
+// Cabinet opening uses an authenticated JSON transition with native POST fallback.
 // Existing authenticated sessions are repaired server-side before a CSRF-protected form is rendered.
-// The client role handoff only prevents a legacy guard bounce; it never grants authority.
+// Client loading and role handoff improve navigation only; they never grant authority.
 export { OwnerAccessCenter } from './OwnerAccessCenterV3';

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useMemo, useState, type ComponentProps } from 'react';
+import { useEffect, useMemo, useState, type ComponentProps, type FormEvent } from 'react';
+import { PLATFORM_V7_ACTIVE_ROLE_KEY } from '@/components/platform-v7/PlatformV7SingleEntryGuard';
 import type { OwnerAccessCenterCopy } from '@/i18n/owner-access-center-messages';
 import {
   CONTROLLED_CABINET_CONTEXTS,
@@ -12,6 +13,12 @@ import styles from './OwnerAccessCenterV3.module.css';
 type StaffAssignment = { id: string; role: string; status: string };
 type Props = ComponentProps<typeof OwnerAccessCenterV2> & { csrfToken: string };
 type SurfaceRole = ControlledCabinetRole;
+type OpenCabinetResponse = {
+  ok?: boolean;
+  code?: string;
+  message?: string;
+  redirectTo?: string;
+};
 
 const CABINETS: ReadonlyArray<{ role: SurfaceRole; cabinetRole: keyof OwnerAccessCenterCopy['cabinetRoles']; icon: string }> = [
   { role: 'operator', cabinetRole: 'ADMIN', icon: '01' },
@@ -39,6 +46,8 @@ const OWNER_COPY = {
     testNetworkBody: 'Для каждого кабинета назначена связанная тестовая организация. Все компании работают вокруг одной канонической тестовой сделки и помечены как тестовые данные.',
     safety: 'Деньги, банковские подтверждения, подпись, лабораторная финализация и решение арбитра не подменяются владельцем и остаются под отдельными серверными правилами.',
     open: 'Открыть кабинет',
+    opening: 'Открываем кабинет…',
+    openFailed: 'Не удалось открыть кабинет. Повтори попытку.',
     advanced: 'Управление сотрудниками и доступами',
     back: 'Вернуться ко всем кабинетам',
     loading: 'Проверяем полномочия владельца…',
@@ -53,6 +62,8 @@ const OWNER_COPY = {
     testNetworkBody: 'Each cabinet is linked to a controlled test organization. All organizations participate in one canonical test deal and are explicitly marked as test data.',
     safety: 'Money movement, bank confirmations, signatures, laboratory finalization and arbitration decisions remain protected by separate server rules.',
     open: 'Open cabinet',
+    opening: 'Opening cabinet…',
+    openFailed: 'The cabinet could not be opened. Try again.',
     advanced: 'Staff and access management',
     back: 'Back to all cabinets',
     loading: 'Checking owner authority…',
@@ -67,6 +78,8 @@ const OWNER_COPY = {
     testNetworkBody: '每个工作台都绑定到受控测试组织。所有组织围绕同一笔标准测试交易运行，并明确标记为测试数据。',
     safety: '资金操作、银行确认、签署、实验室终审和仲裁决定仍受独立服务器规则保护。',
     open: '打开工作台',
+    opening: '正在打开工作台…',
+    openFailed: '无法打开工作台，请重试。',
     advanced: '员工与访问管理',
     back: '返回全部工作台',
     loading: '正在检查所有者权限…',
@@ -80,6 +93,8 @@ export function OwnerAccessCenter(props: Props) {
   const [checking, setChecking] = useState(apiAvailable);
   const [isOwner, setIsOwner] = useState(false);
   const [advanced, setAdvanced] = useState(false);
+  const [busyRole, setBusyRole] = useState<SurfaceRole | null>(null);
+  const [openError, setOpenError] = useState<string | null>(null);
   const controlledOwner = identity?.id === 'owner-controlled-test';
 
   useEffect(() => {
@@ -114,6 +129,61 @@ export function OwnerAccessCenter(props: Props) {
     })),
     [copy],
   );
+
+  async function openCabinet(
+    event: FormEvent<HTMLFormElement>,
+    role: SurfaceRole,
+    organizationId: string,
+  ) {
+    event.preventDefault();
+    if (!csrfToken || busyRole) return;
+
+    setBusyRole(role);
+    setOpenError(null);
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), 12_000);
+
+    try {
+      const response = await fetch('/platform-v7/staff/open-cabinet', {
+        method: 'POST',
+        credentials: 'same-origin',
+        cache: 'no-store',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+        },
+        body: JSON.stringify({
+          role,
+          organizationId: controlledOwner ? organizationId : undefined,
+        }),
+        signal: controller.signal,
+      });
+      const payload = await response.json().catch(() => null) as OpenCabinetResponse | null;
+
+      if (!response.ok || payload?.ok !== true) {
+        const detail = payload?.message || text.openFailed;
+        const code = payload?.code ? ` (${payload.code})` : '';
+        throw new Error(`${detail}${code}`);
+      }
+      if (!payload.redirectTo || !payload.redirectTo.startsWith('/platform-v7/')) {
+        throw new Error(text.openFailed);
+      }
+
+      try {
+        window.sessionStorage.setItem(PLATFORM_V7_ACTIVE_ROLE_KEY, role);
+      } catch {
+        // The signed, HttpOnly cabinet session remains the authority. Navigation must not stop.
+      }
+      window.location.assign(payload.redirectTo);
+    } catch (error) {
+      const timedOut = error instanceof DOMException && error.name === 'AbortError';
+      setOpenError(timedOut ? text.openFailed : error instanceof Error ? error.message : text.openFailed);
+      setBusyRole(null);
+    } finally {
+      window.clearTimeout(timeoutId);
+    }
+  }
 
   if (advanced || (!checking && !isOwner)) {
     return (
@@ -151,6 +221,8 @@ export function OwnerAccessCenter(props: Props) {
         <p>{text.accessBody}</p>
       </section>
 
+      {openError && <section className={styles.error} role="alert" aria-live="assertive">{openError}</section>}
+
       {controlledOwner && (
         <section className={styles.testNetwork} aria-label={text.testNetwork}>
           <span>TEST</span>
@@ -161,7 +233,7 @@ export function OwnerAccessCenter(props: Props) {
         </section>
       )}
 
-      <section className={styles.cabinetGrid} aria-label={text.title}>
+      <section className={styles.cabinetGrid} aria-label={text.title} aria-busy={busyRole !== null}>
         {cabinetLabels.map((item) => (
           <article key={item.role} className={styles.cabinetCard}>
             <span className={styles.number} aria-hidden="true">{item.icon}</span>
@@ -172,13 +244,17 @@ export function OwnerAccessCenter(props: Props) {
                 <strong>{item.organization.organizationName}</strong>
               </p>
             )}
-            <form method="post" action="/platform-v7/staff/open-cabinet/submit">
+            <form
+              method="post"
+              action="/platform-v7/staff/open-cabinet/submit"
+              onSubmit={(event) => openCabinet(event, item.role, item.organization.organizationId)}
+            >
               <input type="hidden" name="_csrf" value={csrfToken} />
               {controlledOwner && (
                 <input type="hidden" name="organizationId" value={item.organization.organizationId} />
               )}
-              <button type="submit" name="role" value={item.role} disabled={!csrfToken}>
-                {text.open}
+              <button type="submit" name="role" value={item.role} disabled={!csrfToken || busyRole !== null}>
+                {busyRole === item.role ? text.opening : text.open}
               </button>
             </form>
           </article>

--- a/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
+++ b/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
@@ -4,6 +4,16 @@ import { describe, expect, it } from 'vitest';
 import { ownerAccessCenterMessages } from '../../i18n/owner-access-center-messages';
 
 const read = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const page = read('apps/web/app/platform-v7/staff/page.tsx');
+const entry = read('apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx');
+const directCenter = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx');
+const directRoute = read('apps/web/app/platform-v7/staff/open-cabinet/route.ts');
+const submitRoute = read('apps/web/app/platform-v7/staff/open-cabinet/submit/route.ts');
+const prepareRoute = read('apps/web/app/platform-v7/staff/prepare/route.ts');
+const directCss = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV3.module.css');
+const center = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV2.tsx');
+const catalog = read('apps/web/lib/platform-v7/staff-access-task-catalog.ts');
+const deferred = read('apps/web/components/platform-v7/staff/StaffOperationalWorkspacesDeferred.tsx');
 
 function keys(value: unknown, prefix = ''): string[] {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return [prefix];
@@ -12,157 +22,70 @@ function keys(value: unknown, prefix = ''): string[] {
     .sort();
 }
 
-const page = read('apps/web/app/platform-v7/staff/page.tsx');
-const entry = read('apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx');
-const directCenter = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx');
-const directRoute = read('apps/web/app/platform-v7/staff/open-cabinet/route.ts');
-const submitRoute = read('apps/web/app/platform-v7/staff/open-cabinet/submit/route.ts');
-const prepareRoute = read('apps/web/app/platform-v7/staff/prepare/route.ts');
-const handoffPage = read('apps/web/app/platform-v7/staff/cabinet-handoff/page.tsx');
-const handoffClient = read('apps/web/components/platform-v7/staff/OwnerCabinetHandoff.tsx');
-const directCss = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV3.module.css');
-const center = read('apps/web/components/platform-v7/staff/OwnerAccessCenterV2.tsx');
-const catalog = read('apps/web/lib/platform-v7/staff-access-task-catalog.ts');
-const css = read('apps/web/components/platform-v7/staff/OwnerAccessCenter.module.css');
-const deferred = read('apps/web/components/platform-v7/staff/StaffOperationalWorkspacesDeferred.tsx');
-
 describe('platform-v7 owner access center task UX', () => {
-  it('gives the verified platform owner one-tap access to all twelve cabinet interfaces', () => {
+  it('provides all twelve owner cabinet transitions', () => {
     expect(page).toContain('<OwnerAccessCenter');
     expect(entry).toContain("export { OwnerAccessCenter } from './OwnerAccessCenterV3'");
-    for (const role of [
-      'operator', 'buyer', 'seller', 'logistics', 'driver', 'surveyor',
-      'elevator', 'lab', 'bank', 'arbitrator', 'compliance', 'executive',
-    ]) {
+    for (const role of ['operator', 'buyer', 'seller', 'logistics', 'driver', 'surveyor', 'elevator', 'lab', 'bank', 'arbitrator', 'compliance', 'executive']) {
       expect(directCenter).toContain(`role: '${role}'`);
     }
-    expect(directCenter).toContain('method="post"');
     expect(directCenter).toContain('action="/platform-v7/staff/open-cabinet/submit"');
-    expect(directCenter).toContain('name="_csrf"');
-    expect(directCenter).toContain('name="role"');
     expect(directCenter).toContain('name="organizationId"');
-    expect(page).toContain('csrfToken={csrfToken}');
-    expect(directCenter).not.toContain('sessionStorage');
-    expect(directCenter).not.toContain("fetch('/platform-v7/staff/open-cabinet'");
     expect(directCenter).not.toContain('Рабочий тикет');
     expect(directCenter).not.toContain('Причина доступа');
   });
 
-  it('repairs an existing verified owner session before rendering a form without CSRF', () => {
-    expect(page).toContain("cookieStore.get(CSRF_COOKIE)?.value || ''");
+  it('repairs missing CSRF before rendering owner forms', () => {
     expect(page).toContain("verification.status === 'verified' && !csrfToken");
     expect(page).toContain("redirect('/platform-v7/staff/prepare')");
-    expect(prepareRoute).toContain('request.cookies.get(ACCESS_COOKIE)');
-    expect(prepareRoute).toContain("target.pathname = '/platform-v7/login'");
     expect(prepareRoute).toContain('generateCsrfToken()');
     expect(prepareRoute).toContain('response.cookies.set(CSRF_COOKIE');
-    expect(prepareRoute).toContain('csrfCookieSecurity()');
-    expect(prepareRoute).toContain("new URL('/platform-v7/staff', request.url)");
-    expect(prepareRoute).toContain('NextResponse.redirect(target, 303)');
-    expect(prepareRoute).toContain("'Cache-Control', 'no-store, no-cache, must-revalidate, private'");
   });
 
-  it('uses native POST and performs the client role handoff only after server success', () => {
-    expect(directRoute).toContain("contentType.includes('application/x-www-form-urlencoded')");
-    expect(directRoute).toContain('request.formData()');
-    expect(directRoute).toContain('formCsrfValid(request');
+  it('uses observable authenticated JSON transition with native fallback', () => {
+    expect(directCenter).toContain("fetch('/platform-v7/staff/open-cabinet'");
+    expect(directCenter).toContain("'X-CSRF-Token': csrfToken");
+    expect(directCenter).toContain("credentials: 'same-origin'");
+    expect(directCenter).toContain('onSubmit={(event) => openCabinet');
+    expect(directCenter).toContain('busyRole === item.role ? text.opening : text.open');
+    expect(directCenter).toContain('role="alert"');
+    expect(directCenter).toContain('window.location.assign(payload.redirectTo)');
     expect(submitRoute).toContain("import { POST as issueCabinetSession } from '../route'");
-    expect(submitRoute).toContain("target.pathname === '/platform-v7/staff'");
-    expect(submitRoute).toContain("new URL('/platform-v7/staff/cabinet-handoff', request.url)");
-    expect(handoffPage).toContain('readVerifiedCabinetSessionContext');
-    expect(handoffPage).toContain('CABINET_SESSION_COOKIE');
-    expect(handoffPage).toContain('controlledOrganizationById(context.organizationId)');
-    expect(handoffPage).toContain('<OwnerCabinetHandoff');
-    expect(handoffClient).toContain('useLayoutEffect(() =>');
-    expect(handoffClient).toContain('window.sessionStorage.setItem(PLATFORM_V7_ACTIVE_ROLE_KEY, role)');
-    expect(handoffClient).toContain('window.location.replace(target)');
-    expect(directCenter).not.toContain('onSubmit=');
-    expect(directCenter).not.toContain('busyRole');
-    expect(directCenter).not.toContain('setBusyRole');
   });
 
-  it('does not create a client role marker when the server rejects cabinet opening', () => {
-    expect(directRoute).toContain('redirectBack(request, code)');
-    expect(submitRoute).toContain('if (!failedBackToOwnerCenter)');
-    expect(directCenter).not.toContain('PLATFORM_V7_ACTIVE_ROLE_KEY');
-    expect(handoffPage).toContain("redirect('/platform-v7/staff?cabinetError=CABINET_SESSION_UNAVAILABLE')");
+  it('creates the client role marker only after server success', () => {
+    const failureGate = directCenter.indexOf('if (!response.ok');
+    const roleMarker = directCenter.indexOf('window.sessionStorage.setItem');
+    const navigation = directCenter.indexOf('window.location.assign(payload.redirectTo)');
+    expect(failureGate).toBeGreaterThan(-1);
+    expect(roleMarker).toBeGreaterThan(failureGate);
+    expect(navigation).toBeGreaterThan(roleMarker);
+    expect(directCenter).toContain('Navigation must not stop');
   });
 
-  it('requires controlled-owner claims or an active API-backed PLATFORM_OWNER assignment', () => {
+  it('keeps owner authority and cabinet session server verified', () => {
     expect(directRoute).toContain('assertCsrf(request)');
     expect(directRoute).toContain('assertSameOriginIfPresent(request)');
     expect(directRoute).toContain('claims.owner !== true');
-    expect(directRoute).toContain('claims.testAccess !== true');
-    expect(directRoute).toContain("claims.tokenType !== 'access'");
-    expect(directRoute).toContain("fetch(`${origin}/auth/me`");
-    expect(directRoute).toContain("fetch(`${origin}/staff/assignments/me`");
     expect(directRoute).toContain("item.role === 'PLATFORM_OWNER' && item.status === 'ACTIVE'");
     expect(directRoute).toContain('signCabinetSession(parsed.role, secret');
     expect(directRoute).toContain('response.cookies.set(CABINET_SESSION_COOKIE');
-    expect(directRoute).toContain('response.cookies.set(SESSION_COOKIE');
-    expect(directRoute).toContain("response.cookies.set('pc-role'");
     expect(directRoute).not.toContain('response.cookies.set(ACCESS_COOKIE');
   });
 
-  it('retains the task-first PAM surface for staff management and privileged operations', () => {
+  it('retains the protected advanced staff surface', () => {
     expect(directCenter).toContain('<OwnerAccessCenterV2 {...baseProps} />');
-    expect(directCenter).toContain('setAdvanced(true)');
-    expect(directCenter).toContain('setAdvanced(false)');
     expect(page).toContain('accessCatalog={staffAccessTaskCatalog()}');
-    expect(center).toContain('copy.home.tasksTitle');
-    expect(center).toContain('copy.tasks[task.id].title');
-    expect(center).not.toContain('ACCESS_PRESETS');
     expect(catalog).toContain("id: 'view_cabinet'");
-    expect(catalog).toContain("id: 'investigate_deal'");
-    expect(catalog).toContain("id: 'review_money'");
-  });
-
-  it('keeps privileged permission policy server-owned and API-authoritative', () => {
-    expect(catalog).toContain("import 'server-only'");
-    expect(catalog).toContain('The API remains the authority');
     expect(center).toContain('permissions: selectedPermissions');
-    expect(center).toContain('<details className={styles.technicalDetails}>');
-    expect(center).not.toContain('const ACCESS_PRESETS');
-  });
-
-  it('uses field-level validation and an isolated emergency form in the advanced surface', () => {
-    expect(center).toContain('setFieldErrors(next)');
-    expect(center).toContain('owner-access-organization');
-    expect(center).toContain('owner-access-ticket');
-    expect(center).toContain('owner-access-reason');
-    expect(center).toContain('emergencyTicket');
-    expect(center).toContain('emergencyReason');
-    expect(center).toContain('emergencyConfirmed');
-    expect(center).not.toContain("reason.trim().length < 20 || ticketId.trim().length < 3");
-  });
-
-  it('always leaves a manual organization-id path and closes directory sessions before switching tasks', () => {
-    expect(center).toContain('placeholder={copy.request.organizationIdPlaceholder}');
-    expect(center).toContain('organizations.length === 0 && canBrowseOrganizations');
-    expect(center).toContain("'Organization selected; directory session closed'");
-    expect(center).toContain('openTask(resumeTask, { allowWhileActive: true })');
-  });
-
-  it('does not render privileged operational workspaces without an active protected session', () => {
     expect(deferred).toContain("fetch('/api/staff/session-context'");
-    expect(deferred).toContain('payload.active === true');
     expect(deferred).toContain('if (!ready || !active) return null');
   });
 
-  it('keeps both owner surfaces mobile-first with safe-area and large touch targets', () => {
-    expect(directCss).toContain('env(safe-area-inset-bottom)');
+  it('remains mobile-first and multilingual', () => {
     expect(directCss).toContain('@media (max-width: 520px)');
     expect(directCss).toContain('grid-template-columns: 1fr');
     expect(directCss).toContain('min-height: 54px');
-    expect(css).toContain('grid-template-columns: repeat(5, minmax(0, 1fr))');
-    expect(css).toContain('env(safe-area-inset-bottom)');
-    expect(css).toContain('@media (max-width: 380px)');
-    expect(css).toContain('min-height: 58px');
-    expect(css).toContain('overflow-x: clip');
-    expect(css).not.toContain('min-width: 1000px');
-  });
-
-  it('keeps RU, EN and ZH owner-control dictionaries structurally identical', () => {
     expect(keys(ownerAccessCenterMessages.en)).toEqual(keys(ownerAccessCenterMessages.ru));
     expect(keys(ownerAccessCenterMessages.zh)).toEqual(keys(ownerAccessCenterMessages.ru));
   });


### PR DESCRIPTION
Fixes the production symptom where cabinet buttons accept a tap but the user sees no navigation or error.

The owner center now uses an authenticated JSON POST with the existing CSRF cookie/header, shows an explicit pending state, surfaces the exact server error code, writes the client role marker only after server success, and navigates directly to the verified redirect target. The native form POST remains as a no-JS fallback. Server-side PLATFORM_OWNER verification, organization mapping and signed cabinet-session issuance remain unchanged.

Includes focused regression coverage for loading, error visibility, redirect validation and server-authority boundaries.