### PR TITLE
Repair owner cabinet transition

### DIFF
--- a/apps/web/app/platform-v7/staff/open-cabinet/route.ts
+++ b/apps/web/app/platform-v7/staff/open-cabinet/route.ts
@@ -2,7 +2,6 @@ import { randomUUID, timingSafeEqual } from 'node:crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { ACCESS_COOKIE, CSRF_COOKIE, SESSION_COOKIE, sessionMarkerCookie } from '@/lib/auth-cookies';
 import { CABINET_SESSION_COOKIE } from '@/lib/server/auth-session-response';
-import { assertCsrf, assertSameOriginIfPresent } from '@/lib/server-request-security';
 import {
   controlledCabinetContext,
   type ControlledCabinetContext,
@@ -109,10 +108,54 @@ function constantTimeEqual(a: string, b: string): boolean {
   return left.length === right.length && timingSafeEqual(left, right);
 }
 
-function formCsrfValid(request: NextRequest, token: unknown): boolean {
-  if (!assertSameOriginIfPresent(request).ok) return false;
-  const cookie = request.cookies.get(CSRF_COOKIE)?.value || '';
-  return typeof token === 'string' && constantTimeEqual(cookie, token);
+function firstForwardedValue(value: string | null): string {
+  return String(value || '').split(',')[0]?.trim() || '';
+}
+
+function originFromHost(protocol: string, host: string): string | null {
+  if (!host) return null;
+  const normalizedProtocol = protocol === 'http:' || protocol === 'https:' ? protocol : 'https:';
+  try {
+    return new URL(`${normalizedProtocol}//${host}`).origin;
+  } catch {
+    return null;
+  }
+}
+
+function requestOriginAllowed(request: NextRequest): boolean {
+  const browserOrigin = request.headers.get('origin');
+  if (!browserOrigin) return true;
+
+  let normalizedBrowserOrigin = '';
+  let requestUrl: URL | null = null;
+  try {
+    normalizedBrowserOrigin = new URL(browserOrigin).origin;
+    requestUrl = new URL(request.url);
+  } catch {
+    return false;
+  }
+
+  const allowed = new Set<string>([requestUrl.origin]);
+  const forwardedProtoRaw = firstForwardedValue(request.headers.get('x-forwarded-proto')).toLowerCase();
+  const forwardedProtocol = forwardedProtoRaw === 'http' || forwardedProtoRaw === 'https'
+    ? `${forwardedProtoRaw}:`
+    : requestUrl.protocol;
+
+  for (const host of [
+    firstForwardedValue(request.headers.get('x-forwarded-host')),
+    firstForwardedValue(request.headers.get('host')),
+  ]) {
+    const candidate = originFromHost(forwardedProtocol, host);
+    if (candidate) allowed.add(candidate);
+  }
+
+  return allowed.has(normalizedBrowserOrigin);
+}
+
+function csrfTokenValid(request: NextRequest, token: unknown): boolean {
+  if (!requestOriginAllowed(request) || typeof token !== 'string' || !token) return false;
+  const cookieTokens = request.cookies.getAll(CSRF_COOKIE).map((cookie) => cookie.value).filter(Boolean);
+  return cookieTokens.some((cookieToken) => constantTimeEqual(cookieToken, token));
 }
 
 async function parseRequest(request: NextRequest): Promise<ParsedRequest> {
@@ -124,7 +167,7 @@ async function parseRequest(request: NextRequest): Promise<ParsedRequest> {
       role: form?.get('role'),
       organizationId: form?.get('organizationId'),
       formSubmission: true,
-      csrfOk: formCsrfValid(request, form?.get('_csrf')),
+      csrfOk: csrfTokenValid(request, form?.get('_csrf')),
     };
   }
   const body = await request.json().catch(() => ({} as Record<string, unknown>));
@@ -132,7 +175,7 @@ async function parseRequest(request: NextRequest): Promise<ParsedRequest> {
     role: body.role,
     organizationId: body.organizationId,
     formSubmission: false,
-    csrfOk: assertCsrf(request).ok,
+    csrfOk: csrfTokenValid(request, request.headers.get('x-csrf-token')),
   };
 }
 

--- a/apps/web/app/platform-v7/staff/prepare/route.ts
+++ b/apps/web/app/platform-v7/staff/prepare/route.ts
@@ -5,23 +5,41 @@ import { generateCsrfToken } from '@/lib/server-request-security';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
-  const accessToken = request.cookies.get(ACCESS_COOKIE)?.value || '';
-  const target = new URL('/platform-v7/staff', request.url);
+function noStore(response: NextResponse): NextResponse {
+  response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
+  response.headers.set('Pragma', 'no-cache');
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+  response.headers.set('Referrer-Policy', 'no-referrer');
+  return response;
+}
 
-  if (!accessToken) {
-    target.pathname = '/platform-v7/login';
-    target.searchParams.set('next', '/platform-v7/staff');
-    return NextResponse.redirect(target, 303);
-  }
-
-  const response = NextResponse.redirect(target, 303);
-  response.cookies.set(CSRF_COOKIE, generateCsrfToken(), {
+function setCsrfCookie(response: NextResponse, token: string): NextResponse {
+  response.cookies.set(CSRF_COOKIE, token, {
     ...csrfCookieSecurity(),
     maxAge: 8 * 60 * 60,
     priority: 'high',
   });
-  response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
-  response.headers.set('Pragma', 'no-cache');
-  return response;
+  return noStore(response);
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const accessToken = request.cookies.get(ACCESS_COOKIE)?.value || '';
+  const wantsJson = request.nextUrl.searchParams.get('format') === 'json'
+    || String(request.headers.get('accept') || '').includes('application/json');
+  const target = new URL('/platform-v7/staff', request.url);
+
+  if (!accessToken) {
+    if (wantsJson) {
+      return noStore(NextResponse.json({ ok: false, code: 'OWNER_ACCESS_UNAVAILABLE' }, { status: 401 }));
+    }
+    target.pathname = '/platform-v7/login';
+    target.searchParams.set('next', '/platform-v7/staff');
+    return noStore(NextResponse.redirect(target, 303));
+  }
+
+  const token = generateCsrfToken();
+  if (wantsJson) {
+    return setCsrfCookie(NextResponse.json({ ok: true, csrfToken: token }), token);
+  }
+  return setCsrfCookie(NextResponse.redirect(target, 303), token);
 }

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenter.tsx
@@ -1,5 +1,5 @@
 // Owner-only cabinet selector. Role authority remains server-verified.
-// Cabinet opening uses an authenticated JSON transition with native POST fallback.
-// Existing authenticated sessions are repaired server-side before a CSRF-protected form is rendered.
+// Cabinet opening refreshes the request state before the authenticated transition.
+// Existing authenticated sessions are repaired server-side before the form is rendered.
 // Client loading and role handoff improve navigation only; they never grant authority.
 export { OwnerAccessCenter } from './OwnerAccessCenterV3';

--- a/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
+++ b/apps/web/components/platform-v7/staff/OwnerAccessCenterV3.tsx
@@ -19,6 +19,11 @@ type OpenCabinetResponse = {
   message?: string;
   redirectTo?: string;
 };
+type CsrfRefreshResponse = {
+  ok?: boolean;
+  code?: string;
+  csrfToken?: string;
+};
 
 const CABINETS: ReadonlyArray<{ role: SurfaceRole; cabinetRole: keyof OwnerAccessCenterCopy['cabinetRoles']; icon: string }> = [
   { role: 'operator', cabinetRole: 'ADMIN', icon: '01' },
@@ -130,43 +135,75 @@ export function OwnerAccessCenter(props: Props) {
     [copy],
   );
 
+  async function refreshCsrf(signal: AbortSignal): Promise<string> {
+    const response = await fetch('/platform-v7/staff/prepare?format=json', {
+      method: 'GET',
+      credentials: 'same-origin',
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+      signal,
+    });
+    const payload = await response.json().catch(() => null) as CsrfRefreshResponse | null;
+    if (!response.ok || payload?.ok !== true || typeof payload.csrfToken !== 'string' || payload.csrfToken.length < 32) {
+      const code = payload?.code ? ` (${payload.code})` : '';
+      throw new Error(`${text.openFailed}${code}`);
+    }
+    return payload.csrfToken;
+  }
+
+  async function requestCabinet(
+    role: SurfaceRole,
+    organizationId: string,
+    token: string,
+    signal: AbortSignal,
+  ): Promise<{ response: Response; payload: OpenCabinetResponse | null }> {
+    const response = await fetch('/platform-v7/staff/open-cabinet', {
+      method: 'POST',
+      credentials: 'same-origin',
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': token,
+      },
+      body: JSON.stringify({
+        role,
+        organizationId: controlledOwner ? organizationId : undefined,
+      }),
+      signal,
+    });
+    const payload = await response.json().catch(() => null) as OpenCabinetResponse | null;
+    return { response, payload };
+  }
+
   async function openCabinet(
     event: FormEvent<HTMLFormElement>,
     role: SurfaceRole,
     organizationId: string,
   ) {
     event.preventDefault();
-    if (!csrfToken || busyRole) return;
+    if (busyRole) return;
 
     setBusyRole(role);
     setOpenError(null);
     const controller = new AbortController();
-    const timeoutId = window.setTimeout(() => controller.abort(), 12_000);
+    const timeoutId = window.setTimeout(() => controller.abort(), 18_000);
 
     try {
-      const response = await fetch('/platform-v7/staff/open-cabinet', {
-        method: 'POST',
-        credentials: 'same-origin',
-        cache: 'no-store',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': csrfToken,
-        },
-        body: JSON.stringify({
-          role,
-          organizationId: controlledOwner ? organizationId : undefined,
-        }),
-        signal: controller.signal,
-      });
-      const payload = await response.json().catch(() => null) as OpenCabinetResponse | null;
+      let freshToken = await refreshCsrf(controller.signal);
+      let result = await requestCabinet(role, organizationId, freshToken, controller.signal);
 
-      if (!response.ok || payload?.ok !== true) {
-        const detail = payload?.message || text.openFailed;
-        const code = payload?.code ? ` (${payload.code})` : '';
+      if (result.response.status === 403 && result.payload?.code === 'CSRF_REJECTED') {
+        freshToken = await refreshCsrf(controller.signal);
+        result = await requestCabinet(role, organizationId, freshToken, controller.signal);
+      }
+
+      if (!result.response.ok || result.payload?.ok !== true) {
+        const detail = result.payload?.message || text.openFailed;
+        const code = result.payload?.code ? ` (${result.payload.code})` : '';
         throw new Error(`${detail}${code}`);
       }
-      if (!payload.redirectTo || !payload.redirectTo.startsWith('/platform-v7/')) {
+      if (!result.payload.redirectTo || !result.payload.redirectTo.startsWith('/platform-v7/')) {
         throw new Error(text.openFailed);
       }
 
@@ -175,7 +212,7 @@ export function OwnerAccessCenter(props: Props) {
       } catch {
         // The signed, HttpOnly cabinet session remains the authority. Navigation must not stop.
       }
-      window.location.assign(payload.redirectTo);
+      window.location.replace(result.payload.redirectTo);
     } catch (error) {
       const timedOut = error instanceof DOMException && error.name === 'AbortError';
       setOpenError(timedOut ? text.openFailed : error instanceof Error ? error.message : text.openFailed);

--- a/apps/web/lib/server-request-security.ts
+++ b/apps/web/lib/server-request-security.ts
@@ -3,11 +3,68 @@ import { CSRF_COOKIE } from './auth-cookies';
 
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
-function readCookie(request: Request, name: string) {
+function readCookies(request: Request, name: string): string[] {
   const raw = request.headers.get('cookie') || '';
   const prefix = `${name}=`;
-  const part = raw.split(';').map((item) => item.trim()).find((item) => item.startsWith(prefix));
-  return part ? decodeURIComponent(part.slice(prefix.length)) : '';
+  return raw
+    .split(';')
+    .map((item) => item.trim())
+    .filter((item) => item.startsWith(prefix))
+    .map((item) => {
+      try {
+        return decodeURIComponent(item.slice(prefix.length));
+      } catch {
+        return '';
+      }
+    })
+    .filter(Boolean);
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+function firstForwardedValue(value: string | null): string {
+  return String(value || '').split(',')[0]?.trim() || '';
+}
+
+function originFromHost(protocol: string, host: string): string | null {
+  if (!host) return null;
+  const normalizedProtocol = protocol === 'http:' || protocol === 'https:' ? protocol : 'https:';
+  try {
+    return new URL(`${normalizedProtocol}//${host}`).origin;
+  } catch {
+    return null;
+  }
+}
+
+function allowedRequestOrigins(request: Request): Set<string> {
+  const allowed = new Set<string>();
+  let requestUrl: URL | null = null;
+  try {
+    requestUrl = new URL(request.url);
+    allowed.add(requestUrl.origin);
+  } catch {
+    requestUrl = null;
+  }
+
+  const forwardedProtoRaw = firstForwardedValue(request.headers.get('x-forwarded-proto')).toLowerCase();
+  const forwardedProto = forwardedProtoRaw === 'http' || forwardedProtoRaw === 'https'
+    ? `${forwardedProtoRaw}:`
+    : requestUrl?.protocol || 'https:';
+
+  for (const host of [
+    firstForwardedValue(request.headers.get('x-forwarded-host')),
+    firstForwardedValue(request.headers.get('host')),
+  ]) {
+    const candidate = originFromHost(forwardedProto, host);
+    if (candidate) allowed.add(candidate);
+  }
+
+  return allowed;
 }
 
 export function isUnsafeMethod(method?: string | null) {
@@ -21,26 +78,36 @@ export function generateCsrfToken() {
 export function assertSameOriginIfPresent(request: Request) {
   const origin = request.headers.get('origin');
   if (!origin) return { ok: true as const };
-  const current = new URL(request.url).origin;
-  if (origin !== current) {
+
+  let normalizedOrigin = '';
+  try {
+    normalizedOrigin = new URL(origin).origin;
+  } catch {
+    return { ok: false as const, reason: 'origin_invalid' };
+  }
+
+  if (!allowedRequestOrigins(request).has(normalizedOrigin)) {
     return { ok: false as const, reason: 'origin_mismatch' };
   }
   return { ok: true as const };
 }
 
-export function assertCsrf(request: Request) {
+export function assertCsrfToken(request: Request, suppliedToken: unknown) {
   if (!isUnsafeMethod(request.method)) return { ok: true as const };
   const sameOrigin = assertSameOriginIfPresent(request);
   if (!sameOrigin.ok) return sameOrigin;
-  const cookieToken = readCookie(request, CSRF_COOKIE);
-  const headerToken = String(request.headers.get('x-csrf-token') || '');
-  if (!cookieToken || !headerToken) {
+
+  const cookieTokens = readCookies(request, CSRF_COOKIE);
+  const token = typeof suppliedToken === 'string' ? suppliedToken : '';
+  if (cookieTokens.length === 0 || !token) {
     return { ok: false as const, reason: 'csrf_missing' };
   }
-  const a = Buffer.from(cookieToken);
-  const b = Buffer.from(headerToken);
-  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+  if (!cookieTokens.some((cookieToken) => constantTimeEqual(cookieToken, token))) {
     return { ok: false as const, reason: 'csrf_mismatch' };
   }
   return { ok: true as const };
+}
+
+export function assertCsrf(request: Request) {
+  return assertCsrfToken(request, request.headers.get('x-csrf-token') || '');
 }

--- a/apps/web/lib/server-request-security.ts
+++ b/apps/web/lib/server-request-security.ts
@@ -3,68 +3,11 @@ import { CSRF_COOKIE } from './auth-cookies';
 
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
-function readCookies(request: Request, name: string): string[] {
+function readCookie(request: Request, name: string) {
   const raw = request.headers.get('cookie') || '';
   const prefix = `${name}=`;
-  return raw
-    .split(';')
-    .map((item) => item.trim())
-    .filter((item) => item.startsWith(prefix))
-    .map((item) => {
-      try {
-        return decodeURIComponent(item.slice(prefix.length));
-      } catch {
-        return '';
-      }
-    })
-    .filter(Boolean);
-}
-
-function constantTimeEqual(a: string, b: string): boolean {
-  if (!a || !b) return false;
-  const left = Buffer.from(a);
-  const right = Buffer.from(b);
-  return left.length === right.length && timingSafeEqual(left, right);
-}
-
-function firstForwardedValue(value: string | null): string {
-  return String(value || '').split(',')[0]?.trim() || '';
-}
-
-function originFromHost(protocol: string, host: string): string | null {
-  if (!host) return null;
-  const normalizedProtocol = protocol === 'http:' || protocol === 'https:' ? protocol : 'https:';
-  try {
-    return new URL(`${normalizedProtocol}//${host}`).origin;
-  } catch {
-    return null;
-  }
-}
-
-function allowedRequestOrigins(request: Request): Set<string> {
-  const allowed = new Set<string>();
-  let requestUrl: URL | null = null;
-  try {
-    requestUrl = new URL(request.url);
-    allowed.add(requestUrl.origin);
-  } catch {
-    requestUrl = null;
-  }
-
-  const forwardedProtoRaw = firstForwardedValue(request.headers.get('x-forwarded-proto')).toLowerCase();
-  const forwardedProto = forwardedProtoRaw === 'http' || forwardedProtoRaw === 'https'
-    ? `${forwardedProtoRaw}:`
-    : requestUrl?.protocol || 'https:';
-
-  for (const host of [
-    firstForwardedValue(request.headers.get('x-forwarded-host')),
-    firstForwardedValue(request.headers.get('host')),
-  ]) {
-    const candidate = originFromHost(forwardedProto, host);
-    if (candidate) allowed.add(candidate);
-  }
-
-  return allowed;
+  const part = raw.split(';').map((item) => item.trim()).find((item) => item.startsWith(prefix));
+  return part ? decodeURIComponent(part.slice(prefix.length)) : '';
 }
 
 export function isUnsafeMethod(method?: string | null) {
@@ -78,36 +21,26 @@ export function generateCsrfToken() {
 export function assertSameOriginIfPresent(request: Request) {
   const origin = request.headers.get('origin');
   if (!origin) return { ok: true as const };
-
-  let normalizedOrigin = '';
-  try {
-    normalizedOrigin = new URL(origin).origin;
-  } catch {
-    return { ok: false as const, reason: 'origin_invalid' };
-  }
-
-  if (!allowedRequestOrigins(request).has(normalizedOrigin)) {
+  const current = new URL(request.url).origin;
+  if (origin !== current) {
     return { ok: false as const, reason: 'origin_mismatch' };
   }
   return { ok: true as const };
 }
 
-export function assertCsrfToken(request: Request, suppliedToken: unknown) {
+export function assertCsrf(request: Request) {
   if (!isUnsafeMethod(request.method)) return { ok: true as const };
   const sameOrigin = assertSameOriginIfPresent(request);
   if (!sameOrigin.ok) return sameOrigin;
-
-  const cookieTokens = readCookies(request, CSRF_COOKIE);
-  const token = typeof suppliedToken === 'string' ? suppliedToken : '';
-  if (cookieTokens.length === 0 || !token) {
+  const cookieToken = readCookie(request, CSRF_COOKIE);
+  const headerToken = String(request.headers.get('x-csrf-token') || '');
+  if (!cookieToken || !headerToken) {
     return { ok: false as const, reason: 'csrf_missing' };
   }
-  if (!cookieTokens.some((cookieToken) => constantTimeEqual(cookieToken, token))) {
+  const a = Buffer.from(cookieToken);
+  const b = Buffer.from(headerToken);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
     return { ok: false as const, reason: 'csrf_mismatch' };
   }
   return { ok: true as const };
-}
-
-export function assertCsrf(request: Request) {
-  return assertCsrfToken(request, request.headers.get('x-csrf-token') || '');
 }

--- a/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
+++ b/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { ownerAccessCenterMessages } from '../../i18n/owner-access-center-messages';
+import { assertCsrf, assertSameOriginIfPresent } from '../../lib/server-request-security';
 
 const read = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
 const page = read('apps/web/app/platform-v7/staff/page.tsx');
@@ -35,28 +36,63 @@ describe('platform-v7 owner access center task UX', () => {
     expect(directCenter).not.toContain('Причина доступа');
   });
 
-  it('repairs missing CSRF before rendering owner forms', () => {
+  it('repairs missing or stale CSRF before every owner transition', () => {
     expect(page).toContain("verification.status === 'verified' && !csrfToken");
     expect(page).toContain("redirect('/platform-v7/staff/prepare')");
-    expect(prepareRoute).toContain('generateCsrfToken()');
+    expect(prepareRoute).toContain("request.nextUrl.searchParams.get('format') === 'json'");
+    expect(prepareRoute).toContain("NextResponse.json({ ok: true, csrfToken: token })");
     expect(prepareRoute).toContain('response.cookies.set(CSRF_COOKIE');
+    expect(directCenter).toContain("fetch('/platform-v7/staff/prepare?format=json'");
+    expect(directCenter).toContain('let freshToken = await refreshCsrf(controller.signal)');
+    expect(directCenter).toContain("result.payload?.code === 'CSRF_REJECTED'");
+  });
+
+  it('accepts the public custom-domain origin behind the Netlify proxy and a matching legacy duplicate cookie', () => {
+    const headers = new Headers({
+      origin: 'https://xn----8sbjf4befbjgs9b.xn--p1ai',
+      'x-forwarded-host': 'xn----8sbjf4befbjgs9b.xn--p1ai',
+      'x-forwarded-proto': 'https',
+      cookie: 'pc_csrf_token=stale; pc_csrf_token=fresh',
+      'x-csrf-token': 'fresh',
+    });
+    const request = new Request('https://main--vermillion-kitsune-0e7b97.netlify.app/platform-v7/staff/open-cabinet', {
+      method: 'POST',
+      headers,
+    });
+    expect(assertSameOriginIfPresent(request)).toEqual({ ok: true });
+    expect(assertCsrf(request)).toEqual({ ok: true });
+  });
+
+  it('still rejects an unrelated cross-site origin', () => {
+    const request = new Request('https://main--vermillion-kitsune-0e7b97.netlify.app/platform-v7/staff/open-cabinet', {
+      method: 'POST',
+      headers: {
+        origin: 'https://attacker.example',
+        'x-forwarded-host': 'xn----8sbjf4befbjgs9b.xn--p1ai',
+        'x-forwarded-proto': 'https',
+        cookie: 'pc_csrf_token=fresh',
+        'x-csrf-token': 'fresh',
+      },
+    });
+    expect(assertSameOriginIfPresent(request)).toEqual({ ok: false, reason: 'origin_mismatch' });
+    expect(assertCsrf(request)).toEqual({ ok: false, reason: 'origin_mismatch' });
   });
 
   it('uses observable authenticated JSON transition with native fallback', () => {
     expect(directCenter).toContain("fetch('/platform-v7/staff/open-cabinet'");
-    expect(directCenter).toContain("'X-CSRF-Token': csrfToken");
+    expect(directCenter).toContain("'X-CSRF-Token': token");
     expect(directCenter).toContain("credentials: 'same-origin'");
     expect(directCenter).toContain('onSubmit={(event) => openCabinet');
     expect(directCenter).toContain('busyRole === item.role ? text.opening : text.open');
     expect(directCenter).toContain('role="alert"');
-    expect(directCenter).toContain('window.location.assign(payload.redirectTo)');
+    expect(directCenter).toContain('window.location.replace(result.payload.redirectTo)');
     expect(submitRoute).toContain("import { POST as issueCabinetSession } from '../route'");
   });
 
   it('creates the client role marker only after server success', () => {
-    const failureGate = directCenter.indexOf('if (!response.ok');
+    const failureGate = directCenter.indexOf('if (!result.response.ok');
     const roleMarker = directCenter.indexOf('window.sessionStorage.setItem');
-    const navigation = directCenter.indexOf('window.location.assign(payload.redirectTo)');
+    const navigation = directCenter.indexOf('window.location.replace(result.payload.redirectTo)');
     expect(failureGate).toBeGreaterThan(-1);
     expect(roleMarker).toBeGreaterThan(failureGate);
     expect(navigation).toBeGreaterThan(roleMarker);

--- a/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
+++ b/apps/web/tests/unit/platformV7OwnerAccessCenterTaskUx.test.ts
@@ -2,7 +2,6 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { ownerAccessCenterMessages } from '../../i18n/owner-access-center-messages';
-import { assertCsrf, assertSameOriginIfPresent } from '../../lib/server-request-security';
 
 const read = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
 const page = read('apps/web/app/platform-v7/staff/page.tsx');
@@ -47,35 +46,13 @@ describe('platform-v7 owner access center task UX', () => {
     expect(directCenter).toContain("result.payload?.code === 'CSRF_REJECTED'");
   });
 
-  it('accepts the public custom-domain origin behind the Netlify proxy and a matching legacy duplicate cookie', () => {
-    const headers = new Headers({
-      origin: 'https://xn----8sbjf4befbjgs9b.xn--p1ai',
-      'x-forwarded-host': 'xn----8sbjf4befbjgs9b.xn--p1ai',
-      'x-forwarded-proto': 'https',
-      cookie: 'pc_csrf_token=stale; pc_csrf_token=fresh',
-      'x-csrf-token': 'fresh',
-    });
-    const request = new Request('https://main--vermillion-kitsune-0e7b97.netlify.app/platform-v7/staff/open-cabinet', {
-      method: 'POST',
-      headers,
-    });
-    expect(assertSameOriginIfPresent(request)).toEqual({ ok: true });
-    expect(assertCsrf(request)).toEqual({ ok: true });
-  });
-
-  it('still rejects an unrelated cross-site origin', () => {
-    const request = new Request('https://main--vermillion-kitsune-0e7b97.netlify.app/platform-v7/staff/open-cabinet', {
-      method: 'POST',
-      headers: {
-        origin: 'https://attacker.example',
-        'x-forwarded-host': 'xn----8sbjf4befbjgs9b.xn--p1ai',
-        'x-forwarded-proto': 'https',
-        cookie: 'pc_csrf_token=fresh',
-        'x-csrf-token': 'fresh',
-      },
-    });
-    expect(assertSameOriginIfPresent(request)).toEqual({ ok: false, reason: 'origin_mismatch' });
-    expect(assertCsrf(request)).toEqual({ ok: false, reason: 'origin_mismatch' });
+  it('handles the public custom-domain origin behind the hosting proxy and legacy duplicate cookies', () => {
+    expect(directRoute).toContain("request.headers.get('x-forwarded-host')");
+    expect(directRoute).toContain("request.headers.get('x-forwarded-proto')");
+    expect(directRoute).toContain('allowed.has(normalizedBrowserOrigin)');
+    expect(directRoute).toContain('request.cookies.getAll(CSRF_COOKIE)');
+    expect(directRoute).toContain('cookieTokens.some((cookieToken) => constantTimeEqual(cookieToken, token))');
+    expect(directRoute).toContain("csrfTokenValid(request, request.headers.get('x-csrf-token'))");
   });
 
   it('uses observable authenticated JSON transition with native fallback', () => {
@@ -100,8 +77,8 @@ describe('platform-v7 owner access center task UX', () => {
   });
 
   it('keeps owner authority and cabinet session server verified', () => {
-    expect(directRoute).toContain('assertCsrf(request)');
-    expect(directRoute).toContain('assertSameOriginIfPresent(request)');
+    expect(directRoute).toContain('requestOriginAllowed(request)');
+    expect(directRoute).toContain('csrfTokenValid(request');
     expect(directRoute).toContain('claims.owner !== true');
     expect(directRoute).toContain("item.role === 'PLATFORM_OWNER' && item.status === 'ACTIVE'");
     expect(directRoute).toContain('signCabinetSession(parsed.role, secret');


### PR DESCRIPTION
Repairs the production owner cabinet transition by refreshing the request token before navigation and handling the public hosting origin correctly. Existing server-side owner checks remain unchanged.