### PR TITLE
Restore complete owner cabinet interfaces

### DIFF
--- a/apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx
+++ b/apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx
@@ -45,6 +45,11 @@ type ControlledOwnerPreview = {
   organizationName: string;
 };
 
+type PreviewState = {
+  path: string;
+  preview: ControlledOwnerPreview | null;
+};
+
 function normalizePath(pathname: string): string {
   return pathname.split('?')[0].replace(/\/$/, '') || '/platform-v7';
 }
@@ -110,6 +115,16 @@ function readControlledOwnerPreview(expectedRole: PlatformRole): ControlledOwner
 export function PlatformV7ProtectedShell({ pathname, children }: { pathname: string; children: React.ReactNode }) {
   const normalizedPath = normalizePath(pathname);
   const isStaffControlCenter = normalizedPath === '/platform-v7/staff' || normalizedPath.startsWith('/platform-v7/staff/');
+  const initialRole = roleFromPath(pathname);
+  const isRoleRoot = ROLE_INTENT_ROOT_PATHS.has(normalizedPath);
+  const [previewState, setPreviewState] = React.useState<PreviewState | null>(null);
+
+  React.useEffect(() => {
+    setPreviewState({
+      path: normalizedPath,
+      preview: isRoleRoot ? readControlledOwnerPreview(initialRole) : null,
+    });
+  }, [initialRole, isRoleRoot, normalizedPath]);
 
   // Staff authority is a separate control plane. It must not inherit business-role
   // navigation, role widgets, onboarding, footer copy or client-side cabinet guards.
@@ -123,20 +138,8 @@ export function PlatformV7ProtectedShell({ pathname, children }: { pathname: str
     );
   }
 
-  const initialRole = roleFromPath(pathname);
-  const isRoleRoot = ROLE_INTENT_ROOT_PATHS.has(normalizedPath);
-  const [ownerPreview, setOwnerPreview] = React.useState<ControlledOwnerPreview | null>(null);
-  const [previewResolved, setPreviewResolved] = React.useState(!isRoleRoot);
-
-  React.useEffect(() => {
-    if (!isRoleRoot) {
-      setOwnerPreview(null);
-      setPreviewResolved(true);
-      return;
-    }
-    setOwnerPreview(readControlledOwnerPreview(initialRole));
-    setPreviewResolved(true);
-  }, [initialRole, isRoleRoot, normalizedPath]);
+  const previewResolved = !isRoleRoot || previewState?.path === normalizedPath;
+  const ownerPreview = previewResolved ? previewState?.preview || null : null;
 
   const workSurface = isRoleRoot
     ? !previewResolved

--- a/apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx
+++ b/apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx
@@ -17,6 +17,11 @@ import { SupportHeaderIcon } from '@/components/platform-v7/SupportHeaderIcon';
 import { HeaderLanguageSwitch } from '@/components/platform-v7/HeaderLanguageSwitch';
 import { StaffControlCenterEntry } from '@/components/platform-v7/StaffControlCenterEntry';
 import { RoleIntentDashboard } from '@/components/platform-v7/RoleIntentDashboard';
+import { SESSION_COOKIE } from '@/lib/auth-cookies';
+import {
+  CONTROLLED_TEST_TENANT_ID,
+  controlledOrganizationById,
+} from '@/lib/platform-v7/controlled-test-organizations';
 import type { PlatformRole } from '@/stores/usePlatformV7RStore';
 
 const ROLE_INTENT_ROOT_PATHS = new Set([
@@ -33,6 +38,12 @@ const ROLE_INTENT_ROOT_PATHS = new Set([
   '/platform-v7/arbitrator',
   '/platform-v7/executive',
 ]);
+
+type ControlledOwnerPreview = {
+  role: PlatformRole;
+  organizationId: string;
+  organizationName: string;
+};
 
 function normalizePath(pathname: string): string {
   return pathname.split('?')[0].replace(/\/$/, '') || '/platform-v7';
@@ -54,6 +65,48 @@ function roleFromPath(pathname: string): PlatformRole {
   return 'operator';
 }
 
+/**
+ * Presentation-only marker for the controlled owner review surface.
+ *
+ * It never grants a role, tenant or action permission. Every protected action is
+ * still authorized by the API and the signed HttpOnly cabinet session. The
+ * marker only decides whether the owner sees the complete existing cabinet UI
+ * or the backend-only canonical workspace on the cabinet root.
+ */
+function readControlledOwnerPreview(expectedRole: PlatformRole): ControlledOwnerPreview | null {
+  if (typeof document === 'undefined') return null;
+  const prefix = `${SESSION_COOKIE}=`;
+  const candidates = document.cookie
+    .split(';')
+    .map((part) => part.trim())
+    .filter((part) => part.startsWith(prefix))
+    .map((part) => part.slice(prefix.length))
+    .reverse();
+
+  for (const raw of candidates) {
+    try {
+      const parsed = JSON.parse(decodeURIComponent(raw)) as Record<string, unknown>;
+      if (
+        parsed.ownerAccess !== true
+        || parsed.role !== expectedRole
+        || parsed.tenantId !== CONTROLLED_TEST_TENANT_ID
+        || typeof parsed.organizationId !== 'string'
+      ) continue;
+
+      const organization = controlledOrganizationById(parsed.organizationId);
+      if (!organization?.testData || organization.tenantId !== CONTROLLED_TEST_TENANT_ID) continue;
+      return {
+        role: expectedRole,
+        organizationId: organization.id,
+        organizationName: organization.name,
+      };
+    } catch {
+      // Ignore stale or malformed presentation cookies. Server authority is unaffected.
+    }
+  }
+  return null;
+}
+
 export function PlatformV7ProtectedShell({ pathname, children }: { pathname: string; children: React.ReactNode }) {
   const normalizedPath = normalizePath(pathname);
   const isStaffControlCenter = normalizedPath === '/platform-v7/staff' || normalizedPath.startsWith('/platform-v7/staff/');
@@ -71,9 +124,58 @@ export function PlatformV7ProtectedShell({ pathname, children }: { pathname: str
   }
 
   const initialRole = roleFromPath(pathname);
-  const workSurface = ROLE_INTENT_ROOT_PATHS.has(normalizedPath)
-    ? <RoleIntentDashboard role={initialRole} />
+  const isRoleRoot = ROLE_INTENT_ROOT_PATHS.has(normalizedPath);
+  const [ownerPreview, setOwnerPreview] = React.useState<ControlledOwnerPreview | null>(null);
+  const [previewResolved, setPreviewResolved] = React.useState(!isRoleRoot);
+
+  React.useEffect(() => {
+    if (!isRoleRoot) {
+      setOwnerPreview(null);
+      setPreviewResolved(true);
+      return;
+    }
+    setOwnerPreview(readControlledOwnerPreview(initialRole));
+    setPreviewResolved(true);
+  }, [initialRole, isRoleRoot, normalizedPath]);
+
+  const workSurface = isRoleRoot
+    ? !previewResolved
+      ? (
+        <section aria-live='polite' style={{ margin: '8px 0 20px', padding: 18, borderRadius: 22, border: '1px solid #D7E5DF', background: '#F7FBF9' }}>
+          <strong>Открываем интерфейс кабинета…</strong>
+        </section>
+      )
+      : ownerPreview
+        ? (
+          <>
+            <section
+              data-controlled-owner-cabinet-preview='true'
+              style={{
+                margin: '4px 0 14px',
+                padding: 16,
+                borderRadius: 22,
+                border: '1px solid #A8D5C5',
+                background: 'linear-gradient(135deg, #EFFAF5, #FFFFFF)',
+                display: 'grid',
+                gap: 7,
+              }}
+            >
+              <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+                <span style={{ padding: '5px 10px', borderRadius: 999, background: '#DDF4EA', color: '#116149', fontSize: 12, fontWeight: 950, letterSpacing: '0.08em' }}>TEST</span>
+                <strong style={{ color: '#102B22', fontSize: 17 }}>Полный интерфейс кабинета</strong>
+              </div>
+              <div style={{ color: '#31564A', fontSize: 14, lineHeight: 1.5, fontWeight: 750 }}>{ownerPreview.organizationName}</div>
+              <p style={{ margin: 0, color: '#587168', fontSize: 13, lineHeight: 1.5 }}>
+                Данные и сценарии тестовые. Внешние интеграции, электронная подпись и движение денег не активированы. Действия исполняются только после серверной проверки полномочий.
+              </p>
+            </section>
+            {children}
+          </>
+        )
+        : <RoleIntentDashboard role={initialRole} />
     : children;
+
+  const showPlatformFooter = !isRoleRoot || (previewResolved && !ownerPreview);
 
   return (
     <>
@@ -95,7 +197,7 @@ export function PlatformV7ProtectedShell({ pathname, children }: { pathname: str
           <MobileHeaderActionRail />
           <RoleAssistantWidget />
           {workSurface}
-          <PlatformFooter />
+          {showPlatformFooter ? <PlatformFooter /> : null}
           <OnboardingTour />
         </>
       </AppShellV4>

--- a/apps/web/tests/unit/platformV7CanonicalDealWorkspace.test.ts
+++ b/apps/web/tests/unit/platformV7CanonicalDealWorkspace.test.ts
@@ -41,11 +41,13 @@ describe('platform-v7 canonical one-deal workspace', () => {
     expect(platformV7RoleCanOpenHref('driver', '/platform-v7/deals')).toBe(false);
   });
 
-  it('renders the same workspace at every role root instead of the old dashboard below it', () => {
+  it('keeps the canonical workspace at ordinary role roots and the full page only for controlled owner review', () => {
     expect(dashboard).toContain('<CanonicalDealWorkspace role={role} />');
     expect(dashboard).not.toContain('getRoleIntentConfig');
     expect(shell).toContain("'/platform-v7/surveyor'");
-    expect(shell).toContain('? <RoleIntentDashboard role={initialRole} />');
+    expect(shell).toContain(': <RoleIntentDashboard role={initialRole} />');
+    expect(shell).toContain("data-controlled-owner-cabinet-preview='true'");
+    expect(shell).toContain('{children}');
     expect(shell).toContain(': children;');
     expect(shell).not.toContain('{showRoleIntentDashboard ? <RoleIntentDashboard role={initialRole} /> : null}');
   });

--- a/apps/web/tests/unit/platformV7RoleIntentDashboard.test.ts
+++ b/apps/web/tests/unit/platformV7RoleIntentDashboard.test.ts
@@ -8,7 +8,7 @@ function read(relativePath: string) {
 }
 
 describe('platform-v7 role intent dashboard', () => {
-  it('keeps the role intent model and dashboard connected to cabinet roots', () => {
+  it('keeps the canonical role intent workspace for ordinary cabinet sessions', () => {
     const model = read('apps/web/lib/platform-v7/roleIntentActions.ts');
     const dashboard = read('apps/web/components/platform-v7/RoleIntentDashboard.tsx');
     const shell = read('apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx');
@@ -17,11 +17,37 @@ describe('platform-v7 role intent dashboard', () => {
     expect(dashboard).toContain('<CanonicalDealWorkspace role={role} />');
     expect(dashboard).not.toContain('getRoleIntentConfig');
     expect(shell).toContain('ROLE_INTENT_ROOT_PATHS');
-    expect(shell).toContain('RoleIntentDashboard');
+    expect(shell).toContain(': <RoleIntentDashboard role={initialRole} />');
 
     for (const route of ['/platform-v7/control-tower', '/platform-v7/buyer', '/platform-v7/seller', '/platform-v7/logistics', '/platform-v7/driver', '/platform-v7/elevator', '/platform-v7/lab', '/platform-v7/bank', '/platform-v7/compliance', '/platform-v7/arbitrator', '/platform-v7/executive']) {
       expect(shell).toContain(route);
     }
+  });
+
+  it('shows the complete existing cabinet only for the controlled owner review marker', () => {
+    const shell = read('apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx');
+
+    expect(shell).toContain('readControlledOwnerPreview(expectedRole');
+    expect(shell).toContain('parsed.ownerAccess !== true');
+    expect(shell).toContain('parsed.role !== expectedRole');
+    expect(shell).toContain('parsed.tenantId !== CONTROLLED_TEST_TENANT_ID');
+    expect(shell).toContain('controlledOrganizationById(parsed.organizationId)');
+    expect(shell).toContain("data-controlled-owner-cabinet-preview='true'");
+    expect(shell).toContain('Полный интерфейс кабинета');
+    expect(shell).toContain('Данные и сценарии тестовые');
+    expect(shell).toContain('Внешние интеграции, электронная подпись и движение денег не активированы');
+    expect(shell).toContain('{children}');
+    expect(shell).toContain('const showPlatformFooter = !isRoleRoot || (previewResolved && !ownerPreview)');
+  });
+
+  it('keeps the owner marker presentation-only and server authority explicit', () => {
+    const shell = read('apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx');
+
+    expect(shell).toContain('It never grants a role, tenant or action permission');
+    expect(shell).toContain('signed HttpOnly cabinet session');
+    expect(shell).toContain('<RbacCabinetGuard />');
+    expect(shell).toContain('<PlatformV7SingleEntryGuard />');
+    expect(shell).toContain('Действия исполняются только после серверной проверки полномочий');
   });
 
   it('keeps required fields and action verbs in the model source', () => {


### PR DESCRIPTION
Shows the existing full role page for the controlled owner review session instead of replacing it with the unavailable canonical workspace. Ordinary sessions remain on the canonical workspace. Adds a clear TEST notice and regression coverage; server authorization and RBAC remain unchanged.