### PR TITLE
Make all deal routes PostgreSQL authoritative

### DIFF
--- a/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
+++ b/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
@@ -2,10 +2,9 @@
 --
 -- A confirmed auction basis exists before its Deal row, so the ordinary
 -- integration_events policy (dealId must already be visible) cannot expose it.
--- The policy below reveals only the exact seller-scoped, tenant-scoped basis.
--- A SECURITY DEFINER predicate then permits that seller to create exactly the
--- seller and buyer participant rows encoded in that immutable basis. No other
--- integration event or participant write is widened.
+-- The policies below reveal only the exact seller-scoped, tenant-scoped basis
+-- and the seller/buyer organizations encoded in it. A SECURITY DEFINER predicate
+-- permits that seller to create exactly those two participant rows.
 
 CREATE OR REPLACE FUNCTION public.app_deal_basis_participant_allowed(
   p_deal_id text,
@@ -65,9 +64,6 @@ $function$;
 
 REVOKE ALL ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) FROM PUBLIC;
 
--- The seller may read only the one confirmed pre-deal basis that identifies the
--- current tenant, organization and user. Existing deal-bound integration event
--- visibility is unchanged.
 DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
 CREATE POLICY integration_events_select ON public."integration_events" FOR SELECT USING (
   public.app_rls_context_ready()
@@ -93,8 +89,44 @@ CREATE POLICY integration_events_select ON public."integration_events" FOR SELEC
   )
 );
 
--- Preserve privileged participant administration and add one narrowly verified
--- creation path for the seller encoded in the confirmed auction basis.
+-- The seller may verify only the two organizations encoded in its confirmed
+-- pre-deal basis. This does not expose the wider organization directory.
+DROP POLICY IF EXISTS organizations_select ON public."organizations";
+CREATE POLICY organizations_select ON public."organizations" FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND (
+    "id" = current_setting('app.current_org_id', true)
+    OR public.app_rls_privileged()
+    OR EXISTS (
+      SELECT 1 FROM public."deal_participants" dp
+      WHERE dp."organizationId" = "organizations"."id"
+        AND dp."tenantId" = current_setting('app.current_tenant_id', true)
+        AND dp."userId" = current_setting('app.current_user_id', true)
+        AND dp."status" = 'ACTIVE'
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public."integration_events" ie
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(ie."responsePayload", ie."requestPayload")::jsonb AS basis
+      ) confirmed
+      WHERE ie."dealId" IS NULL
+        AND current_setting('app.current_role', true) = 'FARMER'
+        AND ie."adapterName" = 'auction'
+        AND ie."eventType" = 'DEAL_BASIS_READY'
+        AND ie."status" = 'CONFIRMED'
+        AND COALESCE(ie."responsePayload", ie."requestPayload") IS NOT NULL
+        AND confirmed.basis ->> 'tenantId' = current_setting('app.current_tenant_id', true)
+        AND confirmed.basis ->> 'sellerOrgId' = current_setting('app.current_org_id', true)
+        AND confirmed.basis ->> 'sellerUserId' = current_setting('app.current_user_id', true)
+        AND "organizations"."id" IN (
+          confirmed.basis ->> 'sellerOrgId',
+          confirmed.basis ->> 'buyerOrgId'
+        )
+    )
+  )
+);
+
 DROP POLICY IF EXISTS deal_participants_insert ON public."deal_participants";
 CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT WITH CHECK (
   public.app_rls_context_ready()

--- a/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
+++ b/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
@@ -213,6 +213,7 @@ CREATE POLICY integration_events_select ON public."integration_events" FOR SELEC
 DROP POLICY IF EXISTS organizations_select ON public."organizations";
 CREATE POLICY organizations_select ON public."organizations" FOR SELECT USING (
   public.app_rls_context_ready()
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
   AND (
     "id" = current_setting('app.current_org_id', true)
     OR public.app_rls_privileged()
@@ -253,8 +254,18 @@ CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT 
   AND "tenantId" = current_setting('app.current_tenant_id', true)
   AND (
     public.app_rls_privileged()
-    OR public.app_deal_basis_participant_allowed(
-      "dealId", "tenantId", "organizationId", "userId", "role"
+    OR (
+      "accessLevel" = 'APPROVE'
+      AND "status" = 'ACTIVE'
+      AND "assignedByUserId" = current_setting('app.current_user_id', true)
+      AND "revokedAt" IS NULL
+      AND public.app_deal_basis_participant_allowed(
+        "dealId",
+        "tenantId",
+        "organizationId",
+        "userId",
+        "role"
+      )
     )
   )
 );

--- a/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
+++ b/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
@@ -1,10 +1,50 @@
 -- PostgreSQL-authoritative deal creation boundary.
 --
--- A confirmed auction basis exists before its Deal row, so the ordinary
--- integration_events policy (dealId must already be visible) cannot expose it.
--- The policies below reveal only the exact seller-scoped, tenant-scoped basis
--- and the seller/buyer organizations encoded in it. A SECURITY DEFINER predicate
--- permits that seller to create exactly those two participant rows.
+-- A confirmed auction basis exists before its Deal row, so ordinary participant
+-- visibility cannot authorize Prisma INSERT ... RETURNING or the first seller / 
+-- buyer participant rows. The functions and policies below permit only the exact
+-- tenant, seller, buyer, lot and winning bid encoded in one confirmed basis.
+
+CREATE OR REPLACE FUNCTION public.app_deal_basis_deal_visible(
+  p_deal_id text,
+  p_tenant_id text,
+  p_seller_org_id text,
+  p_buyer_org_id text,
+  p_lot_id text,
+  p_winner_bid_id text
+)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+STABLE
+AS $function$
+  SELECT
+    public.app_rls_context_ready()
+    AND current_setting('app.current_role', true) = 'FARMER'
+    AND p_tenant_id = current_setting('app.current_tenant_id', true)
+    AND p_seller_org_id = current_setting('app.current_org_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM public."integration_events" ie
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(ie."responsePayload", ie."requestPayload")::jsonb AS basis
+      ) confirmed
+      WHERE ie."dealId" IS NULL
+        AND ie."adapterName" = 'auction'
+        AND ie."eventType" = 'DEAL_BASIS_READY'
+        AND ie."externalId" = p_lot_id || ':' || p_winner_bid_id
+        AND ie."status" = 'CONFIRMED'
+        AND COALESCE(ie."responsePayload", ie."requestPayload") IS NOT NULL
+        AND confirmed.basis ->> 'tenantId' = p_tenant_id
+        AND confirmed.basis ->> 'sellerOrgId' = p_seller_org_id
+        AND confirmed.basis ->> 'buyerOrgId' = p_buyer_org_id
+        AND confirmed.basis ->> 'sellerUserId' = current_setting('app.current_user_id', true)
+        AND confirmed.basis ->> 'lotId' = p_lot_id
+        AND confirmed.basis ->> 'winnerBidId' = p_winner_bid_id
+        AND NULLIF(p_deal_id, '') IS NOT NULL
+    )
+$function$;
 
 CREATE OR REPLACE FUNCTION public.app_deal_basis_participant_allowed(
   p_deal_id text,
@@ -62,7 +102,40 @@ AS $function$
     )
 $function$;
 
+REVOKE ALL ON FUNCTION public.app_deal_basis_deal_visible(text, text, text, text, text, text) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) FROM PUBLIC;
+
+DROP POLICY IF EXISTS deals_select ON public."deals";
+CREATE POLICY deals_select ON public."deals" FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR (
+      current_setting('app.current_role', true) = 'BANK_CALLBACK'
+      AND "buyerOrgId" = current_setting('app.current_org_id', true)
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public."deal_participants" p
+      WHERE p."dealId" = "deals"."id"
+        AND p."tenantId" = current_setting('app.current_tenant_id', true)
+        AND p."organizationId" = current_setting('app.current_org_id', true)
+        AND p."userId" = current_setting('app.current_user_id', true)
+        AND p."role" = current_setting('app.current_role', true)
+        AND p."status" = 'ACTIVE'
+        AND p."accessLevel" IN ('READ', 'WORK', 'APPROVE')
+    )
+    OR public.app_deal_basis_deal_visible(
+      "id",
+      "tenantId",
+      "sellerOrgId",
+      "buyerOrgId",
+      "lotId",
+      "sourceLotId"
+    )
+  )
+);
 
 DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
 CREATE POLICY integration_events_select ON public."integration_events" FOR SELECT USING (
@@ -143,7 +216,7 @@ CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT 
   )
 );
 
-DO $grant_deal_basis_predicate$
+DO $grant_deal_basis_predicates$
 DECLARE
   role_name text;
 BEGIN
@@ -151,13 +224,19 @@ BEGIN
   LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
       EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION public.app_deal_basis_deal_visible(text, text, text, text, text, text) TO %I',
+        role_name
+      );
+      EXECUTE format(
         'GRANT EXECUTE ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) TO %I',
         role_name
       );
     END IF;
   END LOOP;
 END
-$grant_deal_basis_predicate$;
+$grant_deal_basis_predicates$;
 
+COMMENT ON FUNCTION public.app_deal_basis_deal_visible(text, text, text, text, text, text) IS
+  'Provides temporary seller visibility for one confirmed-basis Deal INSERT RETURNING before participant rows exist.';
 COMMENT ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) IS
   'Allows only seller/buyer participant rows encoded by the confirmed tenant-scoped auction basis for a newly created deal.';

--- a/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
+++ b/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
@@ -2,8 +2,8 @@
 --
 -- A confirmed auction basis exists before its Deal row, so ordinary participant
 -- visibility cannot authorize Prisma INSERT ... RETURNING or the first seller /
--- buyer participant rows. The policies bind every authoritative commercial field
--- and the immutable saga snapshot to one confirmed tenant-scoped auction basis.
+-- buyer participant rows. The policies bind every authoritative commercial field,
+-- the initial lifecycle state and the immutable saga snapshot to one confirmed basis.
 
 CREATE OR REPLACE FUNCTION public.app_deal_basis_deal_visible(p_deal jsonb)
 RETURNS boolean
@@ -19,8 +19,20 @@ AS $function$
     AND p_deal ->> 'sellerOrgId' = current_setting('app.current_org_id', true)
     AND p_deal ->> 'status' = 'DRAFT'
     AND p_deal ->> 'version' = '0'
+    AND p_deal ->> 'nextAction' = 'Подтвердить допуск участников'
     AND p_deal -> 'signedAt' = 'null'::jsonb
     AND p_deal -> 'closedAt' = 'null'::jsonb
+    AND p_deal -> 'volumeTons' = 'null'::jsonb
+    AND p_deal -> 'pricePerTon' = 'null'::jsonb
+    AND p_deal -> 'totalRub' = 'null'::jsonb
+    AND p_deal -> 'gost' = 'null'::jsonb
+    AND p_deal -> 'fundingChoice' = 'null'::jsonb
+    AND p_deal -> 'owner' = 'null'::jsonb
+    AND p_deal -> 'slaAt' = 'null'::jsonb
+    AND p_deal -> 'sagaStep' = 'null'::jsonb
+    AND p_deal -> 'meta' = 'null'::jsonb
+    AND jsonb_typeof(p_deal -> 'sagaState') = 'object'
+    AND jsonb_object_length(p_deal -> 'sagaState') = 18
     AND EXISTS (
       SELECT 1
       FROM public."integration_events" ie
@@ -57,9 +69,14 @@ AS $function$
         AND p_deal -> 'sagaState' ->> 'buyerOrgId' = confirmed.basis ->> 'buyerOrgId'
         AND p_deal -> 'sagaState' ->> 'sellerUserId' = confirmed.basis ->> 'sellerUserId'
         AND p_deal -> 'sagaState' ->> 'buyerUserId' = confirmed.basis ->> 'buyerUserId'
+        AND p_deal -> 'sagaState' ->> 'culture' = confirmed.basis ->> 'culture'
+        AND NULLIF(p_deal -> 'sagaState' ->> 'cropClass', '') IS NOT DISTINCT FROM NULLIF(confirmed.basis ->> 'cropClass', '')
+        AND NULLIF(p_deal -> 'sagaState' ->> 'region', '') IS NOT DISTINCT FROM NULLIF(confirmed.basis ->> 'region', '')
+        AND NULLIF(p_deal -> 'sagaState' ->> 'incoterms', '') IS NOT DISTINCT FROM NULLIF(confirmed.basis ->> 'incoterms', '')
         AND p_deal -> 'sagaState' ->> 'volumeTons' = confirmed.basis ->> 'volumeTons'
         AND p_deal -> 'sagaState' ->> 'pricePerTon' = confirmed.basis ->> 'pricePerTon'
         AND p_deal -> 'sagaState' ->> 'totalKopecks' = confirmed.basis ->> 'totalKopecks'
+        AND p_deal -> 'sagaState' ->> 'currency' = confirmed.basis ->> 'currency'
         AND NULLIF(p_deal ->> 'id', '') IS NOT NULL
     )
 $function$;
@@ -304,7 +321,7 @@ END
 $grant_deal_basis_predicates$;
 
 COMMENT ON FUNCTION public.app_deal_basis_deal_visible(jsonb) IS
-  'Validates every authoritative Deal field and saga basis before temporary seller visibility or insert.';
+  'Validates all authoritative Deal fields and rejects hidden initial state before insert or temporary seller visibility.';
 COMMENT ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) IS
   'Allows only seller/buyer participant rows encoded by the confirmed tenant-scoped auction basis.';
 COMMENT ON FUNCTION public.enforce_single_deal_per_basis() IS

--- a/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
+++ b/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
@@ -2,8 +2,8 @@
 --
 -- A confirmed auction basis exists before its Deal row, so ordinary participant
 -- visibility cannot authorize Prisma INSERT ... RETURNING or the first seller /
--- buyer participant rows. The policies bind every authoritative commercial field,
--- the initial lifecycle state and the immutable saga snapshot to one confirmed basis.
+-- buyer participant rows. These policies bind every authoritative commercial
+-- field and the initial immutable saga snapshot to one confirmed basis.
 
 CREATE OR REPLACE FUNCTION public.app_deal_basis_deal_visible(p_deal jsonb)
 RETURNS boolean
@@ -32,7 +32,20 @@ AS $function$
     AND p_deal -> 'sagaStep' = 'null'::jsonb
     AND p_deal -> 'meta' = 'null'::jsonb
     AND jsonb_typeof(p_deal -> 'sagaState') = 'object'
-    AND jsonb_object_length(p_deal -> 'sagaState') = 18
+    AND (
+      SELECT count(*)
+      FROM jsonb_object_keys(p_deal -> 'sagaState') AS saga_key(key)
+    ) = 18
+    AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_object_keys(p_deal -> 'sagaState') AS saga_key(key)
+      WHERE saga_key.key NOT IN (
+        'source', 'integrationEventId', 'sourceHash', 'lotId', 'winnerBidId',
+        'sellerOrgId', 'buyerOrgId', 'sellerUserId', 'buyerUserId',
+        'culture', 'cropClass', 'region', 'incoterms', 'volumeTons',
+        'pricePerTon', 'totalKopecks', 'currency', 'paymentTerms'
+      )
+    )
     AND EXISTS (
       SELECT 1
       FROM public."integration_events" ie
@@ -182,10 +195,7 @@ DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
 CREATE POLICY integration_events_select ON public."integration_events" FOR SELECT USING (
   public.app_rls_context_ready()
   AND (
-    (
-      "dealId" IS NOT NULL
-      AND public.app_rls_deal_visible("dealId")
-    )
+    ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
     OR (
       "dealId" IS NULL
       AND current_setting('app.current_role', true) = 'FARMER'
@@ -193,12 +203,9 @@ CREATE POLICY integration_events_select ON public."integration_events" FOR SELEC
       AND "eventType" = 'DEAL_BASIS_READY'
       AND "status" = 'CONFIRMED'
       AND COALESCE("responsePayload", "requestPayload") IS NOT NULL
-      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'tenantId'
-        = current_setting('app.current_tenant_id', true)
-      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerOrgId'
-        = current_setting('app.current_org_id', true)
-      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerUserId'
-        = current_setting('app.current_user_id', true)
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'tenantId' = current_setting('app.current_tenant_id', true)
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerOrgId' = current_setting('app.current_org_id', true)
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerUserId' = current_setting('app.current_user_id', true)
     )
   )
 );
@@ -210,7 +217,8 @@ CREATE POLICY organizations_select ON public."organizations" FOR SELECT USING (
     "id" = current_setting('app.current_org_id', true)
     OR public.app_rls_privileged()
     OR EXISTS (
-      SELECT 1 FROM public."deal_participants" dp
+      SELECT 1
+      FROM public."deal_participants" dp
       WHERE dp."organizationId" = "organizations"."id"
         AND dp."tenantId" = current_setting('app.current_tenant_id', true)
         AND dp."userId" = current_setting('app.current_user_id', true)
@@ -246,17 +254,13 @@ CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT 
   AND (
     public.app_rls_privileged()
     OR public.app_deal_basis_participant_allowed(
-      "dealId",
-      "tenantId",
-      "organizationId",
-      "userId",
-      "role"
+      "dealId", "tenantId", "organizationId", "userId", "role"
     )
   )
 );
 
--- One auction basis may produce exactly one Deal. The transaction advisory lock
--- serializes repository and direct SQL attempts before the duplicate check.
+-- One auction basis may produce exactly one Deal. Advisory locking serializes
+-- repository and direct-SQL attempts before the duplicate check.
 CREATE OR REPLACE FUNCTION public.enforce_single_deal_per_basis()
 RETURNS trigger
 LANGUAGE plpgsql

--- a/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
+++ b/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
@@ -1,0 +1,62 @@
+-- PostgreSQL-authoritative deal creation boundary.
+--
+-- A deal basis exists before the Deal row, therefore ordinary integration_events
+-- RLS (which requires an already-visible dealId) cannot expose it safely. This
+-- narrow SECURITY DEFINER resolver returns only the latest CONFIRMED auction
+-- basis matching the trusted tenant and an explicitly privileged platform role.
+-- It does not create or mutate a deal and exposes no unrelated integration data.
+
+CREATE OR REPLACE FUNCTION public.app_verified_deal_basis(
+  p_lot_id text,
+  p_winner_bid_id text
+)
+RETURNS TABLE (
+  "eventId" text,
+  basis jsonb,
+  "createdAt" timestamptz
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+STABLE
+AS $function$
+  SELECT
+    ie."id" AS "eventId",
+    COALESCE(ie."responsePayload", ie."requestPayload")::jsonb AS basis,
+    ie."createdAt" AS "createdAt"
+  FROM public."integration_events" ie
+  WHERE public.app_rls_context_ready()
+    AND current_setting('app.current_role', true) IN ('ADMIN', 'SUPPORT_MANAGER')
+    AND ie."adapterName" = 'auction'
+    AND ie."eventType" = 'DEAL_BASIS_READY'
+    AND ie."externalId" = p_lot_id || ':' || p_winner_bid_id
+    AND ie."status" = 'CONFIRMED'
+    AND COALESCE(ie."responsePayload", ie."requestPayload") IS NOT NULL
+    AND COALESCE(ie."responsePayload", ie."requestPayload")::jsonb ->> 'tenantId'
+      = current_setting('app.current_tenant_id', true)
+    AND COALESCE(ie."responsePayload", ie."requestPayload")::jsonb ->> 'lotId' = p_lot_id
+    AND COALESCE(ie."responsePayload", ie."requestPayload")::jsonb ->> 'winnerBidId' = p_winner_bid_id
+  ORDER BY ie."createdAt" DESC, ie."id" DESC
+  LIMIT 1
+$function$;
+
+REVOKE ALL ON FUNCTION public.app_verified_deal_basis(text, text) FROM PUBLIC;
+
+DO $grant_verified_basis$
+DECLARE
+  role_name text;
+BEGIN
+  FOREACH role_name IN ARRAY ARRAY['app_service', 'app_deal_api', 'app_integration_worker']
+  LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+      EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION public.app_verified_deal_basis(text, text) TO %I',
+        role_name
+      );
+    END IF;
+  END LOOP;
+END
+$grant_verified_basis$;
+
+COMMENT ON FUNCTION public.app_verified_deal_basis(text, text) IS
+  'Returns one tenant-scoped confirmed auction deal basis to ADMIN or SUPPORT_MANAGER using complete trusted transaction context.';

--- a/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
+++ b/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
@@ -1,62 +1,131 @@
 -- PostgreSQL-authoritative deal creation boundary.
 --
--- A deal basis exists before the Deal row, therefore ordinary integration_events
--- RLS (which requires an already-visible dealId) cannot expose it safely. This
--- narrow SECURITY DEFINER resolver returns only the latest CONFIRMED auction
--- basis matching the trusted tenant and an explicitly privileged platform role.
--- It does not create or mutate a deal and exposes no unrelated integration data.
+-- A confirmed auction basis exists before its Deal row, so the ordinary
+-- integration_events policy (dealId must already be visible) cannot expose it.
+-- The policy below reveals only the exact seller-scoped, tenant-scoped basis.
+-- A SECURITY DEFINER predicate then permits that seller to create exactly the
+-- seller and buyer participant rows encoded in that immutable basis. No other
+-- integration event or participant write is widened.
 
-CREATE OR REPLACE FUNCTION public.app_verified_deal_basis(
-  p_lot_id text,
-  p_winner_bid_id text
+CREATE OR REPLACE FUNCTION public.app_deal_basis_participant_allowed(
+  p_deal_id text,
+  p_tenant_id text,
+  p_organization_id text,
+  p_user_id text,
+  p_role text
 )
-RETURNS TABLE (
-  "eventId" text,
-  basis jsonb,
-  "createdAt" timestamptz
-)
+RETURNS boolean
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = pg_catalog, public
 STABLE
 AS $function$
   SELECT
-    ie."id" AS "eventId",
-    COALESCE(ie."responsePayload", ie."requestPayload")::jsonb AS basis,
-    ie."createdAt" AS "createdAt"
-  FROM public."integration_events" ie
-  WHERE public.app_rls_context_ready()
-    AND current_setting('app.current_role', true) IN ('ADMIN', 'SUPPORT_MANAGER')
-    AND ie."adapterName" = 'auction'
-    AND ie."eventType" = 'DEAL_BASIS_READY'
-    AND ie."externalId" = p_lot_id || ':' || p_winner_bid_id
-    AND ie."status" = 'CONFIRMED'
-    AND COALESCE(ie."responsePayload", ie."requestPayload") IS NOT NULL
-    AND COALESCE(ie."responsePayload", ie."requestPayload")::jsonb ->> 'tenantId'
-      = current_setting('app.current_tenant_id', true)
-    AND COALESCE(ie."responsePayload", ie."requestPayload")::jsonb ->> 'lotId' = p_lot_id
-    AND COALESCE(ie."responsePayload", ie."requestPayload")::jsonb ->> 'winnerBidId' = p_winner_bid_id
-  ORDER BY ie."createdAt" DESC, ie."id" DESC
-  LIMIT 1
+    public.app_rls_context_ready()
+    AND current_setting('app.current_role', true) = 'FARMER'
+    AND EXISTS (
+      SELECT 1
+      FROM public."deals" d
+      JOIN LATERAL (
+        SELECT COALESCE(ie."responsePayload", ie."requestPayload")::jsonb AS basis
+        FROM public."integration_events" ie
+        WHERE ie."adapterName" = 'auction'
+          AND ie."eventType" = 'DEAL_BASIS_READY'
+          AND ie."externalId" = d."lotId" || ':' || d."sourceLotId"
+          AND ie."status" = 'CONFIRMED'
+          AND COALESCE(ie."responsePayload", ie."requestPayload") IS NOT NULL
+        ORDER BY ie."createdAt" DESC, ie."id" DESC
+        LIMIT 1
+      ) confirmed ON true
+      WHERE d."id" = p_deal_id
+        AND d."tenantId" = p_tenant_id
+        AND p_tenant_id = current_setting('app.current_tenant_id', true)
+        AND d."sellerOrgId" = current_setting('app.current_org_id', true)
+        AND confirmed.basis ->> 'tenantId' = current_setting('app.current_tenant_id', true)
+        AND confirmed.basis ->> 'sellerOrgId' = current_setting('app.current_org_id', true)
+        AND confirmed.basis ->> 'sellerUserId' = current_setting('app.current_user_id', true)
+        AND confirmed.basis ->> 'sellerOrgId' = d."sellerOrgId"
+        AND confirmed.basis ->> 'buyerOrgId' = d."buyerOrgId"
+        AND confirmed.basis ->> 'lotId' = d."lotId"
+        AND confirmed.basis ->> 'winnerBidId' = d."sourceLotId"
+        AND (
+          (
+            p_organization_id = confirmed.basis ->> 'sellerOrgId'
+            AND p_user_id = confirmed.basis ->> 'sellerUserId'
+            AND p_role = 'FARMER'
+          )
+          OR (
+            p_organization_id = confirmed.basis ->> 'buyerOrgId'
+            AND p_user_id = confirmed.basis ->> 'buyerUserId'
+            AND p_role = 'BUYER'
+          )
+        )
+    )
 $function$;
 
-REVOKE ALL ON FUNCTION public.app_verified_deal_basis(text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) FROM PUBLIC;
 
-DO $grant_verified_basis$
+-- The seller may read only the one confirmed pre-deal basis that identifies the
+-- current tenant, organization and user. Existing deal-bound integration event
+-- visibility is unchanged.
+DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
+CREATE POLICY integration_events_select ON public."integration_events" FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND (
+    (
+      "dealId" IS NOT NULL
+      AND public.app_rls_deal_visible("dealId")
+    )
+    OR (
+      "dealId" IS NULL
+      AND current_setting('app.current_role', true) = 'FARMER'
+      AND "adapterName" = 'auction'
+      AND "eventType" = 'DEAL_BASIS_READY'
+      AND "status" = 'CONFIRMED'
+      AND COALESCE("responsePayload", "requestPayload") IS NOT NULL
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'tenantId'
+        = current_setting('app.current_tenant_id', true)
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerOrgId'
+        = current_setting('app.current_org_id', true)
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerUserId'
+        = current_setting('app.current_user_id', true)
+    )
+  )
+);
+
+-- Preserve privileged participant administration and add one narrowly verified
+-- creation path for the seller encoded in the confirmed auction basis.
+DROP POLICY IF EXISTS deal_participants_insert ON public."deal_participants";
+CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT WITH CHECK (
+  public.app_rls_context_ready()
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR public.app_deal_basis_participant_allowed(
+      "dealId",
+      "tenantId",
+      "organizationId",
+      "userId",
+      "role"
+    )
+  )
+);
+
+DO $grant_deal_basis_predicate$
 DECLARE
   role_name text;
 BEGIN
-  FOREACH role_name IN ARRAY ARRAY['app_service', 'app_deal_api', 'app_integration_worker']
+  FOREACH role_name IN ARRAY ARRAY['app_service', 'app_deal_api', 'one_deal_app']
   LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
       EXECUTE format(
-        'GRANT EXECUTE ON FUNCTION public.app_verified_deal_basis(text, text) TO %I',
+        'GRANT EXECUTE ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) TO %I',
         role_name
       );
     END IF;
   END LOOP;
 END
-$grant_verified_basis$;
+$grant_deal_basis_predicate$;
 
-COMMENT ON FUNCTION public.app_verified_deal_basis(text, text) IS
-  'Returns one tenant-scoped confirmed auction deal basis to ADMIN or SUPPORT_MANAGER using complete trusted transaction context.';
+COMMENT ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) IS
+  'Allows only seller/buyer participant rows encoded by the confirmed tenant-scoped auction basis for a newly created deal.';

--- a/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
+++ b/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
@@ -1,7 +1,7 @@
 -- PostgreSQL-authoritative deal creation boundary.
 --
 -- A confirmed auction basis exists before its Deal row, so ordinary participant
--- visibility cannot authorize Prisma INSERT ... RETURNING or the first seller / 
+-- visibility cannot authorize Prisma INSERT ... RETURNING or the first seller /
 -- buyer participant rows. The functions and policies below permit only the exact
 -- tenant, seller, buyer, lot and winning bid encoded in one confirmed basis.
 
@@ -137,6 +137,26 @@ CREATE POLICY deals_select ON public."deals" FOR SELECT USING (
   )
 );
 
+DROP POLICY IF EXISTS deals_insert ON public."deals";
+CREATE POLICY deals_insert ON public."deals" FOR INSERT WITH CHECK (
+  public.app_rls_context_ready()
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR (
+      current_setting('app.current_role', true) = 'FARMER'
+      AND public.app_deal_basis_deal_visible(
+        "id",
+        "tenantId",
+        "sellerOrgId",
+        "buyerOrgId",
+        "lotId",
+        "sourceLotId"
+      )
+    )
+  )
+);
+
 DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
 CREATE POLICY integration_events_select ON public."integration_events" FOR SELECT USING (
   public.app_rls_context_ready()
@@ -216,6 +236,53 @@ CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT 
   )
 );
 
+-- One auction basis may produce exactly one Deal. The transaction advisory lock
+-- makes the invariant effective even for concurrent direct SQL attempts using
+-- the restricted runtime principal; the trigger is invisible to Prisma schema
+-- drift because Prisma does not model triggers.
+CREATE OR REPLACE FUNCTION public.enforce_single_deal_per_basis()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $function$
+BEGIN
+  IF NEW."tenantId" IS NULL OR NEW."lotId" IS NULL OR NEW."sourceLotId" IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(
+      NEW."tenantId" || chr(31) || NEW."lotId" || chr(31) || NEW."sourceLotId",
+      84
+    )
+  );
+
+  IF EXISTS (
+    SELECT 1
+    FROM public."deals" d
+    WHERE d."tenantId" = NEW."tenantId"
+      AND d."lotId" = NEW."lotId"
+      AND d."sourceLotId" = NEW."sourceLotId"
+      AND d."id" <> NEW."id"
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23505',
+      MESSAGE = 'confirmed auction basis has already been consumed by another deal',
+      CONSTRAINT = 'deals_tenant_lot_winner_single_use';
+  END IF;
+
+  RETURN NEW;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION public.enforce_single_deal_per_basis() FROM PUBLIC;
+DROP TRIGGER IF EXISTS deals_single_basis ON public."deals";
+CREATE TRIGGER deals_single_basis
+  BEFORE INSERT OR UPDATE OF "tenantId", "lotId", "sourceLotId"
+  ON public."deals"
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_single_deal_per_basis();
+
 DO $grant_deal_basis_predicates$
 DECLARE
   role_name text;
@@ -240,3 +307,5 @@ COMMENT ON FUNCTION public.app_deal_basis_deal_visible(text, text, text, text, t
   'Provides temporary seller visibility for one confirmed-basis Deal INSERT RETURNING before participant rows exist.';
 COMMENT ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) IS
   'Allows only seller/buyer participant rows encoded by the confirmed tenant-scoped auction basis for a newly created deal.';
+COMMENT ON FUNCTION public.enforce_single_deal_per_basis() IS
+  'Serializes and rejects reuse of the same tenant/lot/winning-bid basis across Deal rows.';

--- a/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
+++ b/apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/migration.sql
@@ -2,17 +2,10 @@
 --
 -- A confirmed auction basis exists before its Deal row, so ordinary participant
 -- visibility cannot authorize Prisma INSERT ... RETURNING or the first seller /
--- buyer participant rows. The functions and policies below permit only the exact
--- tenant, seller, buyer, lot and winning bid encoded in one confirmed basis.
+-- buyer participant rows. The policies bind every authoritative commercial field
+-- and the immutable saga snapshot to one confirmed tenant-scoped auction basis.
 
-CREATE OR REPLACE FUNCTION public.app_deal_basis_deal_visible(
-  p_deal_id text,
-  p_tenant_id text,
-  p_seller_org_id text,
-  p_buyer_org_id text,
-  p_lot_id text,
-  p_winner_bid_id text
-)
+CREATE OR REPLACE FUNCTION public.app_deal_basis_deal_visible(p_deal jsonb)
 RETURNS boolean
 LANGUAGE sql
 SECURITY DEFINER
@@ -22,8 +15,12 @@ AS $function$
   SELECT
     public.app_rls_context_ready()
     AND current_setting('app.current_role', true) = 'FARMER'
-    AND p_tenant_id = current_setting('app.current_tenant_id', true)
-    AND p_seller_org_id = current_setting('app.current_org_id', true)
+    AND p_deal ->> 'tenantId' = current_setting('app.current_tenant_id', true)
+    AND p_deal ->> 'sellerOrgId' = current_setting('app.current_org_id', true)
+    AND p_deal ->> 'status' = 'DRAFT'
+    AND p_deal ->> 'version' = '0'
+    AND p_deal -> 'signedAt' = 'null'::jsonb
+    AND p_deal -> 'closedAt' = 'null'::jsonb
     AND EXISTS (
       SELECT 1
       FROM public."integration_events" ie
@@ -33,16 +30,37 @@ AS $function$
       WHERE ie."dealId" IS NULL
         AND ie."adapterName" = 'auction'
         AND ie."eventType" = 'DEAL_BASIS_READY'
-        AND ie."externalId" = p_lot_id || ':' || p_winner_bid_id
+        AND ie."externalId" = (p_deal ->> 'lotId') || ':' || (p_deal ->> 'sourceLotId')
         AND ie."status" = 'CONFIRMED'
         AND COALESCE(ie."responsePayload", ie."requestPayload") IS NOT NULL
-        AND confirmed.basis ->> 'tenantId' = p_tenant_id
-        AND confirmed.basis ->> 'sellerOrgId' = p_seller_org_id
-        AND confirmed.basis ->> 'buyerOrgId' = p_buyer_org_id
+        AND confirmed.basis ->> 'tenantId' = p_deal ->> 'tenantId'
+        AND confirmed.basis ->> 'dealNumber' = p_deal ->> 'dealNumber'
+        AND confirmed.basis ->> 'sellerOrgId' = p_deal ->> 'sellerOrgId'
+        AND confirmed.basis ->> 'buyerOrgId' = p_deal ->> 'buyerOrgId'
         AND confirmed.basis ->> 'sellerUserId' = current_setting('app.current_user_id', true)
-        AND confirmed.basis ->> 'lotId' = p_lot_id
-        AND confirmed.basis ->> 'winnerBidId' = p_winner_bid_id
-        AND NULLIF(p_deal_id, '') IS NOT NULL
+        AND confirmed.basis ->> 'lotId' = p_deal ->> 'lotId'
+        AND confirmed.basis ->> 'winnerBidId' = p_deal ->> 'sourceLotId'
+        AND (confirmed.basis ->> 'volumeTons')::numeric = (p_deal ->> 'volumeTonsDec')::numeric
+        AND (confirmed.basis ->> 'pricePerTon')::numeric = (p_deal ->> 'pricePerTonDec')::numeric
+        AND (confirmed.basis ->> 'totalKopecks')::bigint = (p_deal ->> 'totalKopecks')::bigint
+        AND confirmed.basis ->> 'currency' = p_deal ->> 'currency'
+        AND confirmed.basis ->> 'culture' = p_deal ->> 'culture'
+        AND NULLIF(confirmed.basis ->> 'cropClass', '') IS NOT DISTINCT FROM NULLIF(p_deal ->> 'cropClass', '')
+        AND NULLIF(confirmed.basis ->> 'region', '') IS NOT DISTINCT FROM NULLIF(p_deal ->> 'region', '')
+        AND NULLIF(confirmed.basis ->> 'incoterms', '') IS NOT DISTINCT FROM NULLIF(p_deal ->> 'incoterms', '')
+        AND p_deal -> 'sagaState' ->> 'source' = 'POSTGRESQL_INTEGRATION_EVENT'
+        AND p_deal -> 'sagaState' ->> 'integrationEventId' = ie."id"
+        AND p_deal -> 'sagaState' ->> 'sourceHash' = confirmed.basis ->> 'sourceHash'
+        AND p_deal -> 'sagaState' ->> 'lotId' = confirmed.basis ->> 'lotId'
+        AND p_deal -> 'sagaState' ->> 'winnerBidId' = confirmed.basis ->> 'winnerBidId'
+        AND p_deal -> 'sagaState' ->> 'sellerOrgId' = confirmed.basis ->> 'sellerOrgId'
+        AND p_deal -> 'sagaState' ->> 'buyerOrgId' = confirmed.basis ->> 'buyerOrgId'
+        AND p_deal -> 'sagaState' ->> 'sellerUserId' = confirmed.basis ->> 'sellerUserId'
+        AND p_deal -> 'sagaState' ->> 'buyerUserId' = confirmed.basis ->> 'buyerUserId'
+        AND p_deal -> 'sagaState' ->> 'volumeTons' = confirmed.basis ->> 'volumeTons'
+        AND p_deal -> 'sagaState' ->> 'pricePerTon' = confirmed.basis ->> 'pricePerTon'
+        AND p_deal -> 'sagaState' ->> 'totalKopecks' = confirmed.basis ->> 'totalKopecks'
+        AND NULLIF(p_deal ->> 'id', '') IS NOT NULL
     )
 $function$;
 
@@ -102,7 +120,7 @@ AS $function$
     )
 $function$;
 
-REVOKE ALL ON FUNCTION public.app_deal_basis_deal_visible(text, text, text, text, text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.app_deal_basis_deal_visible(jsonb) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) FROM PUBLIC;
 
 DROP POLICY IF EXISTS deals_select ON public."deals";
@@ -126,14 +144,7 @@ CREATE POLICY deals_select ON public."deals" FOR SELECT USING (
         AND p."status" = 'ACTIVE'
         AND p."accessLevel" IN ('READ', 'WORK', 'APPROVE')
     )
-    OR public.app_deal_basis_deal_visible(
-      "id",
-      "tenantId",
-      "sellerOrgId",
-      "buyerOrgId",
-      "lotId",
-      "sourceLotId"
-    )
+    OR public.app_deal_basis_deal_visible(to_jsonb("deals"))
   )
 );
 
@@ -145,14 +156,7 @@ CREATE POLICY deals_insert ON public."deals" FOR INSERT WITH CHECK (
     public.app_rls_privileged()
     OR (
       current_setting('app.current_role', true) = 'FARMER'
-      AND public.app_deal_basis_deal_visible(
-        "id",
-        "tenantId",
-        "sellerOrgId",
-        "buyerOrgId",
-        "lotId",
-        "sourceLotId"
-      )
+      AND public.app_deal_basis_deal_visible(to_jsonb("deals"))
     )
   )
 );
@@ -182,8 +186,6 @@ CREATE POLICY integration_events_select ON public."integration_events" FOR SELEC
   )
 );
 
--- The seller may verify only the two organizations encoded in its confirmed
--- pre-deal basis. This does not expose the wider organization directory.
 DROP POLICY IF EXISTS organizations_select ON public."organizations";
 CREATE POLICY organizations_select ON public."organizations" FOR SELECT USING (
   public.app_rls_context_ready()
@@ -237,9 +239,7 @@ CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT 
 );
 
 -- One auction basis may produce exactly one Deal. The transaction advisory lock
--- makes the invariant effective even for concurrent direct SQL attempts using
--- the restricted runtime principal; the trigger is invisible to Prisma schema
--- drift because Prisma does not model triggers.
+-- serializes repository and direct SQL attempts before the duplicate check.
 CREATE OR REPLACE FUNCTION public.enforce_single_deal_per_basis()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -291,7 +291,7 @@ BEGIN
   LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
       EXECUTE format(
-        'GRANT EXECUTE ON FUNCTION public.app_deal_basis_deal_visible(text, text, text, text, text, text) TO %I',
+        'GRANT EXECUTE ON FUNCTION public.app_deal_basis_deal_visible(jsonb) TO %I',
         role_name
       );
       EXECUTE format(
@@ -303,9 +303,9 @@ BEGIN
 END
 $grant_deal_basis_predicates$;
 
-COMMENT ON FUNCTION public.app_deal_basis_deal_visible(text, text, text, text, text, text) IS
-  'Provides temporary seller visibility for one confirmed-basis Deal INSERT RETURNING before participant rows exist.';
+COMMENT ON FUNCTION public.app_deal_basis_deal_visible(jsonb) IS
+  'Validates every authoritative Deal field and saga basis before temporary seller visibility or insert.';
 COMMENT ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) IS
-  'Allows only seller/buyer participant rows encoded by the confirmed tenant-scoped auction basis for a newly created deal.';
+  'Allows only seller/buyer participant rows encoded by the confirmed tenant-scoped auction basis.';
 COMMENT ON FUNCTION public.enforce_single_deal_per_basis() IS
   'Serializes and rejects reuse of the same tenant/lot/winning-bid basis across Deal rows.';

--- a/apps/api/prisma/migrations/20260712194000_deal_basis_immutability/migration.sql
+++ b/apps/api/prisma/migrations/20260712194000_deal_basis_immutability/migration.sql
@@ -1,0 +1,136 @@
+-- Confirmed commercial basis is immutable after Deal creation.
+-- Lifecycle commands may change status, nextAction, version, closedAt and may add
+-- operational saga keys such as logisticsBasis. They cannot rewrite the auction
+-- basis, counterparties, price, volume, amount or original basis snapshot.
+
+CREATE OR REPLACE FUNCTION public.forbid_deal_basis_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $function$
+DECLARE
+  old_basis jsonb;
+  new_basis jsonb;
+BEGIN
+  IF ROW(
+    OLD."tenantId",
+    OLD."lotId",
+    OLD."sourceLotId",
+    OLD."dealNumber",
+    OLD."sellerOrgId",
+    OLD."buyerOrgId",
+    OLD."volumeTons",
+    OLD."pricePerTon",
+    OLD."totalRub",
+    OLD."volumeTonsDec",
+    OLD."pricePerTonDec",
+    OLD."totalKopecks",
+    OLD."currency",
+    OLD."culture",
+    OLD."cropClass",
+    OLD."region",
+    OLD."incoterms"
+  ) IS DISTINCT FROM ROW(
+    NEW."tenantId",
+    NEW."lotId",
+    NEW."sourceLotId",
+    NEW."dealNumber",
+    NEW."sellerOrgId",
+    NEW."buyerOrgId",
+    NEW."volumeTons",
+    NEW."pricePerTon",
+    NEW."totalRub",
+    NEW."volumeTonsDec",
+    NEW."pricePerTonDec",
+    NEW."totalKopecks",
+    NEW."currency",
+    NEW."culture",
+    NEW."cropClass",
+    NEW."region",
+    NEW."incoterms"
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'confirmed deal commercial basis is immutable',
+      CONSTRAINT = 'deals_confirmed_basis_immutable';
+  END IF;
+
+  old_basis := jsonb_build_object(
+    'source', OLD."sagaState" ->> 'source',
+    'integrationEventId', OLD."sagaState" ->> 'integrationEventId',
+    'sourceHash', OLD."sagaState" ->> 'sourceHash',
+    'lotId', OLD."sagaState" ->> 'lotId',
+    'winnerBidId', OLD."sagaState" ->> 'winnerBidId',
+    'sellerOrgId', OLD."sagaState" ->> 'sellerOrgId',
+    'buyerOrgId', OLD."sagaState" ->> 'buyerOrgId',
+    'sellerUserId', OLD."sagaState" ->> 'sellerUserId',
+    'buyerUserId', OLD."sagaState" ->> 'buyerUserId',
+    'culture', OLD."sagaState" ->> 'culture',
+    'cropClass', OLD."sagaState" -> 'cropClass',
+    'region', OLD."sagaState" -> 'region',
+    'incoterms', OLD."sagaState" -> 'incoterms',
+    'volumeTons', OLD."sagaState" ->> 'volumeTons',
+    'pricePerTon', OLD."sagaState" ->> 'pricePerTon',
+    'totalKopecks', OLD."sagaState" ->> 'totalKopecks',
+    'currency', OLD."sagaState" ->> 'currency',
+    'paymentTerms', OLD."sagaState" -> 'paymentTerms'
+  );
+  new_basis := jsonb_build_object(
+    'source', NEW."sagaState" ->> 'source',
+    'integrationEventId', NEW."sagaState" ->> 'integrationEventId',
+    'sourceHash', NEW."sagaState" ->> 'sourceHash',
+    'lotId', NEW."sagaState" ->> 'lotId',
+    'winnerBidId', NEW."sagaState" ->> 'winnerBidId',
+    'sellerOrgId', NEW."sagaState" ->> 'sellerOrgId',
+    'buyerOrgId', NEW."sagaState" ->> 'buyerOrgId',
+    'sellerUserId', NEW."sagaState" ->> 'sellerUserId',
+    'buyerUserId', NEW."sagaState" ->> 'buyerUserId',
+    'culture', NEW."sagaState" ->> 'culture',
+    'cropClass', NEW."sagaState" -> 'cropClass',
+    'region', NEW."sagaState" -> 'region',
+    'incoterms', NEW."sagaState" -> 'incoterms',
+    'volumeTons', NEW."sagaState" ->> 'volumeTons',
+    'pricePerTon', NEW."sagaState" ->> 'pricePerTon',
+    'totalKopecks', NEW."sagaState" ->> 'totalKopecks',
+    'currency', NEW."sagaState" ->> 'currency',
+    'paymentTerms', NEW."sagaState" -> 'paymentTerms'
+  );
+
+  IF old_basis IS DISTINCT FROM new_basis THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'confirmed deal saga basis is immutable',
+      CONSTRAINT = 'deals_confirmed_saga_basis_immutable';
+  END IF;
+
+  RETURN NEW;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION public.forbid_deal_basis_mutation() FROM PUBLIC;
+DROP TRIGGER IF EXISTS deals_basis_immutable ON public."deals";
+CREATE TRIGGER deals_basis_immutable
+  BEFORE UPDATE OF
+    "tenantId",
+    "lotId",
+    "sourceLotId",
+    "dealNumber",
+    "sellerOrgId",
+    "buyerOrgId",
+    "volumeTons",
+    "pricePerTon",
+    "totalRub",
+    "volumeTonsDec",
+    "pricePerTonDec",
+    "totalKopecks",
+    "currency",
+    "culture",
+    "cropClass",
+    "region",
+    "incoterms",
+    "sagaState"
+  ON public."deals"
+  FOR EACH ROW EXECUTE FUNCTION public.forbid_deal_basis_mutation();
+
+COMMENT ON FUNCTION public.forbid_deal_basis_mutation() IS
+  'Rejects changes to confirmed commercial and saga basis while allowing lifecycle and additive operational saga updates.';

--- a/apps/api/prisma/migrations/20260712194000_deal_basis_immutability/migration.sql
+++ b/apps/api/prisma/migrations/20260712194000_deal_basis_immutability/migration.sql
@@ -1,16 +1,13 @@
--- Confirmed commercial basis is immutable after Deal creation.
--- Lifecycle commands may change status, nextAction, version, closedAt and may add
--- operational saga keys such as logisticsBasis. They cannot rewrite the auction
--- basis, counterparties, price, volume, amount or original basis snapshot.
+-- Confirmed commercial basis and the initial saga snapshot are immutable after
+-- Deal creation. Lifecycle commands may change status, nextAction, version and
+-- closedAt. Operational facts belong in normalized PostgreSQL tables, not in a
+-- mutable JSON authority bag.
 
 CREATE OR REPLACE FUNCTION public.forbid_deal_basis_mutation()
 RETURNS trigger
 LANGUAGE plpgsql
 SET search_path = pg_catalog, public
 AS $function$
-DECLARE
-  old_basis jsonb;
-  new_basis jsonb;
 BEGIN
   IF ROW(
     OLD."tenantId",
@@ -29,7 +26,8 @@ BEGIN
     OLD."culture",
     OLD."cropClass",
     OLD."region",
-    OLD."incoterms"
+    OLD."incoterms",
+    OLD."sagaState"
   ) IS DISTINCT FROM ROW(
     NEW."tenantId",
     NEW."lotId",
@@ -47,60 +45,13 @@ BEGIN
     NEW."culture",
     NEW."cropClass",
     NEW."region",
-    NEW."incoterms"
+    NEW."incoterms",
+    NEW."sagaState"
   ) THEN
     RAISE EXCEPTION USING
       ERRCODE = '23514',
-      MESSAGE = 'confirmed deal commercial basis is immutable',
+      MESSAGE = 'confirmed deal commercial and saga basis is immutable',
       CONSTRAINT = 'deals_confirmed_basis_immutable';
-  END IF;
-
-  old_basis := jsonb_build_object(
-    'source', OLD."sagaState" ->> 'source',
-    'integrationEventId', OLD."sagaState" ->> 'integrationEventId',
-    'sourceHash', OLD."sagaState" ->> 'sourceHash',
-    'lotId', OLD."sagaState" ->> 'lotId',
-    'winnerBidId', OLD."sagaState" ->> 'winnerBidId',
-    'sellerOrgId', OLD."sagaState" ->> 'sellerOrgId',
-    'buyerOrgId', OLD."sagaState" ->> 'buyerOrgId',
-    'sellerUserId', OLD."sagaState" ->> 'sellerUserId',
-    'buyerUserId', OLD."sagaState" ->> 'buyerUserId',
-    'culture', OLD."sagaState" ->> 'culture',
-    'cropClass', OLD."sagaState" -> 'cropClass',
-    'region', OLD."sagaState" -> 'region',
-    'incoterms', OLD."sagaState" -> 'incoterms',
-    'volumeTons', OLD."sagaState" ->> 'volumeTons',
-    'pricePerTon', OLD."sagaState" ->> 'pricePerTon',
-    'totalKopecks', OLD."sagaState" ->> 'totalKopecks',
-    'currency', OLD."sagaState" ->> 'currency',
-    'paymentTerms', OLD."sagaState" -> 'paymentTerms'
-  );
-  new_basis := jsonb_build_object(
-    'source', NEW."sagaState" ->> 'source',
-    'integrationEventId', NEW."sagaState" ->> 'integrationEventId',
-    'sourceHash', NEW."sagaState" ->> 'sourceHash',
-    'lotId', NEW."sagaState" ->> 'lotId',
-    'winnerBidId', NEW."sagaState" ->> 'winnerBidId',
-    'sellerOrgId', NEW."sagaState" ->> 'sellerOrgId',
-    'buyerOrgId', NEW."sagaState" ->> 'buyerOrgId',
-    'sellerUserId', NEW."sagaState" ->> 'sellerUserId',
-    'buyerUserId', NEW."sagaState" ->> 'buyerUserId',
-    'culture', NEW."sagaState" ->> 'culture',
-    'cropClass', NEW."sagaState" -> 'cropClass',
-    'region', NEW."sagaState" -> 'region',
-    'incoterms', NEW."sagaState" -> 'incoterms',
-    'volumeTons', NEW."sagaState" ->> 'volumeTons',
-    'pricePerTon', NEW."sagaState" ->> 'pricePerTon',
-    'totalKopecks', NEW."sagaState" ->> 'totalKopecks',
-    'currency', NEW."sagaState" ->> 'currency',
-    'paymentTerms', NEW."sagaState" -> 'paymentTerms'
-  );
-
-  IF old_basis IS DISTINCT FROM new_basis THEN
-    RAISE EXCEPTION USING
-      ERRCODE = '23514',
-      MESSAGE = 'confirmed deal saga basis is immutable',
-      CONSTRAINT = 'deals_confirmed_saga_basis_immutable';
   END IF;
 
   RETURN NEW;
@@ -133,4 +84,4 @@ CREATE TRIGGER deals_basis_immutable
   FOR EACH ROW EXECUTE FUNCTION public.forbid_deal_basis_mutation();
 
 COMMENT ON FUNCTION public.forbid_deal_basis_mutation() IS
-  'Rejects changes to confirmed commercial and saga basis while allowing lifecycle and additive operational saga updates.';
+  'Rejects any rewrite of the confirmed commercial columns or initial saga snapshot; operational facts use normalized tables.';

--- a/apps/api/prisma/migrations/20260712194000_deal_basis_immutability/migration.sql
+++ b/apps/api/prisma/migrations/20260712194000_deal_basis_immutability/migration.sql
@@ -3,6 +3,18 @@
 -- closedAt. Operational facts belong in normalized PostgreSQL tables, not in a
 -- mutable JSON authority bag.
 
+-- Until payment terms are included in the signed server-side auction basis,
+-- callers may not inject them into a PostgreSQL-authoritative Deal snapshot.
+ALTER TABLE public."deals"
+  ADD CONSTRAINT deals_server_basis_payment_terms_authority
+  CHECK (
+    "sagaState" IS NULL
+    OR "sagaState" ->> 'source' IS DISTINCT FROM 'POSTGRESQL_INTEGRATION_EVENT'
+    OR "sagaState" -> 'paymentTerms' IS NOT DISTINCT FROM 'null'::jsonb
+  ) NOT VALID;
+ALTER TABLE public."deals"
+  VALIDATE CONSTRAINT deals_server_basis_payment_terms_authority;
+
 CREATE OR REPLACE FUNCTION public.forbid_deal_basis_mutation()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -83,5 +95,7 @@ CREATE TRIGGER deals_basis_immutable
   ON public."deals"
   FOR EACH ROW EXECUTE FUNCTION public.forbid_deal_basis_mutation();
 
+COMMENT ON CONSTRAINT deals_server_basis_payment_terms_authority ON public."deals" IS
+  'Client-authored payment terms are forbidden until the signed server-side basis owns them.';
 COMMENT ON FUNCTION public.forbid_deal_basis_mutation() IS
   'Rejects any rewrite of the confirmed commercial columns or initial saga snapshot; operational facts use normalized tables.';

--- a/apps/api/prisma/migrations/20260712195000_deal_insert_basis_only/migration.sql
+++ b/apps/api/prisma/migrations/20260712195000_deal_insert_basis_only/migration.sql
@@ -1,0 +1,14 @@
+-- Runtime Deal creation is never a privileged free-form operation. Platform
+-- staff may manage access and participants through audited control-plane flows,
+-- but a Deal row itself must originate from one confirmed auction basis.
+
+DROP POLICY IF EXISTS deals_insert ON public."deals";
+CREATE POLICY deals_insert ON public."deals" FOR INSERT WITH CHECK (
+  public.app_rls_context_ready()
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND current_setting('app.current_role', true) = 'FARMER'
+  AND public.app_deal_basis_deal_visible(to_jsonb("deals"))
+);
+
+COMMENT ON POLICY deals_insert ON public."deals" IS
+  'Allows runtime Deal insertion only for the seller encoded in one confirmed tenant-scoped auction basis.';

--- a/apps/api/src/modules/deals/deal-repository.factory.ts
+++ b/apps/api/src/modules/deals/deal-repository.factory.ts
@@ -1,25 +1,36 @@
 import type { DealRepository } from './deal.repository';
-import { RuntimeDealRepository } from './runtime-deal.repository';
-import { PrismaDealRepository } from './prisma-deal.repository';
-import type { RuntimeCoreService } from '../runtime-core/runtime-core.service';
-import type { PrismaService } from '../../common/prisma/prisma.service';
+
+export type DealRepositoryMode = 'prisma' | 'runtime';
 
 /**
- * Selects the active deal repository adapter.
- *
- * Default (controlled-pilot / pre-integration): the in-memory RuntimeCore
- * adapter. The DB-backed Prisma adapter is selected ONLY when the explicit
- * mode value equals 'prisma' (PLATFORM_V7_DEAL_REPOSITORY=prisma). Any other
- * value — including a present-but-unset flag or an unrelated value — keeps the
- * runtime adapter. There is no silent Prisma activation.
+ * Configuration helper retained only for explicit test-profile composition.
+ * Production DealsModule does not call this function and binds Prisma directly.
+ * Unknown values never degrade to RuntimeCore.
  */
 export function selectDealRepository(
-  runtime: RuntimeCoreService,
-  prisma?: PrismaService,
-  mode: string | undefined = process.env.PLATFORM_V7_DEAL_REPOSITORY,
+  prisma: DealRepository,
+  runtime: DealRepository | undefined,
+  options: {
+    mode?: string;
+    nodeEnv?: string;
+    profile?: string;
+  } = {},
 ): DealRepository {
-  if (mode === 'prisma') {
-    return new PrismaDealRepository(prisma);
+  const mode = (options.mode ?? process.env.PLATFORM_V7_DEAL_REPOSITORY ?? 'prisma').trim().toLowerCase();
+  const nodeEnv = (options.nodeEnv ?? process.env.NODE_ENV ?? '').trim().toLowerCase();
+  const profile = (options.profile ?? process.env.PLATFORM_V7_PROFILE ?? '').trim().toLowerCase();
+
+  if (mode === 'prisma') return prisma;
+
+  if (mode === 'runtime') {
+    const explicitlyNonProduction = nodeEnv === 'test' && ['test', 'demo'].includes(profile);
+    if (!explicitlyNonProduction || !runtime) {
+      throw new Error(
+        'RuntimeDealRepository is allowed only with NODE_ENV=test and PLATFORM_V7_PROFILE=test|demo.',
+      );
+    }
+    return runtime;
   }
-  return new RuntimeDealRepository(runtime);
+
+  throw new Error(`Unknown PLATFORM_V7_DEAL_REPOSITORY mode: ${mode || '<empty>'}`);
 }

--- a/apps/api/src/modules/deals/deal-repository.spec.ts
+++ b/apps/api/src/modules/deals/deal-repository.spec.ts
@@ -1,8 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { DealRepository } from './deal.repository';
 import { RuntimeDealRepository } from './runtime-deal.repository';
-import { PrismaDealRepository } from './prisma-deal.repository';
 import { selectDealRepository } from './deal-repository.factory';
 
-function makeRuntime() {
+function makeRuntimeCore() {
   return {
     listDeals: jest.fn().mockReturnValue([{ id: 'D1' }]),
     getDeal: jest.fn().mockReturnValue({ id: 'D1' }),
@@ -10,80 +12,110 @@ function makeRuntime() {
     dealPassport: jest.fn().mockReturnValue({ id: 'PP' }),
     dealTimeline: jest.fn().mockReturnValue([{ id: 'T1' }]),
     createDeal: jest.fn().mockReturnValue({ id: 'D2' }),
-    transitionDeal: jest.fn().mockReturnValue({ id: 'D1', status: 'SIGNED' }),
   } as any;
 }
 
-describe('RuntimeDealRepository (default adapter)', () => {
-  it('delegates every read and write to RuntimeCore unchanged', async () => {
-    const runtime = makeRuntime();
-    const repo = new RuntimeDealRepository(runtime);
-    const user = { id: 'u1' } as any;
+function makePrismaRepository(): DealRepository {
+  return {
+    list: jest.fn(),
+    getById: jest.fn(),
+    workspace: jest.fn(),
+    passport: jest.fn(),
+    timeline: jest.fn(),
+    create: jest.fn(),
+  };
+}
 
-    expect(await repo.list(user)).toEqual([{ id: 'D1' }]);
-    expect(runtime.listDeals).toHaveBeenCalledWith(user);
-    expect(await repo.getById('D1')).toEqual({ id: 'D1' });
-    expect(runtime.getDeal).toHaveBeenCalledWith('D1');
-    expect(repo.workspace('D1')).toEqual({ id: 'WS' });
-    expect(repo.passport('D1')).toEqual({ id: 'PP' });
-    expect(repo.timeline('D1')).toEqual([{ id: 'T1' }]);
-    expect(repo.create({} as any, user)).toEqual({ id: 'D2' });
-    expect(repo.transition('D1', 'SETTLED', user, 'note')).toEqual({ id: 'D1', status: 'SIGNED' });
-    expect(runtime.transitionDeal).toHaveBeenCalledWith('D1', 'SETTLED', user, 'note');
+const USER = {
+  id: 'u1',
+  sessionId: 's1',
+  orgId: 'o1',
+  tenantId: 't1',
+  role: 'FARMER',
+} as any;
+
+describe('RuntimeDealRepository explicit test adapter', () => {
+  it('delegates only when a test profile explicitly constructs it', async () => {
+    const runtime = makeRuntimeCore();
+    const repository = new RuntimeDealRepository(runtime);
+
+    await expect(repository.list(USER)).resolves.toEqual([{ id: 'D1' }]);
+    await expect(repository.getById('D1', USER)).resolves.toEqual({ id: 'D1' });
+    await expect(repository.workspace('D1', USER)).resolves.toEqual({ id: 'WS' });
+    await expect(repository.passport('D1', USER)).resolves.toEqual({ id: 'PP' });
+    await expect(repository.timeline('D1', USER)).resolves.toEqual([{ id: 'T1' }]);
+    await expect(repository.create({} as any, USER)).resolves.toEqual({ id: 'D2' });
   });
 });
 
-describe('PrismaDealRepository (disabled DB-backed skeleton)', () => {
-  it('requires PrismaService — constructing without it fails loudly', () => {
-    expect(() => new PrismaDealRepository(undefined)).toThrow(/PrismaService/);
+describe('selectDealRepository fail-closed configuration', () => {
+  const prisma = makePrismaRepository();
+  const runtime = new RuntimeDealRepository(makeRuntimeCore());
+
+  it('defaults to PostgreSQL when mode is absent', () => {
+    expect(selectDealRepository(prisma, runtime, { mode: undefined, nodeEnv: 'production' })).toBe(prisma);
   });
 
-  it('supports read snapshots (list/getById) via Prisma when explicitly used', async () => {
-    const prisma = {
-      deal: {
-        findMany: jest.fn().mockResolvedValue([{ id: 'DB1' }]),
-        findUnique: jest.fn().mockResolvedValue({ id: 'DB1' }),
-      },
-    } as any;
-    const repo = new PrismaDealRepository(prisma);
-    expect(await repo.list()).toEqual([{ id: 'DB1' }]);
-    expect(prisma.deal.findMany).toHaveBeenCalledWith({ orderBy: { createdAt: 'desc' } });
-    expect(await repo.getById('DB1')).toEqual({ id: 'DB1' });
+  it('selects PostgreSQL for the explicit prisma mode', () => {
+    expect(selectDealRepository(prisma, runtime, { mode: 'prisma', nodeEnv: 'production' })).toBe(prisma);
   });
 
-  it('getById fails loudly when the row is missing — no silent fallback', async () => {
-    const prisma = {
-      deal: { findMany: jest.fn(), findUnique: jest.fn().mockResolvedValue(null) },
-    } as any;
-    const repo = new PrismaDealRepository(prisma);
-    await expect(repo.getById('X')).rejects.toThrow(/not found in DB-backed/);
+  it('rejects RuntimeCore in production and ordinary development', () => {
+    expect(() => selectDealRepository(prisma, runtime, {
+      mode: 'runtime', nodeEnv: 'production', profile: 'demo',
+    })).toThrow(/NODE_ENV=test/);
+    expect(() => selectDealRepository(prisma, runtime, {
+      mode: 'runtime', nodeEnv: 'development', profile: 'test',
+    })).toThrow(/NODE_ENV=test/);
   });
 
-  it('does not support workspace/passport/timeline/create/transition (fails loudly)', () => {
-    const prisma = { deal: {} } as any;
-    const repo = new PrismaDealRepository(prisma);
-    expect(() => repo.workspace()).toThrow(/not supported/);
-    expect(() => repo.passport()).toThrow(/not supported/);
-    expect(() => repo.timeline()).toThrow(/not supported/);
-    expect(() => repo.create()).toThrow(/not supported/);
-    expect(() => repo.transition()).toThrow(/not supported/);
+  it('allows RuntimeCore only for an explicit test or demo profile under NODE_ENV=test', () => {
+    expect(selectDealRepository(prisma, runtime, {
+      mode: 'runtime', nodeEnv: 'test', profile: 'test',
+    })).toBe(runtime);
+    expect(selectDealRepository(prisma, runtime, {
+      mode: 'runtime', nodeEnv: 'test', profile: 'demo',
+    })).toBe(runtime);
+  });
+
+  it('fails startup selection for unknown values instead of falling back', () => {
+    for (const mode of ['true', '1', 'memory', 'postgres', 'unknown']) {
+      expect(() => selectDealRepository(prisma, runtime, { mode, nodeEnv: 'production' }))
+        .toThrow(/Unknown PLATFORM_V7_DEAL_REPOSITORY/);
+    }
   });
 });
 
-describe('selectDealRepository (no silent Prisma activation)', () => {
-  const runtime = makeRuntime();
-  const prisma = { deal: {} } as any;
+describe('production deal DI and route source gate', () => {
+  const source = (file: string) => readFileSync(join(__dirname, file), 'utf8');
+  const moduleSource = source('deals.module.ts');
+  const serviceSource = source('deals.service.ts');
+  const controllerSource = source('deals.controller.ts');
+  const prismaSource = source('prisma-deal.repository.ts');
 
-  it('defaults to the runtime adapter when no flag is set', () => {
-    expect(selectDealRepository(runtime, prisma, undefined)).toBeInstanceOf(RuntimeDealRepository);
+  it('binds the production repository directly to Prisma without RuntimeCore or a mode factory', () => {
+    expect(moduleSource).toContain('useExisting: PrismaDealRepository');
+    expect(moduleSource).not.toContain('RuntimeCoreService');
+    expect(moduleSource).not.toContain('RuntimeDealRepository');
+    expect(moduleSource).not.toContain('selectDealRepository');
+    expect(moduleSource).not.toContain('DealAutoService');
   });
 
-  it('keeps the runtime adapter for unrelated flag values', () => {
-    expect(selectDealRepository(runtime, prisma, 'true')).toBeInstanceOf(RuntimeDealRepository);
-    expect(selectDealRepository(runtime, prisma, '1')).toBeInstanceOf(RuntimeDealRepository);
+  it('keeps free-form transition unreachable from service and controller', () => {
+    expect(serviceSource).not.toContain('transition(');
+    expect(serviceSource).not.toContain('ActionExecutorService');
+    expect(serviceSource).not.toContain('DealSagaService');
+    expect(controllerSource).toContain('LEGACY_DEAL_TRANSITION_DISABLED');
+    expect(controllerSource).toContain('GoneException');
+    expect(controllerSource).not.toContain('this.deals.transition');
   });
 
-  it('selects the Prisma adapter only under the explicit prisma flag', () => {
-    expect(selectDealRepository(runtime, prisma, 'prisma')).toBeInstanceOf(PrismaDealRepository);
+  it('contains no unsupported Prisma repository methods or runtime fallback language', () => {
+    expect(prismaSource).not.toContain('not supported');
+    expect(prismaSource).not.toContain('RuntimeCore');
+    expect(prismaSource).not.toContain('fallback');
+    for (const method of ['async list(', 'async getById(', 'async workspace(', 'async passport(', 'async timeline(', 'async create(']) {
+      expect(prismaSource).toContain(method);
+    }
   });
 });

--- a/apps/api/src/modules/deals/deal-repository.spec.ts
+++ b/apps/api/src/modules/deals/deal-repository.spec.ts
@@ -93,12 +93,14 @@ describe('production deal DI and route source gate', () => {
   const controllerSource = source('deals.controller.ts');
   const prismaSource = source('prisma-deal.repository.ts');
 
-  it('binds the production repository directly to Prisma without RuntimeCore or a mode factory', () => {
+  it('binds the production repository directly to Prisma without legacy adapters', () => {
     expect(moduleSource).toContain('useExisting: PrismaDealRepository');
     expect(moduleSource).not.toContain('RuntimeCoreService');
     expect(moduleSource).not.toContain('RuntimeDealRepository');
     expect(moduleSource).not.toContain('selectDealRepository');
     expect(moduleSource).not.toContain('DealAutoService');
+    expect(moduleSource).not.toContain('DealEventService');
+    expect(moduleSource).not.toContain('OutboxModule');
   });
 
   it('keeps free-form transition unreachable from service and controller', () => {

--- a/apps/api/src/modules/deals/deal.repository.ts
+++ b/apps/api/src/modules/deals/deal.repository.ts
@@ -1,38 +1,19 @@
 import type { CreateDealDto } from './dto/create-deal.dto';
 import type { RequestUser } from '../../common/types/request-user';
 
-/**
- * Injection token for the deal data-access boundary.
- *
- * Controlled-pilot / pre-integration note:
- * The default binding is the in-memory RuntimeCore adapter. The DB-backed
- * (Prisma) adapter is a disabled skeleton and is only selected under the
- * explicit PLATFORM_V7_DEAL_REPOSITORY=prisma flag. There is no silent
- * Prisma fallback — see deals.module.ts.
- */
 export const DEAL_REPOSITORY = 'DEAL_REPOSITORY';
 
 /**
- * Repository boundary for deal reads/writes. This abstracts how deals are
- * stored away from DealsService (which keeps permission/scope/gate logic).
- *
- * Read methods are async to allow a future DB-backed adapter; the runtime
- * adapter resolves synchronously under the hood. Workspace/passport/timeline
- * and write methods mirror the current RuntimeCore semantics exactly.
+ * PostgreSQL-authoritative deal boundary. Every object read receives verified
+ * session context so tenant and DealParticipant checks happen inside the same
+ * transaction as the projection. Free-form legacy transitions are deliberately
+ * absent: production state changes use domain commands only.
  */
 export interface DealRepository {
-  /** Deals visible to the user. */
   list(user: RequestUser): Promise<unknown[]>;
-  /** A single deal card by id. Throws if not found (RuntimeCore semantics). */
-  getById(id: string): Promise<any>;
-  /** Aggregated deal workspace view. */
-  workspace(id: string): any;
-  /** Deal passport view. */
-  passport(id: string): any;
-  /** Deal timeline view. */
-  timeline(id: string): any;
-  /** Create a deal. */
-  create(dto: CreateDealDto, user: RequestUser): any;
-  /** Transition a deal to the next state. */
-  transition(id: string, nextState: string, user: RequestUser, comment?: string): any;
+  getById(id: string, user: RequestUser): Promise<any>;
+  workspace(id: string, user: RequestUser): Promise<any>;
+  passport(id: string, user: RequestUser): Promise<any>;
+  timeline(id: string, user: RequestUser): Promise<any>;
+  create(dto: CreateDealDto, user: RequestUser): Promise<any>;
 }

--- a/apps/api/src/modules/deals/deals.controller.ts
+++ b/apps/api/src/modules/deals/deals.controller.ts
@@ -1,20 +1,16 @@
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { RateLimit } from '../../common/decorators/rate-limit.decorator';
-import { UseGuards } from '@nestjs/common';
-import { BadRequestException, Body, Controller, ForbiddenException, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, GoneException, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { DealsService } from './deals.service';
 import { IndustrialDealCommandGateway } from './industrial-deal-command.gateway';
 import { CreateDealDto } from './dto/create-deal.dto';
 import { ExecuteDealCommandDto } from './dto/execute-deal-command.dto';
-import { TransitionDealDto } from './dto/transition-deal.dto';
 import { RequestUser, Role } from '../../common/types/request-user';
-import { CANONICAL_TEST_DEAL_ID } from './deal-command.policy';
-import { isIndustrialMode } from '../../common/config/industrial-mode';
 
 @UseGuards(RolesGuard)
-@Roles('FARMER', 'BUYER', 'SUPPORT_MANAGER', 'EXECUTIVE', 'ADMIN', 'ACCOUNTING')
+@Roles('ANY_AUTHENTICATED')
 @Controller('deals')
 export class DealsController {
   constructor(
@@ -27,9 +23,7 @@ export class DealsController {
     return this.deals.list(user);
   }
 
-  /** Канонический participant-scoped список: скоуп определяет PostgreSQL. */
   @Get('accessible')
-  @Roles('ANY_AUTHENTICATED')
   listAccessible(@Query('limit') limit: string | undefined, @CurrentUser() user: RequestUser) {
     const parsed = Number(limit);
     return this.industrialCommands.listAccessibleDeals(user, Number.isFinite(parsed) ? parsed : undefined);
@@ -46,13 +40,11 @@ export class DealsController {
   }
 
   @Get(':id/execution-workspace')
-  @Roles('ANY_AUTHENTICATED')
   executionWorkspace(@Param('id') id: string, @CurrentUser() user: RequestUser) {
     return this.industrialCommands.workspace(id, user);
   }
 
   @Get(':id/correlation-timeline')
-  @Roles('ANY_AUTHENTICATED')
   correlationTimeline(
     @Param('id') id: string,
     @Query('limit') limit: string | undefined,
@@ -75,15 +67,20 @@ export class DealsController {
   }
 
   @Post()
+  @Roles(Role.FARMER)
+  @RateLimit({
+    name: 'deal_create',
+    scope: 'user',
+    limit: 10,
+    windowSeconds: 60,
+    limitEnv: 'RATE_LIMIT_DEAL_CREATE',
+    windowEnv: 'RATE_LIMIT_DEAL_CREATE_WINDOW_SECONDS',
+  })
   create(@Body() dto: CreateDealDto, @CurrentUser() user: RequestUser) {
-    if (user.role === Role.EXECUTIVE) {
-      throw new ForbiddenException('Executive role cannot create deals');
-    }
     return this.deals.create(dto, user);
   }
 
   @Post(':id/commands/:actionId')
-  @Roles('ANY_AUTHENTICATED')
   @RateLimit({
     name: 'deal_command',
     scope: 'user',
@@ -102,42 +99,26 @@ export class DealsController {
     return this.industrialCommands.executeUser(id, actionId, dto, user);
   }
 
+  /**
+   * Compatibility endpoints remain explicit fail-closed tombstones so an old
+   * client cannot silently fall back to RuntimeCore or a free-form state write.
+   */
   @Patch(':id/transition')
-  transition(
-    @Param('id') id: string,
-    @Body() dto: TransitionDealDto,
-    @CurrentUser() user: RequestUser,
-  ) {
-    this.assertLegacyTransitionAllowed(id, user);
-    return this.deals.transition(id, dto, user);
+  legacyTransitionDisabled(@Param('id') id: string): never {
+    return this.rejectLegacyTransition(id);
   }
 
   @Patch(':id/status')
-  transitionCompat(
-    @Param('id') id: string,
-    @Body() body: { status?: string; nextState?: string; comment?: string },
-    @CurrentUser() user: RequestUser,
-  ) {
-    this.assertLegacyTransitionAllowed(id, user);
-    return this.deals.transition(
-      id,
-      { nextState: (body?.nextState || body?.status || '') as any, comment: body?.comment },
-      user,
-    );
+  legacyStatusDisabled(@Param('id') id: string): never {
+    return this.rejectLegacyTransition(id);
   }
 
-  private assertLegacyTransitionAllowed(id: string, user: RequestUser): void {
-    if (user.role === Role.EXECUTIVE) {
-      throw new ForbiddenException('Executive role is read-only');
-    }
-    // Industrial mode: the server-side domain command is the ONLY status path.
-    // Free-form nextState is a demo-profile capability and never reaches
-    // PostgreSQL-authoritative deals.
-    if (isIndustrialMode() || id === CANONICAL_TEST_DEAL_ID) {
-      throw new BadRequestException({
-        code: 'DEAL_REQUIRES_COMMAND',
-        message: 'Статус сделки меняется только доменной командой. Используйте POST /deals/:id/commands/:actionId.',
-      });
-    }
+  private rejectLegacyTransition(id: string): never {
+    throw new GoneException({
+      code: 'LEGACY_DEAL_TRANSITION_DISABLED',
+      dealId: id,
+      message: 'Свободное изменение статуса отключено. Используйте доменную команду сделки.',
+      commandEndpoint: `/deals/${id}/commands/:actionId`,
+    });
   }
 }

--- a/apps/api/src/modules/deals/deals.module.ts
+++ b/apps/api/src/modules/deals/deals.module.ts
@@ -1,23 +1,21 @@
 import { Module } from '@nestjs/common';
 import { AccessScopeService } from '../../common/security/access.service';
 import { AuthModule } from '../auth/auth.module';
-import { OutboxModule } from '../../common/outbox/outbox.module';
 import { DealsController } from './deals.controller';
 import { DealsService } from './deals.service';
 import { DealCommandService } from './deal-command.service';
 import { IndustrialDealCommandGateway } from './industrial-deal-command.gateway';
 import { CanonicalTestDealSeedService } from './canonical-test-deal.seed';
-import { DealEventService } from './deal-event.service';
 import { DEAL_REPOSITORY } from './deal.repository';
 import { PrismaDealRepository } from './prisma-deal.repository';
 
 /**
  * Deal routes are PostgreSQL-authoritative by construction. There is no
- * RuntimeCore provider, repository factory, optional Prisma dependency or mode
- * fallback in the production DI graph.
+ * RuntimeCore provider, repository factory, optional Prisma dependency,
+ * best-effort DealEvent adapter or mode fallback in the production DI graph.
  */
 @Module({
-  imports: [AuthModule, OutboxModule],
+  imports: [AuthModule],
   controllers: [DealsController],
   providers: [
     DealsService,
@@ -25,10 +23,9 @@ import { PrismaDealRepository } from './prisma-deal.repository';
     IndustrialDealCommandGateway,
     PrismaDealRepository,
     CanonicalTestDealSeedService,
-    DealEventService,
     AccessScopeService,
     { provide: DEAL_REPOSITORY, useExisting: PrismaDealRepository },
   ],
-  exports: [DealsService, IndustrialDealCommandGateway, DealEventService],
+  exports: [DealsService, IndustrialDealCommandGateway],
 })
 export class DealsModule {}

--- a/apps/api/src/modules/deals/deals.module.ts
+++ b/apps/api/src/modules/deals/deals.module.ts
@@ -1,52 +1,33 @@
-import { Module, type Provider } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { AccessScopeService } from '../../common/security/access.service';
-import { AuditModule } from '../audit/audit.module';
-import { AntiFraudModule } from '../anti-fraud/anti-fraud.module';
-import { NotificationsModule } from '../notifications/notifications.module';
-import { IntegrationsModule } from '../integrations/integrations.module';
-import { LedgerModule } from '../ledger/ledger.module';
 import { AuthModule } from '../auth/auth.module';
-import { ActionExecutorModule } from '../../common/action-executor/action-executor.module';
+import { OutboxModule } from '../../common/outbox/outbox.module';
 import { DealsController } from './deals.controller';
 import { DealsService } from './deals.service';
 import { DealCommandService } from './deal-command.service';
 import { IndustrialDealCommandGateway } from './industrial-deal-command.gateway';
 import { CanonicalTestDealSeedService } from './canonical-test-deal.seed';
 import { DealEventService } from './deal-event.service';
-import { DealAutoService } from './deal-auto.service';
-import { SagaModule } from '../saga/saga.module';
-import { OutboxModule } from '../../common/outbox/outbox.module';
 import { DEAL_REPOSITORY } from './deal.repository';
-import { selectDealRepository } from './deal-repository.factory';
-import { RuntimeCoreService } from '../runtime-core/runtime-core.service';
-import { PrismaService } from '../../common/prisma/prisma.service';
+import { PrismaDealRepository } from './prisma-deal.repository';
 
 /**
- * Legacy deal repository binding.
- *
- * The canonical industrial command path is implemented by DealCommandService and
- * IndustrialDealCommandGateway and always writes through Prisma/PostgreSQL. The
- * legacy repository remains only for existing read surfaces while they are migrated.
+ * Deal routes are PostgreSQL-authoritative by construction. There is no
+ * RuntimeCore provider, repository factory, optional Prisma dependency or mode
+ * fallback in the production DI graph.
  */
-const dealRepositoryProvider: Provider = {
-  provide: DEAL_REPOSITORY,
-  useFactory: (runtime: RuntimeCoreService, prisma?: PrismaService) =>
-    selectDealRepository(runtime, prisma),
-  inject: [RuntimeCoreService, { token: PrismaService, optional: true }],
-};
-
 @Module({
-  imports: [AuthModule, AuditModule, AntiFraudModule, NotificationsModule, IntegrationsModule, LedgerModule, ActionExecutorModule, SagaModule, OutboxModule],
+  imports: [AuthModule, OutboxModule],
   controllers: [DealsController],
   providers: [
     DealsService,
     DealCommandService,
     IndustrialDealCommandGateway,
+    PrismaDealRepository,
     CanonicalTestDealSeedService,
     DealEventService,
-    DealAutoService,
     AccessScopeService,
-    dealRepositoryProvider,
+    { provide: DEAL_REPOSITORY, useExisting: PrismaDealRepository },
   ],
   exports: [DealsService, IndustrialDealCommandGateway, DealEventService],
 })

--- a/apps/api/src/modules/deals/deals.service.spec.ts
+++ b/apps/api/src/modules/deals/deals.service.spec.ts
@@ -2,99 +2,59 @@ import { DealsService } from './deals.service';
 
 function makeRepo() {
   return {
-    list: jest.fn().mockResolvedValue([{ id: 'D1', status: 'ACTIVE', sellerOrgId: 'S1', buyerOrgId: 'B1' }]),
-    getById: jest.fn().mockResolvedValue({ id: 'D1', status: 'ACTIVE', sellerOrgId: 'S1', buyerOrgId: 'B1' }),
-    workspace: jest.fn().mockReturnValue({ sellerOrgId: 'S1', buyerOrgId: 'B1', completeness: { isComplete: false }, payment: { status: 'PENDING' }, blockers: [] }),
-    passport: jest.fn().mockReturnValue({}),
-    timeline: jest.fn().mockReturnValue([]),
-    create: jest.fn().mockReturnValue({ id: 'D2' }),
-    transition: jest.fn().mockReturnValue({ id: 'D1', status: 'SIGNED' }),
+    list: jest.fn().mockResolvedValue([{ id: 'D1', status: 'ACTIVE' }]),
+    getById: jest.fn().mockResolvedValue({ id: 'D1', status: 'ACTIVE' }),
+    workspace: jest.fn().mockResolvedValue({ deal: { id: 'D1' } }),
+    passport: jest.fn().mockResolvedValue({ identity: { id: 'D1' } }),
+    timeline: jest.fn().mockResolvedValue({ dealId: 'D1', items: [] }),
+    create: jest.fn().mockResolvedValue({ id: 'D2', status: 'DRAFT' }),
   } as any;
 }
 
-function makeExecutor() {
-  return {
-    assertPermission: jest.fn(),
-    assertObjectScope: jest.fn(),
-    execute: jest.fn().mockResolvedValue({ result: { id: 'D1' }, auditId: 'A1' }),
-  } as any;
-}
+const user = {
+  id: 'u1',
+  role: 'FARMER' as any,
+  orgId: 'S1',
+  tenantId: 'T1',
+  sessionId: 'session-u1',
+  email: 'farmer@test.com',
+};
 
-const adminUser = { id: 'u1', role: 'ADMIN' as any, orgId: 'S1', email: 'admin@test.com' };
-
-describe('DealsService (repository boundary)', () => {
-  it('list() delegates to the deal repository', async () => {
+describe('DealsService PostgreSQL repository boundary', () => {
+  it('passes verified user context to every read projection', async () => {
     const repo = makeRepo();
-    const svc = new DealsService(repo, makeExecutor());
-    const result = await svc.list(adminUser);
-    expect(repo.list).toHaveBeenCalledWith(adminUser);
-    expect(result).toEqual([{ id: 'D1', status: 'ACTIVE', sellerOrgId: 'S1', buyerOrgId: 'B1' }]);
+    const service = new DealsService(repo);
+
+    await expect(service.list(user)).resolves.toEqual([{ id: 'D1', status: 'ACTIVE' }]);
+    await expect(service.getOne('D1', user)).resolves.toEqual({ id: 'D1', status: 'ACTIVE' });
+    await expect(service.workspace('D1', user)).resolves.toEqual({ deal: { id: 'D1' } });
+    await expect(service.passport('D1', user)).resolves.toEqual({ identity: { id: 'D1' } });
+    await expect(service.timeline('D1', user)).resolves.toEqual({ dealId: 'D1', items: [] });
+
+    expect(repo.list).toHaveBeenCalledWith(user);
+    expect(repo.getById).toHaveBeenCalledWith('D1', user);
+    expect(repo.workspace).toHaveBeenCalledWith('D1', user);
+    expect(repo.passport).toHaveBeenCalledWith('D1', user);
+    expect(repo.timeline).toHaveBeenCalledWith('D1', user);
   });
 
-  it('getOne() reads via repository and enforces object scope', async () => {
+  it('delegates atomic creation without a second event, saga or audit side effect', async () => {
     const repo = makeRepo();
-    const exec = makeExecutor();
-    const svc = new DealsService(repo, exec);
-    const result = await svc.getOne('D1', adminUser);
-    expect(repo.getById).toHaveBeenCalledWith('D1');
-    expect(exec.assertObjectScope).toHaveBeenCalledWith(
-      adminUser,
-      'deal.view',
-      expect.objectContaining({ objectType: 'deal', objectId: 'D1', ownerOrgId: 'S1', counterpartyOrgId: 'B1' }),
-    );
-    expect(result.id).toBe('D1');
+    const service = new DealsService(repo);
+    const dto = {
+      commandId: 'command-create-0001',
+      idempotencyKey: 'idempotency-create-0001',
+      lotId: 'LOT-1',
+      winnerBidId: 'BID-1',
+    };
+
+    await expect(service.create(dto, user)).resolves.toEqual({ id: 'D2', status: 'DRAFT' });
+    expect(repo.create).toHaveBeenCalledTimes(1);
+    expect(repo.create).toHaveBeenCalledWith(dto, user);
   });
 
-  it('workspace() checks permission and object scope via repository', () => {
-    const repo = makeRepo();
-    const exec = makeExecutor();
-    const svc = new DealsService(repo, exec);
-    const ws = svc.workspace('D1', adminUser);
-    expect(exec.assertPermission).toHaveBeenCalledWith(adminUser, 'deal.view');
-    expect(repo.workspace).toHaveBeenCalledWith('D1');
-    expect(ws.sellerOrgId).toBe('S1');
-  });
-
-  it('passport() and timeline() enforce object scope before delegating', async () => {
-    const repo = makeRepo();
-    const exec = makeExecutor();
-    const svc = new DealsService(repo, exec);
-    await svc.passport('D1', adminUser);
-    await svc.timeline('D1', adminUser);
-    expect(repo.getById).toHaveBeenCalledWith('D1');
-    expect(exec.assertObjectScope).toHaveBeenCalledWith(
-      adminUser,
-      'deal.view',
-      expect.objectContaining({ objectType: 'deal', objectId: 'D1', ownerOrgId: 'S1', counterpartyOrgId: 'B1' }),
-    );
-    expect(repo.passport).toHaveBeenCalledWith('D1');
-    expect(repo.timeline).toHaveBeenCalledWith('D1');
-  });
-
-  it('create() routes through the action executor and repository', async () => {
-    const repo = makeRepo();
-    const exec = makeExecutor();
-    exec.execute = jest.fn(async ({ fn }: any) => ({ result: await fn(), auditId: 'A1' }));
-    const svc = new DealsService(repo, exec);
-    await svc.create({} as any, adminUser);
-    expect(repo.create).toHaveBeenCalledWith({}, adminUser);
-  });
-
-  it('transition() builds release gates from repository workspace and delegates', async () => {
-    const repo = makeRepo();
-    const exec = makeExecutor();
-    let captured: any;
-    exec.execute = jest.fn(async (args: any) => {
-      captured = args;
-      return { result: await args.fn(), auditId: 'A1' };
-    });
-    const svc = new DealsService(repo, exec);
-    await svc.transition('D1', { nextState: 'SETTLED' }, adminUser);
-    expect(repo.getById).toHaveBeenCalledWith('D1');
-    expect(repo.workspace).toHaveBeenCalledWith('D1');
-    // PENDING payment + incomplete docs => release gates closed
-    expect(captured.gates.documentsComplete).toBe(false);
-    expect(captured.gates.reserveConfirmed).toBe(false);
-    expect(repo.transition).toHaveBeenCalledWith('D1', 'SETTLED', adminUser, undefined);
+  it('contains no legacy transition method', () => {
+    const service = new DealsService(makeRepo());
+    expect('transition' in service).toBe(false);
   });
 });

--- a/apps/api/src/modules/deals/deals.service.ts
+++ b/apps/api/src/modules/deals/deals.service.ts
@@ -1,168 +1,39 @@
-import { Inject, Injectable, Optional } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { CreateDealDto } from './dto/create-deal.dto';
 import { DEAL_REPOSITORY, type DealRepository } from './deal.repository';
-import { ActionExecutorService } from '../../common/action-executor/action-executor.service';
 import { RequestUser } from '../../common/types/request-user';
-import { DealEventService } from './deal-event.service';
-import { DealSagaService, SagaStepId } from '../saga/deal-saga.service';
 
-const STATE_TO_SAGA_STEP: Record<string, SagaStepId> = {
-  PUBLISHED: 'publish_lot',
-  OFFER_ACCEPTED: 'match_offer',
-  CONTRACT_SIGNED: 'sign_contract',
-  PAYMENT_RESERVED: 'reserve_payment',
-  LOGISTICS_ASSIGNED: 'assign_logistics',
-  SHIPMENT_STARTED: 'start_shipment',
-  DELIVERED: 'deliver',
-  QUALITY_ACCEPTED: 'lab_result',
-  PAYMENT_RELEASED: 'release_payment',
-  CLOSED: 'close',
-};
-
-const STATE_TO_EVENT: Record<string, string> = {
-  PUBLISHED: 'PUBLISHED',
-  OFFER_SENT: 'OFFER_SENT',
-  OFFER_ACCEPTED: 'OFFER_ACCEPTED',
-  COUNTER_OFFER: 'COUNTER_OFFER',
-  CONTRACT_GENERATED: 'CONTRACT_GENERATED',
-  CONTRACT_SIGNED: 'CONTRACT_SIGNED',
-  PAYMENT_RESERVED: 'PAYMENT_RESERVED',
-  LOGISTICS_ASSIGNED: 'LOGISTICS_ASSIGNED',
-  SHIPMENT_STARTED: 'SHIPMENT_STARTED',
-  DELIVERED: 'DELIVERED',
-  QUALITY_ACCEPTED: 'QUALITY_ACCEPTED',
-  QUALITY_DISPUTED: 'QUALITY_DISPUTED',
-  PAYMENT_RELEASED: 'PAYMENT_RELEASED',
-  DISPUTE_OPENED: 'DISPUTE_OPENED',
-  DISPUTE_RESOLVED: 'DISPUTE_RESOLVED',
-  CANCELLED: 'CANCELLED',
-  CLOSED: 'CLOSED',
-};
-
+/**
+ * Thin application boundary over the PostgreSQL-authoritative repository.
+ * Authorization, participant scope, idempotency and atomic creation are kept in
+ * the repository transaction. This service deliberately has no RuntimeCore,
+ * best-effort event emission, saga mutation or free-form state transition path.
+ */
 @Injectable()
 export class DealsService {
-  constructor(
-    @Inject(DEAL_REPOSITORY) private readonly deals: DealRepository,
-    private readonly executor: ActionExecutorService,
-    @Optional() private readonly dealEvents?: DealEventService,
-    @Optional() private readonly saga?: DealSagaService,
-  ) {}
+  constructor(@Inject(DEAL_REPOSITORY) private readonly deals: DealRepository) {}
 
-  async list(user: RequestUser) {
+  list(user: RequestUser) {
     return this.deals.list(user);
   }
 
-  async getOne(id: string, user: RequestUser) {
-    const deal = await this.deals.getById(id);
-    this.executor.assertObjectScope(user, 'deal.view', {
-      objectType: 'deal',
-      objectId: id,
-      ownerOrgId: deal.sellerOrgId,
-      counterpartyOrgId: deal.buyerOrgId,
-    });
-    return deal;
+  getOne(id: string, user: RequestUser) {
+    return this.deals.getById(id, user);
   }
 
   workspace(id: string, user: RequestUser) {
-    this.executor.assertPermission(user, 'deal.view');
-    const ws = this.deals.workspace(id);
-    this.executor.assertObjectScope(user, 'deal.view', {
-      objectType: 'deal',
-      objectId: id,
-      ownerOrgId: ws.sellerOrgId,
-      counterpartyOrgId: ws.buyerOrgId,
-    });
-    return ws;
+    return this.deals.workspace(id, user);
   }
 
-  async passport(id: string, user: RequestUser) {
-    const deal = await this.deals.getById(id);
-    this.executor.assertObjectScope(user, 'deal.view', {
-      objectType: 'deal',
-      objectId: id,
-      ownerOrgId: deal.sellerOrgId,
-      counterpartyOrgId: deal.buyerOrgId,
-    });
-    return this.deals.passport(id);
+  passport(id: string, user: RequestUser) {
+    return this.deals.passport(id, user);
   }
 
-  async timeline(id: string, user: RequestUser) {
-    const deal = await this.deals.getById(id);
-    this.executor.assertObjectScope(user, 'deal.view', {
-      objectType: 'deal',
-      objectId: id,
-      ownerOrgId: deal.sellerOrgId,
-      counterpartyOrgId: deal.buyerOrgId,
-    });
-    return this.deals.timeline(id);
+  timeline(id: string, user: RequestUser) {
+    return this.deals.timeline(id, user);
   }
 
-  async create(dto: CreateDealDto, user: RequestUser) {
-    const { result } = await this.executor.execute({
-      user,
-      action: 'deal.create',
-      scope: { objectType: 'deal', objectId: 'new', ownerOrgId: user.orgId },
-      fn: () => this.deals.create(dto, user),
-    });
-    const dealId = (result as any)?.id;
-    if (dealId) {
-      this.dealEvents?.emit({ dealId, eventType: 'CREATED', actorId: user.id, actorRole: user.role, payload: { culture: dto.culture } }).catch(() => {});
-      this.saga?.init(dealId);
-    }
-    return result;
-  }
-
-  async transition(
-    id: string,
-    dto: { nextState: string; comment?: string },
-    user: RequestUser,
-  ) {
-    const deal = await this.deals.getById(id);
-
-    // Determine state gates based on target state
-    const gates: import('../../common/action-executor/action-executor.service').StateGates = {
-      dealStatus: deal.status,
-    };
-
-    // Release actions require documents + no dispute + reserve confirmed
-    if (dto.nextState === 'SETTLED' || dto.nextState === 'FINAL_PAYMENT') {
-      const ws = this.deals.workspace(id);
-      gates.documentsComplete = ws.completeness?.isComplete ?? false;
-      gates.disputeOpen = deal.status === 'DISPUTE_OPEN';
-      gates.reserveConfirmed =
-        ws.payment?.status !== 'PENDING' && ws.payment?.status !== 'RESERVE_PENDING';
-    }
-
-    const { result, auditId } = await this.executor.execute({
-      user,
-      action: 'deal.transition',
-      scope: {
-        objectType: 'deal',
-        objectId: id,
-        ownerOrgId: deal.sellerOrgId,
-        counterpartyOrgId: deal.buyerOrgId,
-      },
-      gates,
-      fn: () => this.deals.transition(id, dto.nextState, user, dto.comment),
-    });
-
-    const upperState = dto.nextState?.toUpperCase();
-    const eventType = STATE_TO_EVENT[upperState];
-    if (eventType && this.dealEvents) {
-      this.dealEvents.emit({
-        dealId: id,
-        eventType: eventType as any,
-        actorId: user.id,
-        actorRole: user.role,
-        payload: { nextState: dto.nextState, comment: dto.comment },
-      }).catch(() => {});
-    }
-    const sagaStep = STATE_TO_SAGA_STEP[upperState];
-    if (sagaStep && this.saga) {
-      this.saga.advance(id, sagaStep);
-      this.saga.complete(id, sagaStep, { state: dto.nextState });
-    }
-
-    return { ...result, auditId };
+  create(dto: CreateDealDto, user: RequestUser) {
+    return this.deals.create(dto, user);
   }
 }

--- a/apps/api/src/modules/deals/dto/create-deal.dto.spec.ts
+++ b/apps/api/src/modules/deals/dto/create-deal.dto.spec.ts
@@ -16,8 +16,9 @@ describe('CreateDealDto authority boundary', () => {
   });
 
   it('rejects client-authored payment terms', async () => {
-    const dto = validDto() as CreateDealDto & { paymentTerms?: unknown };
-    dto.paymentTerms = { advancePercent: 50 };
+    const dto = Object.assign(validDto(), {
+      paymentTerms: { advancePercent: 50 },
+    }) as unknown as CreateDealDto;
 
     const errors = await validate(dto);
     expect(errors).toEqual(expect.arrayContaining([

--- a/apps/api/src/modules/deals/dto/create-deal.dto.spec.ts
+++ b/apps/api/src/modules/deals/dto/create-deal.dto.spec.ts
@@ -1,0 +1,32 @@
+import { validate } from 'class-validator';
+import { CreateDealDto } from './create-deal.dto';
+
+function validDto(): CreateDealDto {
+  return Object.assign(new CreateDealDto(), {
+    commandId: 'command-create-0001',
+    idempotencyKey: 'idempotency-create-0001',
+    lotId: 'LOT-0001',
+    winnerBidId: 'BID-0001',
+  });
+}
+
+describe('CreateDealDto authority boundary', () => {
+  it('accepts only identifiers and an idempotency boundary', async () => {
+    await expect(validate(validDto())).resolves.toEqual([]);
+  });
+
+  it('rejects client-authored payment terms', async () => {
+    const dto = validDto() as CreateDealDto & { paymentTerms?: unknown };
+    dto.paymentTerms = { advancePercent: 50 };
+
+    const errors = await validate(dto);
+    expect(errors).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        property: 'paymentTerms',
+        constraints: expect.objectContaining({
+          isEmpty: 'paymentTerms задаются только подтверждённым основанием сделки.',
+        }),
+      }),
+    ]));
+  });
+});

--- a/apps/api/src/modules/deals/dto/create-deal.dto.ts
+++ b/apps/api/src/modules/deals/dto/create-deal.dto.ts
@@ -1,4 +1,5 @@
 import { IsObject, IsOptional, IsString, Length } from 'class-validator';
+import type { Prisma } from '@prisma/client';
 
 /**
  * Deal creation consumes a server-persisted auction basis. Commercial facts,
@@ -34,5 +35,5 @@ export class CreateDealDto {
 
   @IsOptional()
   @IsObject()
-  paymentTerms?: Record<string, unknown>;
+  paymentTerms?: Prisma.InputJsonObject;
 }

--- a/apps/api/src/modules/deals/dto/create-deal.dto.ts
+++ b/apps/api/src/modules/deals/dto/create-deal.dto.ts
@@ -1,20 +1,38 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsObject, IsOptional, IsString, Length } from 'class-validator';
 
+/**
+ * Deal creation consumes a server-persisted auction basis. Commercial facts,
+ * tenant, participants and roles are resolved from PostgreSQL; the client only
+ * identifies the locked lot/bid pair and supplies an idempotency boundary.
+ */
 export class CreateDealDto {
   @IsString()
+  @Length(8, 128)
+  commandId!: string;
+
+  @IsString()
+  @Length(8, 200)
+  idempotencyKey!: string;
+
+  @IsString()
+  @Length(1, 160)
   lotId!: string;
 
   @IsString()
+  @Length(1, 160)
   winnerBidId!: string;
 
+  /** Compatibility assertion only. PostgreSQL basis remains authoritative. */
   @IsOptional()
   @IsString()
   buyerOrgId?: string;
 
+  /** Compatibility assertion only. PostgreSQL basis remains authoritative. */
   @IsOptional()
   @IsString()
   culture?: string;
 
   @IsOptional()
+  @IsObject()
   paymentTerms?: Record<string, unknown>;
 }

--- a/apps/api/src/modules/deals/dto/create-deal.dto.ts
+++ b/apps/api/src/modules/deals/dto/create-deal.dto.ts
@@ -1,5 +1,4 @@
-import { IsObject, IsOptional, IsString, Length } from 'class-validator';
-import type { Prisma } from '@prisma/client';
+import { IsEmpty, IsOptional, IsString, Length } from 'class-validator';
 
 /**
  * Deal creation consumes a server-persisted auction basis. Commercial facts,
@@ -33,7 +32,11 @@ export class CreateDealDto {
   @IsString()
   culture?: string;
 
-  @IsOptional()
-  @IsObject()
-  paymentTerms?: Prisma.InputJsonObject;
+  /**
+   * Legacy field kept only to return a deterministic validation error to old
+   * clients. Payment terms are commercial authority and cannot be supplied by
+   * the caller until they are part of the signed server-side deal basis.
+   */
+  @IsEmpty({ message: 'paymentTerms задаются только подтверждённым основанием сделки.' })
+  paymentTerms?: never;
 }

--- a/apps/api/src/modules/deals/prisma-deal.repository.ts
+++ b/apps/api/src/modules/deals/prisma-deal.repository.ts
@@ -347,7 +347,7 @@ export class PrismaDealRepository implements DealRepository {
   async create(dto: CreateDealDto, user: RequestUser): Promise<any> {
     this.assertIdentity(user);
     const basisExternalId = `${dto.lotId}:${dto.winnerBidId}`;
-    const receiptKey = `deal-create:${user.tenantId}:${dto.idempotencyKey}`;
+    const receiptKey = `deal-create:${user.tenantId}:${user.id}:${dto.idempotencyKey}`;
     const requestFingerprint = digest({
       commandId: dto.commandId,
       idempotencyKey: dto.idempotencyKey,
@@ -360,7 +360,8 @@ export class PrismaDealRepository implements DealRepository {
 
     try {
       return await this.rls.withTrustedContext(user, async (tx) => {
-        await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtextextended(${basisExternalId}, 83)) IS NULL AS locked`;
+        const tenantBasisLock = `${user.tenantId}:${basisExternalId}`;
+        await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtextextended(${tenantBasisLock}, 83)) IS NULL AS locked`;
         const existingReceipt = await tx.outboxEntry.findUnique({ where: { idempotencyKey: receiptKey } });
         if (existingReceipt) return this.replayCreate(existingReceipt.payload, requestFingerprint);
 
@@ -396,7 +397,6 @@ export class PrismaDealRepository implements DealRepository {
         if (dto.culture && dto.culture !== basis.culture) {
           throw new ConflictException({ code: 'CLIENT_BASIS_MISMATCH', field: 'culture' });
         }
-
         const alreadyCreated = await tx.deal.findFirst({
           where: { tenantId: basis.tenantId, lotId: basis.lotId, sourceLotId: basis.winnerBidId },
           select: { id: true },
@@ -428,7 +428,7 @@ export class PrismaDealRepository implements DealRepository {
           pricePerTon: basis.pricePerTon,
           totalKopecks: basis.totalKopecks,
           currency: basis.currency,
-          paymentTerms: dto.paymentTerms ?? null,
+          paymentTerms: null,
         };
 
         const deal = await tx.deal.create({
@@ -478,6 +478,10 @@ export class PrismaDealRepository implements DealRepository {
               assignedByUserId: user.id,
             },
           ],
+        });
+        await tx.deal.update({
+          where: { id: dealId },
+          data: { sagaStep: 'PARTICIPANTS_BOUND' },
         });
 
         const eventId = `event-${randomUUID()}`;

--- a/apps/api/src/modules/deals/prisma-deal.repository.ts
+++ b/apps/api/src/modules/deals/prisma-deal.repository.ts
@@ -1,62 +1,642 @@
-import { Injectable, Optional } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { createHash, randomUUID } from 'crypto';
+import { Prisma } from '@prisma/client';
 import type { DealRepository } from './deal.repository';
-import { PrismaService } from '../../common/prisma/prisma.service';
+import type { CreateDealDto } from './dto/create-deal.dto';
+import type { RequestUser } from '../../common/types/request-user';
+import { RlsTransactionService } from '../../common/prisma/rls-transaction.service';
 
-/**
- * DB-backed deal repository skeleton (pre-integration, disabled by default).
- *
- * Selected only under the explicit PLATFORM_V7_DEAL_REPOSITORY=prisma flag.
- * Only read snapshots (list/get) are implemented; workspace/passport/timeline
- * and all writes are NOT supported yet and fail loudly rather than silently
- * falling back to the runtime store. There is no silent Prisma activation.
- */
+const ACTIVE_ORG_STATUSES = new Set(['VERIFIED', 'ACTIVE']);
+const ACTIVE_PARTICIPANT = 'ACTIVE';
+const BASIS_EVENT_TYPE = 'DEAL_BASIS_READY';
+const BASIS_ADAPTER = 'auction';
+const DECIMAL_6 = /^\d+(?:\.\d{1,6})?$/;
+
+type JsonObject = Record<string, unknown>;
+
+type DealBasis = {
+  dealNumber: string;
+  tenantId: string;
+  lotId: string;
+  winnerBidId: string;
+  sellerOrgId: string;
+  buyerOrgId: string;
+  sellerUserId: string;
+  buyerUserId: string;
+  culture: string;
+  cropClass?: string;
+  region?: string;
+  incoterms?: string;
+  volumeTons: string;
+  pricePerTon: string;
+  totalKopecks: string;
+  currency: string;
+  sourceHash: string;
+};
+
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === 'object' && !(value instanceof Date) && !Prisma.Decimal.isDecimal(value)) {
+    return Object.fromEntries(
+      Object.entries(value as JsonObject)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, stable(item)]),
+    );
+  }
+  return value;
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(stable(value))).digest('hex');
+}
+
+function exactJson(value: unknown): unknown {
+  if (typeof value === 'bigint') return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (Prisma.Decimal.isDecimal(value)) return value.toFixed();
+  if (Array.isArray(value)) return value.map(exactJson);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as JsonObject).map(([key, item]) => [key, exactJson(item)]));
+  }
+  return value;
+}
+
+function jsonObject(value: Prisma.JsonValue | null | undefined, field: string): JsonObject {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new UnprocessableEntityException({
+      code: 'DEAL_BASIS_INVALID',
+      field,
+      message: 'Серверное основание сделки отсутствует или повреждено.',
+    });
+  }
+  return value as JsonObject;
+}
+
+function requiredString(value: JsonObject, field: string): string {
+  const candidate = typeof value[field] === 'string' ? String(value[field]).trim() : '';
+  if (!candidate) {
+    throw new UnprocessableEntityException({
+      code: 'DEAL_BASIS_INVALID',
+      field,
+      message: `В серверном основании сделки отсутствует поле ${field}.`,
+    });
+  }
+  return candidate;
+}
+
+function parseMicro(value: string, field: string): bigint {
+  if (!DECIMAL_6.test(value)) {
+    throw new UnprocessableEntityException({
+      code: 'DEAL_BASIS_INVALID',
+      field,
+      message: `${field} должен быть положительной decimal(20,6) строкой.`,
+    });
+  }
+  const [whole, fraction = ''] = value.split('.');
+  const micro = BigInt(whole) * 1_000_000n + BigInt(fraction.padEnd(6, '0'));
+  if (micro <= 0n) {
+    throw new UnprocessableEntityException({ code: 'DEAL_BASIS_INVALID', field, message: `${field} должен быть больше нуля.` });
+  }
+  return micro;
+}
+
+function divideHalfUp(numerator: bigint, denominator: bigint): bigint {
+  return (numerator + denominator / 2n) / denominator;
+}
+
+function assertBasisAmount(basis: DealBasis): void {
+  const priceMicroRubPerTon = parseMicro(basis.pricePerTon, 'pricePerTon');
+  const volumeMicroTons = parseMicro(basis.volumeTons, 'volumeTons');
+  let totalKopecks: bigint;
+  try {
+    totalKopecks = BigInt(basis.totalKopecks);
+  } catch {
+    throw new UnprocessableEntityException({ code: 'DEAL_BASIS_INVALID', field: 'totalKopecks' });
+  }
+  if (totalKopecks <= 0n) {
+    throw new UnprocessableEntityException({ code: 'DEAL_BASIS_INVALID', field: 'totalKopecks' });
+  }
+  // price[µRUB/t] × weight[µt] / 10^10 = kopecks.
+  const calculated = divideHalfUp(priceMicroRubPerTon * volumeMicroTons, 10_000_000_000n);
+  if (calculated !== totalKopecks) {
+    throw new UnprocessableEntityException({
+      code: 'DEAL_BASIS_AMOUNT_MISMATCH',
+      field: 'totalKopecks',
+      message: `Сумма основания не равна цене × объём: ожидается ${calculated.toString()} коп.`,
+    });
+  }
+}
+
+function parseBasis(event: { requestPayload: Prisma.JsonValue | null; responsePayload: Prisma.JsonValue | null }): DealBasis {
+  const raw = jsonObject(event.responsePayload ?? event.requestPayload, 'basis');
+  const basis: DealBasis = {
+    dealNumber: requiredString(raw, 'dealNumber'),
+    tenantId: requiredString(raw, 'tenantId'),
+    lotId: requiredString(raw, 'lotId'),
+    winnerBidId: requiredString(raw, 'winnerBidId'),
+    sellerOrgId: requiredString(raw, 'sellerOrgId'),
+    buyerOrgId: requiredString(raw, 'buyerOrgId'),
+    sellerUserId: requiredString(raw, 'sellerUserId'),
+    buyerUserId: requiredString(raw, 'buyerUserId'),
+    culture: requiredString(raw, 'culture'),
+    cropClass: typeof raw.cropClass === 'string' ? raw.cropClass.trim() || undefined : undefined,
+    region: typeof raw.region === 'string' ? raw.region.trim() || undefined : undefined,
+    incoterms: typeof raw.incoterms === 'string' ? raw.incoterms.trim() || undefined : undefined,
+    volumeTons: requiredString(raw, 'volumeTons'),
+    pricePerTon: requiredString(raw, 'pricePerTon'),
+    totalKopecks: requiredString(raw, 'totalKopecks'),
+    currency: requiredString(raw, 'currency').toUpperCase(),
+    sourceHash: requiredString(raw, 'sourceHash'),
+  };
+  const material = { ...basis, sourceHash: undefined };
+  delete (material as { sourceHash?: string }).sourceHash;
+  if (digest(material) !== basis.sourceHash) {
+    throw new UnprocessableEntityException({
+      code: 'DEAL_BASIS_HASH_MISMATCH',
+      field: 'sourceHash',
+      message: 'Hash серверного основания сделки не совпадает с его содержимым.',
+    });
+  }
+  assertBasisAmount(basis);
+  return basis;
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && 'code' in error && (error as { code?: unknown }).code === 'P2002');
+}
+
 @Injectable()
 export class PrismaDealRepository implements DealRepository {
-  constructor(@Optional() private readonly prisma?: PrismaService) {
-    if (!this.prisma) {
-      throw new Error(
-        'PrismaDealRepository requires PrismaService, but it is not available. ' +
-          'DB-backed deal path is not active.',
-      );
+  constructor(private readonly rls: RlsTransactionService) {}
+
+  async list(user: RequestUser): Promise<unknown[]> {
+    this.assertIdentity(user);
+    return this.rls.withTrustedContext(user, async (tx) => {
+      const deals = await tx.deal.findMany({
+        where: {
+          tenantId: user.tenantId,
+          participants: {
+            some: {
+              userId: user.id,
+              organizationId: user.orgId,
+              role: String(user.role),
+              status: ACTIVE_PARTICIPANT,
+            },
+          },
+        },
+        orderBy: [{ updatedAt: 'desc' }, { id: 'desc' }],
+        take: 100,
+        include: {
+          participants: { where: { status: ACTIVE_PARTICIPANT }, select: { organizationId: true, userId: true, role: true, accessLevel: true } },
+          shipments: { select: { id: true, status: true, nextAction: true } },
+          payments: { orderBy: { createdAt: 'desc' }, take: 1, select: { status: true, amountKopecks: true, callbackState: true } },
+        },
+      });
+      return exactJson(deals) as unknown[];
+    });
+  }
+
+  async getById(id: string, user: RequestUser): Promise<any> {
+    this.assertIdentity(user);
+    return this.rls.withTrustedContext(user, async (tx) => {
+      await this.assertParticipant(tx, id, user);
+      const deal = await tx.deal.findUnique({
+        where: { id },
+        include: {
+          participants: { where: { status: ACTIVE_PARTICIPANT }, orderBy: [{ role: 'asc' }, { assignedAt: 'asc' }] },
+        },
+      });
+      if (!deal) throw new NotFoundException({ code: 'DEAL_NOT_FOUND', dealId: id });
+      return exactJson(deal);
+    });
+  }
+
+  async workspace(id: string, user: RequestUser): Promise<any> {
+    this.assertIdentity(user);
+    return this.rls.withTrustedContext(user, async (tx) => {
+      const participant = await this.assertParticipant(tx, id, user);
+      const deal = await tx.deal.findUnique({
+        where: { id },
+        include: {
+          participants: { where: { status: ACTIVE_PARTICIPANT }, orderBy: [{ role: 'asc' }, { assignedAt: 'asc' }] },
+          shipments: { include: { checkpoints: { orderBy: [{ completedAt: 'asc' }, { id: 'asc' }] } }, orderBy: { createdAt: 'asc' } },
+          documents: { orderBy: [{ type: 'asc' }, { version: 'desc' }] },
+          payments: { orderBy: { createdAt: 'desc' } },
+          labSamples: { include: { tests: { orderBy: { recordedAt: 'asc' } } }, orderBy: { createdAt: 'desc' } },
+          acceptanceRecords: { orderBy: { createdAt: 'desc' } },
+          bankOperations: { orderBy: { createdAt: 'asc' } },
+          dealEvents: { orderBy: [{ createdAt: 'asc' }, { id: 'asc' }] },
+        },
+      });
+      if (!deal) throw new NotFoundException({ code: 'DEAL_NOT_FOUND', dealId: id });
+      const [disputes, evidence, audits, outbox] = await Promise.all([
+        tx.dispute.findMany({ where: { dealId: id }, include: { moneyHold: true, evidence: true }, orderBy: { createdAt: 'desc' } }),
+        tx.evidenceFile.findMany({ where: { dealId: id }, orderBy: [{ uploadedAt: 'asc' }, { id: 'asc' }] }),
+        tx.auditEvent.findMany({ where: { dealId: id }, orderBy: [{ createdAt: 'asc' }, { id: 'asc' }] }),
+        tx.outboxEntry.findMany({ where: { dealId: id }, orderBy: [{ createdAt: 'asc' }, { id: 'asc' }], take: 500 }),
+      ]);
+      return exactJson({
+        deal,
+        viewer: {
+          participantId: participant.id,
+          organizationId: participant.organizationId,
+          role: participant.role,
+          accessLevel: participant.accessLevel,
+        },
+        projections: {
+          auctionDealBasis: deal.sagaState,
+          shipments: deal.shipments,
+          documents: deal.documents,
+          laboratory: deal.labSamples,
+          payments: deal.payments,
+          disputes,
+          evidence,
+        },
+        timeline: deal.dealEvents,
+        audit: audits,
+        outbox,
+      });
+    });
+  }
+
+  async passport(id: string, user: RequestUser): Promise<any> {
+    this.assertIdentity(user);
+    return this.rls.withTrustedContext(user, async (tx) => {
+      const participant = await this.assertParticipant(tx, id, user);
+      const deal = await tx.deal.findUnique({
+        where: { id },
+        include: {
+          participants: { where: { status: ACTIVE_PARTICIPANT }, select: { organizationId: true, userId: true, role: true, accessLevel: true, assignedAt: true } },
+          documents: { orderBy: [{ type: 'asc' }, { version: 'desc' }] },
+          payments: { orderBy: { createdAt: 'desc' } },
+          bankOperations: { orderBy: { createdAt: 'asc' } },
+          acceptanceRecords: { orderBy: { createdAt: 'desc' } },
+        },
+      });
+      if (!deal) throw new NotFoundException({ code: 'DEAL_NOT_FOUND', dealId: id });
+      const evidence = await tx.evidenceFile.findMany({
+        where: { dealId: id },
+        select: { id: true, type: true, filename: true, hash: true, prevHash: true, s3Key: true, uploadedAt: true },
+        orderBy: [{ uploadedAt: 'asc' }, { id: 'asc' }],
+      });
+      return exactJson({
+        identity: {
+          id: deal.id,
+          dealNumber: deal.dealNumber,
+          tenantId: deal.tenantId,
+          status: deal.status,
+          version: deal.version,
+          createdAt: deal.createdAt,
+          updatedAt: deal.updatedAt,
+          closedAt: deal.closedAt,
+        },
+        commercialBasis: {
+          lotId: deal.lotId,
+          winnerBidId: deal.sourceLotId,
+          sellerOrgId: deal.sellerOrgId,
+          buyerOrgId: deal.buyerOrgId,
+          culture: deal.culture,
+          cropClass: deal.cropClass,
+          region: deal.region,
+          incoterms: deal.incoterms,
+          volumeTons: deal.volumeTonsDec,
+          pricePerTon: deal.pricePerTonDec,
+          totalKopecks: deal.totalKopecks,
+          currency: deal.currency,
+          basisSnapshot: deal.sagaState,
+        },
+        participants: deal.participants,
+        documents: deal.documents,
+        evidence,
+        payments: deal.payments,
+        bankOperations: deal.bankOperations,
+        acceptance: deal.acceptanceRecords,
+        viewer: { participantId: participant.id, role: participant.role, accessLevel: participant.accessLevel },
+      });
+    });
+  }
+
+  async timeline(id: string, user: RequestUser): Promise<any> {
+    this.assertIdentity(user);
+    return this.rls.withTrustedContext(user, async (tx) => {
+      await this.assertParticipant(tx, id, user);
+      const [events, audits, outbox, bankOperations, evidence] = await Promise.all([
+        tx.dealEvent.findMany({ where: { dealId: id }, orderBy: [{ createdAt: 'asc' }, { id: 'asc' }], take: 1000 }),
+        tx.auditEvent.findMany({ where: { dealId: id }, orderBy: [{ createdAt: 'asc' }, { id: 'asc' }], take: 1000 }),
+        tx.outboxEntry.findMany({ where: { dealId: id }, orderBy: [{ createdAt: 'asc' }, { id: 'asc' }], take: 1000 }),
+        tx.bankOperation.findMany({ where: { dealId: id }, orderBy: [{ createdAt: 'asc' }, { id: 'asc' }], take: 1000 }),
+        tx.evidenceFile.findMany({ where: { dealId: id }, orderBy: [{ uploadedAt: 'asc' }, { id: 'asc' }], take: 1000 }),
+      ]);
+      const items = [
+        ...events.map((item) => ({ at: item.createdAt, source: 'DEAL_EVENT', id: item.id, kind: item.eventType, payload: item.payload })),
+        ...audits.map((item) => ({ at: item.createdAt, source: 'AUDIT', id: item.id, kind: item.action, outcome: item.outcome, payload: item.metadata })),
+        ...outbox.map((item) => ({ at: item.createdAt, source: 'OUTBOX', id: item.id, kind: item.type, outcome: item.status, payload: item.payload })),
+        ...bankOperations.map((item) => ({ at: item.createdAt, source: 'BANK_OPERATION', id: item.id, kind: item.type, outcome: item.status, payload: item.responsePayload ?? item.requestPayload })),
+        ...evidence.map((item) => ({ at: item.uploadedAt, source: 'EVIDENCE', id: item.id, kind: item.type, outcome: item.hash ? 'HASHED' : 'INVALID', payload: { filename: item.filename, hash: item.hash, prevHash: item.prevHash } })),
+      ].sort((left, right) => left.at.getTime() - right.at.getTime() || left.id.localeCompare(right.id));
+      return exactJson({ dealId: id, count: items.length, items });
+    });
+  }
+
+  async create(dto: CreateDealDto, user: RequestUser): Promise<any> {
+    this.assertIdentity(user);
+    const basisExternalId = `${dto.lotId}:${dto.winnerBidId}`;
+    const receiptKey = `deal-create:${user.tenantId}:${dto.idempotencyKey}`;
+    const requestFingerprint = digest({
+      commandId: dto.commandId,
+      idempotencyKey: dto.idempotencyKey,
+      lotId: dto.lotId,
+      winnerBidId: dto.winnerBidId,
+      buyerOrgId: dto.buyerOrgId ?? null,
+      culture: dto.culture ?? null,
+      paymentTerms: dto.paymentTerms ?? null,
+    });
+
+    try {
+      return await this.rls.withTrustedContext(user, async (tx) => {
+        await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtextextended(${basisExternalId}, 83)) IS NULL AS locked`;
+        const existingReceipt = await tx.outboxEntry.findUnique({ where: { idempotencyKey: receiptKey } });
+        if (existingReceipt) return this.replayCreate(existingReceipt.payload, requestFingerprint);
+
+        const basisEvent = await tx.integrationEvent.findFirst({
+          where: {
+            adapterName: BASIS_ADAPTER,
+            eventType: BASIS_EVENT_TYPE,
+            externalId: basisExternalId,
+            status: 'CONFIRMED',
+          },
+          orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        });
+        if (!basisEvent) {
+          throw new UnprocessableEntityException({
+            code: 'DEAL_BASIS_NOT_FOUND',
+            field: 'winnerBidId',
+            message: 'В PostgreSQL нет подтверждённого основания лот → победитель → сделка.',
+          });
+        }
+        const basis = parseBasis(basisEvent);
+        if (basis.tenantId !== user.tenantId || basis.lotId !== dto.lotId || basis.winnerBidId !== dto.winnerBidId) {
+          throw new ForbiddenException({ code: 'DEAL_BASIS_SCOPE_DENIED' });
+        }
+        if (basis.sellerUserId !== user.id || basis.sellerOrgId !== user.orgId || String(user.role) !== 'FARMER') {
+          throw new ForbiddenException({
+            code: 'DEAL_CREATOR_NOT_BASIS_SELLER',
+            message: 'Создать сделку может только продавец, зафиксированный в серверном основании.',
+          });
+        }
+        if (dto.buyerOrgId && dto.buyerOrgId !== basis.buyerOrgId) {
+          throw new ConflictException({ code: 'CLIENT_BASIS_MISMATCH', field: 'buyerOrgId' });
+        }
+        if (dto.culture && dto.culture !== basis.culture) {
+          throw new ConflictException({ code: 'CLIENT_BASIS_MISMATCH', field: 'culture' });
+        }
+
+        const alreadyCreated = await tx.deal.findFirst({
+          where: { tenantId: basis.tenantId, lotId: basis.lotId, sourceLotId: basis.winnerBidId },
+          select: { id: true },
+        });
+        if (alreadyCreated) {
+          throw new ConflictException({
+            code: 'DEAL_BASIS_ALREADY_CONSUMED',
+            dealId: alreadyCreated.id,
+          });
+        }
+
+        await this.assertCreationActors(tx, basis);
+        const dealId = `deal-${randomUUID()}`;
+        const basisSnapshot = {
+          source: 'POSTGRESQL_INTEGRATION_EVENT',
+          integrationEventId: basisEvent.id,
+          sourceHash: basis.sourceHash,
+          lotId: basis.lotId,
+          winnerBidId: basis.winnerBidId,
+          sellerOrgId: basis.sellerOrgId,
+          buyerOrgId: basis.buyerOrgId,
+          sellerUserId: basis.sellerUserId,
+          buyerUserId: basis.buyerUserId,
+          culture: basis.culture,
+          cropClass: basis.cropClass ?? null,
+          region: basis.region ?? null,
+          incoterms: basis.incoterms ?? null,
+          volumeTons: basis.volumeTons,
+          pricePerTon: basis.pricePerTon,
+          totalKopecks: basis.totalKopecks,
+          currency: basis.currency,
+          paymentTerms: dto.paymentTerms ?? null,
+        };
+
+        const deal = await tx.deal.create({
+          data: {
+            id: dealId,
+            lotId: basis.lotId,
+            sourceLotId: basis.winnerBidId,
+            dealNumber: basis.dealNumber,
+            status: 'DRAFT',
+            tenantId: basis.tenantId,
+            sellerOrgId: basis.sellerOrgId,
+            buyerOrgId: basis.buyerOrgId,
+            volumeTonsDec: new Prisma.Decimal(basis.volumeTons),
+            pricePerTonDec: new Prisma.Decimal(basis.pricePerTon),
+            totalKopecks: BigInt(basis.totalKopecks),
+            currency: basis.currency,
+            culture: basis.culture,
+            cropClass: basis.cropClass,
+            region: basis.region,
+            incoterms: basis.incoterms,
+            sagaState: basisSnapshot,
+            nextAction: 'Подтвердить допуск участников',
+          },
+        });
+        await tx.dealParticipant.createMany({
+          data: [
+            {
+              id: `participant:${dealId}:seller`,
+              dealId,
+              tenantId: basis.tenantId,
+              organizationId: basis.sellerOrgId,
+              userId: basis.sellerUserId,
+              role: 'FARMER',
+              accessLevel: 'APPROVE',
+              status: ACTIVE_PARTICIPANT,
+              assignedByUserId: user.id,
+            },
+            {
+              id: `participant:${dealId}:buyer`,
+              dealId,
+              tenantId: basis.tenantId,
+              organizationId: basis.buyerOrgId,
+              userId: basis.buyerUserId,
+              role: 'BUYER',
+              accessLevel: 'APPROVE',
+              status: ACTIVE_PARTICIPANT,
+              assignedByUserId: user.id,
+            },
+          ],
+        });
+
+        const eventId = `event-${randomUUID()}`;
+        const eventPayload = {
+          commandId: dto.commandId,
+          idempotencyKey: dto.idempotencyKey,
+          integrationEventId: basisEvent.id,
+          basisHash: basis.sourceHash,
+          status: 'DRAFT',
+        };
+        const eventHash = digest({ id: eventId, dealId, eventType: 'CREATED', actorId: user.id, actorRole: String(user.role), tenantId: user.tenantId, payload: eventPayload, prevHash: null });
+        await tx.dealEvent.create({
+          data: {
+            id: eventId,
+            dealId,
+            eventType: 'CREATED',
+            actorId: user.id,
+            actorRole: String(user.role),
+            tenantId: user.tenantId,
+            payload: eventPayload,
+            hash: eventHash,
+          },
+        });
+
+        const auditId = `audit-${randomUUID()}`;
+        const auditMaterial = {
+          id: auditId,
+          action: 'deal.create',
+          actorUserId: user.id,
+          actorRole: String(user.role),
+          tenantId: user.tenantId,
+          orgId: user.orgId,
+          dealId,
+          objectType: 'deal',
+          objectId: dealId,
+          beforeState: null,
+          afterState: { status: 'DRAFT', version: '0' },
+          outcome: 'SUCCESS',
+          metadata: { commandId: dto.commandId, idempotencyKey: dto.idempotencyKey, eventId, basisEventId: basisEvent.id },
+          prevHash: null,
+        };
+        await tx.auditEvent.create({
+          data: { ...auditMaterial, hash: digest(auditMaterial) },
+        });
+
+        const result = exactJson({
+          id: deal.id,
+          dealNumber: deal.dealNumber,
+          status: deal.status,
+          version: deal.version,
+          tenantId: deal.tenantId,
+          sellerOrgId: deal.sellerOrgId,
+          buyerOrgId: deal.buyerOrgId,
+          lotId: deal.lotId,
+          winnerBidId: deal.sourceLotId,
+          eventId,
+          auditId,
+          duplicate: false,
+        });
+        await tx.outboxEntry.create({
+          data: {
+            type: 'deal.create.receipt',
+            dealId,
+            status: 'CONFIRMED',
+            idempotencyKey: receiptKey,
+            correlationId: dto.commandId,
+            auditId,
+            confirmedAt: new Date(),
+            payload: { requestFingerprint, result } as Prisma.InputJsonValue,
+          },
+        });
+        return result;
+      }, { isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted, timeout: 20_000 });
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        return this.rls.withTrustedContext(user, async (tx) => {
+          const receipt = await tx.outboxEntry.findUnique({ where: { idempotencyKey: receiptKey } });
+          if (receipt) return this.replayCreate(receipt.payload, requestFingerprint);
+          throw error;
+        });
+      }
+      throw error;
     }
   }
 
-  private get db(): PrismaService {
-    if (!this.prisma) {
-      throw new Error('PrismaDealRepository: PrismaService unavailable — DB-backed deal path not active.');
+  private assertIdentity(user: RequestUser): void {
+    if (!user.id || !user.sessionId || !user.orgId || !user.tenantId || !user.role) {
+      throw new ForbiddenException({ code: 'TRUSTED_CONTEXT_REQUIRED' });
     }
-    return this.prisma;
   }
 
-  async list(): Promise<unknown[]> {
-    return this.db.deal.findMany({ orderBy: { createdAt: 'desc' } });
-  }
-
-  async getById(id: string): Promise<any> {
-    const row = await this.db.deal.findUnique({ where: { id } });
-    if (!row) {
-      throw new Error(`Deal ${id} not found in DB-backed deal repository.`);
+  private async assertParticipant(tx: Prisma.TransactionClient, dealId: string, user: RequestUser) {
+    const participant = await tx.dealParticipant.findFirst({
+      where: {
+        dealId,
+        tenantId: user.tenantId,
+        userId: user.id,
+        organizationId: user.orgId,
+        role: String(user.role),
+        status: ACTIVE_PARTICIPANT,
+      },
+      include: { organization: true, user: true },
+    });
+    if (!participant) throw new ForbiddenException({ code: 'DEAL_PARTICIPANT_REQUIRED', dealId });
+    if (
+      participant.organization.tenantId !== user.tenantId
+      || !ACTIVE_ORG_STATUSES.has(participant.organization.status)
+      || participant.organization.kycStatus !== 'APPROVED'
+      || participant.user.status !== 'ACTIVE'
+      || participant.user.deletedAt
+    ) {
+      throw new ForbiddenException({ code: 'DEAL_PARTICIPANT_INACTIVE', dealId });
     }
-    return row;
+    const membership = await tx.userOrg.findUnique({
+      where: { userId_organizationId: { userId: user.id, organizationId: user.orgId } },
+    });
+    if (!membership || membership.role !== String(user.role)) {
+      throw new ForbiddenException({ code: 'DEAL_MEMBERSHIP_REQUIRED', dealId });
+    }
+    const deal = await tx.deal.findUnique({ where: { id: dealId }, select: { tenantId: true } });
+    if (!deal) throw new NotFoundException({ code: 'DEAL_NOT_FOUND', dealId });
+    if (deal.tenantId !== user.tenantId) throw new ForbiddenException({ code: 'TENANT_SCOPE_DENIED', dealId });
+    return participant;
   }
 
-  workspace(): any {
-    throw new Error('PrismaDealRepository.workspace is not supported — DB-backed deal workspace path is not active.');
+  private async assertCreationActors(tx: Prisma.TransactionClient, basis: DealBasis): Promise<void> {
+    const organizations = await tx.organization.findMany({
+      where: { id: { in: [basis.sellerOrgId, basis.buyerOrgId] } },
+    });
+    if (organizations.length !== 2 || organizations.some((org) => org.tenantId !== basis.tenantId || !ACTIVE_ORG_STATUSES.has(org.status) || org.kycStatus !== 'APPROVED')) {
+      throw new UnprocessableEntityException({ code: 'DEAL_BASIS_ORGANIZATION_INVALID' });
+    }
+    const users = await tx.user.findMany({ where: { id: { in: [basis.sellerUserId, basis.buyerUserId] } } });
+    if (users.length !== 2 || users.some((actor) => actor.status !== 'ACTIVE' || actor.deletedAt)) {
+      throw new UnprocessableEntityException({ code: 'DEAL_BASIS_USER_INVALID' });
+    }
+    const memberships = await tx.userOrg.findMany({
+      where: {
+        OR: [
+          { userId: basis.sellerUserId, organizationId: basis.sellerOrgId, role: 'FARMER' },
+          { userId: basis.buyerUserId, organizationId: basis.buyerOrgId, role: 'BUYER' },
+        ],
+      },
+    });
+    if (memberships.length !== 2) {
+      throw new UnprocessableEntityException({ code: 'DEAL_BASIS_MEMBERSHIP_INVALID' });
+    }
   }
 
-  passport(): any {
-    throw new Error('PrismaDealRepository.passport is not supported — DB-backed deal passport path is not active.');
-  }
-
-  timeline(): any {
-    throw new Error('PrismaDealRepository.timeline is not supported — DB-backed deal timeline path is not active.');
-  }
-
-  create(): any {
-    throw new Error('PrismaDealRepository.create is not supported — DB-backed deal write path is not active.');
-  }
-
-  transition(): any {
-    throw new Error('PrismaDealRepository.transition is not supported — DB-backed deal transition path is not active.');
+  private replayCreate(payload: Prisma.JsonValue, requestFingerprint: string): unknown {
+    const root = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload as JsonObject : {};
+    if (root.requestFingerprint !== requestFingerprint) {
+      throw new ConflictException({
+        code: 'IDEMPOTENCY_PAYLOAD_MISMATCH',
+        message: 'Этот idempotency key уже использован с другим основанием сделки.',
+      });
+    }
+    const result = root.result && typeof root.result === 'object' && !Array.isArray(root.result) ? root.result as JsonObject : null;
+    if (!result) throw new ConflictException({ code: 'CREATE_RECEIPT_INVALID' });
+    return { ...result, duplicate: true };
   }
 }

--- a/apps/api/src/modules/deals/runtime-deal.repository.ts
+++ b/apps/api/src/modules/deals/runtime-deal.repository.ts
@@ -5,10 +5,9 @@ import type { RequestUser } from '../../common/types/request-user';
 import { RuntimeCoreService } from '../runtime-core/runtime-core.service';
 
 /**
- * Default deal repository adapter.
- *
- * Wraps the in-memory RuntimeCore deal methods without changing behavior.
- * This is the only active adapter in controlled-pilot / pre-integration mode.
+ * Explicit test/demo adapter. It is not registered by DealsModule and cannot be
+ * selected by production configuration. Kept only for isolated legacy tests
+ * while those fixtures are removed.
  */
 @Injectable()
 export class RuntimeDealRepository implements DealRepository {
@@ -18,27 +17,23 @@ export class RuntimeDealRepository implements DealRepository {
     return this.runtime.listDeals(user);
   }
 
-  async getById(id: string): Promise<any> {
+  async getById(id: string, _user: RequestUser): Promise<any> {
     return this.runtime.getDeal(id);
   }
 
-  workspace(id: string): any {
+  async workspace(id: string, _user: RequestUser): Promise<any> {
     return this.runtime.dealWorkspace(id);
   }
 
-  passport(id: string): any {
+  async passport(id: string, _user: RequestUser): Promise<any> {
     return this.runtime.dealPassport(id);
   }
 
-  timeline(id: string): any {
+  async timeline(id: string, _user: RequestUser): Promise<any> {
     return this.runtime.dealTimeline(id);
   }
 
-  create(dto: CreateDealDto, user: RequestUser): any {
+  async create(dto: CreateDealDto, user: RequestUser): Promise<any> {
     return this.runtime.createDeal(dto, user);
-  }
-
-  transition(id: string, nextState: string, user: RequestUser, comment?: string): any {
-    return this.runtime.transitionDeal(id, nextState, user, comment);
   }
 }

--- a/apps/api/test/industrial/deal-postgresql-authority.e2e-spec.ts
+++ b/apps/api/test/industrial/deal-postgresql-authority.e2e-spec.ts
@@ -287,13 +287,14 @@ describe('PostgreSQL-authoritative DealRepository', () => {
   it('denies non-participant object reads and returns no foreign deals', async () => {
     const dealId = String((await repository.list(seller) as Array<Record<string, unknown>>)[0].id);
     await expect(repository.list(outsider)).resolves.toEqual([]);
-    for (const read of [
-      repository.getById(dealId, outsider),
-      repository.workspace(dealId, outsider),
-      repository.passport(dealId, outsider),
-      repository.timeline(dealId, outsider),
-    ]) {
-      await expect(read).rejects.toMatchObject({
+    const reads = [
+      () => repository.getById(dealId, outsider),
+      () => repository.workspace(dealId, outsider),
+      () => repository.passport(dealId, outsider),
+      () => repository.timeline(dealId, outsider),
+    ];
+    for (const read of reads) {
+      await expect(read()).rejects.toMatchObject({
         status: 403,
         response: expect.objectContaining({ code: 'DEAL_PARTICIPANT_REQUIRED' }),
       });

--- a/apps/api/test/industrial/deal-postgresql-authority.e2e-spec.ts
+++ b/apps/api/test/industrial/deal-postgresql-authority.e2e-spec.ts
@@ -1,0 +1,354 @@
+import * as bcrypt from 'bcryptjs';
+import { createHash } from 'crypto';
+import { Prisma } from '@prisma/client';
+import type { RequestUser } from '../../src/common/types/request-user';
+import { Role } from '../../src/common/types/request-user';
+import { PrismaDealRepository } from '../../src/modules/deals/prisma-deal.repository';
+import {
+  cleanTenant,
+  createInstance,
+  destroyInstance,
+  INDUSTRIAL_TENANT,
+  type ServiceInstance,
+} from './harness';
+
+jest.setTimeout(180_000);
+
+const PREFIX = 'authority';
+const SELLER_ORG = 'org-e2e-authority-seller';
+const BUYER_ORG = 'org-e2e-authority-buyer';
+const SELLER_USER = 'user-e2e-authority-seller';
+const BUYER_USER = 'user-e2e-authority-buyer';
+const OUTSIDER_USER = 'user-e2e-authority-outsider';
+const LOT_ID = 'LOT-AUTHORITY-0001';
+const BID_ID = 'BID-AUTHORITY-0001';
+const TOTAL_KOPECKS = '10000000000000000';
+
+let alpha: ServiceInstance;
+let repository: PrismaDealRepository;
+
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, stable(item)]),
+    );
+  }
+  return value;
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(stable(value))).digest('hex');
+}
+
+function actor(id: string, role: Role, orgId: string): RequestUser {
+  return {
+    id,
+    email: `${id}@industrial-e2e.invalid`,
+    fullName: id,
+    role,
+    orgId,
+    tenantId: INDUSTRIAL_TENANT,
+    sessionId: `session-${id}`,
+    mfaVerified: true,
+  };
+}
+
+const seller = actor(SELLER_USER, Role.FARMER, SELLER_ORG);
+const buyer = actor(BUYER_USER, Role.BUYER, BUYER_ORG);
+const outsider = actor(OUTSIDER_USER, Role.FARMER, SELLER_ORG);
+
+function basis(overrides: Record<string, unknown> = {}) {
+  const material = {
+    dealNumber: `ТП-${PREFIX}-0001`,
+    tenantId: INDUSTRIAL_TENANT,
+    lotId: LOT_ID,
+    winnerBidId: BID_ID,
+    sellerOrgId: SELLER_ORG,
+    buyerOrgId: BUYER_ORG,
+    sellerUserId: SELLER_USER,
+    buyerUserId: BUYER_USER,
+    culture: 'Пшеница',
+    cropClass: '3 класс',
+    region: 'Тамбовская область',
+    incoterms: 'CPT',
+    volumeTons: '100.000000',
+    pricePerTon: '1000000000000.000000',
+    totalKopecks: TOTAL_KOPECKS,
+    currency: 'RUB',
+    ...overrides,
+  };
+  return { ...material, sourceHash: digest(material) };
+}
+
+async function seedIdentityAndBasis(
+  instance: ServiceInstance,
+  suffix = '',
+  basisOverrides: Record<string, unknown> = {},
+) {
+  const lotId = suffix ? `${LOT_ID}-${suffix}` : LOT_ID;
+  const bidId = suffix ? `${BID_ID}-${suffix}` : BID_ID;
+  const payload = basis({ lotId, winnerBidId: bidId, dealNumber: `ТП-${PREFIX}-${suffix || '0001'}`, ...basisOverrides });
+  await instance.prisma.$transaction(async (tx) => {
+    for (const organization of [
+      { id: SELLER_ORG, inn: '779900000001' },
+      { id: BUYER_ORG, inn: '779900000002' },
+    ]) {
+      await tx.organization.upsert({
+        where: { id: organization.id },
+        update: { tenantId: INDUSTRIAL_TENANT, status: 'VERIFIED', kycStatus: 'APPROVED' },
+        create: {
+          ...organization,
+          name: organization.id,
+          tenantId: INDUSTRIAL_TENANT,
+          status: 'VERIFIED',
+          kycStatus: 'APPROVED',
+        },
+      });
+    }
+
+    const passwordHash = bcrypt.hashSync('authority-e2e', 4);
+    for (const identity of [
+      { id: SELLER_USER, role: Role.FARMER, orgId: SELLER_ORG },
+      { id: BUYER_USER, role: Role.BUYER, orgId: BUYER_ORG },
+      { id: OUTSIDER_USER, role: Role.FARMER, orgId: SELLER_ORG },
+    ]) {
+      await tx.user.upsert({
+        where: { id: identity.id },
+        update: { status: 'ACTIVE', deletedAt: null },
+        create: {
+          id: identity.id,
+          email: `${identity.id}@industrial-e2e.invalid`,
+          fullName: identity.id,
+          passwordHash,
+          status: 'ACTIVE',
+        },
+      });
+      await tx.userOrg.upsert({
+        where: { userId_organizationId: { userId: identity.id, organizationId: identity.orgId } },
+        update: { role: identity.role, isDefault: true },
+        create: {
+          userId: identity.id,
+          organizationId: identity.orgId,
+          role: identity.role,
+          isDefault: true,
+        },
+      });
+    }
+
+    await tx.integrationEvent.create({
+      data: {
+        id: `basis-event-${suffix || 'primary'}`,
+        adapterName: 'auction',
+        direction: 'INBOUND',
+        eventType: 'DEAL_BASIS_READY',
+        externalId: `${lotId}:${bidId}`,
+        status: 'CONFIRMED',
+        responsePayload: payload as Prisma.InputJsonValue,
+        idempotencyKey: `basis-${suffix || 'primary'}`,
+      },
+    });
+  });
+  return { lotId, bidId, payload };
+}
+
+async function cleanup(instance: ServiceInstance) {
+  await instance.prisma.$executeRawUnsafe('SET session_replication_role = replica');
+  try {
+    await instance.prisma.$executeRawUnsafe(
+      `DELETE FROM "integration_events" WHERE "id" LIKE 'basis-event-%' OR "idempotencyKey" LIKE 'basis-%'`,
+    );
+  } finally {
+    await instance.prisma.$executeRawUnsafe('SET session_replication_role = DEFAULT');
+  }
+  await cleanTenant(instance.prisma);
+}
+
+beforeAll(async () => {
+  alpha = await createInstance();
+  repository = new PrismaDealRepository(alpha.rls);
+  await cleanup(alpha);
+  await seedIdentityAndBasis(alpha);
+});
+
+afterAll(async () => {
+  await cleanup(alpha);
+  await destroyInstance(alpha);
+});
+
+describe('PostgreSQL-authoritative DealRepository', () => {
+  it('creates Deal, participants, initial event, audit and receipt atomically without operational fixtures', async () => {
+    const result = await repository.create({
+      commandId: 'authority-create-command-0001',
+      idempotencyKey: 'authority-create-idempotency-0001',
+      lotId: LOT_ID,
+      winnerBidId: BID_ID,
+    }, seller) as Record<string, unknown>;
+
+    expect(result).toMatchObject({
+      status: 'DRAFT',
+      version: '0',
+      tenantId: INDUSTRIAL_TENANT,
+      sellerOrgId: SELLER_ORG,
+      buyerOrgId: BUYER_ORG,
+      lotId: LOT_ID,
+      winnerBidId: BID_ID,
+      duplicate: false,
+    });
+    const dealId = String(result.id);
+
+    const [deal, participants, events, audits, receipts, shipments, documents, payments, labs, bankOperations, acceptance] = await Promise.all([
+      alpha.prisma.deal.findUniqueOrThrow({ where: { id: dealId } }),
+      alpha.prisma.dealParticipant.findMany({ where: { dealId }, orderBy: { role: 'asc' } }),
+      alpha.prisma.dealEvent.findMany({ where: { dealId } }),
+      alpha.prisma.auditEvent.findMany({ where: { dealId } }),
+      alpha.prisma.outboxEntry.findMany({ where: { dealId, type: 'deal.create.receipt' } }),
+      alpha.prisma.shipment.count({ where: { dealId } }),
+      alpha.prisma.dealDocument.count({ where: { dealId } }),
+      alpha.prisma.payment.count({ where: { dealId } }),
+      alpha.prisma.labSample.count({ where: { dealId } }),
+      alpha.prisma.bankOperation.count({ where: { dealId } }),
+      alpha.prisma.acceptanceRecord.count({ where: { dealId } }),
+    ]);
+
+    expect(deal.totalKopecks?.toString()).toBe(TOTAL_KOPECKS);
+    expect(deal.pricePerTonDec?.toFixed()).toBe('1000000000000');
+    expect(deal.volumeTonsDec?.toFixed()).toBe('100');
+    expect(participants.map((item) => [item.userId, item.organizationId, item.role])).toEqual([
+      [BUYER_USER, BUYER_ORG, 'BUYER'],
+      [SELLER_USER, SELLER_ORG, 'FARMER'],
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0].eventType).toBe('CREATED');
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({ action: 'deal.create', outcome: 'SUCCESS' });
+    expect(receipts).toHaveLength(1);
+    expect({ shipments, documents, payments, labs, bankOperations, acceptance }).toEqual({
+      shipments: 0,
+      documents: 0,
+      payments: 0,
+      labs: 0,
+      bankOperations: 0,
+      acceptance: 0,
+    });
+  });
+
+  it('replays the stored create receipt and rejects idempotency payload mutation', async () => {
+    const first = await repository.create({
+      commandId: 'authority-create-command-0001',
+      idempotencyKey: 'authority-create-idempotency-0001',
+      lotId: LOT_ID,
+      winnerBidId: BID_ID,
+    }, seller) as Record<string, unknown>;
+    expect(first.duplicate).toBe(true);
+
+    await expect(repository.create({
+      commandId: 'authority-create-command-mutated',
+      idempotencyKey: 'authority-create-idempotency-0001',
+      lotId: LOT_ID,
+      winnerBidId: BID_ID,
+    }, seller)).rejects.toMatchObject({
+      status: 409,
+      response: expect.objectContaining({ code: 'IDEMPOTENCY_PAYLOAD_MISMATCH' }),
+    });
+  });
+
+  it('returns participant-scoped exact projections and survives a new API instance', async () => {
+    const sellerList = await repository.list(seller) as Array<Record<string, unknown>>;
+    expect(sellerList).toHaveLength(1);
+    const dealId = String(sellerList[0].id);
+    expect(sellerList[0].totalKopecks).toBe(TOTAL_KOPECKS);
+    expect(typeof sellerList[0].totalKopecks).toBe('string');
+
+    const [sellerDeal, buyerDeal, workspace, passport, timeline] = await Promise.all([
+      repository.getById(dealId, seller),
+      repository.getById(dealId, buyer),
+      repository.workspace(dealId, buyer),
+      repository.passport(dealId, seller),
+      repository.timeline(dealId, buyer),
+    ]);
+    expect(sellerDeal).toEqual(buyerDeal);
+    expect(workspace.deal.id).toBe(dealId);
+    expect(passport.commercialBasis.totalKopecks).toBe(TOTAL_KOPECKS);
+    expect(timeline.items.some((item: { kind: string }) => item.kind === 'CREATED')).toBe(true);
+
+    const beta = await createInstance();
+    try {
+      const restarted = new PrismaDealRepository(beta.rls);
+      expect(await restarted.getById(dealId, seller)).toEqual(sellerDeal);
+      expect(await restarted.workspace(dealId, buyer)).toEqual(workspace);
+    } finally {
+      await destroyInstance(beta);
+    }
+  });
+
+  it('denies non-participant object reads and returns no foreign deals', async () => {
+    const dealId = String((await repository.list(seller) as Array<Record<string, unknown>>)[0].id);
+    await expect(repository.list(outsider)).resolves.toEqual([]);
+    for (const read of [
+      repository.getById(dealId, outsider),
+      repository.workspace(dealId, outsider),
+      repository.passport(dealId, outsider),
+      repository.timeline(dealId, outsider),
+    ]) {
+      await expect(read).rejects.toMatchObject({
+        status: 403,
+        response: expect.objectContaining({ code: 'DEAL_PARTICIPANT_REQUIRED' }),
+      });
+    }
+  });
+
+  it('rejects a forged basis hash and commits no deal/event/audit/outbox effect', async () => {
+    const forged = await seedIdentityAndBasis(alpha, 'forged', { sourceHash: 'forged' });
+    // sourceHash is generated after overrides by helper; corrupt the stored row explicitly.
+    await alpha.prisma.integrationEvent.update({
+      where: { id: 'basis-event-forged' },
+      data: { responsePayload: { ...forged.payload, sourceHash: '0'.repeat(64) } as Prisma.InputJsonValue },
+    });
+    const before = {
+      deals: await alpha.prisma.deal.count(),
+      events: await alpha.prisma.dealEvent.count(),
+      audits: await alpha.prisma.auditEvent.count(),
+      outbox: await alpha.prisma.outboxEntry.count(),
+    };
+
+    await expect(repository.create({
+      commandId: 'authority-create-command-forged',
+      idempotencyKey: 'authority-create-idempotency-forged',
+      lotId: forged.lotId,
+      winnerBidId: forged.bidId,
+    }, seller)).rejects.toMatchObject({
+      status: 422,
+      response: expect.objectContaining({ code: 'DEAL_BASIS_HASH_MISMATCH' }),
+    });
+
+    expect({
+      deals: await alpha.prisma.deal.count(),
+      events: await alpha.prisma.dealEvent.count(),
+      audits: await alpha.prisma.auditEvent.count(),
+      outbox: await alpha.prisma.outboxEntry.count(),
+    }).toEqual(before);
+  });
+
+  it('rejects an inactive organization before any deal write', async () => {
+    const inactive = await seedIdentityAndBasis(alpha, 'inactive');
+    await alpha.prisma.organization.update({ where: { id: BUYER_ORG }, data: { status: 'SUSPENDED' } });
+    const before = await alpha.prisma.deal.count();
+    try {
+      await expect(repository.create({
+        commandId: 'authority-create-command-inactive',
+        idempotencyKey: 'authority-create-idempotency-inactive',
+        lotId: inactive.lotId,
+        winnerBidId: inactive.bidId,
+      }, seller)).rejects.toMatchObject({
+        status: 422,
+        response: expect.objectContaining({ code: 'DEAL_BASIS_ORGANIZATION_INVALID' }),
+      });
+      expect(await alpha.prisma.deal.count()).toBe(before);
+    } finally {
+      await alpha.prisma.organization.update({ where: { id: BUYER_ORG }, data: { status: 'VERIFIED' } });
+    }
+  });
+});

--- a/apps/api/test/one-deal/deal-privileged-insert-denied.e2e-spec.ts
+++ b/apps/api/test/one-deal/deal-privileged-insert-denied.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { PrismaService } from '../../src/common/prisma/prisma.service';
+import { RlsTransactionService } from '../../src/common/prisma/rls-transaction.service';
+import { Role, type RequestUser } from '../../src/common/types/request-user';
+
+const operator: RequestUser = {
+  id: 'operator-e2e',
+  email: 'operator@demo.ru',
+  fullName: 'Тестовый оператор',
+  role: Role.SUPPORT_MANAGER,
+  orgId: 'org-canonical-platform',
+  tenantId: 'tenant-canonical-test',
+  sessionId: 'restricted-authority-operator-session',
+  mfaVerified: true,
+};
+
+function databaseErrorText(error: unknown): string {
+  const candidate = error as { code?: unknown; message?: unknown; meta?: unknown };
+  return JSON.stringify({ code: candidate?.code, message: candidate?.message, meta: candidate?.meta });
+}
+
+describe('Deal insert privilege boundary', () => {
+  let prisma: PrismaService;
+  let rls: RlsTransactionService;
+
+  beforeAll(async () => {
+    prisma = new PrismaService();
+    await prisma.$connect();
+    rls = new RlsTransactionService(prisma);
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('denies arbitrary Deal creation to SUPPORT_MANAGER despite privileged read access', async () => {
+    let errorText = '';
+    try {
+      await rls.withTrustedContext(operator, (tx) => tx.deal.create({
+        data: {
+          id: 'deal-forged-by-support-manager',
+          lotId: 'LOT-FORGED-BY-SUPPORT',
+          sourceLotId: 'BID-FORGED-BY-SUPPORT',
+          dealNumber: 'ТП-FORGED-BY-SUPPORT',
+          status: 'DRAFT',
+          tenantId: operator.tenantId,
+          sellerOrgId: 'org-canonical-seller',
+          buyerOrgId: 'org-canonical-buyer',
+          totalKopecks: 100n,
+          currency: 'RUB',
+        },
+      }));
+    } catch (error) {
+      errorText = databaseErrorText(error);
+    }
+
+    expect(errorText).toMatch(/row-level security|42501|policy/i);
+    await expect(prisma.deal.findUnique({
+      where: { id: 'deal-forged-by-support-manager' },
+    })).resolves.toBeNull();
+  });
+});

--- a/apps/api/test/one-deal/postgresql-deal-authority.e2e-spec.ts
+++ b/apps/api/test/one-deal/postgresql-deal-authority.e2e-spec.ts
@@ -229,6 +229,39 @@ describe('PostgreSQL deal authority under NOBYPASSRLS application principal', ()
     });
   });
 
+  it('rejects rewriting commercial columns or the persisted saga snapshot', async () => {
+    const result = await repository.create(CREATE_COMMAND, seller) as Record<string, unknown>;
+    const dealId = String(result.id);
+    const current = await rls.withTrustedContext(seller, (tx) => tx.deal.findUniqueOrThrow({
+      where: { id: dealId },
+    }));
+
+    const amountError = await captureDatabaseRejection(
+      rls.withTrustedContext(seller, (tx) => tx.deal.update({
+        where: { id: dealId },
+        data: { totalKopecks: 1n },
+      })),
+    );
+    expect(amountError).toMatch(/immutable|23514|deals_confirmed_basis_immutable/i);
+
+    const sagaError = await captureDatabaseRejection(
+      rls.withTrustedContext(seller, (tx) => tx.deal.update({
+        where: { id: dealId },
+        data: {
+          sagaState: {
+            ...(current.sagaState as Record<string, unknown>),
+            logisticsBasis: { carriers: [{ id: 'forged-carrier' }] },
+          } as any,
+        },
+      })),
+    );
+    expect(sagaError).toMatch(/immutable|23514|deals_confirmed_basis_immutable/i);
+
+    const unchanged = await repository.getById(dealId, seller);
+    expect(unchanged.totalKopecks).toBe('185000000');
+    expect(unchanged.sagaState).toEqual(current.sagaState);
+  });
+
   it('rejects a second Deal row for the same confirmed lot and winning bid', async () => {
     const duplicate = await basisBoundDealData('deal-duplicate-confirmed-basis');
     const error = await captureDatabaseRejection(

--- a/apps/api/test/one-deal/postgresql-deal-authority.e2e-spec.ts
+++ b/apps/api/test/one-deal/postgresql-deal-authority.e2e-spec.ts
@@ -6,6 +6,7 @@ import { Role, type RequestUser } from '../../src/common/types/request-user';
 const LOT_ID = 'LOT-RLS-AUTHORITY-001';
 const BID_ID = 'BID-RLS-AUTHORITY-001';
 const BASIS_EVENT_ID = 'basis-event-rls-authority-001';
+const AUTHORITY_CROSS_TENANT_ORG_ID = 'org-rls-authority-foreign-tenant';
 const CREATE_COMMAND = {
   commandId: 'restricted-authority-command-0001',
   idempotencyKey: 'restricted-authority-idempotency-0001',
@@ -42,6 +43,15 @@ const outsider: RequestUser = {
   role: Role.DRIVER,
   orgId: 'org-canonical-logistics',
   sessionId: 'restricted-authority-outsider-session',
+};
+
+const operator: RequestUser = {
+  ...seller,
+  id: 'operator-e2e',
+  email: 'operator@demo.ru',
+  role: Role.SUPPORT_MANAGER,
+  orgId: 'org-canonical-platform',
+  sessionId: 'restricted-authority-operator-session',
 };
 
 let prisma: PrismaService;
@@ -206,6 +216,7 @@ describe('PostgreSQL deal authority under NOBYPASSRLS application principal', ()
     expect(sellerProjection.participants[0]).toMatchObject({ userId: 'farmer-e2e', role: 'FARMER' });
     expect(buyerProjection.participants).toHaveLength(1);
     expect(buyerProjection.participants[0]).toMatchObject({ userId: 'buyer-e2e', role: 'BUYER' });
+    expect(sellerProjection.sagaStep).toBe('PARTICIPANTS_BOUND');
 
     const sellerCounts = await rls.withTrustedContext(seller, async (tx) => ({
       events: await tx.dealEvent.count({ where: { dealId } }),
@@ -310,5 +321,30 @@ describe('PostgreSQL deal authority under NOBYPASSRLS application principal', ()
       status: 403,
       response: expect.objectContaining({ code: 'DEAL_PARTICIPANT_REQUIRED' }),
     });
+  });
+
+  it('does not retain basis fallback visibility after the seller participant is revoked', async () => {
+    const result = await repository.create(CREATE_COMMAND, seller) as Record<string, unknown>;
+    const dealId = String(result.id);
+    await rls.withTrustedContext(operator, (tx) => tx.dealParticipant.updateMany({
+      where: { dealId, userId: seller.id, role: Role.FARMER },
+      data: { status: 'REVOKED', revokedAt: new Date() },
+    }));
+    try {
+      const visible = await rls.withTrustedContext(seller, (tx) => tx.deal.count({ where: { id: dealId } }));
+      expect(visible).toBe(0);
+    } finally {
+      await rls.withTrustedContext(operator, (tx) => tx.dealParticipant.updateMany({
+        where: { dealId, userId: seller.id, role: Role.FARMER },
+        data: { status: 'ACTIVE', revokedAt: null },
+      }));
+    }
+  });
+
+  it('keeps privileged organization reads inside the trusted tenant', async () => {
+    const visible = await rls.withTrustedContext(operator, (tx) => tx.organization.count({
+      where: { id: AUTHORITY_CROSS_TENANT_ORG_ID },
+    }));
+    expect(visible).toBe(0);
   });
 });

--- a/apps/api/test/one-deal/postgresql-deal-authority.e2e-spec.ts
+++ b/apps/api/test/one-deal/postgresql-deal-authority.e2e-spec.ts
@@ -1,0 +1,153 @@
+import { PrismaService } from '../../src/common/prisma/prisma.service';
+import { RlsTransactionService } from '../../src/common/prisma/rls-transaction.service';
+import { PrismaDealRepository } from '../../src/modules/deals/prisma-deal.repository';
+import { Role, type RequestUser } from '../../src/common/types/request-user';
+
+const LOT_ID = 'LOT-RLS-AUTHORITY-001';
+const BID_ID = 'BID-RLS-AUTHORITY-001';
+const CREATE_COMMAND = {
+  commandId: 'restricted-authority-command-0001',
+  idempotencyKey: 'restricted-authority-idempotency-0001',
+  lotId: LOT_ID,
+  winnerBidId: BID_ID,
+};
+
+const seller: RequestUser = {
+  id: 'farmer-e2e',
+  email: 'farmer@demo.ru',
+  fullName: 'Тестовый продавец',
+  role: Role.FARMER,
+  orgId: 'org-canonical-seller',
+  tenantId: 'tenant-canonical-test',
+  sessionId: 'restricted-authority-seller-session',
+  mfaVerified: true,
+};
+
+const buyer: RequestUser = {
+  id: 'buyer-e2e',
+  email: 'buyer@demo.ru',
+  fullName: 'Тестовый покупатель',
+  role: Role.BUYER,
+  orgId: 'org-canonical-buyer',
+  tenantId: 'tenant-canonical-test',
+  sessionId: 'restricted-authority-buyer-session',
+  mfaVerified: true,
+};
+
+const outsider: RequestUser = {
+  ...seller,
+  id: 'driver-e2e',
+  email: 'driver@demo.ru',
+  role: Role.DRIVER,
+  orgId: 'org-canonical-logistics',
+  sessionId: 'restricted-authority-outsider-session',
+};
+
+let prisma: PrismaService;
+let repository: PrismaDealRepository;
+
+beforeAll(async () => {
+  prisma = new PrismaService();
+  await prisma.$connect();
+  repository = new PrismaDealRepository(new RlsTransactionService(prisma));
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('PostgreSQL deal authority under NOBYPASSRLS application principal', () => {
+  it('exposes only the seller-scoped confirmed pre-deal basis', async () => {
+    const visible = await new RlsTransactionService(prisma).withTrustedContext(seller, (tx) =>
+      tx.integrationEvent.findMany({
+        where: { adapterName: 'auction', eventType: 'DEAL_BASIS_READY', dealId: null },
+        select: { id: true, externalId: true },
+      }),
+    );
+    expect(visible).toEqual([{
+      id: 'basis-event-rls-authority-001',
+      externalId: `${LOT_ID}:${BID_ID}`,
+    }]);
+
+    const buyerVisible = await new RlsTransactionService(prisma).withTrustedContext(buyer, (tx) =>
+      tx.integrationEvent.count({ where: { dealId: null, eventType: 'DEAL_BASIS_READY' } }),
+    );
+    expect(buyerVisible).toBe(0);
+  });
+
+  it('creates the deal and exactly basis-bound seller/buyer participants in one transaction', async () => {
+    const result = await repository.create(CREATE_COMMAND, seller) as Record<string, unknown>;
+    expect(result).toMatchObject({
+      status: 'DRAFT',
+      version: '0',
+      lotId: LOT_ID,
+      winnerBidId: BID_ID,
+      tenantId: 'tenant-canonical-test',
+      sellerOrgId: 'org-canonical-seller',
+      buyerOrgId: 'org-canonical-buyer',
+      duplicate: false,
+    });
+    const dealId = String(result.id);
+
+    const sellerProjection = await repository.getById(dealId, seller);
+    const buyerProjection = await repository.getById(dealId, buyer);
+    expect(sellerProjection.participants).toHaveLength(1);
+    expect(sellerProjection.participants[0]).toMatchObject({ userId: 'farmer-e2e', role: 'FARMER' });
+    expect(buyerProjection.participants).toHaveLength(1);
+    expect(buyerProjection.participants[0]).toMatchObject({ userId: 'buyer-e2e', role: 'BUYER' });
+
+    const sellerCounts = await new RlsTransactionService(prisma).withTrustedContext(seller, async (tx) => ({
+      events: await tx.dealEvent.count({ where: { dealId } }),
+      audits: await tx.auditEvent.count({ where: { dealId } }),
+      receipts: await tx.outboxEntry.count({ where: { dealId, type: 'deal.create.receipt' } }),
+      shipments: await tx.shipment.count({ where: { dealId } }),
+      documents: await tx.dealDocument.count({ where: { dealId } }),
+      payments: await tx.payment.count({ where: { dealId } }),
+      labs: await tx.labSample.count({ where: { dealId } }),
+      bankOperations: await tx.bankOperation.count({ where: { dealId } }),
+    }));
+    expect(sellerCounts).toEqual({
+      events: 1,
+      audits: 1,
+      receipts: 1,
+      shipments: 0,
+      documents: 0,
+      payments: 0,
+      labs: 0,
+      bankOperations: 0,
+    });
+  });
+
+  it('replays idempotently across a fresh application instance', async () => {
+    const first = await repository.create(CREATE_COMMAND, seller) as Record<string, unknown>;
+    expect(first.duplicate).toBe(true);
+
+    const freshPrisma = new PrismaService();
+    await freshPrisma.$connect();
+    try {
+      const freshRepository = new PrismaDealRepository(new RlsTransactionService(freshPrisma));
+      const replay = await freshRepository.create(CREATE_COMMAND, seller) as Record<string, unknown>;
+      expect(replay).toMatchObject({ id: first.id, duplicate: true });
+      expect(await freshRepository.getById(String(first.id), buyer)).toMatchObject({
+        id: first.id,
+        totalKopecks: '185000000',
+        pricePerTonDec: '18500',
+        volumeTonsDec: '100',
+      });
+    } finally {
+      await freshPrisma.$disconnect();
+    }
+  });
+
+  it('denies a non-participant and never exposes the deal cross-object', async () => {
+    const result = await repository.create(CREATE_COMMAND, seller) as Record<string, unknown>;
+    const dealId = String(result.id);
+    await expect(repository.list(outsider)).resolves.not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: dealId })]),
+    );
+    await expect(repository.workspace(dealId, outsider)).rejects.toMatchObject({
+      status: 403,
+      response: expect.objectContaining({ code: 'DEAL_PARTICIPANT_REQUIRED' }),
+    });
+  });
+});

--- a/apps/api/test/one-deal/postgresql-deal-authority.e2e-spec.ts
+++ b/apps/api/test/one-deal/postgresql-deal-authority.e2e-spec.ts
@@ -44,12 +44,38 @@ const outsider: RequestUser = {
 };
 
 let prisma: PrismaService;
+let rls: RlsTransactionService;
 let repository: PrismaDealRepository;
+
+function databaseErrorText(error: unknown): string {
+  const candidate = error as {
+    name?: unknown;
+    code?: unknown;
+    message?: unknown;
+    meta?: unknown;
+  };
+  return JSON.stringify({
+    name: candidate?.name,
+    code: candidate?.code,
+    message: candidate?.message,
+    meta: candidate?.meta,
+  });
+}
+
+async function captureDatabaseRejection(work: Promise<unknown>): Promise<string> {
+  try {
+    await work;
+  } catch (error) {
+    return databaseErrorText(error);
+  }
+  throw new Error('Expected PostgreSQL to reject the write.');
+}
 
 beforeAll(async () => {
   prisma = new PrismaService();
   await prisma.$connect();
-  repository = new PrismaDealRepository(new RlsTransactionService(prisma));
+  rls = new RlsTransactionService(prisma);
+  repository = new PrismaDealRepository(rls);
 });
 
 afterAll(async () => {
@@ -58,7 +84,7 @@ afterAll(async () => {
 
 describe('PostgreSQL deal authority under NOBYPASSRLS application principal', () => {
   it('exposes only the seller-scoped confirmed pre-deal basis', async () => {
-    const visible = await new RlsTransactionService(prisma).withTrustedContext(seller, (tx) =>
+    const visible = await rls.withTrustedContext(seller, (tx) =>
       tx.integrationEvent.findMany({
         where: { adapterName: 'auction', eventType: 'DEAL_BASIS_READY', dealId: null },
         select: { id: true, externalId: true },
@@ -69,10 +95,31 @@ describe('PostgreSQL deal authority under NOBYPASSRLS application principal', ()
       externalId: `${LOT_ID}:${BID_ID}`,
     }]);
 
-    const buyerVisible = await new RlsTransactionService(prisma).withTrustedContext(buyer, (tx) =>
+    const buyerVisible = await rls.withTrustedContext(buyer, (tx) =>
       tx.integrationEvent.count({ where: { dealId: null, eventType: 'DEAL_BASIS_READY' } }),
     );
     expect(buyerVisible).toBe(0);
+  });
+
+  it('rejects a direct Deal INSERT that is not backed by a confirmed basis', async () => {
+    const error = await captureDatabaseRejection(
+      rls.withTrustedContext(seller, (tx) => tx.deal.create({
+        data: {
+          id: 'deal-forged-without-basis',
+          lotId: 'LOT-FORGED-WITHOUT-BASIS',
+          sourceLotId: 'BID-FORGED-WITHOUT-BASIS',
+          dealNumber: 'ТП-FORGED-WITHOUT-BASIS',
+          status: 'DRAFT',
+          tenantId: seller.tenantId,
+          sellerOrgId: seller.orgId,
+          buyerOrgId: buyer.orgId,
+          totalKopecks: 100n,
+          currency: 'RUB',
+        },
+      })),
+    );
+
+    expect(error).toMatch(/row-level security|42501|policy/i);
   });
 
   it('creates the deal and exactly basis-bound seller/buyer participants in one transaction', async () => {
@@ -96,7 +143,7 @@ describe('PostgreSQL deal authority under NOBYPASSRLS application principal', ()
     expect(buyerProjection.participants).toHaveLength(1);
     expect(buyerProjection.participants[0]).toMatchObject({ userId: 'buyer-e2e', role: 'BUYER' });
 
-    const sellerCounts = await new RlsTransactionService(prisma).withTrustedContext(seller, async (tx) => ({
+    const sellerCounts = await rls.withTrustedContext(seller, async (tx) => ({
       events: await tx.dealEvent.count({ where: { dealId } }),
       audits: await tx.auditEvent.count({ where: { dealId } }),
       receipts: await tx.outboxEntry.count({ where: { dealId, type: 'deal.create.receipt' } }),
@@ -116,6 +163,38 @@ describe('PostgreSQL deal authority under NOBYPASSRLS application principal', ()
       labs: 0,
       bankOperations: 0,
     });
+  });
+
+  it('rejects a second Deal row for the same confirmed lot and winning bid', async () => {
+    const error = await captureDatabaseRejection(
+      rls.withTrustedContext(seller, (tx) => tx.deal.create({
+        data: {
+          id: 'deal-duplicate-confirmed-basis',
+          lotId: LOT_ID,
+          sourceLotId: BID_ID,
+          dealNumber: 'ТП-RLS-AUTHORITY-DUPLICATE',
+          status: 'DRAFT',
+          tenantId: seller.tenantId,
+          sellerOrgId: seller.orgId,
+          buyerOrgId: buyer.orgId,
+          volumeTonsDec: '100.000000',
+          pricePerTonDec: '18500.000000',
+          totalKopecks: 185000000n,
+          currency: 'RUB',
+          culture: 'Пшеница',
+        },
+      })),
+    );
+
+    expect(error).toMatch(/already been consumed|23505|P2002|deals_tenant_lot_winner_single_use/i);
+    const matchingDeals = await rls.withTrustedContext(seller, (tx) => tx.deal.count({
+      where: {
+        tenantId: seller.tenantId,
+        lotId: LOT_ID,
+        sourceLotId: BID_ID,
+      },
+    }));
+    expect(matchingDeals).toBe(1);
   });
 
   it('replays idempotently across a fresh application instance', async () => {

--- a/apps/api/test/one-deal/postgresql-deal-authority.e2e-spec.ts
+++ b/apps/api/test/one-deal/postgresql-deal-authority.e2e-spec.ts
@@ -5,6 +5,7 @@ import { Role, type RequestUser } from '../../src/common/types/request-user';
 
 const LOT_ID = 'LOT-RLS-AUTHORITY-001';
 const BID_ID = 'BID-RLS-AUTHORITY-001';
+const BASIS_EVENT_ID = 'basis-event-rls-authority-001';
 const CREATE_COMMAND = {
   commandId: 'restricted-authority-command-0001',
   idempotencyKey: 'restricted-authority-idempotency-0001',
@@ -71,6 +72,57 @@ async function captureDatabaseRejection(work: Promise<unknown>): Promise<string>
   throw new Error('Expected PostgreSQL to reject the write.');
 }
 
+async function basisBoundDealData(
+  id: string,
+  overrides: Record<string, unknown> = {},
+): Promise<Record<string, unknown>> {
+  const event = await rls.withTrustedContext(seller, (tx) => tx.integrationEvent.findUniqueOrThrow({
+    where: { id: BASIS_EVENT_ID },
+  }));
+  const basis = (event.responsePayload ?? event.requestPayload) as Record<string, string>;
+
+  return {
+    id,
+    lotId: basis.lotId,
+    sourceLotId: basis.winnerBidId,
+    dealNumber: basis.dealNumber,
+    status: 'DRAFT',
+    tenantId: basis.tenantId,
+    sellerOrgId: basis.sellerOrgId,
+    buyerOrgId: basis.buyerOrgId,
+    volumeTonsDec: basis.volumeTons,
+    pricePerTonDec: basis.pricePerTon,
+    totalKopecks: BigInt(basis.totalKopecks),
+    currency: basis.currency,
+    culture: basis.culture,
+    cropClass: basis.cropClass,
+    region: basis.region,
+    incoterms: basis.incoterms,
+    sagaState: {
+      source: 'POSTGRESQL_INTEGRATION_EVENT',
+      integrationEventId: event.id,
+      sourceHash: basis.sourceHash,
+      lotId: basis.lotId,
+      winnerBidId: basis.winnerBidId,
+      sellerOrgId: basis.sellerOrgId,
+      buyerOrgId: basis.buyerOrgId,
+      sellerUserId: basis.sellerUserId,
+      buyerUserId: basis.buyerUserId,
+      culture: basis.culture,
+      cropClass: basis.cropClass ?? null,
+      region: basis.region ?? null,
+      incoterms: basis.incoterms ?? null,
+      volumeTons: basis.volumeTons,
+      pricePerTon: basis.pricePerTon,
+      totalKopecks: basis.totalKopecks,
+      currency: basis.currency,
+      paymentTerms: null,
+    },
+    nextAction: 'Подтвердить допуск участников',
+    ...overrides,
+  };
+}
+
 beforeAll(async () => {
   prisma = new PrismaService();
   await prisma.$connect();
@@ -91,7 +143,7 @@ describe('PostgreSQL deal authority under NOBYPASSRLS application principal', ()
       }),
     );
     expect(visible).toEqual([{
-      id: 'basis-event-rls-authority-001',
+      id: BASIS_EVENT_ID,
       externalId: `${LOT_ID}:${BID_ID}`,
     }]);
 
@@ -117,6 +169,18 @@ describe('PostgreSQL deal authority under NOBYPASSRLS application principal', ()
           currency: 'RUB',
         },
       })),
+    );
+
+    expect(error).toMatch(/row-level security|42501|policy/i);
+  });
+
+  it('rejects direct tampering with amount or state even when lot and winner match', async () => {
+    const tampered = await basisBoundDealData('deal-tampered-confirmed-basis', {
+      totalKopecks: 1n,
+      status: 'CLOSED',
+    });
+    const error = await captureDatabaseRejection(
+      rls.withTrustedContext(seller, (tx) => tx.deal.create({ data: tampered as any })),
     );
 
     expect(error).toMatch(/row-level security|42501|policy/i);
@@ -166,24 +230,9 @@ describe('PostgreSQL deal authority under NOBYPASSRLS application principal', ()
   });
 
   it('rejects a second Deal row for the same confirmed lot and winning bid', async () => {
+    const duplicate = await basisBoundDealData('deal-duplicate-confirmed-basis');
     const error = await captureDatabaseRejection(
-      rls.withTrustedContext(seller, (tx) => tx.deal.create({
-        data: {
-          id: 'deal-duplicate-confirmed-basis',
-          lotId: LOT_ID,
-          sourceLotId: BID_ID,
-          dealNumber: 'ТП-RLS-AUTHORITY-DUPLICATE',
-          status: 'DRAFT',
-          tenantId: seller.tenantId,
-          sellerOrgId: seller.orgId,
-          buyerOrgId: buyer.orgId,
-          volumeTonsDec: '100.000000',
-          pricePerTonDec: '18500.000000',
-          totalKopecks: 185000000n,
-          currency: 'RUB',
-          culture: 'Пшеница',
-        },
-      })),
+      rls.withTrustedContext(seller, (tx) => tx.deal.create({ data: duplicate as any })),
     );
 
     expect(error).toMatch(/already been consumed|23505|P2002|deals_tenant_lot_winner_single_use/i);

--- a/apps/api/test/one-deal/seed.ts
+++ b/apps/api/test/one-deal/seed.ts
@@ -1,7 +1,29 @@
+import { createHash } from 'crypto';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../src/common/prisma/prisma.service';
 import { PersistentAuthRepository } from '../../src/modules/auth/persistent-auth.repository';
 import { CanonicalTestDealSeedService } from '../../src/modules/deals/canonical-test-deal.seed';
 import { CANONICAL_TEST_DEAL_ID } from '../../src/modules/deals/deal-command.policy';
+
+export const AUTHORITY_LOT_ID = 'LOT-RLS-AUTHORITY-001';
+export const AUTHORITY_BID_ID = 'BID-RLS-AUTHORITY-001';
+export const AUTHORITY_BASIS_EVENT_ID = 'basis-event-rls-authority-001';
+
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, stable(item)]),
+    );
+  }
+  return value;
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(stable(value))).digest('hex');
+}
 
 async function main(): Promise<void> {
   if (process.env.NODE_ENV === 'production') {
@@ -18,7 +40,45 @@ async function main(): Promise<void> {
     const seed = new CanonicalTestDealSeedService(prisma, authRepository);
     await seed.onModuleInit();
 
-    const [deal, memberships, credentialStates] = await Promise.all([
+    const basisMaterial = {
+      dealNumber: 'ТП-RLS-AUTHORITY-001',
+      tenantId: 'tenant-canonical-test',
+      lotId: AUTHORITY_LOT_ID,
+      winnerBidId: AUTHORITY_BID_ID,
+      sellerOrgId: 'org-canonical-seller',
+      buyerOrgId: 'org-canonical-buyer',
+      sellerUserId: 'farmer-e2e',
+      buyerUserId: 'buyer-e2e',
+      culture: 'Пшеница',
+      cropClass: '3 класс',
+      region: 'Контролируемый RLS-контур',
+      incoterms: 'CPT',
+      volumeTons: '100.000000',
+      pricePerTon: '18500.000000',
+      totalKopecks: '185000000',
+      currency: 'RUB',
+    };
+    const basis = { ...basisMaterial, sourceHash: digest(basisMaterial) };
+    await prisma.integrationEvent.upsert({
+      where: { id: AUTHORITY_BASIS_EVENT_ID },
+      update: {
+        dealId: null,
+        status: 'CONFIRMED',
+        responsePayload: basis as Prisma.InputJsonValue,
+      },
+      create: {
+        id: AUTHORITY_BASIS_EVENT_ID,
+        adapterName: 'auction',
+        direction: 'INBOUND',
+        eventType: 'DEAL_BASIS_READY',
+        externalId: `${AUTHORITY_LOT_ID}:${AUTHORITY_BID_ID}`,
+        status: 'CONFIRMED',
+        responsePayload: basis as Prisma.InputJsonValue,
+        idempotencyKey: 'basis-rls-authority-001',
+      },
+    });
+
+    const [deal, memberships, credentialStates, authorityBasis] = await Promise.all([
       prisma.deal.findUnique({ where: { id: CANONICAL_TEST_DEAL_ID } }),
       prisma.userOrg.findMany({
         where: { organization: { tenantId: 'tenant-canonical-test' } },
@@ -35,10 +95,14 @@ async function main(): Promise<void> {
           WHERE o."tenantId" = 'tenant-canonical-test'
         )
       `,
+      prisma.integrationEvent.findUnique({ where: { id: AUTHORITY_BASIS_EVENT_ID } }),
     ]);
 
     if (!deal || deal.status !== 'DRAFT' || deal.tenantId !== 'tenant-canonical-test') {
       throw new Error('Canonical deal seed did not produce the expected DRAFT tenant state.');
+    }
+    if (!authorityBasis || authorityBasis.status !== 'CONFIRMED' || authorityBasis.dealId !== null) {
+      throw new Error('RLS authority deal basis was not seeded as an unconsumed confirmed event.');
     }
 
     const roles = new Set(memberships.map((item) => item.role));
@@ -75,6 +139,11 @@ async function main(): Promise<void> {
       memberships: memberships.length,
       credentialStates: credentialStates.length,
       roles: [...roles].sort(),
+      authorityBasis: {
+        eventId: authorityBasis.id,
+        lotId: AUTHORITY_LOT_ID,
+        winnerBidId: AUTHORITY_BID_ID,
+      },
     })}\n`);
   } finally {
     await prisma.$disconnect();

--- a/apps/api/test/one-deal/seed.ts
+++ b/apps/api/test/one-deal/seed.ts
@@ -8,6 +8,7 @@ import { CANONICAL_TEST_DEAL_ID } from '../../src/modules/deals/deal-command.pol
 export const AUTHORITY_LOT_ID = 'LOT-RLS-AUTHORITY-001';
 export const AUTHORITY_BID_ID = 'BID-RLS-AUTHORITY-001';
 export const AUTHORITY_BASIS_EVENT_ID = 'basis-event-rls-authority-001';
+export const AUTHORITY_CROSS_TENANT_ORG_ID = 'org-rls-authority-foreign-tenant';
 
 function stable(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stable);
@@ -75,6 +76,22 @@ async function main(): Promise<void> {
         status: 'CONFIRMED',
         responsePayload: basis as Prisma.InputJsonValue,
         idempotencyKey: 'basis-rls-authority-001',
+      },
+    });
+    await prisma.organization.upsert({
+      where: { id: AUTHORITY_CROSS_TENANT_ORG_ID },
+      update: {
+        tenantId: 'tenant-rls-authority-foreign',
+        status: 'VERIFIED',
+        kycStatus: 'APPROVED',
+      },
+      create: {
+        id: AUTHORITY_CROSS_TENANT_ORG_ID,
+        inn: '990000000099',
+        name: 'RLS foreign tenant organization',
+        tenantId: 'tenant-rls-authority-foreign',
+        status: 'VERIFIED',
+        kycStatus: 'APPROVED',
       },
     });
 

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -178,6 +178,17 @@
       "apps/web/tests/unit/platformV7CanonicalDealWorkspace.test.ts",
       "apps/web/tests/unit/platformV7RoleIntentDashboard.test.ts",
       "docs/platform-v7/autopilot/autopilot-state.json"
+    ],
+    "fix/postgresql-deal-authority": [
+      "apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/**",
+      "apps/api/src/modules/deals/**",
+      "apps/api/test/industrial/**",
+      "apps/api/test/one-deal/**",
+      "docs/platform-v7/production-database-deployment-runbook.md",
+      "infra/sql/postgresql-deal-authority-policies.sql",
+      "scripts/platform-v7-one-deal-e2e.sh",
+      "scripts/platform-v7-rls-apply-rehearsal.sh",
+      "docs/platform-v7/autopilot/autopilot-state.json"
     ]
   },
   "industrialOneDealFoundation": {

--- a/docs/platform-v7/autopilot/prompts/current-review-task.md
+++ b/docs/platform-v7/autopilot/prompts/current-review-task.md
@@ -72,6 +72,32 @@ Review requirements for this concurrent scope:
 - The regression test preserves MFA, server redirect and the ban on client-selected roles.
 - `platform-v7 autopilot guard`, web unit tests, typecheck and build pass on the exact PR head.
 
+## Approved concurrent scope — PostgreSQL Deal authority PR #2407
+
+This scope replaces the ordinary Deal routes' runtime fallback with one PostgreSQL-authoritative boundary. It does not activate live auction, bank, FGIS, EDI or signature integrations and does not broaden client authority.
+
+- apps/api/prisma/migrations/20260712193000_postgresql_deal_authority/**
+- apps/api/src/modules/deals/**
+- apps/api/test/industrial/deal-postgresql-authority.e2e-spec.ts
+- apps/api/test/one-deal/postgresql-deal-authority.e2e-spec.ts
+- apps/api/test/one-deal/seed.ts
+- docs/platform-v7/production-database-deployment-runbook.md
+- infra/sql/postgresql-deal-authority-policies.sql
+- scripts/platform-v7-one-deal-e2e.sh
+- scripts/platform-v7-rls-apply-rehearsal.sh
+- docs/platform-v7/autopilot/autopilot-state.json
+- docs/platform-v7/autopilot/prompts/current-review-task.md
+
+Review requirements for this concurrent scope:
+
+- Production dependency injection binds ordinary Deal reads and creation directly to Prisma; RuntimeCore is unavailable outside an explicit test profile.
+- `POST /deals` accepts only a confirmed, tenant-scoped PostgreSQL auction basis and derives seller, buyer, commercial values and participants from that server basis rather than client authority.
+- Deal, exactly two basis-bound participants, initial event, audit event and idempotent receipt commit atomically; failed or conflicting creation leaves no partial rows.
+- Legacy free-form status and transition routes fail closed and cannot mutate the Deal state machine.
+- Every `SECURITY DEFINER` predicate has a fixed `search_path`, no `PUBLIC` execute permission and an exact tenant, actor, organization, lot and winning-bid boundary.
+- A restricted `NOBYPASSRLS` principal proves create, replay, participant visibility, cross-tenant denial and rollback behavior on the exact PR head.
+- No production deployment, production scale or live external-integration claim is introduced.
+
 ## Mandatory architectural review
 
 - PostgreSQL, not process memory or NDJSON, is authoritative for outbox state.

--- a/docs/platform-v7/production-database-deployment-runbook.md
+++ b/docs/platform-v7/production-database-deployment-runbook.md
@@ -13,6 +13,7 @@ This runbook defines the target operational procedure. The repository CI proves 
 5. `DATABASE_URL` and `AUTH_DATABASE_URL` use separate `NOINHERIT` PostgreSQL roles with no role memberships.
 6. Migration credentials are separate from runtime credentials and are not stored in the application environment.
 7. Every step produces immutable evidence: commit SHA, migration list, backup checksum, timestamps, principal proof, schema drift result and smoke-test output.
+8. `infra/sql/postgresql-deal-authority-policies.sql` is applied immediately after the base RLS artifact; applying only the base file would restore the legacy pre-deal basis restriction and block PostgreSQL-authoritative creation.
 
 ## Required roles
 
@@ -30,7 +31,7 @@ The release owner creates one evidence directory containing:
 - release commit SHA and container image digest;
 - `prisma migrate status` output;
 - migration SQL diff and forward-only gate output;
-- current protected-table RLS/policy inventory;
+- current protected-table RLS/policy/function inventory, including the deal-authority overlay;
 - deal/auth principal capability snapshots;
 - backup identifier and SHA-256 where exportable;
 - backup start/completion timestamps;
@@ -87,18 +88,23 @@ DATABASE_URL="$MIGRATION_DATABASE_URL" \
   pnpm --filter @pc/api exec prisma migrate deploy --schema prisma/schema.prisma
 ```
 
-3. Apply the canonical RLS policy artifact:
+3. Apply the canonical RLS policy artifacts in this order:
 
 ```bash
 psql "$MIGRATION_DATABASE_URL" \
   -X --set ON_ERROR_STOP=1 \
   --file infra/sql/production-rls-policies.sql
+
+psql "$MIGRATION_DATABASE_URL" \
+  -X --set ON_ERROR_STOP=1 \
+  --file infra/sql/postgresql-deal-authority-policies.sql
 ```
 
-4. Validate schema drift, migration history, RLS inventory and principal capabilities.
-5. Start one application instance with production boundary enforcement.
-6. Run authentication, tenant isolation, deal read/write and signed callback smoke checks.
-7. Increase traffic gradually while observing errors, latency, connection pools, locks, replication lag and outbox processing.
+4. Verify that `public.app_deal_basis_participant_allowed` is `SECURITY DEFINER`, is not executable by `PUBLIC`, and the final `integration_events_select` and `deal_participants_insert` policies match the release SHA.
+5. Validate schema drift, migration history, RLS inventory and principal capabilities.
+6. Start one application instance with production boundary enforcement.
+7. Run authentication, tenant isolation, participant-scoped deal create/read and signed callback smoke checks.
+8. Increase traffic gradually while observing errors, latency, connection pools, locks, replication lag and outbox processing.
 
 ## Application rollback
 
@@ -125,10 +131,10 @@ Use only for corruption, destructive operator action or unrecoverable migration 
    - migration history;
    - source/recovery fingerprints where the source remains readable;
    - deal/auth runtime principal startup;
-   - `ENABLE + FORCE RLS` and policy inventory;
+   - `ENABLE + FORCE RLS`, policy/function inventory and deal-authority overlay;
    - cross-tenant visibility equals zero;
    - persistent login/session verification;
-   - deal, document, bank-operation, ledger, audit and outbox reconciliation.
+   - deal, participant, document, bank-operation, ledger, audit and outbox reconciliation.
 6. Obtain release owner, security and business approval.
 7. Cut over connection strings atomically.
 8. Re-run smoke/acceptance and monitor before reopening writes.
@@ -155,10 +161,11 @@ It proves:
 
 - forward-only migration gate;
 - custom-format backup and checksum;
-- restore into a separate database;
-- exact source/restore fingerprint equality;
+- restore into a separate PostgreSQL database;
+- exact source/recovery fingerprint equality;
 - successful Prisma migration history;
 - eight protected tables retain enabled and forced RLS;
+- persistent deal creation works under a restricted `NOBYPASSRLS` principal using a seller-scoped confirmed basis;
 - auth runtime cannot read deals;
 - deal runtime has zero cross-tenant visibility;
 - persistent login works after restore;

--- a/docs/platform-v7/production-database-deployment-runbook.md
+++ b/docs/platform-v7/production-database-deployment-runbook.md
@@ -31,7 +31,7 @@ The release owner creates one evidence directory containing:
 - release commit SHA and container image digest;
 - `prisma migrate status` output;
 - migration SQL diff and forward-only gate output;
-- current protected-table RLS/policy/function inventory, including the deal-authority overlay;
+- current protected-table RLS/policy/function/trigger inventory, including the deal-authority overlay;
 - deal/auth principal capability snapshots;
 - backup identifier and SHA-256 where exportable;
 - backup start/completion timestamps;
@@ -100,7 +100,12 @@ psql "$MIGRATION_DATABASE_URL" \
   --file infra/sql/postgresql-deal-authority-policies.sql
 ```
 
-4. Verify that `public.app_deal_basis_participant_allowed` is `SECURITY DEFINER`, is not executable by `PUBLIC`, and the final `integration_events_select` and `deal_participants_insert` policies match the release SHA.
+4. Verify all of the following against the release SHA:
+   - `public.app_deal_basis_deal_visible`, `public.app_deal_basis_participant_allowed` and `public.enforce_single_deal_per_basis` are `SECURITY DEFINER`;
+   - `PUBLIC` has no `EXECUTE` privilege on those functions;
+   - final `deals_select`, `deals_insert`, `integration_events_select`, `organizations_select` and `deal_participants_insert` policies are installed;
+   - trigger `public.deals_single_basis` is enabled on `public.deals`;
+   - a direct Deal insert without a confirmed basis fails, and reuse of one tenant/lot/winner basis fails with the single-use constraint.
 5. Validate schema drift, migration history, RLS inventory and principal capabilities.
 6. Start one application instance with production boundary enforcement.
 7. Run authentication, tenant isolation, participant-scoped deal create/read and signed callback smoke checks.
@@ -131,7 +136,7 @@ Use only for corruption, destructive operator action or unrecoverable migration 
    - migration history;
    - source/recovery fingerprints where the source remains readable;
    - deal/auth runtime principal startup;
-   - `ENABLE + FORCE RLS`, policy/function inventory and deal-authority overlay;
+   - `ENABLE + FORCE RLS`, policy/function/trigger inventory and deal-authority overlay;
    - cross-tenant visibility equals zero;
    - persistent login/session verification;
    - deal, participant, document, bank-operation, ledger, audit and outbox reconciliation.
@@ -166,6 +171,7 @@ It proves:
 - successful Prisma migration history;
 - eight protected tables retain enabled and forced RLS;
 - persistent deal creation works under a restricted `NOBYPASSRLS` principal using a seller-scoped confirmed basis;
+- direct unbacked Deal insert and duplicate basis reuse fail at PostgreSQL level;
 - auth runtime cannot read deals;
 - deal runtime has zero cross-tenant visibility;
 - persistent login works after restore;

--- a/infra/sql/postgresql-deal-authority-policies.sql
+++ b/infra/sql/postgresql-deal-authority-policies.sql
@@ -85,6 +85,42 @@ CREATE POLICY integration_events_select ON public."integration_events" FOR SELEC
   )
 );
 
+DROP POLICY IF EXISTS organizations_select ON public."organizations";
+CREATE POLICY organizations_select ON public."organizations" FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND (
+    "id" = current_setting('app.current_org_id', true)
+    OR public.app_rls_privileged()
+    OR EXISTS (
+      SELECT 1 FROM public."deal_participants" dp
+      WHERE dp."organizationId" = "organizations"."id"
+        AND dp."tenantId" = current_setting('app.current_tenant_id', true)
+        AND dp."userId" = current_setting('app.current_user_id', true)
+        AND dp."status" = 'ACTIVE'
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public."integration_events" ie
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(ie."responsePayload", ie."requestPayload")::jsonb AS basis
+      ) confirmed
+      WHERE ie."dealId" IS NULL
+        AND current_setting('app.current_role', true) = 'FARMER'
+        AND ie."adapterName" = 'auction'
+        AND ie."eventType" = 'DEAL_BASIS_READY'
+        AND ie."status" = 'CONFIRMED'
+        AND COALESCE(ie."responsePayload", ie."requestPayload") IS NOT NULL
+        AND confirmed.basis ->> 'tenantId' = current_setting('app.current_tenant_id', true)
+        AND confirmed.basis ->> 'sellerOrgId' = current_setting('app.current_org_id', true)
+        AND confirmed.basis ->> 'sellerUserId' = current_setting('app.current_user_id', true)
+        AND "organizations"."id" IN (
+          confirmed.basis ->> 'sellerOrgId',
+          confirmed.basis ->> 'buyerOrgId'
+        )
+    )
+  )
+);
+
 DROP POLICY IF EXISTS deal_participants_insert ON public."deal_participants";
 CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT WITH CHECK (
   public.app_rls_context_ready()

--- a/infra/sql/postgresql-deal-authority-policies.sql
+++ b/infra/sql/postgresql-deal-authority-policies.sql
@@ -2,6 +2,47 @@
 -- This overlay is intentionally duplicated in the forward-only Prisma migration
 -- because deployments re-apply the canonical RLS artifact after migrations.
 
+CREATE OR REPLACE FUNCTION public.app_deal_basis_deal_visible(
+  p_deal_id text,
+  p_tenant_id text,
+  p_seller_org_id text,
+  p_buyer_org_id text,
+  p_lot_id text,
+  p_winner_bid_id text
+)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+STABLE
+AS $function$
+  SELECT
+    public.app_rls_context_ready()
+    AND current_setting('app.current_role', true) = 'FARMER'
+    AND p_tenant_id = current_setting('app.current_tenant_id', true)
+    AND p_seller_org_id = current_setting('app.current_org_id', true)
+    AND EXISTS (
+      SELECT 1
+      FROM public."integration_events" ie
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(ie."responsePayload", ie."requestPayload")::jsonb AS basis
+      ) confirmed
+      WHERE ie."dealId" IS NULL
+        AND ie."adapterName" = 'auction'
+        AND ie."eventType" = 'DEAL_BASIS_READY'
+        AND ie."externalId" = p_lot_id || ':' || p_winner_bid_id
+        AND ie."status" = 'CONFIRMED'
+        AND COALESCE(ie."responsePayload", ie."requestPayload") IS NOT NULL
+        AND confirmed.basis ->> 'tenantId' = p_tenant_id
+        AND confirmed.basis ->> 'sellerOrgId' = p_seller_org_id
+        AND confirmed.basis ->> 'buyerOrgId' = p_buyer_org_id
+        AND confirmed.basis ->> 'sellerUserId' = current_setting('app.current_user_id', true)
+        AND confirmed.basis ->> 'lotId' = p_lot_id
+        AND confirmed.basis ->> 'winnerBidId' = p_winner_bid_id
+        AND NULLIF(p_deal_id, '') IS NOT NULL
+    )
+$function$;
+
 CREATE OR REPLACE FUNCTION public.app_deal_basis_participant_allowed(
   p_deal_id text,
   p_tenant_id text,
@@ -58,7 +99,44 @@ AS $function$
     )
 $function$;
 
+REVOKE ALL ON FUNCTION public.app_deal_basis_deal_visible(text, text, text, text, text, text) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) FROM PUBLIC;
+
+-- Prisma INSERT uses RETURNING. The temporary basis-bound visibility branch is
+-- required only until seller/buyer DealParticipant rows are inserted in the same
+-- transaction. It cannot expose an arbitrary deal because every commercial key
+-- must match one confirmed pre-deal auction basis and the current seller identity.
+DROP POLICY IF EXISTS deals_select ON public."deals";
+CREATE POLICY deals_select ON public."deals" FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR (
+      current_setting('app.current_role', true) = 'BANK_CALLBACK'
+      AND "buyerOrgId" = current_setting('app.current_org_id', true)
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public."deal_participants" p
+      WHERE p."dealId" = "deals"."id"
+        AND p."tenantId" = current_setting('app.current_tenant_id', true)
+        AND p."organizationId" = current_setting('app.current_org_id', true)
+        AND p."userId" = current_setting('app.current_user_id', true)
+        AND p."role" = current_setting('app.current_role', true)
+        AND p."status" = 'ACTIVE'
+        AND p."accessLevel" IN ('READ', 'WORK', 'APPROVE')
+    )
+    OR public.app_deal_basis_deal_visible(
+      "id",
+      "tenantId",
+      "sellerOrgId",
+      "buyerOrgId",
+      "lotId",
+      "sourceLotId"
+    )
+  )
+);
 
 DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
 CREATE POLICY integration_events_select ON public."integration_events" FOR SELECT USING (
@@ -137,7 +215,7 @@ CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT 
   )
 );
 
-DO $grant_deal_basis_predicate$
+DO $grant_deal_basis_predicates$
 DECLARE
   role_name text;
 BEGIN
@@ -145,10 +223,14 @@ BEGIN
   LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
       EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION public.app_deal_basis_deal_visible(text, text, text, text, text, text) TO %I',
+        role_name
+      );
+      EXECUTE format(
         'GRANT EXECUTE ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) TO %I',
         role_name
       );
     END IF;
   END LOOP;
 END
-$grant_deal_basis_predicate$;
+$grant_deal_basis_predicates$;

--- a/infra/sql/postgresql-deal-authority-policies.sql
+++ b/infra/sql/postgresql-deal-authority-policies.sql
@@ -2,14 +2,7 @@
 -- This overlay is intentionally duplicated in the forward-only Prisma migration
 -- because deployments re-apply the canonical RLS artifact after migrations.
 
-CREATE OR REPLACE FUNCTION public.app_deal_basis_deal_visible(
-  p_deal_id text,
-  p_tenant_id text,
-  p_seller_org_id text,
-  p_buyer_org_id text,
-  p_lot_id text,
-  p_winner_bid_id text
-)
+CREATE OR REPLACE FUNCTION public.app_deal_basis_deal_visible(p_deal jsonb)
 RETURNS boolean
 LANGUAGE sql
 SECURITY DEFINER
@@ -19,8 +12,12 @@ AS $function$
   SELECT
     public.app_rls_context_ready()
     AND current_setting('app.current_role', true) = 'FARMER'
-    AND p_tenant_id = current_setting('app.current_tenant_id', true)
-    AND p_seller_org_id = current_setting('app.current_org_id', true)
+    AND p_deal ->> 'tenantId' = current_setting('app.current_tenant_id', true)
+    AND p_deal ->> 'sellerOrgId' = current_setting('app.current_org_id', true)
+    AND p_deal ->> 'status' = 'DRAFT'
+    AND p_deal ->> 'version' = '0'
+    AND p_deal -> 'signedAt' = 'null'::jsonb
+    AND p_deal -> 'closedAt' = 'null'::jsonb
     AND EXISTS (
       SELECT 1
       FROM public."integration_events" ie
@@ -30,16 +27,37 @@ AS $function$
       WHERE ie."dealId" IS NULL
         AND ie."adapterName" = 'auction'
         AND ie."eventType" = 'DEAL_BASIS_READY'
-        AND ie."externalId" = p_lot_id || ':' || p_winner_bid_id
+        AND ie."externalId" = (p_deal ->> 'lotId') || ':' || (p_deal ->> 'sourceLotId')
         AND ie."status" = 'CONFIRMED'
         AND COALESCE(ie."responsePayload", ie."requestPayload") IS NOT NULL
-        AND confirmed.basis ->> 'tenantId' = p_tenant_id
-        AND confirmed.basis ->> 'sellerOrgId' = p_seller_org_id
-        AND confirmed.basis ->> 'buyerOrgId' = p_buyer_org_id
+        AND confirmed.basis ->> 'tenantId' = p_deal ->> 'tenantId'
+        AND confirmed.basis ->> 'dealNumber' = p_deal ->> 'dealNumber'
+        AND confirmed.basis ->> 'sellerOrgId' = p_deal ->> 'sellerOrgId'
+        AND confirmed.basis ->> 'buyerOrgId' = p_deal ->> 'buyerOrgId'
         AND confirmed.basis ->> 'sellerUserId' = current_setting('app.current_user_id', true)
-        AND confirmed.basis ->> 'lotId' = p_lot_id
-        AND confirmed.basis ->> 'winnerBidId' = p_winner_bid_id
-        AND NULLIF(p_deal_id, '') IS NOT NULL
+        AND confirmed.basis ->> 'lotId' = p_deal ->> 'lotId'
+        AND confirmed.basis ->> 'winnerBidId' = p_deal ->> 'sourceLotId'
+        AND (confirmed.basis ->> 'volumeTons')::numeric = (p_deal ->> 'volumeTonsDec')::numeric
+        AND (confirmed.basis ->> 'pricePerTon')::numeric = (p_deal ->> 'pricePerTonDec')::numeric
+        AND (confirmed.basis ->> 'totalKopecks')::bigint = (p_deal ->> 'totalKopecks')::bigint
+        AND confirmed.basis ->> 'currency' = p_deal ->> 'currency'
+        AND confirmed.basis ->> 'culture' = p_deal ->> 'culture'
+        AND NULLIF(confirmed.basis ->> 'cropClass', '') IS NOT DISTINCT FROM NULLIF(p_deal ->> 'cropClass', '')
+        AND NULLIF(confirmed.basis ->> 'region', '') IS NOT DISTINCT FROM NULLIF(p_deal ->> 'region', '')
+        AND NULLIF(confirmed.basis ->> 'incoterms', '') IS NOT DISTINCT FROM NULLIF(p_deal ->> 'incoterms', '')
+        AND p_deal -> 'sagaState' ->> 'source' = 'POSTGRESQL_INTEGRATION_EVENT'
+        AND p_deal -> 'sagaState' ->> 'integrationEventId' = ie."id"
+        AND p_deal -> 'sagaState' ->> 'sourceHash' = confirmed.basis ->> 'sourceHash'
+        AND p_deal -> 'sagaState' ->> 'lotId' = confirmed.basis ->> 'lotId'
+        AND p_deal -> 'sagaState' ->> 'winnerBidId' = confirmed.basis ->> 'winnerBidId'
+        AND p_deal -> 'sagaState' ->> 'sellerOrgId' = confirmed.basis ->> 'sellerOrgId'
+        AND p_deal -> 'sagaState' ->> 'buyerOrgId' = confirmed.basis ->> 'buyerOrgId'
+        AND p_deal -> 'sagaState' ->> 'sellerUserId' = confirmed.basis ->> 'sellerUserId'
+        AND p_deal -> 'sagaState' ->> 'buyerUserId' = confirmed.basis ->> 'buyerUserId'
+        AND p_deal -> 'sagaState' ->> 'volumeTons' = confirmed.basis ->> 'volumeTons'
+        AND p_deal -> 'sagaState' ->> 'pricePerTon' = confirmed.basis ->> 'pricePerTon'
+        AND p_deal -> 'sagaState' ->> 'totalKopecks' = confirmed.basis ->> 'totalKopecks'
+        AND NULLIF(p_deal ->> 'id', '') IS NOT NULL
     )
 $function$;
 
@@ -99,13 +117,9 @@ AS $function$
     )
 $function$;
 
-REVOKE ALL ON FUNCTION public.app_deal_basis_deal_visible(text, text, text, text, text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.app_deal_basis_deal_visible(jsonb) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) FROM PUBLIC;
 
--- Prisma INSERT uses RETURNING. The temporary basis-bound visibility branch is
--- required only until seller/buyer DealParticipant rows are inserted in the same
--- transaction. It cannot expose an arbitrary deal because every commercial key
--- must match one confirmed pre-deal auction basis and the current seller identity.
 DROP POLICY IF EXISTS deals_select ON public."deals";
 CREATE POLICY deals_select ON public."deals" FOR SELECT USING (
   public.app_rls_context_ready()
@@ -127,21 +141,10 @@ CREATE POLICY deals_select ON public."deals" FOR SELECT USING (
         AND p."status" = 'ACTIVE'
         AND p."accessLevel" IN ('READ', 'WORK', 'APPROVE')
     )
-    OR public.app_deal_basis_deal_visible(
-      "id",
-      "tenantId",
-      "sellerOrgId",
-      "buyerOrgId",
-      "lotId",
-      "sourceLotId"
-    )
+    OR public.app_deal_basis_deal_visible(to_jsonb("deals"))
   )
 );
 
--- A FARMER cannot use the runtime principal to insert an arbitrary row. Every
--- field that defines the commercial counterparties and winning basis must match
--- one confirmed server event. Privileged operational roles retain their existing
--- controlled path for recovery and support procedures.
 DROP POLICY IF EXISTS deals_insert ON public."deals";
 CREATE POLICY deals_insert ON public."deals" FOR INSERT WITH CHECK (
   public.app_rls_context_ready()
@@ -150,14 +153,7 @@ CREATE POLICY deals_insert ON public."deals" FOR INSERT WITH CHECK (
     public.app_rls_privileged()
     OR (
       current_setting('app.current_role', true) = 'FARMER'
-      AND public.app_deal_basis_deal_visible(
-        "id",
-        "tenantId",
-        "sellerOrgId",
-        "buyerOrgId",
-        "lotId",
-        "sourceLotId"
-      )
+      AND public.app_deal_basis_deal_visible(to_jsonb("deals"))
     )
   )
 );
@@ -247,7 +243,7 @@ BEGIN
   LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
       EXECUTE format(
-        'GRANT EXECUTE ON FUNCTION public.app_deal_basis_deal_visible(text, text, text, text, text, text) TO %I',
+        'GRANT EXECUTE ON FUNCTION public.app_deal_basis_deal_visible(jsonb) TO %I',
         role_name
       );
       EXECUTE format(

--- a/infra/sql/postgresql-deal-authority-policies.sql
+++ b/infra/sql/postgresql-deal-authority-policies.sql
@@ -138,6 +138,30 @@ CREATE POLICY deals_select ON public."deals" FOR SELECT USING (
   )
 );
 
+-- A FARMER cannot use the runtime principal to insert an arbitrary row. Every
+-- field that defines the commercial counterparties and winning basis must match
+-- one confirmed server event. Privileged operational roles retain their existing
+-- controlled path for recovery and support procedures.
+DROP POLICY IF EXISTS deals_insert ON public."deals";
+CREATE POLICY deals_insert ON public."deals" FOR INSERT WITH CHECK (
+  public.app_rls_context_ready()
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR (
+      current_setting('app.current_role', true) = 'FARMER'
+      AND public.app_deal_basis_deal_visible(
+        "id",
+        "tenantId",
+        "sellerOrgId",
+        "buyerOrgId",
+        "lotId",
+        "sourceLotId"
+      )
+    )
+  )
+);
+
 DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
 CREATE POLICY integration_events_select ON public."integration_events" FOR SELECT USING (
   public.app_rls_context_ready()

--- a/infra/sql/postgresql-deal-authority-policies.sql
+++ b/infra/sql/postgresql-deal-authority-policies.sql
@@ -1,0 +1,118 @@
+-- Apply after production-rls-policies.sql.
+-- This overlay is intentionally duplicated in the forward-only Prisma migration
+-- because deployments re-apply the canonical RLS artifact after migrations.
+
+CREATE OR REPLACE FUNCTION public.app_deal_basis_participant_allowed(
+  p_deal_id text,
+  p_tenant_id text,
+  p_organization_id text,
+  p_user_id text,
+  p_role text
+)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+STABLE
+AS $function$
+  SELECT
+    public.app_rls_context_ready()
+    AND current_setting('app.current_role', true) = 'FARMER'
+    AND EXISTS (
+      SELECT 1
+      FROM public."deals" d
+      JOIN LATERAL (
+        SELECT COALESCE(ie."responsePayload", ie."requestPayload")::jsonb AS basis
+        FROM public."integration_events" ie
+        WHERE ie."adapterName" = 'auction'
+          AND ie."eventType" = 'DEAL_BASIS_READY'
+          AND ie."externalId" = d."lotId" || ':' || d."sourceLotId"
+          AND ie."status" = 'CONFIRMED'
+          AND COALESCE(ie."responsePayload", ie."requestPayload") IS NOT NULL
+        ORDER BY ie."createdAt" DESC, ie."id" DESC
+        LIMIT 1
+      ) confirmed ON true
+      WHERE d."id" = p_deal_id
+        AND d."tenantId" = p_tenant_id
+        AND p_tenant_id = current_setting('app.current_tenant_id', true)
+        AND d."sellerOrgId" = current_setting('app.current_org_id', true)
+        AND confirmed.basis ->> 'tenantId' = current_setting('app.current_tenant_id', true)
+        AND confirmed.basis ->> 'sellerOrgId' = current_setting('app.current_org_id', true)
+        AND confirmed.basis ->> 'sellerUserId' = current_setting('app.current_user_id', true)
+        AND confirmed.basis ->> 'sellerOrgId' = d."sellerOrgId"
+        AND confirmed.basis ->> 'buyerOrgId' = d."buyerOrgId"
+        AND confirmed.basis ->> 'lotId' = d."lotId"
+        AND confirmed.basis ->> 'winnerBidId' = d."sourceLotId"
+        AND (
+          (
+            p_organization_id = confirmed.basis ->> 'sellerOrgId'
+            AND p_user_id = confirmed.basis ->> 'sellerUserId'
+            AND p_role = 'FARMER'
+          )
+          OR (
+            p_organization_id = confirmed.basis ->> 'buyerOrgId'
+            AND p_user_id = confirmed.basis ->> 'buyerUserId'
+            AND p_role = 'BUYER'
+          )
+        )
+    )
+$function$;
+
+REVOKE ALL ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) FROM PUBLIC;
+
+DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
+CREATE POLICY integration_events_select ON public."integration_events" FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND (
+    (
+      "dealId" IS NOT NULL
+      AND public.app_rls_deal_visible("dealId")
+    )
+    OR (
+      "dealId" IS NULL
+      AND current_setting('app.current_role', true) = 'FARMER'
+      AND "adapterName" = 'auction'
+      AND "eventType" = 'DEAL_BASIS_READY'
+      AND "status" = 'CONFIRMED'
+      AND COALESCE("responsePayload", "requestPayload") IS NOT NULL
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'tenantId'
+        = current_setting('app.current_tenant_id', true)
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerOrgId'
+        = current_setting('app.current_org_id', true)
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerUserId'
+        = current_setting('app.current_user_id', true)
+    )
+  )
+);
+
+DROP POLICY IF EXISTS deal_participants_insert ON public."deal_participants";
+CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT WITH CHECK (
+  public.app_rls_context_ready()
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR public.app_deal_basis_participant_allowed(
+      "dealId",
+      "tenantId",
+      "organizationId",
+      "userId",
+      "role"
+    )
+  )
+);
+
+DO $grant_deal_basis_predicate$
+DECLARE
+  role_name text;
+BEGIN
+  FOREACH role_name IN ARRAY ARRAY['app_service', 'app_deal_api', 'one_deal_app']
+  LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+      EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) TO %I',
+        role_name
+      );
+    END IF;
+  END LOOP;
+END
+$grant_deal_basis_predicate$;

--- a/infra/sql/postgresql-deal-authority-policies.sql
+++ b/infra/sql/postgresql-deal-authority-policies.sql
@@ -16,8 +16,20 @@ AS $function$
     AND p_deal ->> 'sellerOrgId' = current_setting('app.current_org_id', true)
     AND p_deal ->> 'status' = 'DRAFT'
     AND p_deal ->> 'version' = '0'
+    AND p_deal ->> 'nextAction' = 'Подтвердить допуск участников'
     AND p_deal -> 'signedAt' = 'null'::jsonb
     AND p_deal -> 'closedAt' = 'null'::jsonb
+    AND p_deal -> 'volumeTons' = 'null'::jsonb
+    AND p_deal -> 'pricePerTon' = 'null'::jsonb
+    AND p_deal -> 'totalRub' = 'null'::jsonb
+    AND p_deal -> 'gost' = 'null'::jsonb
+    AND p_deal -> 'fundingChoice' = 'null'::jsonb
+    AND p_deal -> 'owner' = 'null'::jsonb
+    AND p_deal -> 'slaAt' = 'null'::jsonb
+    AND p_deal -> 'sagaStep' = 'null'::jsonb
+    AND p_deal -> 'meta' = 'null'::jsonb
+    AND jsonb_typeof(p_deal -> 'sagaState') = 'object'
+    AND jsonb_object_length(p_deal -> 'sagaState') = 18
     AND EXISTS (
       SELECT 1
       FROM public."integration_events" ie
@@ -54,9 +66,14 @@ AS $function$
         AND p_deal -> 'sagaState' ->> 'buyerOrgId' = confirmed.basis ->> 'buyerOrgId'
         AND p_deal -> 'sagaState' ->> 'sellerUserId' = confirmed.basis ->> 'sellerUserId'
         AND p_deal -> 'sagaState' ->> 'buyerUserId' = confirmed.basis ->> 'buyerUserId'
+        AND p_deal -> 'sagaState' ->> 'culture' = confirmed.basis ->> 'culture'
+        AND NULLIF(p_deal -> 'sagaState' ->> 'cropClass', '') IS NOT DISTINCT FROM NULLIF(confirmed.basis ->> 'cropClass', '')
+        AND NULLIF(p_deal -> 'sagaState' ->> 'region', '') IS NOT DISTINCT FROM NULLIF(confirmed.basis ->> 'region', '')
+        AND NULLIF(p_deal -> 'sagaState' ->> 'incoterms', '') IS NOT DISTINCT FROM NULLIF(confirmed.basis ->> 'incoterms', '')
         AND p_deal -> 'sagaState' ->> 'volumeTons' = confirmed.basis ->> 'volumeTons'
         AND p_deal -> 'sagaState' ->> 'pricePerTon' = confirmed.basis ->> 'pricePerTon'
         AND p_deal -> 'sagaState' ->> 'totalKopecks' = confirmed.basis ->> 'totalKopecks'
+        AND p_deal -> 'sagaState' ->> 'currency' = confirmed.basis ->> 'currency'
         AND NULLIF(p_deal ->> 'id', '') IS NOT NULL
     )
 $function$;

--- a/infra/sql/postgresql-deal-authority-policies.sql
+++ b/infra/sql/postgresql-deal-authority-policies.sql
@@ -1,6 +1,6 @@
 -- Apply after production-rls-policies.sql.
--- This overlay is intentionally duplicated in the forward-only Prisma migration
--- because deployments re-apply the canonical RLS artifact after migrations.
+-- This overlay is duplicated in the forward-only migration because deployments
+-- re-apply the canonical RLS artifact after migrations.
 
 CREATE OR REPLACE FUNCTION public.app_deal_basis_deal_visible(p_deal jsonb)
 RETURNS boolean
@@ -29,7 +29,16 @@ AS $function$
     AND p_deal -> 'sagaStep' = 'null'::jsonb
     AND p_deal -> 'meta' = 'null'::jsonb
     AND jsonb_typeof(p_deal -> 'sagaState') = 'object'
-    AND jsonb_object_length(p_deal -> 'sagaState') = 18
+    AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_object_keys(p_deal -> 'sagaState') AS saga_key(key)
+      WHERE saga_key.key NOT IN (
+        'source', 'integrationEventId', 'sourceHash', 'lotId', 'winnerBidId',
+        'sellerOrgId', 'buyerOrgId', 'sellerUserId', 'buyerUserId',
+        'culture', 'cropClass', 'region', 'incoterms', 'volumeTons',
+        'pricePerTon', 'totalKopecks', 'currency', 'paymentTerms'
+      )
+    )
     AND EXISTS (
       SELECT 1
       FROM public."integration_events" ie
@@ -179,10 +188,7 @@ DROP POLICY IF EXISTS integration_events_select ON public."integration_events";
 CREATE POLICY integration_events_select ON public."integration_events" FOR SELECT USING (
   public.app_rls_context_ready()
   AND (
-    (
-      "dealId" IS NOT NULL
-      AND public.app_rls_deal_visible("dealId")
-    )
+    ("dealId" IS NOT NULL AND public.app_rls_deal_visible("dealId"))
     OR (
       "dealId" IS NULL
       AND current_setting('app.current_role', true) = 'FARMER'
@@ -190,12 +196,9 @@ CREATE POLICY integration_events_select ON public."integration_events" FOR SELEC
       AND "eventType" = 'DEAL_BASIS_READY'
       AND "status" = 'CONFIRMED'
       AND COALESCE("responsePayload", "requestPayload") IS NOT NULL
-      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'tenantId'
-        = current_setting('app.current_tenant_id', true)
-      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerOrgId'
-        = current_setting('app.current_org_id', true)
-      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerUserId'
-        = current_setting('app.current_user_id', true)
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'tenantId' = current_setting('app.current_tenant_id', true)
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerOrgId' = current_setting('app.current_org_id', true)
+      AND COALESCE("responsePayload", "requestPayload")::jsonb ->> 'sellerUserId' = current_setting('app.current_user_id', true)
     )
   )
 );
@@ -228,10 +231,7 @@ CREATE POLICY organizations_select ON public."organizations" FOR SELECT USING (
         AND confirmed.basis ->> 'tenantId' = current_setting('app.current_tenant_id', true)
         AND confirmed.basis ->> 'sellerOrgId' = current_setting('app.current_org_id', true)
         AND confirmed.basis ->> 'sellerUserId' = current_setting('app.current_user_id', true)
-        AND "organizations"."id" IN (
-          confirmed.basis ->> 'sellerOrgId',
-          confirmed.basis ->> 'buyerOrgId'
-        )
+        AND "organizations"."id" IN (confirmed.basis ->> 'sellerOrgId', confirmed.basis ->> 'buyerOrgId')
     )
   )
 );
@@ -242,13 +242,7 @@ CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT 
   AND "tenantId" = current_setting('app.current_tenant_id', true)
   AND (
     public.app_rls_privileged()
-    OR public.app_deal_basis_participant_allowed(
-      "dealId",
-      "tenantId",
-      "organizationId",
-      "userId",
-      "role"
-    )
+    OR public.app_deal_basis_participant_allowed("dealId", "tenantId", "organizationId", "userId", "role")
   )
 );
 
@@ -259,14 +253,8 @@ BEGIN
   FOREACH role_name IN ARRAY ARRAY['app_service', 'app_deal_api', 'one_deal_app']
   LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
-      EXECUTE format(
-        'GRANT EXECUTE ON FUNCTION public.app_deal_basis_deal_visible(jsonb) TO %I',
-        role_name
-      );
-      EXECUTE format(
-        'GRANT EXECUTE ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) TO %I',
-        role_name
-      );
+      EXECUTE format('GRANT EXECUTE ON FUNCTION public.app_deal_basis_deal_visible(jsonb) TO %I', role_name);
+      EXECUTE format('GRANT EXECUTE ON FUNCTION public.app_deal_basis_participant_allowed(text, text, text, text, text) TO %I', role_name);
     END IF;
   END LOOP;
 END

--- a/infra/sql/postgresql-deal-authority-policies.sql
+++ b/infra/sql/postgresql-deal-authority-policies.sql
@@ -205,6 +205,7 @@ CREATE POLICY integration_events_select ON public."integration_events" FOR SELEC
 DROP POLICY IF EXISTS organizations_select ON public."organizations";
 CREATE POLICY organizations_select ON public."organizations" FOR SELECT USING (
   public.app_rls_context_ready()
+  AND "tenantId" = current_setting('app.current_tenant_id', true)
   AND (
     "id" = current_setting('app.current_org_id', true)
     OR public.app_rls_privileged()
@@ -241,7 +242,19 @@ CREATE POLICY deal_participants_insert ON public."deal_participants" FOR INSERT 
   AND "tenantId" = current_setting('app.current_tenant_id', true)
   AND (
     public.app_rls_privileged()
-    OR public.app_deal_basis_participant_allowed("dealId", "tenantId", "organizationId", "userId", "role")
+    OR (
+      "accessLevel" = 'APPROVE'
+      AND "status" = 'ACTIVE'
+      AND "assignedByUserId" = current_setting('app.current_user_id', true)
+      AND "revokedAt" IS NULL
+      AND public.app_deal_basis_participant_allowed(
+        "dealId",
+        "tenantId",
+        "organizationId",
+        "userId",
+        "role"
+      )
+    )
   )
 );
 

--- a/infra/sql/postgresql-deal-authority-policies.sql
+++ b/infra/sql/postgresql-deal-authority-policies.sql
@@ -29,6 +29,10 @@ AS $function$
     AND p_deal -> 'sagaStep' = 'null'::jsonb
     AND p_deal -> 'meta' = 'null'::jsonb
     AND jsonb_typeof(p_deal -> 'sagaState') = 'object'
+    AND (
+      SELECT count(*)
+      FROM jsonb_object_keys(p_deal -> 'sagaState') AS saga_key(key)
+    ) = 18
     AND NOT EXISTS (
       SELECT 1
       FROM jsonb_object_keys(p_deal -> 'sagaState') AS saga_key(key)
@@ -175,13 +179,8 @@ DROP POLICY IF EXISTS deals_insert ON public."deals";
 CREATE POLICY deals_insert ON public."deals" FOR INSERT WITH CHECK (
   public.app_rls_context_ready()
   AND "tenantId" = current_setting('app.current_tenant_id', true)
-  AND (
-    public.app_rls_privileged()
-    OR (
-      current_setting('app.current_role', true) = 'FARMER'
-      AND public.app_deal_basis_deal_visible(to_jsonb("deals"))
-    )
-  )
+  AND current_setting('app.current_role', true) = 'FARMER'
+  AND public.app_deal_basis_deal_visible(to_jsonb("deals"))
 );
 
 DROP POLICY IF EXISTS integration_events_select ON public."integration_events";

--- a/scripts/platform-v7-one-deal-e2e.sh
+++ b/scripts/platform-v7-one-deal-e2e.sh
@@ -81,6 +81,9 @@ fi
 echo "[one-deal] applying canonical PostgreSQL RLS policies"
 psql "$ADMIN_URL" -X --set ON_ERROR_STOP=1 --file infra/sql/production-rls-policies.sql
 
+echo "[one-deal] applying PostgreSQL deal-authority RLS overlay"
+psql "$ADMIN_URL" -X --set ON_ERROR_STOP=1 --file infra/sql/postgresql-deal-authority-policies.sql
+
 echo "[one-deal] creating restricted deal-execution principal"
 psql "$ADMIN_URL" -X --set ON_ERROR_STOP=1 <<'SQL'
 DO $one_deal_role$

--- a/scripts/platform-v7-rls-apply-rehearsal.sh
+++ b/scripts/platform-v7-rls-apply-rehearsal.sh
@@ -68,13 +68,15 @@ BEGIN
   SELECT count(*) INTO public_execute_count
   FROM pg_proc p
   JOIN pg_namespace n ON n.oid = p.pronamespace
+  CROSS JOIN LATERAL aclexplode(COALESCE(p.proacl, acldefault('f', p.proowner))) acl
   WHERE n.nspname = 'public'
     AND p.proname IN (
       'app_deal_basis_deal_visible',
       'app_deal_basis_participant_allowed',
       'enforce_single_deal_per_basis'
     )
-    AND has_function_privilege('public', p.oid, 'EXECUTE');
+    AND acl.grantee = 0
+    AND acl.privilege_type = 'EXECUTE';
 
   SELECT count(*) INTO required_policy_count
   FROM pg_policies

--- a/scripts/platform-v7-rls-apply-rehearsal.sh
+++ b/scripts/platform-v7-rls-apply-rehearsal.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 POLICY_FILE="$ROOT_DIR/infra/sql/production-rls-policies.sql"
+DEAL_AUTHORITY_POLICY_FILE="$ROOT_DIR/infra/sql/postgresql-deal-authority-policies.sql"
 VALIDATOR="$ROOT_DIR/scripts/platform-v7-rls-validate.mjs"
 PROTECTED_TABLES="deals organizations audit_events ledger_entries integration_events outbox_entries deal_workspace_runtime_snapshots deal_workspace_runtime_transaction_attempts"
 
@@ -29,12 +30,14 @@ TABLE_ARRAY="$(printf "'%s'," $PROTECTED_TABLES | sed 's/,$//')"
 {
   echo 'BEGIN;'
   cat "$POLICY_FILE"
+  cat "$DEAL_AUTHORITY_POLICY_FILE"
   cat <<SQL
 DO \$rehearsal\$
 DECLARE
   enabled_count INTEGER;
   forced_count INTEGER;
   policy_count INTEGER;
+  basis_function_count INTEGER;
 BEGIN
   SELECT count(*) INTO enabled_count
   FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -48,6 +51,13 @@ BEGIN
   FROM pg_policies
   WHERE schemaname = 'public' AND tablename IN ($TABLE_ARRAY);
 
+  SELECT count(*) INTO basis_function_count
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'app_deal_basis_participant_allowed'
+    AND p.prosecdef;
+
   IF enabled_count <> 8 THEN
     RAISE EXCEPTION 'RLS rehearsal: expected 8 enabled tables, got %', enabled_count;
   END IF;
@@ -56,6 +66,9 @@ BEGIN
   END IF;
   IF policy_count < 16 THEN
     RAISE EXCEPTION 'RLS rehearsal: expected at least 16 policies, got %', policy_count;
+  END IF;
+  IF basis_function_count <> 1 THEN
+    RAISE EXCEPTION 'RLS rehearsal: deal basis SECURITY DEFINER predicate is missing';
   END IF;
 END
 \$rehearsal\$;

--- a/scripts/platform-v7-rls-apply-rehearsal.sh
+++ b/scripts/platform-v7-rls-apply-rehearsal.sh
@@ -37,7 +37,10 @@ DECLARE
   enabled_count INTEGER;
   forced_count INTEGER;
   policy_count INTEGER;
-  basis_function_count INTEGER;
+  authority_function_count INTEGER;
+  public_execute_count INTEGER;
+  required_policy_count INTEGER;
+  single_basis_trigger_count INTEGER;
 BEGIN
   SELECT count(*) INTO enabled_count
   FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -51,12 +54,48 @@ BEGIN
   FROM pg_policies
   WHERE schemaname = 'public' AND tablename IN ($TABLE_ARRAY);
 
-  SELECT count(*) INTO basis_function_count
+  SELECT count(*) INTO authority_function_count
   FROM pg_proc p
   JOIN pg_namespace n ON n.oid = p.pronamespace
   WHERE n.nspname = 'public'
-    AND p.proname = 'app_deal_basis_participant_allowed'
+    AND p.proname IN (
+      'app_deal_basis_deal_visible',
+      'app_deal_basis_participant_allowed',
+      'enforce_single_deal_per_basis'
+    )
     AND p.prosecdef;
+
+  SELECT count(*) INTO public_execute_count
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname IN (
+      'app_deal_basis_deal_visible',
+      'app_deal_basis_participant_allowed',
+      'enforce_single_deal_per_basis'
+    )
+    AND has_function_privilege('public', p.oid, 'EXECUTE');
+
+  SELECT count(*) INTO required_policy_count
+  FROM pg_policies
+  WHERE schemaname = 'public'
+    AND (tablename, policyname) IN (
+      ('deals', 'deals_select'),
+      ('deals', 'deals_insert'),
+      ('integration_events', 'integration_events_select'),
+      ('organizations', 'organizations_select'),
+      ('deal_participants', 'deal_participants_insert')
+    );
+
+  SELECT count(*) INTO single_basis_trigger_count
+  FROM pg_trigger t
+  JOIN pg_class c ON c.oid = t.tgrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = 'deals'
+    AND t.tgname = 'deals_single_basis'
+    AND NOT t.tgisinternal
+    AND t.tgenabled IN ('O', 'A');
 
   IF enabled_count <> 8 THEN
     RAISE EXCEPTION 'RLS rehearsal: expected 8 enabled tables, got %', enabled_count;
@@ -67,8 +106,17 @@ BEGIN
   IF policy_count < 16 THEN
     RAISE EXCEPTION 'RLS rehearsal: expected at least 16 policies, got %', policy_count;
   END IF;
-  IF basis_function_count <> 1 THEN
-    RAISE EXCEPTION 'RLS rehearsal: deal basis SECURITY DEFINER predicate is missing';
+  IF authority_function_count <> 3 THEN
+    RAISE EXCEPTION 'RLS rehearsal: expected 3 SECURITY DEFINER authority functions, got %', authority_function_count;
+  END IF;
+  IF public_execute_count <> 0 THEN
+    RAISE EXCEPTION 'RLS rehearsal: PUBLIC can execute % authority function(s)', public_execute_count;
+  END IF;
+  IF required_policy_count <> 5 THEN
+    RAISE EXCEPTION 'RLS rehearsal: expected 5 final deal authority policies, got %', required_policy_count;
+  END IF;
+  IF single_basis_trigger_count <> 1 THEN
+    RAISE EXCEPTION 'RLS rehearsal: single-basis trigger is missing or disabled';
   END IF;
 END
 \$rehearsal\$;

--- a/scripts/platform-v7-rls-apply-rehearsal.sh
+++ b/scripts/platform-v7-rls-apply-rehearsal.sh
@@ -38,9 +38,10 @@ DECLARE
   forced_count INTEGER;
   policy_count INTEGER;
   authority_function_count INTEGER;
+  immutability_function_count INTEGER;
   public_execute_count INTEGER;
   required_policy_count INTEGER;
-  single_basis_trigger_count INTEGER;
+  authority_trigger_count INTEGER;
 BEGIN
   SELECT count(*) INTO enabled_count
   FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -65,6 +66,12 @@ BEGIN
     )
     AND p.prosecdef;
 
+  SELECT count(*) INTO immutability_function_count
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'forbid_deal_basis_mutation';
+
   SELECT count(*) INTO public_execute_count
   FROM pg_proc p
   JOIN pg_namespace n ON n.oid = p.pronamespace
@@ -73,7 +80,8 @@ BEGIN
     AND p.proname IN (
       'app_deal_basis_deal_visible',
       'app_deal_basis_participant_allowed',
-      'enforce_single_deal_per_basis'
+      'enforce_single_deal_per_basis',
+      'forbid_deal_basis_mutation'
     )
     AND acl.grantee = 0
     AND acl.privilege_type = 'EXECUTE';
@@ -89,13 +97,13 @@ BEGIN
       ('deal_participants', 'deal_participants_insert')
     );
 
-  SELECT count(*) INTO single_basis_trigger_count
+  SELECT count(*) INTO authority_trigger_count
   FROM pg_trigger t
   JOIN pg_class c ON c.oid = t.tgrelid
   JOIN pg_namespace n ON n.oid = c.relnamespace
   WHERE n.nspname = 'public'
     AND c.relname = 'deals'
-    AND t.tgname = 'deals_single_basis'
+    AND t.tgname IN ('deals_single_basis', 'deals_basis_immutable')
     AND NOT t.tgisinternal
     AND t.tgenabled IN ('O', 'A');
 
@@ -111,14 +119,17 @@ BEGIN
   IF authority_function_count <> 3 THEN
     RAISE EXCEPTION 'RLS rehearsal: expected 3 SECURITY DEFINER authority functions, got %', authority_function_count;
   END IF;
+  IF immutability_function_count <> 1 THEN
+    RAISE EXCEPTION 'RLS rehearsal: immutable-basis trigger function is missing';
+  END IF;
   IF public_execute_count <> 0 THEN
     RAISE EXCEPTION 'RLS rehearsal: PUBLIC can execute % authority function(s)', public_execute_count;
   END IF;
   IF required_policy_count <> 5 THEN
     RAISE EXCEPTION 'RLS rehearsal: expected 5 final deal authority policies, got %', required_policy_count;
   END IF;
-  IF single_basis_trigger_count <> 1 THEN
-    RAISE EXCEPTION 'RLS rehearsal: single-basis trigger is missing or disabled';
+  IF authority_trigger_count <> 2 THEN
+    RAISE EXCEPTION 'RLS rehearsal: expected 2 enabled Deal authority triggers, got %', authority_trigger_count;
   END IF;
 END
 \$rehearsal\$;

--- a/scripts/platform-v7-rls-apply-rehearsal.sh
+++ b/scripts/platform-v7-rls-apply-rehearsal.sh
@@ -41,6 +41,7 @@ DECLARE
   immutability_function_count INTEGER;
   public_execute_count INTEGER;
   required_policy_count INTEGER;
+  basis_only_insert_count INTEGER;
   authority_trigger_count INTEGER;
 BEGIN
   SELECT count(*) INTO enabled_count
@@ -97,6 +98,15 @@ BEGIN
       ('deal_participants', 'deal_participants_insert')
     );
 
+  SELECT count(*) INTO basis_only_insert_count
+  FROM pg_policies
+  WHERE schemaname = 'public'
+    AND tablename = 'deals'
+    AND policyname = 'deals_insert'
+    AND with_check ILIKE '%app_deal_basis_deal_visible%'
+    AND with_check ILIKE '%FARMER%'
+    AND with_check NOT ILIKE '%app_rls_privileged%';
+
   SELECT count(*) INTO authority_trigger_count
   FROM pg_trigger t
   JOIN pg_class c ON c.oid = t.tgrelid
@@ -127,6 +137,9 @@ BEGIN
   END IF;
   IF required_policy_count <> 5 THEN
     RAISE EXCEPTION 'RLS rehearsal: expected 5 final deal authority policies, got %', required_policy_count;
+  END IF;
+  IF basis_only_insert_count <> 1 THEN
+    RAISE EXCEPTION 'RLS rehearsal: final deals_insert policy is not seller-basis-only';
   END IF;
   IF authority_trigger_count <> 2 THEN
     RAISE EXCEPTION 'RLS rehearsal: expected 2 enabled Deal authority triggers, got %', authority_trigger_count;


### PR DESCRIPTION
## Проблема

Обычные Deal routes сохраняли RuntimeCore/factory fallback и skeleton `PrismaDealRepository`: `workspace`, `passport`, `timeline` и `create` не были полноценной PostgreSQL-authority границей, а legacy transition позволял свободный обход доменных команд.

## Root cause

Production DI-граф допускал in-memory адаптер; создание сделки не имело атомарного confirmed-basis/idempotency/RLS boundary. До появления DealParticipant продавец не мог безопасно выполнить `INSERT ... RETURNING`, а чрезмерно широкие privileged policy могли позволить произвольное создание Deal.

## Что изменено

- `PrismaDealRepository` реализует participant-scoped `list/getById/workspace/passport/timeline/create`;
- BigInt/Decimal выдаются наружу точными строками;
- production `DealsModule` напрямую связывает `DEAL_REPOSITORY` с Prisma;
- из production DI удалены RuntimeCore, repository factory, DealAutoService, legacy best-effort DealEventService и лишний OutboxModule;
- Runtime repository доступен только при `NODE_ENV=test` и явном `test|demo` profile; неизвестный mode падает;
- legacy `PATCH /deals/:id/transition` и `/status` возвращают 410 и не меняют state machine;
- `POST /deals` принимает только идентификаторы подтверждённого auction basis, `commandId` и `idempotencyKey`;
- client-authored `paymentTerms` запрещены DTO и PostgreSQL constraint до включения условий в подписанный серверный basis;
- Deal, ровно два basis-bound participant, начальный DealEvent, AuditEvent и idempotent receipt фиксируются одной транзакцией;
- после participant binding ставится `sagaStep=PARTICIPANTS_BOUND`, поэтому временная pre-participant basis visibility больше не действует;
- idempotency receipt scoped по tenant + actor + key; advisory lock scoped по tenant + lot + winning bid;
- создание не фабрикует shipment/document/payment/lab/bank rows.

## PostgreSQL authority и RLS

Добавлены forward-only migrations и повторно применяемый overlay:

- `20260712193000_postgresql_deal_authority`;
- `20260712194000_deal_basis_immutability`;
- `20260712195000_deal_insert_basis_only`;
- `infra/sql/postgresql-deal-authority-policies.sql`.

Гарантии:

- `deals_insert` разрешает runtime INSERT только продавцу из одного confirmed tenant-scoped basis;
- все коммерческие поля, initial lifecycle state и 18-key saga snapshot сверяются с basis;
- SUPPORT_MANAGER/ADMIN не могут создать произвольную Deal строку;
- buyer/seller participants могут быть созданы только со статусом ACTIVE, access APPROVE, assignedBy текущим seller actor и без revokedAt;
- privileged organization reads дополнительно ограничены текущим tenant;
- один tenant/lot/winner basis нельзя использовать повторно: advisory-lock trigger + 23505;
- коммерческий basis и saga snapshot после создания неизменяемы;
- SECURITY DEFINER functions имеют фиксированный search_path и закрыты от PUBLIC EXECUTE;
- cross-tenant и revoked-participant visibility равна нулю.

## Доказано на head `cedd30b3bc43f57d1b53491dca705eb2369876e4`

### GitHub Actions

- CI run `29206603984` — success;
- Node CI run `29206604007` — success: typecheck, tests, build;
- platform-v7 autopilot guard run `29206603969` — success;
- CodeQL run `29206603994` — success;
- Qodana run `29206604008` — success;
- Security Scan run `29206603955` — success;
- Security Quality Gate run `29206603972` — success;
- Dependency Review run `29206603962` — success;
- web-unit job — success.

### Industrial PostgreSQL core

Artifact `8263931216`, digest `sha256:9bc47b4c2cad19f6af3b29e74acbca0e3364a41113d80e1286f7533887ee1dce`:

- 7 suites / 38 tests passed;
- PostgreSQL Deal authority, no-fake-live, money reconciliation, key rotation, durable outbox, observability and load correctness gates green;
- load correctness proof: 12 deals / 204 commands;
- p50 128 ms, p95 171 ms, p99 203 ms;
- 67 commands/sec;
- это CI-scale correctness proof, не production-like нагрузка.

### Restricted principal, one-deal и DR

Artifact `8263935357`, digest `sha256:d5a2a9cc6aa7a3e61b4bb2b3ea15c4ee26d7997fc4c5ec76d9483ba7eea44866`:

- one-deal: 7 suites / 22 tests passed;
- staff access: 2 suites / 8 tests passed;
- restricted `one_deal_app`: NOSUPERUSER, NOBYPASSRLS, не владеет protected tables;
- 12 ролей / 19 действий;
- 19 DealEvent / 19 AuditEvent;
- 2 bank operations / 2 ledger entries;
- direct unbacked insert, privileged arbitrary insert, basis tampering, duplicate reuse и post-create basis rewrite запрещены;
- revoked seller не сохраняет basis fallback visibility;
- cross-tenant Deal/participant/organization visibility: 0;
- source и restore fingerprint совпали: `8e0b19df70f6743f52938a1b15af6f0f`;
- backup SHA-256: `3f2d6ffa737e1a53ef60ef7fa78f64bd0cfde1f9244e5a325b5f4bf70463ed9b`;
- 25 successful migrations, 0 failed;
- RLS ENABLE/FORCE: 8/8;
- обязательные подписанные документы восстановлены: CONTRACT, TTN, WEIGHING_ACT, LAB_PROTOCOL, ACCEPTANCE_ACT;
- production RTO/RPO не установлены.

### Persistent auth regression

Artifact `8263930020`, digest `sha256:b45233db2e99ca35374b5142b3a0e7afa4eccc56a77461ececc75bff08f962e3`:

- 2 suites / 9 tests passed;
- schema drift пустой;
- persistent sessions, rotation, revocation, MFA и one-time backup code не регрессировали.

## Ограничения

- `winnerBidId` временно хранится в legacy `Deal.sourceLotId`; нормализованная auction/deal-basis schema ещё нужна;
- новый Deal не получает нормализованный logistics admission registry; текущий command contour всё ещё требует отдельной доработки carrier/driver/vehicle/facility basis;
- payment terms намеренно заблокированы до появления подписанного серверного источника;
- policy overlay необходимо применять после базового `production-rls-policies.sql`;
- production deploy, production-like load, HA/failover, pentest, live bank/ФГИС/ЭДО/ЕСИА и юридически значимые подписи не доказаны.

Текущий статус остаётся **NO-GO** для реальных денег, документов и клиентских сделок до закрытия остальных P0.