### PR TITLE
Normalize PostgreSQL logistics admission

### DIFF
--- a/apps/api/prisma/migrations/20260712200000_postgresql_logistics_admission/migration.sql
+++ b/apps/api/prisma/migrations/20260712200000_postgresql_logistics_admission/migration.sql
@@ -1,0 +1,676 @@
+-- Normalized PostgreSQL logistics admission registry.
+--
+-- Operational logistics authority is separated from Deal.sagaState. The global
+-- registries describe verified carriers, drivers, vehicles, driver/vehicle links
+-- and facilities. A Deal receives one immutable admission snapshot that can be
+-- consumed exactly once by the assign_logistics command.
+
+CREATE SCHEMA IF NOT EXISTS logistics;
+
+CREATE TABLE logistics.carriers (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  valid_from TIMESTAMPTZ NOT NULL,
+  valid_until TIMESTAMPTZ,
+  verified_at TIMESTAMPTZ,
+  verified_by_user_id TEXT,
+  source_hash TEXT NOT NULL,
+  evidence_ref TEXT,
+  version BIGINT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT logistics_carriers_org_fk FOREIGN KEY (organization_id)
+    REFERENCES public."organizations"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_carriers_verifier_fk FOREIGN KEY (verified_by_user_id)
+    REFERENCES public."users"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_carriers_tenant_org_unique UNIQUE (tenant_id, organization_id),
+  CONSTRAINT logistics_carriers_status_check CHECK (status IN ('PENDING', 'VERIFIED', 'SUSPENDED', 'REVOKED')),
+  CONSTRAINT logistics_carriers_validity_check CHECK (valid_until IS NULL OR valid_until > valid_from),
+  CONSTRAINT logistics_carriers_hash_check CHECK (length(source_hash) >= 32)
+);
+
+CREATE TABLE logistics.drivers (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  carrier_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  valid_from TIMESTAMPTZ NOT NULL,
+  valid_until TIMESTAMPTZ,
+  verified_at TIMESTAMPTZ,
+  verified_by_user_id TEXT,
+  source_hash TEXT NOT NULL,
+  evidence_ref TEXT,
+  version BIGINT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT logistics_drivers_carrier_fk FOREIGN KEY (carrier_id)
+    REFERENCES logistics.carriers(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_drivers_user_fk FOREIGN KEY (user_id)
+    REFERENCES public."users"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_drivers_verifier_fk FOREIGN KEY (verified_by_user_id)
+    REFERENCES public."users"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_drivers_tenant_user_carrier_unique UNIQUE (tenant_id, user_id, carrier_id),
+  CONSTRAINT logistics_drivers_status_check CHECK (status IN ('PENDING', 'ACTIVE', 'SUSPENDED', 'REVOKED')),
+  CONSTRAINT logistics_drivers_validity_check CHECK (valid_until IS NULL OR valid_until > valid_from),
+  CONSTRAINT logistics_drivers_hash_check CHECK (length(source_hash) >= 32)
+);
+
+CREATE TABLE logistics.vehicles (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  carrier_id TEXT NOT NULL,
+  registration_number TEXT NOT NULL,
+  vehicle_type TEXT,
+  capacity_tons NUMERIC(20,6),
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  valid_from TIMESTAMPTZ NOT NULL,
+  valid_until TIMESTAMPTZ,
+  verified_at TIMESTAMPTZ,
+  verified_by_user_id TEXT,
+  source_hash TEXT NOT NULL,
+  evidence_ref TEXT,
+  version BIGINT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT logistics_vehicles_carrier_fk FOREIGN KEY (carrier_id)
+    REFERENCES logistics.carriers(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_vehicles_verifier_fk FOREIGN KEY (verified_by_user_id)
+    REFERENCES public."users"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_vehicles_tenant_registration_unique UNIQUE (tenant_id, registration_number),
+  CONSTRAINT logistics_vehicles_status_check CHECK (status IN ('PENDING', 'ACTIVE', 'SUSPENDED', 'REVOKED')),
+  CONSTRAINT logistics_vehicles_capacity_check CHECK (capacity_tons IS NULL OR capacity_tons > 0),
+  CONSTRAINT logistics_vehicles_validity_check CHECK (valid_until IS NULL OR valid_until > valid_from),
+  CONSTRAINT logistics_vehicles_hash_check CHECK (length(source_hash) >= 32)
+);
+
+CREATE TABLE logistics.driver_vehicle_links (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  driver_id TEXT NOT NULL,
+  vehicle_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  valid_from TIMESTAMPTZ NOT NULL,
+  valid_until TIMESTAMPTZ,
+  verified_at TIMESTAMPTZ,
+  verified_by_user_id TEXT,
+  source_hash TEXT NOT NULL,
+  evidence_ref TEXT,
+  version BIGINT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT logistics_driver_vehicle_driver_fk FOREIGN KEY (driver_id)
+    REFERENCES logistics.drivers(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_driver_vehicle_vehicle_fk FOREIGN KEY (vehicle_id)
+    REFERENCES logistics.vehicles(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_driver_vehicle_verifier_fk FOREIGN KEY (verified_by_user_id)
+    REFERENCES public."users"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_driver_vehicle_unique UNIQUE (tenant_id, driver_id, vehicle_id),
+  CONSTRAINT logistics_driver_vehicle_status_check CHECK (status IN ('PENDING', 'ACTIVE', 'SUSPENDED', 'REVOKED')),
+  CONSTRAINT logistics_driver_vehicle_validity_check CHECK (valid_until IS NULL OR valid_until > valid_from),
+  CONSTRAINT logistics_driver_vehicle_hash_check CHECK (length(source_hash) >= 32)
+);
+
+CREATE TABLE logistics.facilities (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  organization_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  name TEXT NOT NULL,
+  address TEXT,
+  latitude NUMERIC(10,7),
+  longitude NUMERIC(10,7),
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  valid_from TIMESTAMPTZ NOT NULL,
+  valid_until TIMESTAMPTZ,
+  verified_at TIMESTAMPTZ,
+  verified_by_user_id TEXT,
+  source_hash TEXT NOT NULL,
+  evidence_ref TEXT,
+  version BIGINT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT logistics_facilities_org_fk FOREIGN KEY (organization_id)
+    REFERENCES public."organizations"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_facilities_verifier_fk FOREIGN KEY (verified_by_user_id)
+    REFERENCES public."users"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_facilities_kind_check CHECK (kind IN ('DISPATCH', 'ACCEPTANCE', 'BOTH')),
+  CONSTRAINT logistics_facilities_status_check CHECK (status IN ('PENDING', 'ACTIVE', 'SUSPENDED', 'REVOKED')),
+  CONSTRAINT logistics_facilities_lat_check CHECK (latitude IS NULL OR latitude BETWEEN -90 AND 90),
+  CONSTRAINT logistics_facilities_lng_check CHECK (longitude IS NULL OR longitude BETWEEN -180 AND 180),
+  CONSTRAINT logistics_facilities_validity_check CHECK (valid_until IS NULL OR valid_until > valid_from),
+  CONSTRAINT logistics_facilities_hash_check CHECK (length(source_hash) >= 32)
+);
+
+CREATE TABLE logistics.deal_admissions (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  deal_id TEXT NOT NULL,
+  carrier_id TEXT NOT NULL,
+  driver_id TEXT NOT NULL,
+  vehicle_id TEXT NOT NULL,
+  driver_vehicle_link_id TEXT NOT NULL,
+  route_from_facility_id TEXT NOT NULL,
+  route_to_facility_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'CONFIRMED',
+  valid_from TIMESTAMPTZ NOT NULL,
+  valid_until TIMESTAMPTZ,
+  approved_by_user_id TEXT NOT NULL,
+  approved_at TIMESTAMPTZ NOT NULL,
+  source_hash TEXT NOT NULL,
+  evidence_ref TEXT,
+  consumed_at TIMESTAMPTZ,
+  consumed_by_user_id TEXT,
+  consumed_by_command_id TEXT,
+  version BIGINT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT logistics_deal_admissions_deal_fk FOREIGN KEY (deal_id)
+    REFERENCES public."deals"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_deal_admissions_carrier_fk FOREIGN KEY (carrier_id)
+    REFERENCES logistics.carriers(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_deal_admissions_driver_fk FOREIGN KEY (driver_id)
+    REFERENCES logistics.drivers(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_deal_admissions_vehicle_fk FOREIGN KEY (vehicle_id)
+    REFERENCES logistics.vehicles(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_deal_admissions_link_fk FOREIGN KEY (driver_vehicle_link_id)
+    REFERENCES logistics.driver_vehicle_links(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_deal_admissions_from_fk FOREIGN KEY (route_from_facility_id)
+    REFERENCES logistics.facilities(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_deal_admissions_to_fk FOREIGN KEY (route_to_facility_id)
+    REFERENCES logistics.facilities(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_deal_admissions_approver_fk FOREIGN KEY (approved_by_user_id)
+    REFERENCES public."users"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_deal_admissions_consumer_fk FOREIGN KEY (consumed_by_user_id)
+    REFERENCES public."users"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_deal_admissions_deal_unique UNIQUE (deal_id),
+  CONSTRAINT logistics_deal_admissions_status_check CHECK (status IN ('CONFIRMED', 'CONSUMED', 'REVOKED')),
+  CONSTRAINT logistics_deal_admissions_validity_check CHECK (valid_until IS NULL OR valid_until > valid_from),
+  CONSTRAINT logistics_deal_admissions_hash_check CHECK (length(source_hash) >= 32),
+  CONSTRAINT logistics_deal_admissions_consumption_check CHECK (
+    (status = 'CONSUMED' AND consumed_at IS NOT NULL AND consumed_by_user_id IS NOT NULL AND consumed_by_command_id IS NOT NULL)
+    OR (status IN ('CONFIRMED', 'REVOKED') AND consumed_at IS NULL AND consumed_by_user_id IS NULL AND consumed_by_command_id IS NULL)
+  )
+);
+
+CREATE TABLE logistics.shipment_bindings (
+  shipment_id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  deal_id TEXT NOT NULL,
+  admission_id TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT logistics_shipment_bindings_shipment_fk FOREIGN KEY (shipment_id)
+    REFERENCES public."shipments"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_shipment_bindings_deal_fk FOREIGN KEY (deal_id)
+    REFERENCES public."deals"(id) ON DELETE RESTRICT,
+  CONSTRAINT logistics_shipment_bindings_admission_fk FOREIGN KEY (admission_id)
+    REFERENCES logistics.deal_admissions(id) ON DELETE RESTRICT
+);
+
+CREATE INDEX logistics_carriers_tenant_status_idx ON logistics.carriers (tenant_id, status);
+CREATE INDEX logistics_drivers_tenant_carrier_status_idx ON logistics.drivers (tenant_id, carrier_id, status);
+CREATE INDEX logistics_vehicles_tenant_carrier_status_idx ON logistics.vehicles (tenant_id, carrier_id, status);
+CREATE INDEX logistics_driver_vehicle_tenant_status_idx ON logistics.driver_vehicle_links (tenant_id, status);
+CREATE INDEX logistics_facilities_tenant_org_status_idx ON logistics.facilities (tenant_id, organization_id, status);
+CREATE INDEX logistics_deal_admissions_tenant_status_idx ON logistics.deal_admissions (tenant_id, status);
+CREATE INDEX logistics_shipment_bindings_deal_idx ON logistics.shipment_bindings (tenant_id, deal_id);
+
+CREATE OR REPLACE FUNCTION logistics.touch_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, logistics
+AS $function$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END
+$function$;
+
+CREATE TRIGGER logistics_carriers_touch BEFORE UPDATE ON logistics.carriers
+  FOR EACH ROW EXECUTE FUNCTION logistics.touch_updated_at();
+CREATE TRIGGER logistics_drivers_touch BEFORE UPDATE ON logistics.drivers
+  FOR EACH ROW EXECUTE FUNCTION logistics.touch_updated_at();
+CREATE TRIGGER logistics_vehicles_touch BEFORE UPDATE ON logistics.vehicles
+  FOR EACH ROW EXECUTE FUNCTION logistics.touch_updated_at();
+CREATE TRIGGER logistics_driver_vehicle_touch BEFORE UPDATE ON logistics.driver_vehicle_links
+  FOR EACH ROW EXECUTE FUNCTION logistics.touch_updated_at();
+CREATE TRIGGER logistics_facilities_touch BEFORE UPDATE ON logistics.facilities
+  FOR EACH ROW EXECUTE FUNCTION logistics.touch_updated_at();
+CREATE TRIGGER logistics_deal_admissions_touch BEFORE UPDATE ON logistics.deal_admissions
+  FOR EACH ROW EXECUTE FUNCTION logistics.touch_updated_at();
+
+CREATE OR REPLACE FUNCTION logistics.enforce_deal_admission_transition()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public, logistics
+AS $function$
+BEGIN
+  IF ROW(
+    OLD.tenant_id, OLD.deal_id, OLD.carrier_id, OLD.driver_id, OLD.vehicle_id,
+    OLD.driver_vehicle_link_id, OLD.route_from_facility_id, OLD.route_to_facility_id,
+    OLD.valid_from, OLD.valid_until, OLD.approved_by_user_id, OLD.approved_at,
+    OLD.source_hash, OLD.evidence_ref
+  ) IS DISTINCT FROM ROW(
+    NEW.tenant_id, NEW.deal_id, NEW.carrier_id, NEW.driver_id, NEW.vehicle_id,
+    NEW.driver_vehicle_link_id, NEW.route_from_facility_id, NEW.route_to_facility_id,
+    NEW.valid_from, NEW.valid_until, NEW.approved_by_user_id, NEW.approved_at,
+    NEW.source_hash, NEW.evidence_ref
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'confirmed logistics admission basis is immutable';
+  END IF;
+
+  IF OLD.status = 'CONFIRMED' AND NEW.status = 'CONSUMED' THEN
+    IF current_setting('app.current_role', true) NOT IN ('LOGISTICIAN', 'SUPPORT_MANAGER', 'ADMIN')
+      OR NEW.consumed_at IS NULL
+      OR NEW.consumed_by_user_id <> current_setting('app.current_user_id', true)
+      OR NULLIF(NEW.consumed_by_command_id, '') IS NULL
+      OR NEW.version <> OLD.version + 1 THEN
+      RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'invalid logistics admission consumption';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF OLD.status = 'CONFIRMED' AND NEW.status = 'REVOKED' THEN
+    IF NOT public.app_rls_privileged() OR NEW.version <> OLD.version + 1 THEN
+      RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'invalid logistics admission revocation';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF ROW(OLD.status, OLD.consumed_at, OLD.consumed_by_user_id, OLD.consumed_by_command_id, OLD.version)
+     IS DISTINCT FROM
+     ROW(NEW.status, NEW.consumed_at, NEW.consumed_by_user_id, NEW.consumed_by_command_id, NEW.version) THEN
+    RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'logistics admission transition is final';
+  END IF;
+
+  RETURN NEW;
+END
+$function$;
+
+CREATE TRIGGER logistics_deal_admission_transition
+  BEFORE UPDATE ON logistics.deal_admissions
+  FOR EACH ROW EXECUTE FUNCTION logistics.enforce_deal_admission_transition();
+
+CREATE OR REPLACE FUNCTION logistics.resolve_deal_admission(
+  p_deal_id TEXT,
+  p_carrier_org_id TEXT,
+  p_driver_user_id TEXT,
+  p_vehicle_id TEXT,
+  p_route_from_facility_id TEXT,
+  p_route_to_facility_id TEXT
+)
+RETURNS TABLE (
+  admission_id TEXT,
+  tenant_id TEXT,
+  deal_id TEXT,
+  carrier_id TEXT,
+  carrier_org_id TEXT,
+  carrier_name TEXT,
+  carrier_source_hash TEXT,
+  driver_id TEXT,
+  driver_user_id TEXT,
+  driver_name TEXT,
+  driver_source_hash TEXT,
+  vehicle_id TEXT,
+  vehicle_registration_number TEXT,
+  vehicle_type TEXT,
+  vehicle_source_hash TEXT,
+  driver_vehicle_link_id TEXT,
+  driver_vehicle_source_hash TEXT,
+  route_from_facility_id TEXT,
+  route_from_name TEXT,
+  route_from_source_hash TEXT,
+  route_to_facility_id TEXT,
+  route_to_name TEXT,
+  route_to_source_hash TEXT,
+  valid_from TIMESTAMPTZ,
+  valid_until TIMESTAMPTZ,
+  admission_source_hash TEXT,
+  evidence_ref TEXT
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, logistics
+STABLE
+AS $function$
+  SELECT
+    da.id,
+    da.tenant_id,
+    da.deal_id,
+    c.id,
+    c.organization_id,
+    carrier_org.name,
+    c.source_hash,
+    dr.id,
+    dr.user_id,
+    driver_user."fullName",
+    dr.source_hash,
+    v.id,
+    v.registration_number,
+    v.vehicle_type,
+    v.source_hash,
+    dvl.id,
+    dvl.source_hash,
+    origin.id,
+    origin.name,
+    origin.source_hash,
+    destination.id,
+    destination.name,
+    destination.source_hash,
+    da.valid_from,
+    da.valid_until,
+    da.source_hash,
+    da.evidence_ref
+  FROM logistics.deal_admissions da
+  JOIN public."deals" deal ON deal.id = da.deal_id
+  JOIN logistics.carriers c ON c.id = da.carrier_id
+  JOIN public."organizations" carrier_org ON carrier_org.id = c.organization_id
+  JOIN logistics.drivers dr ON dr.id = da.driver_id
+  JOIN public."users" driver_user ON driver_user.id = dr.user_id
+  JOIN public."user_orgs" driver_membership
+    ON driver_membership."userId" = dr.user_id
+   AND driver_membership."organizationId" = c.organization_id
+   AND driver_membership.role = 'DRIVER'
+  JOIN logistics.vehicles v ON v.id = da.vehicle_id
+  JOIN logistics.driver_vehicle_links dvl ON dvl.id = da.driver_vehicle_link_id
+  JOIN logistics.facilities origin ON origin.id = da.route_from_facility_id
+  JOIN logistics.facilities destination ON destination.id = da.route_to_facility_id
+  WHERE public.app_rls_context_ready()
+    AND current_setting('app.current_role', true) IN ('LOGISTICIAN', 'SUPPORT_MANAGER', 'ADMIN')
+    AND da.tenant_id = current_setting('app.current_tenant_id', true)
+    AND da.deal_id = p_deal_id
+    AND public.app_rls_deal_visible(da.deal_id)
+    AND c.organization_id = p_carrier_org_id
+    AND dr.user_id = p_driver_user_id
+    AND v.id = p_vehicle_id
+    AND origin.id = p_route_from_facility_id
+    AND destination.id = p_route_to_facility_id
+    AND da.status = 'CONFIRMED'
+    AND now() >= da.valid_from
+    AND (da.valid_until IS NULL OR now() < da.valid_until)
+    AND c.tenant_id = da.tenant_id
+    AND c.status = 'VERIFIED'
+    AND now() >= c.valid_from
+    AND (c.valid_until IS NULL OR now() < c.valid_until)
+    AND carrier_org."tenantId" = da.tenant_id
+    AND carrier_org.status = 'VERIFIED'
+    AND carrier_org."kycStatus" = 'APPROVED'
+    AND dr.tenant_id = da.tenant_id
+    AND dr.carrier_id = c.id
+    AND dr.status = 'ACTIVE'
+    AND now() >= dr.valid_from
+    AND (dr.valid_until IS NULL OR now() < dr.valid_until)
+    AND driver_user.status = 'ACTIVE'
+    AND driver_user."deletedAt" IS NULL
+    AND v.tenant_id = da.tenant_id
+    AND v.carrier_id = c.id
+    AND v.status = 'ACTIVE'
+    AND now() >= v.valid_from
+    AND (v.valid_until IS NULL OR now() < v.valid_until)
+    AND dvl.tenant_id = da.tenant_id
+    AND dvl.driver_id = dr.id
+    AND dvl.vehicle_id = v.id
+    AND dvl.status = 'ACTIVE'
+    AND now() >= dvl.valid_from
+    AND (dvl.valid_until IS NULL OR now() < dvl.valid_until)
+    AND origin.tenant_id = da.tenant_id
+    AND origin.organization_id = deal."sellerOrgId"
+    AND origin.kind IN ('DISPATCH', 'BOTH')
+    AND origin.status = 'ACTIVE'
+    AND now() >= origin.valid_from
+    AND (origin.valid_until IS NULL OR now() < origin.valid_until)
+    AND destination.tenant_id = da.tenant_id
+    AND destination.organization_id = deal."buyerOrgId"
+    AND destination.kind IN ('ACCEPTANCE', 'BOTH')
+    AND destination.status = 'ACTIVE'
+    AND now() >= destination.valid_from
+    AND (destination.valid_until IS NULL OR now() < destination.valid_until)
+  LIMIT 1
+$function$;
+
+CREATE OR REPLACE FUNCTION logistics.consume_deal_admission(
+  p_admission_id TEXT,
+  p_shipment_id TEXT,
+  p_command_id TEXT
+)
+RETURNS TABLE (admission_id TEXT, status TEXT, version BIGINT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, logistics
+AS $function$
+DECLARE
+  consumed logistics.deal_admissions%ROWTYPE;
+  shipment_deal_id TEXT;
+BEGIN
+  IF NOT public.app_rls_context_ready()
+    OR current_setting('app.current_role', true) NOT IN ('LOGISTICIAN', 'SUPPORT_MANAGER', 'ADMIN')
+    OR NULLIF(p_command_id, '') IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'trusted logistics command context is required';
+  END IF;
+
+  SELECT s."dealId" INTO shipment_deal_id
+  FROM public."shipments" s
+  WHERE s.id = p_shipment_id;
+
+  UPDATE logistics.deal_admissions da
+  SET status = 'CONSUMED',
+      consumed_at = now(),
+      consumed_by_user_id = current_setting('app.current_user_id', true),
+      consumed_by_command_id = p_command_id,
+      version = da.version + 1
+  WHERE da.id = p_admission_id
+    AND da.status = 'CONFIRMED'
+    AND da.tenant_id = current_setting('app.current_tenant_id', true)
+    AND da.deal_id = shipment_deal_id
+    AND public.app_rls_deal_visible(da.deal_id)
+  RETURNING da.* INTO consumed;
+
+  IF consumed.id IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'logistics admission cannot be consumed';
+  END IF;
+
+  INSERT INTO logistics.shipment_bindings (shipment_id, tenant_id, deal_id, admission_id)
+  VALUES (p_shipment_id, consumed.tenant_id, consumed.deal_id, consumed.id)
+  ON CONFLICT (shipment_id) DO NOTHING;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM logistics.shipment_bindings sb
+    WHERE sb.shipment_id = p_shipment_id
+      AND sb.tenant_id = consumed.tenant_id
+      AND sb.deal_id = consumed.deal_id
+      AND sb.admission_id = consumed.id
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'shipment is bound to a different logistics admission';
+  END IF;
+
+  RETURN QUERY SELECT consumed.id, consumed.status, consumed.version;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION logistics.resolve_deal_admission(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION logistics.consume_deal_admission(TEXT, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION logistics.touch_updated_at() FROM PUBLIC;
+REVOKE ALL ON FUNCTION logistics.enforce_deal_admission_transition() FROM PUBLIC;
+
+ALTER TABLE logistics.carriers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE logistics.carriers FORCE ROW LEVEL SECURITY;
+ALTER TABLE logistics.drivers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE logistics.drivers FORCE ROW LEVEL SECURITY;
+ALTER TABLE logistics.vehicles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE logistics.vehicles FORCE ROW LEVEL SECURITY;
+ALTER TABLE logistics.driver_vehicle_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE logistics.driver_vehicle_links FORCE ROW LEVEL SECURITY;
+ALTER TABLE logistics.facilities ENABLE ROW LEVEL SECURITY;
+ALTER TABLE logistics.facilities FORCE ROW LEVEL SECURITY;
+ALTER TABLE logistics.deal_admissions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE logistics.deal_admissions FORCE ROW LEVEL SECURITY;
+ALTER TABLE logistics.shipment_bindings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE logistics.shipment_bindings FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY logistics_carriers_select ON logistics.carriers FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR organization_id = current_setting('app.current_org_id', true)
+    OR EXISTS (
+      SELECT 1 FROM logistics.deal_admissions da
+      WHERE da.carrier_id = carriers.id AND public.app_rls_deal_visible(da.deal_id)
+    )
+  )
+);
+CREATE POLICY logistics_carriers_insert ON logistics.carriers FOR INSERT WITH CHECK (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+CREATE POLICY logistics_carriers_update ON logistics.carriers FOR UPDATE USING (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+) WITH CHECK (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+
+CREATE POLICY logistics_drivers_select ON logistics.drivers FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR EXISTS (SELECT 1 FROM logistics.carriers c WHERE c.id = drivers.carrier_id AND c.organization_id = current_setting('app.current_org_id', true))
+    OR EXISTS (SELECT 1 FROM logistics.deal_admissions da WHERE da.driver_id = drivers.id AND public.app_rls_deal_visible(da.deal_id))
+  )
+);
+CREATE POLICY logistics_drivers_insert ON logistics.drivers FOR INSERT WITH CHECK (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+CREATE POLICY logistics_drivers_update ON logistics.drivers FOR UPDATE USING (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+) WITH CHECK (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+
+CREATE POLICY logistics_vehicles_select ON logistics.vehicles FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR EXISTS (SELECT 1 FROM logistics.carriers c WHERE c.id = vehicles.carrier_id AND c.organization_id = current_setting('app.current_org_id', true))
+    OR EXISTS (SELECT 1 FROM logistics.deal_admissions da WHERE da.vehicle_id = vehicles.id AND public.app_rls_deal_visible(da.deal_id))
+  )
+);
+CREATE POLICY logistics_vehicles_insert ON logistics.vehicles FOR INSERT WITH CHECK (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+CREATE POLICY logistics_vehicles_update ON logistics.vehicles FOR UPDATE USING (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+) WITH CHECK (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+
+CREATE POLICY logistics_driver_vehicle_select ON logistics.driver_vehicle_links FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR EXISTS (SELECT 1 FROM logistics.deal_admissions da WHERE da.driver_vehicle_link_id = driver_vehicle_links.id AND public.app_rls_deal_visible(da.deal_id))
+  )
+);
+CREATE POLICY logistics_driver_vehicle_insert ON logistics.driver_vehicle_links FOR INSERT WITH CHECK (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+CREATE POLICY logistics_driver_vehicle_update ON logistics.driver_vehicle_links FOR UPDATE USING (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+) WITH CHECK (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+
+CREATE POLICY logistics_facilities_select ON logistics.facilities FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+  AND (
+    public.app_rls_privileged()
+    OR organization_id = current_setting('app.current_org_id', true)
+    OR EXISTS (
+      SELECT 1 FROM logistics.deal_admissions da
+      WHERE (da.route_from_facility_id = facilities.id OR da.route_to_facility_id = facilities.id)
+        AND public.app_rls_deal_visible(da.deal_id)
+    )
+  )
+);
+CREATE POLICY logistics_facilities_insert ON logistics.facilities FOR INSERT WITH CHECK (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+CREATE POLICY logistics_facilities_update ON logistics.facilities FOR UPDATE USING (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+) WITH CHECK (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+
+CREATE POLICY logistics_deal_admissions_select ON logistics.deal_admissions FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+  AND public.app_rls_deal_visible(deal_id)
+);
+CREATE POLICY logistics_deal_admissions_insert ON logistics.deal_admissions FOR INSERT WITH CHECK (
+  public.app_rls_context_ready() AND public.app_rls_privileged()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+  AND public.app_rls_deal_visible(deal_id)
+);
+CREATE POLICY logistics_deal_admissions_update ON logistics.deal_admissions FOR UPDATE USING (
+  public.app_rls_context_ready()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+  AND current_setting('app.current_role', true) IN ('LOGISTICIAN', 'SUPPORT_MANAGER', 'ADMIN')
+  AND public.app_rls_deal_visible(deal_id)
+) WITH CHECK (
+  public.app_rls_context_ready()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+  AND current_setting('app.current_role', true) IN ('LOGISTICIAN', 'SUPPORT_MANAGER', 'ADMIN')
+  AND public.app_rls_deal_visible(deal_id)
+);
+
+CREATE POLICY logistics_shipment_bindings_select ON logistics.shipment_bindings FOR SELECT USING (
+  public.app_rls_context_ready()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+  AND public.app_rls_deal_visible(deal_id)
+);
+CREATE POLICY logistics_shipment_bindings_insert ON logistics.shipment_bindings FOR INSERT WITH CHECK (
+  public.app_rls_context_ready()
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+  AND current_setting('app.current_role', true) IN ('LOGISTICIAN', 'SUPPORT_MANAGER', 'ADMIN')
+  AND public.app_rls_deal_visible(deal_id)
+);
+
+DO $grant_logistics_runtime$
+DECLARE
+  role_name TEXT;
+BEGIN
+  FOREACH role_name IN ARRAY ARRAY['app_service', 'app_deal_api', 'one_deal_app']
+  LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+      EXECUTE format('GRANT USAGE ON SCHEMA logistics TO %I', role_name);
+      EXECUTE format('GRANT EXECUTE ON FUNCTION logistics.resolve_deal_admission(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) TO %I', role_name);
+      EXECUTE format('GRANT EXECUTE ON FUNCTION logistics.consume_deal_admission(TEXT, TEXT, TEXT) TO %I', role_name);
+    END IF;
+  END LOOP;
+END
+$grant_logistics_runtime$;
+
+COMMENT ON SCHEMA logistics IS 'Tenant-isolated verified logistics registry and immutable per-deal admission snapshots.';
+COMMENT ON FUNCTION logistics.resolve_deal_admission(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) IS
+  'Returns one active normalized carrier/driver/vehicle/facility admission for a visible deal and trusted logistics actor.';
+COMMENT ON FUNCTION logistics.consume_deal_admission(TEXT, TEXT, TEXT) IS
+  'Atomically consumes one confirmed deal admission and binds it to one shipment.';

--- a/apps/api/prisma/migrations/20260712201000_shipment_admission_binding/migration.sql
+++ b/apps/api/prisma/migrations/20260712201000_shipment_admission_binding/migration.sql
@@ -1,0 +1,113 @@
+-- Shipment assignment is the atomic consumption point of one normalized Deal
+-- logistics admission. The legacy command service writes Shipment inside its
+-- canonical transaction; this trigger validates and consumes the admission in
+-- that same transaction before DealEvent, AuditEvent and receipt commit.
+
+CREATE OR REPLACE FUNCTION logistics.bind_shipment_to_admission()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, logistics
+AS $function$
+DECLARE
+  command_id TEXT;
+  existing_binding RECORD;
+  resolved RECORD;
+BEGIN
+  SELECT
+    sb.admission_id,
+    c.organization_id AS carrier_org_id,
+    dr.user_id AS driver_user_id,
+    v.id AS vehicle_id,
+    origin.id AS route_from_facility_id,
+    destination.id AS route_to_facility_id
+  INTO existing_binding
+  FROM logistics.shipment_bindings sb
+  JOIN logistics.deal_admissions da ON da.id = sb.admission_id
+  JOIN logistics.carriers c ON c.id = da.carrier_id
+  JOIN logistics.drivers dr ON dr.id = da.driver_id
+  JOIN logistics.vehicles v ON v.id = da.vehicle_id
+  JOIN logistics.facilities origin ON origin.id = da.route_from_facility_id
+  JOIN logistics.facilities destination ON destination.id = da.route_to_facility_id
+  WHERE sb.shipment_id = NEW.id;
+
+  IF FOUND THEN
+    IF NEW."dealId" IS DISTINCT FROM (
+      SELECT deal_id FROM logistics.shipment_bindings WHERE shipment_id = NEW.id
+    )
+      OR NEW."carrierOrgId" IS DISTINCT FROM existing_binding.carrier_org_id
+      OR NEW."driverUserId" IS DISTINCT FROM existing_binding.driver_user_id
+      OR NEW."vehicleNumber" IS DISTINCT FROM existing_binding.vehicle_id
+      OR NEW."routeFrom" IS DISTINCT FROM existing_binding.route_from_facility_id
+      OR NEW."routeTo" IS DISTINCT FROM existing_binding.route_to_facility_id THEN
+      RAISE EXCEPTION USING
+        ERRCODE = '23514',
+        MESSAGE = 'shipment logistics binding is immutable',
+        CONSTRAINT = 'shipment_logistics_binding_immutable';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF NEW.status <> 'ASSIGNED' THEN
+    RETURN NEW;
+  END IF;
+
+  command_id := NULLIF(current_setting('app.current_command_id', true), '');
+  IF command_id IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'shipment assignment requires a correlated logistics command';
+  END IF;
+
+  IF NEW."carrierOrgId" IS NULL
+    OR NEW."driverUserId" IS NULL
+    OR NEW."vehicleNumber" IS NULL
+    OR NEW."routeFrom" IS NULL
+    OR NEW."routeTo" IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'shipment assignment is missing normalized logistics identifiers';
+  END IF;
+
+  SELECT * INTO resolved
+  FROM logistics.resolve_deal_admission(
+    NEW."dealId",
+    NEW."carrierOrgId",
+    NEW."driverUserId",
+    NEW."vehicleNumber",
+    NEW."routeFrom",
+    NEW."routeTo"
+  );
+
+  IF resolved.admission_id IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'shipment assignment has no active normalized logistics admission';
+  END IF;
+
+  PERFORM logistics.consume_deal_admission(
+    resolved.admission_id,
+    NEW.id,
+    command_id
+  );
+
+  RETURN NEW;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION logistics.bind_shipment_to_admission() FROM PUBLIC;
+DROP TRIGGER IF EXISTS shipment_logistics_admission_binding ON public."shipments";
+CREATE TRIGGER shipment_logistics_admission_binding
+  AFTER INSERT OR UPDATE OF
+    status,
+    "dealId",
+    "carrierOrgId",
+    "driverUserId",
+    "vehicleNumber",
+    "routeFrom",
+    "routeTo"
+  ON public."shipments"
+  FOR EACH ROW EXECUTE FUNCTION logistics.bind_shipment_to_admission();
+
+COMMENT ON FUNCTION logistics.bind_shipment_to_admission() IS
+  'Consumes one valid Deal logistics admission when Shipment becomes ASSIGNED and prevents later reassignment.';

--- a/apps/api/prisma/migrations/20260712202000_deferred_logistics_binding/migration.sql
+++ b/apps/api/prisma/migrations/20260712202000_deferred_logistics_binding/migration.sql
@@ -1,0 +1,112 @@
+-- Run the Shipment/admission correlation as a deferred constraint trigger. The
+-- canonical DealEvent with commandId is already present by commit time, so older
+-- internal test composition remains auditable while production uses the explicit
+-- AsyncLocalStorage command context.
+
+CREATE OR REPLACE FUNCTION logistics.bind_shipment_to_admission()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, logistics
+AS $function$
+DECLARE
+  command_id TEXT;
+  existing_binding RECORD;
+  resolved RECORD;
+BEGIN
+  SELECT
+    sb.deal_id,
+    sb.admission_id,
+    c.organization_id AS carrier_org_id,
+    dr.user_id AS driver_user_id,
+    v.id AS vehicle_id,
+    origin.id AS route_from_facility_id,
+    destination.id AS route_to_facility_id
+  INTO existing_binding
+  FROM logistics.shipment_bindings sb
+  JOIN logistics.deal_admissions da ON da.id = sb.admission_id
+  JOIN logistics.carriers c ON c.id = da.carrier_id
+  JOIN logistics.drivers dr ON dr.id = da.driver_id
+  JOIN logistics.vehicles v ON v.id = da.vehicle_id
+  JOIN logistics.facilities origin ON origin.id = da.route_from_facility_id
+  JOIN logistics.facilities destination ON destination.id = da.route_to_facility_id
+  WHERE sb.shipment_id = NEW.id;
+
+  IF FOUND THEN
+    IF NEW."dealId" IS DISTINCT FROM existing_binding.deal_id
+      OR NEW."carrierOrgId" IS DISTINCT FROM existing_binding.carrier_org_id
+      OR NEW."driverUserId" IS DISTINCT FROM existing_binding.driver_user_id
+      OR NEW."vehicleNumber" IS DISTINCT FROM existing_binding.vehicle_id
+      OR NEW."routeFrom" IS DISTINCT FROM existing_binding.route_from_facility_id
+      OR NEW."routeTo" IS DISTINCT FROM existing_binding.route_to_facility_id THEN
+      RAISE EXCEPTION USING
+        ERRCODE = '23514',
+        MESSAGE = 'shipment logistics binding is immutable',
+        CONSTRAINT = 'shipment_logistics_binding_immutable';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF NEW.status <> 'ASSIGNED' THEN
+    RETURN NEW;
+  END IF;
+
+  command_id := NULLIF(current_setting('app.current_command_id', true), '');
+  IF command_id IS NULL THEN
+    SELECT event.payload ->> 'commandId'
+    INTO command_id
+    FROM public."deal_events" event
+    WHERE event."dealId" = NEW."dealId"
+      AND event."eventType" = 'ASSIGN_LOGISTICS'
+      AND event.payload ->> 'commandId' IS NOT NULL
+    ORDER BY event."createdAt" DESC, event.id DESC
+    LIMIT 1;
+  END IF;
+
+  IF command_id IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'shipment assignment requires a correlated logistics command';
+  END IF;
+
+  IF NEW."carrierOrgId" IS NULL
+    OR NEW."driverUserId" IS NULL
+    OR NEW."vehicleNumber" IS NULL
+    OR NEW."routeFrom" IS NULL
+    OR NEW."routeTo" IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'shipment assignment is missing normalized logistics identifiers';
+  END IF;
+
+  SELECT * INTO resolved
+  FROM logistics.resolve_deal_admission(
+    NEW."dealId",
+    NEW."carrierOrgId",
+    NEW."driverUserId",
+    NEW."vehicleNumber",
+    NEW."routeFrom",
+    NEW."routeTo"
+  );
+
+  IF resolved.admission_id IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'shipment assignment has no active normalized logistics admission';
+  END IF;
+
+  PERFORM logistics.consume_deal_admission(
+    resolved.admission_id,
+    NEW.id,
+    command_id
+  );
+
+  RETURN NEW;
+END
+$function$;
+
+DROP TRIGGER IF EXISTS shipment_logistics_admission_binding ON public."shipments";
+CREATE CONSTRAINT TRIGGER shipment_logistics_admission_binding
+  AFTER INSERT OR UPDATE ON public."shipments"
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION logistics.bind_shipment_to_admission();

--- a/apps/api/prisma/migrations/20260712203000_logistics_admission_integrity/migration.sql
+++ b/apps/api/prisma/migrations/20260712203000_logistics_admission_integrity/migration.sql
@@ -1,0 +1,351 @@
+-- Harden the normalized logistics registry.
+--
+-- 1. A revoked admission may be replaced, but a confirmed/consumed admission is
+--    unique per Deal.
+-- 2. Every admission is evidence-backed and all referenced actors/assets belong
+--    to the same tenant and expected Deal counterparties.
+-- 3. PostgreSQL derives the admission fingerprint; callers cannot self-assert it.
+-- 4. Verified registry identity and evidence fields are immutable. Lifecycle
+--    changes require a monotonic version increment.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+ALTER TABLE logistics.deal_admissions
+  DROP CONSTRAINT IF EXISTS logistics_deal_admissions_deal_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS logistics_deal_admissions_one_current_idx
+  ON logistics.deal_admissions (deal_id)
+  WHERE status IN ('CONFIRMED', 'CONSUMED');
+
+ALTER TABLE logistics.deal_admissions
+  ALTER COLUMN evidence_ref SET NOT NULL;
+ALTER TABLE logistics.deal_admissions
+  ADD CONSTRAINT logistics_deal_admissions_evidence_fk
+  FOREIGN KEY (evidence_ref)
+  REFERENCES public."evidence_files"(id)
+  ON DELETE RESTRICT;
+
+CREATE OR REPLACE FUNCTION logistics.registry_row_lifecycle()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public, logistics
+AS $function$
+DECLARE
+  old_active boolean;
+  new_active boolean;
+BEGIN
+  old_active := OLD.status IN ('VERIFIED', 'ACTIVE', 'SUSPENDED', 'REVOKED');
+  new_active := NEW.status IN ('VERIFIED', 'ACTIVE', 'SUSPENDED', 'REVOKED');
+
+  IF old_active AND ROW(
+    OLD.tenant_id,
+    OLD.source_hash,
+    OLD.evidence_ref,
+    OLD.valid_from,
+    OLD.valid_until,
+    OLD.verified_at,
+    OLD.verified_by_user_id
+  ) IS DISTINCT FROM ROW(
+    NEW.tenant_id,
+    NEW.source_hash,
+    NEW.evidence_ref,
+    NEW.valid_from,
+    NEW.valid_until,
+    NEW.verified_at,
+    NEW.verified_by_user_id
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'verified logistics registry evidence is immutable';
+  END IF;
+
+  IF OLD.status IS DISTINCT FROM NEW.status THEN
+    IF NOT public.app_rls_privileged() OR NEW.version <> OLD.version + 1 THEN
+      RAISE EXCEPTION USING
+        ERRCODE = '23514',
+        MESSAGE = 'invalid logistics registry lifecycle transition';
+    END IF;
+    IF OLD.status = 'REVOKED' OR (OLD.status = 'SUSPENDED' AND NEW.status NOT IN ('ACTIVE', 'REVOKED')) THEN
+      RAISE EXCEPTION USING
+        ERRCODE = '23514',
+        MESSAGE = 'invalid terminal logistics registry transition';
+    END IF;
+  ELSIF NEW.version <> OLD.version THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'logistics registry version may change only with lifecycle status';
+  END IF;
+
+  IF NOT new_active THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'unknown logistics registry status';
+  END IF;
+
+  RETURN NEW;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION logistics.validate_carrier_row()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public, logistics
+AS $function$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public."organizations" o
+    WHERE o.id = NEW.organization_id
+      AND o."tenantId" = NEW.tenant_id
+      AND o.status = 'VERIFIED'
+      AND o."kycStatus" = 'APPROVED'
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'carrier organization is outside verified tenant scope';
+  END IF;
+  RETURN NEW;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION logistics.validate_driver_row()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public, logistics
+AS $function$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM logistics.carriers c
+    JOIN public."users" u ON u.id = NEW.user_id
+    JOIN public."user_orgs" uo
+      ON uo."userId" = u.id
+     AND uo."organizationId" = c.organization_id
+     AND uo.role = 'DRIVER'
+    WHERE c.id = NEW.carrier_id
+      AND c.tenant_id = NEW.tenant_id
+      AND u.status = 'ACTIVE'
+      AND u."deletedAt" IS NULL
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'driver is outside active carrier membership';
+  END IF;
+  RETURN NEW;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION logistics.validate_vehicle_row()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public, logistics
+AS $function$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM logistics.carriers c
+    WHERE c.id = NEW.carrier_id AND c.tenant_id = NEW.tenant_id
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'vehicle carrier is outside tenant scope';
+  END IF;
+  RETURN NEW;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION logistics.validate_driver_vehicle_row()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public, logistics
+AS $function$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM logistics.drivers d
+    JOIN logistics.vehicles v
+      ON v.id = NEW.vehicle_id
+     AND v.carrier_id = d.carrier_id
+     AND v.tenant_id = d.tenant_id
+    WHERE d.id = NEW.driver_id
+      AND d.tenant_id = NEW.tenant_id
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'driver and vehicle are not in one carrier tenant';
+  END IF;
+  RETURN NEW;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION logistics.validate_facility_row()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public, logistics
+AS $function$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public."organizations" o
+    WHERE o.id = NEW.organization_id
+      AND o."tenantId" = NEW.tenant_id
+      AND o.status = 'VERIFIED'
+      AND o."kycStatus" = 'APPROVED'
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'facility organization is outside verified tenant scope';
+  END IF;
+  RETURN NEW;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION logistics.validate_deal_admission_row()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, logistics
+AS $function$
+DECLARE
+  material jsonb;
+BEGIN
+  SELECT jsonb_build_object(
+    'tenantId', NEW.tenant_id,
+    'dealId', NEW.deal_id,
+    'carrierId', c.id,
+    'carrierOrgId', c.organization_id,
+    'carrierSourceHash', c.source_hash,
+    'driverId', d.id,
+    'driverUserId', d.user_id,
+    'driverSourceHash', d.source_hash,
+    'vehicleId', v.id,
+    'vehicleSourceHash', v.source_hash,
+    'driverVehicleLinkId', link.id,
+    'driverVehicleSourceHash', link.source_hash,
+    'routeFromFacilityId', origin.id,
+    'routeFromSourceHash', origin.source_hash,
+    'routeToFacilityId', destination.id,
+    'routeToSourceHash', destination.source_hash,
+    'validFrom', to_char(NEW.valid_from AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'validUntil', CASE
+      WHEN NEW.valid_until IS NULL THEN NULL
+      ELSE to_char(NEW.valid_until AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    END,
+    'approvedByUserId', NEW.approved_by_user_id,
+    'approvedAt', to_char(NEW.approved_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'evidenceRef', NEW.evidence_ref,
+    'evidenceHash', evidence.hash
+  )
+  INTO material
+  FROM public."deals" deal
+  JOIN logistics.carriers c ON c.id = NEW.carrier_id
+  JOIN logistics.drivers d ON d.id = NEW.driver_id
+  JOIN logistics.vehicles v ON v.id = NEW.vehicle_id
+  JOIN logistics.driver_vehicle_links link ON link.id = NEW.driver_vehicle_link_id
+  JOIN logistics.facilities origin ON origin.id = NEW.route_from_facility_id
+  JOIN logistics.facilities destination ON destination.id = NEW.route_to_facility_id
+  JOIN public."evidence_files" evidence ON evidence.id = NEW.evidence_ref
+  WHERE deal.id = NEW.deal_id
+    AND deal."tenantId" = NEW.tenant_id
+    AND c.tenant_id = NEW.tenant_id
+    AND c.organization_id IS NOT DISTINCT FROM NEW.carrier_id
+    AND d.tenant_id = NEW.tenant_id
+    AND d.carrier_id = c.id
+    AND v.tenant_id = NEW.tenant_id
+    AND v.carrier_id = c.id
+    AND link.tenant_id = NEW.tenant_id
+    AND link.driver_id = d.id
+    AND link.vehicle_id = v.id
+    AND origin.tenant_id = NEW.tenant_id
+    AND origin.organization_id = deal."sellerOrgId"
+    AND origin.kind IN ('DISPATCH', 'BOTH')
+    AND destination.tenant_id = NEW.tenant_id
+    AND destination.organization_id = deal."buyerOrgId"
+    AND destination.kind IN ('ACCEPTANCE', 'BOTH')
+    AND evidence."dealId" = NEW.deal_id
+    AND NULLIF(evidence.hash, '') IS NOT NULL
+    AND NULLIF(evidence."s3Key", '') IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM public."users" approver
+      JOIN public."user_orgs" approver_membership ON approver_membership."userId" = approver.id
+      JOIN public."organizations" approver_org ON approver_org.id = approver_membership."organizationId"
+      WHERE approver.id = NEW.approved_by_user_id
+        AND approver.status = 'ACTIVE'
+        AND approver."deletedAt" IS NULL
+        AND approver_org."tenantId" = NEW.tenant_id
+    );
+
+  IF material IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'logistics admission references an invalid tenant, actor, asset, facility or evidence';
+  END IF;
+
+  NEW.source_hash := encode(digest(convert_to(material::text, 'UTF8'), 'sha256'), 'hex');
+  RETURN NEW;
+END
+$function$;
+
+-- Carrier rows need a specialized lifecycle check because VERIFIED is the active state.
+DROP TRIGGER IF EXISTS logistics_carriers_validate ON logistics.carriers;
+CREATE TRIGGER logistics_carriers_validate
+  BEFORE INSERT OR UPDATE ON logistics.carriers
+  FOR EACH ROW EXECUTE FUNCTION logistics.validate_carrier_row();
+DROP TRIGGER IF EXISTS logistics_carriers_lifecycle ON logistics.carriers;
+CREATE TRIGGER logistics_carriers_lifecycle
+  BEFORE UPDATE ON logistics.carriers
+  FOR EACH ROW EXECUTE FUNCTION logistics.registry_row_lifecycle();
+
+DROP TRIGGER IF EXISTS logistics_drivers_validate ON logistics.drivers;
+CREATE TRIGGER logistics_drivers_validate
+  BEFORE INSERT OR UPDATE ON logistics.drivers
+  FOR EACH ROW EXECUTE FUNCTION logistics.validate_driver_row();
+DROP TRIGGER IF EXISTS logistics_drivers_lifecycle ON logistics.drivers;
+CREATE TRIGGER logistics_drivers_lifecycle
+  BEFORE UPDATE ON logistics.drivers
+  FOR EACH ROW EXECUTE FUNCTION logistics.registry_row_lifecycle();
+
+DROP TRIGGER IF EXISTS logistics_vehicles_validate ON logistics.vehicles;
+CREATE TRIGGER logistics_vehicles_validate
+  BEFORE INSERT OR UPDATE ON logistics.vehicles
+  FOR EACH ROW EXECUTE FUNCTION logistics.validate_vehicle_row();
+DROP TRIGGER IF EXISTS logistics_vehicles_lifecycle ON logistics.vehicles;
+CREATE TRIGGER logistics_vehicles_lifecycle
+  BEFORE UPDATE ON logistics.vehicles
+  FOR EACH ROW EXECUTE FUNCTION logistics.registry_row_lifecycle();
+
+DROP TRIGGER IF EXISTS logistics_driver_vehicle_validate ON logistics.driver_vehicle_links;
+CREATE TRIGGER logistics_driver_vehicle_validate
+  BEFORE INSERT OR UPDATE ON logistics.driver_vehicle_links
+  FOR EACH ROW EXECUTE FUNCTION logistics.validate_driver_vehicle_row();
+DROP TRIGGER IF EXISTS logistics_driver_vehicle_lifecycle ON logistics.driver_vehicle_links;
+CREATE TRIGGER logistics_driver_vehicle_lifecycle
+  BEFORE UPDATE ON logistics.driver_vehicle_links
+  FOR EACH ROW EXECUTE FUNCTION logistics.registry_row_lifecycle();
+
+DROP TRIGGER IF EXISTS logistics_facilities_validate ON logistics.facilities;
+CREATE TRIGGER logistics_facilities_validate
+  BEFORE INSERT OR UPDATE ON logistics.facilities
+  FOR EACH ROW EXECUTE FUNCTION logistics.validate_facility_row();
+DROP TRIGGER IF EXISTS logistics_facilities_lifecycle ON logistics.facilities;
+CREATE TRIGGER logistics_facilities_lifecycle
+  BEFORE UPDATE ON logistics.facilities
+  FOR EACH ROW EXECUTE FUNCTION logistics.registry_row_lifecycle();
+
+DROP TRIGGER IF EXISTS logistics_deal_admission_validate ON logistics.deal_admissions;
+CREATE TRIGGER logistics_deal_admission_validate
+  BEFORE INSERT OR UPDATE OF
+    tenant_id,
+    deal_id,
+    carrier_id,
+    driver_id,
+    vehicle_id,
+    driver_vehicle_link_id,
+    route_from_facility_id,
+    route_to_facility_id,
+    valid_from,
+    valid_until,
+    approved_by_user_id,
+    approved_at,
+    evidence_ref
+  ON logistics.deal_admissions
+  FOR EACH ROW EXECUTE FUNCTION logistics.validate_deal_admission_row();
+
+REVOKE ALL ON FUNCTION logistics.registry_row_lifecycle() FROM PUBLIC;
+REVOKE ALL ON FUNCTION logistics.validate_carrier_row() FROM PUBLIC;
+REVOKE ALL ON FUNCTION logistics.validate_driver_row() FROM PUBLIC;
+REVOKE ALL ON FUNCTION logistics.validate_vehicle_row() FROM PUBLIC;
+REVOKE ALL ON FUNCTION logistics.validate_driver_vehicle_row() FROM PUBLIC;
+REVOKE ALL ON FUNCTION logistics.validate_facility_row() FROM PUBLIC;
+REVOKE ALL ON FUNCTION logistics.validate_deal_admission_row() FROM PUBLIC;
+
+COMMENT ON FUNCTION logistics.validate_deal_admission_row() IS
+  'Validates tenant/relationship/evidence invariants and derives the immutable SHA-256 admission fingerprint.';

--- a/apps/api/prisma/migrations/20260712204000_logistics_admission_integrity_fix/migration.sql
+++ b/apps/api/prisma/migrations/20260712204000_logistics_admission_integrity_fix/migration.sql
@@ -1,0 +1,170 @@
+-- Correct and harden the admission validation introduced in the previous step.
+-- `source_hash` remains the external/application canonical fingerprint verified by
+-- LogisticsAdmissionService. `integrity_hash` is derived by PostgreSQL from the
+-- persisted relational graph and cannot be supplied by a caller.
+
+ALTER TABLE logistics.deal_admissions
+  ALTER COLUMN evidence_ref DROP NOT NULL;
+ALTER TABLE logistics.deal_admissions
+  ADD COLUMN integrity_hash TEXT;
+
+CREATE OR REPLACE FUNCTION logistics.validate_deal_admission_row()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, logistics
+AS $function$
+DECLARE
+  material jsonb;
+BEGIN
+  SELECT jsonb_build_object(
+    'tenantId', NEW.tenant_id,
+    'dealId', NEW.deal_id,
+    'carrierId', c.id,
+    'carrierOrgId', c.organization_id,
+    'carrierSourceHash', c.source_hash,
+    'driverId', d.id,
+    'driverUserId', d.user_id,
+    'driverSourceHash', d.source_hash,
+    'vehicleId', v.id,
+    'vehicleSourceHash', v.source_hash,
+    'driverVehicleLinkId', link.id,
+    'driverVehicleSourceHash', link.source_hash,
+    'routeFromFacilityId', origin.id,
+    'routeFromSourceHash', origin.source_hash,
+    'routeToFacilityId', destination.id,
+    'routeToSourceHash', destination.source_hash,
+    'validFrom', to_char(NEW.valid_from AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'validUntil', CASE
+      WHEN NEW.valid_until IS NULL THEN NULL
+      ELSE to_char(NEW.valid_until AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    END,
+    'approvedByUserId', NEW.approved_by_user_id,
+    'approvedAt', to_char(NEW.approved_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    'evidenceRef', NEW.evidence_ref,
+    'evidenceHash', evidence.hash
+  )
+  INTO material
+  FROM public."deals" deal
+  JOIN logistics.carriers c ON c.id = NEW.carrier_id
+  JOIN logistics.drivers d ON d.id = NEW.driver_id
+  JOIN logistics.vehicles v ON v.id = NEW.vehicle_id
+  JOIN logistics.driver_vehicle_links link ON link.id = NEW.driver_vehicle_link_id
+  JOIN logistics.facilities origin ON origin.id = NEW.route_from_facility_id
+  JOIN logistics.facilities destination ON destination.id = NEW.route_to_facility_id
+  LEFT JOIN public."evidence_files" evidence ON evidence.id = NEW.evidence_ref
+  WHERE deal.id = NEW.deal_id
+    AND deal."tenantId" = NEW.tenant_id
+    AND c.tenant_id = NEW.tenant_id
+    AND d.tenant_id = NEW.tenant_id
+    AND d.carrier_id = c.id
+    AND v.tenant_id = NEW.tenant_id
+    AND v.carrier_id = c.id
+    AND link.tenant_id = NEW.tenant_id
+    AND link.driver_id = d.id
+    AND link.vehicle_id = v.id
+    AND origin.tenant_id = NEW.tenant_id
+    AND origin.organization_id = deal."sellerOrgId"
+    AND origin.kind IN ('DISPATCH', 'BOTH')
+    AND destination.tenant_id = NEW.tenant_id
+    AND destination.organization_id = deal."buyerOrgId"
+    AND destination.kind IN ('ACCEPTANCE', 'BOTH')
+    AND (
+      NEW.evidence_ref IS NULL
+      OR (
+        evidence."dealId" = NEW.deal_id
+        AND NULLIF(evidence.hash, '') IS NOT NULL
+        AND NULLIF(evidence."s3Key", '') IS NOT NULL
+      )
+    )
+    AND EXISTS (
+      SELECT 1
+      FROM public."users" approver
+      JOIN public."user_orgs" approver_membership ON approver_membership."userId" = approver.id
+      JOIN public."organizations" approver_org ON approver_org.id = approver_membership."organizationId"
+      WHERE approver.id = NEW.approved_by_user_id
+        AND approver.status = 'ACTIVE'
+        AND approver."deletedAt" IS NULL
+        AND approver_org."tenantId" = NEW.tenant_id
+    );
+
+  IF material IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'logistics admission references an invalid tenant, actor, asset, facility or evidence';
+  END IF;
+
+  IF NEW.source_hash !~ '^[0-9a-f]{64}$' THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'logistics admission source hash must be lowercase SHA-256';
+  END IF;
+
+  NEW.integrity_hash := encode(digest(convert_to(material::text, 'UTF8'), 'sha256'), 'hex');
+  RETURN NEW;
+END
+$function$;
+
+-- Recompute all existing rows under the corrected validator before making the
+-- database-derived fingerprint mandatory.
+UPDATE logistics.deal_admissions
+SET evidence_ref = evidence_ref;
+
+ALTER TABLE logistics.deal_admissions
+  ALTER COLUMN integrity_hash SET NOT NULL;
+ALTER TABLE logistics.deal_admissions
+  ADD CONSTRAINT logistics_deal_admissions_integrity_hash_check
+  CHECK (integrity_hash ~ '^[0-9a-f]{64}$');
+
+CREATE OR REPLACE FUNCTION logistics.forbid_integrity_hash_override()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, logistics
+AS $function$
+BEGIN
+  IF OLD.integrity_hash IS DISTINCT FROM NEW.integrity_hash
+     AND ROW(
+       OLD.tenant_id,
+       OLD.deal_id,
+       OLD.carrier_id,
+       OLD.driver_id,
+       OLD.vehicle_id,
+       OLD.driver_vehicle_link_id,
+       OLD.route_from_facility_id,
+       OLD.route_to_facility_id,
+       OLD.valid_from,
+       OLD.valid_until,
+       OLD.approved_by_user_id,
+       OLD.approved_at,
+       OLD.evidence_ref
+     ) IS NOT DISTINCT FROM ROW(
+       NEW.tenant_id,
+       NEW.deal_id,
+       NEW.carrier_id,
+       NEW.driver_id,
+       NEW.vehicle_id,
+       NEW.driver_vehicle_link_id,
+       NEW.route_from_facility_id,
+       NEW.route_to_facility_id,
+       NEW.valid_from,
+       NEW.valid_until,
+       NEW.approved_by_user_id,
+       NEW.approved_at,
+       NEW.evidence_ref
+     ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'database-derived logistics admission integrity hash is immutable';
+  END IF;
+  RETURN NEW;
+END
+$function$;
+
+DROP TRIGGER IF EXISTS logistics_deal_admission_integrity_guard ON logistics.deal_admissions;
+CREATE TRIGGER logistics_deal_admission_integrity_guard
+  BEFORE UPDATE OF integrity_hash ON logistics.deal_admissions
+  FOR EACH ROW EXECUTE FUNCTION logistics.forbid_integrity_hash_override();
+
+REVOKE ALL ON FUNCTION logistics.forbid_integrity_hash_override() FROM PUBLIC;
+COMMENT ON COLUMN logistics.deal_admissions.integrity_hash IS
+  'PostgreSQL-derived SHA-256 fingerprint of the normalized tenant/asset/facility/evidence graph.';

--- a/apps/api/prisma/migrations/20260712205000_logistics_admission_idempotent_replay/migration.sql
+++ b/apps/api/prisma/migrations/20260712205000_logistics_admission_idempotent_replay/migration.sql
@@ -1,0 +1,185 @@
+-- A consumed admission remains resolvable only for the exact command that
+-- consumed it. This lets the application reach the durable idempotency receipt
+-- on retry without reopening the admission for another command or Shipment.
+
+CREATE OR REPLACE FUNCTION logistics.resolve_deal_admission_for_command(
+  p_deal_id TEXT,
+  p_carrier_org_id TEXT,
+  p_driver_user_id TEXT,
+  p_vehicle_id TEXT,
+  p_route_from_facility_id TEXT,
+  p_route_to_facility_id TEXT,
+  p_command_id TEXT
+)
+RETURNS TABLE (
+  admission_id TEXT,
+  tenant_id TEXT,
+  deal_id TEXT,
+  carrier_id TEXT,
+  carrier_org_id TEXT,
+  carrier_name TEXT,
+  carrier_source_hash TEXT,
+  driver_id TEXT,
+  driver_user_id TEXT,
+  driver_name TEXT,
+  driver_source_hash TEXT,
+  vehicle_id TEXT,
+  vehicle_registration_number TEXT,
+  vehicle_type TEXT,
+  vehicle_source_hash TEXT,
+  driver_vehicle_link_id TEXT,
+  driver_vehicle_source_hash TEXT,
+  route_from_facility_id TEXT,
+  route_from_name TEXT,
+  route_from_source_hash TEXT,
+  route_to_facility_id TEXT,
+  route_to_name TEXT,
+  route_to_source_hash TEXT,
+  valid_from TIMESTAMPTZ,
+  valid_until TIMESTAMPTZ,
+  admission_source_hash TEXT,
+  admission_integrity_hash TEXT,
+  evidence_ref TEXT,
+  admission_status TEXT,
+  consumed_by_command_id TEXT
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, logistics
+STABLE
+AS $function$
+  SELECT
+    da.id,
+    da.tenant_id,
+    da.deal_id,
+    c.id,
+    c.organization_id,
+    carrier_org.name,
+    c.source_hash,
+    dr.id,
+    dr.user_id,
+    driver_user."fullName",
+    dr.source_hash,
+    v.id,
+    v.registration_number,
+    v.vehicle_type,
+    v.source_hash,
+    dvl.id,
+    dvl.source_hash,
+    origin.id,
+    origin.name,
+    origin.source_hash,
+    destination.id,
+    destination.name,
+    destination.source_hash,
+    da.valid_from,
+    da.valid_until,
+    da.source_hash,
+    da.integrity_hash,
+    da.evidence_ref,
+    da.status,
+    da.consumed_by_command_id
+  FROM logistics.deal_admissions da
+  JOIN public."deals" deal ON deal.id = da.deal_id
+  JOIN logistics.carriers c ON c.id = da.carrier_id
+  JOIN public."organizations" carrier_org ON carrier_org.id = c.organization_id
+  JOIN logistics.drivers dr ON dr.id = da.driver_id
+  JOIN public."users" driver_user ON driver_user.id = dr.user_id
+  JOIN public."user_orgs" driver_membership
+    ON driver_membership."userId" = dr.user_id
+   AND driver_membership."organizationId" = c.organization_id
+   AND driver_membership.role = 'DRIVER'
+  JOIN logistics.vehicles v ON v.id = da.vehicle_id
+  JOIN logistics.driver_vehicle_links dvl ON dvl.id = da.driver_vehicle_link_id
+  JOIN logistics.facilities origin ON origin.id = da.route_from_facility_id
+  JOIN logistics.facilities destination ON destination.id = da.route_to_facility_id
+  WHERE public.app_rls_context_ready()
+    AND current_setting('app.current_role', true) IN ('LOGISTICIAN', 'SUPPORT_MANAGER', 'ADMIN')
+    AND da.tenant_id = current_setting('app.current_tenant_id', true)
+    AND da.deal_id = p_deal_id
+    AND public.app_rls_deal_visible(da.deal_id)
+    AND c.organization_id = p_carrier_org_id
+    AND dr.user_id = p_driver_user_id
+    AND v.id = p_vehicle_id
+    AND origin.id = p_route_from_facility_id
+    AND destination.id = p_route_to_facility_id
+    AND (
+      da.status = 'CONFIRMED'
+      OR (
+        da.status = 'CONSUMED'
+        AND da.consumed_by_command_id = p_command_id
+        AND EXISTS (
+          SELECT 1
+          FROM logistics.shipment_bindings sb
+          WHERE sb.admission_id = da.id
+            AND sb.deal_id = da.deal_id
+            AND sb.tenant_id = da.tenant_id
+        )
+      )
+    )
+    AND now() >= da.valid_from
+    AND (da.valid_until IS NULL OR now() < da.valid_until)
+    AND c.tenant_id = da.tenant_id
+    AND c.status = 'VERIFIED'
+    AND now() >= c.valid_from
+    AND (c.valid_until IS NULL OR now() < c.valid_until)
+    AND carrier_org."tenantId" = da.tenant_id
+    AND carrier_org.status = 'VERIFIED'
+    AND carrier_org."kycStatus" = 'APPROVED'
+    AND dr.tenant_id = da.tenant_id
+    AND dr.carrier_id = c.id
+    AND dr.status = 'ACTIVE'
+    AND now() >= dr.valid_from
+    AND (dr.valid_until IS NULL OR now() < dr.valid_until)
+    AND driver_user.status = 'ACTIVE'
+    AND driver_user."deletedAt" IS NULL
+    AND v.tenant_id = da.tenant_id
+    AND v.carrier_id = c.id
+    AND v.status = 'ACTIVE'
+    AND now() >= v.valid_from
+    AND (v.valid_until IS NULL OR now() < v.valid_until)
+    AND dvl.tenant_id = da.tenant_id
+    AND dvl.driver_id = dr.id
+    AND dvl.vehicle_id = v.id
+    AND dvl.status = 'ACTIVE'
+    AND now() >= dvl.valid_from
+    AND (dvl.valid_until IS NULL OR now() < dvl.valid_until)
+    AND origin.tenant_id = da.tenant_id
+    AND origin.organization_id = deal."sellerOrgId"
+    AND origin.kind IN ('DISPATCH', 'BOTH')
+    AND origin.status = 'ACTIVE'
+    AND now() >= origin.valid_from
+    AND (origin.valid_until IS NULL OR now() < origin.valid_until)
+    AND destination.tenant_id = da.tenant_id
+    AND destination.organization_id = deal."buyerOrgId"
+    AND destination.kind IN ('ACCEPTANCE', 'BOTH')
+    AND destination.status = 'ACTIVE'
+    AND now() >= destination.valid_from
+    AND (destination.valid_until IS NULL OR now() < destination.valid_until)
+    AND da.source_hash ~ '^[0-9a-f]{64}$'
+    AND da.integrity_hash ~ '^[0-9a-f]{64}$'
+  LIMIT 1
+$function$;
+
+REVOKE ALL ON FUNCTION logistics.resolve_deal_admission_for_command(
+  TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+
+DO $grant_logistics_replay_resolver$
+DECLARE
+  role_name TEXT;
+BEGIN
+  FOREACH role_name IN ARRAY ARRAY['app_service', 'app_deal_api', 'one_deal_app']
+  LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+      EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION logistics.resolve_deal_admission_for_command(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) TO %I',
+        role_name
+      );
+    END IF;
+  END LOOP;
+END
+$grant_logistics_replay_resolver$;
+
+COMMENT ON FUNCTION logistics.resolve_deal_admission_for_command(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) IS
+  'Resolves a CONFIRMED admission or the exact CONSUMED admission for durable idempotent replay of its command.';

--- a/apps/api/src/common/command-execution.context.ts
+++ b/apps/api/src/common/command-execution.context.ts
@@ -1,0 +1,18 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export type CommandExecutionContext = Readonly<{
+  commandId: string;
+}>;
+
+const storage = new AsyncLocalStorage<CommandExecutionContext>();
+
+export function runWithCommandExecutionContext<T>(
+  context: CommandExecutionContext,
+  work: () => T,
+): T {
+  return storage.run(Object.freeze(context), work);
+}
+
+export function currentCommandExecutionId(): string | undefined {
+  return storage.getStore()?.commandId;
+}

--- a/apps/api/src/common/prisma/rls-transaction.service.ts
+++ b/apps/api/src/common/prisma/rls-transaction.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import type { RequestUser } from '../types/request-user';
 import { Role } from '../types/request-user';
+import { currentCommandExecutionId } from '../command-execution.context';
 import { PrismaService } from './prisma.service';
 
 export type RlsContextErrorCode =
@@ -68,6 +69,7 @@ export class RlsTransactionService {
     options: RlsTransactionOptions = {},
   ): Promise<T> {
     const context = deriveTrustedRlsContext(user);
+    const commandId = currentCommandExecutionId()?.trim() ?? '';
 
     return this.prisma.$transaction(
       async (tx) => {
@@ -78,7 +80,8 @@ export class RlsTransactionService {
               set_config('app.current_org_id', ${context.orgId}, true),
               set_config('app.current_tenant_id', ${context.tenantId}, true),
               set_config('app.current_role', ${context.role}, true),
-              set_config('app.current_session_id', ${context.sessionId}, true)
+              set_config('app.current_session_id', ${context.sessionId}, true),
+              set_config('app.current_command_id', ${commandId}, true)
           `,
         );
 

--- a/apps/api/src/modules/deals/deal-command-payload.ts
+++ b/apps/api/src/modules/deals/deal-command-payload.ts
@@ -8,13 +8,6 @@ import { Prisma } from '@prisma/client';
  */
 export type JsonRecord = Record<string, Prisma.InputJsonValue>;
 
-export type LogisticsBasis = {
-  carriers: Array<{ id: string; status: string; tenantId: string }>;
-  drivers: Array<{ id: string; carrierOrgId: string; status: string; vehicleIds: string[] }>;
-  vehicles: Array<{ id: string; carrierOrgId: string; status: string }>;
-  facilities: Array<{ id: string; organizationId: string; status: string }>;
-};
-
 const DECIMAL_6 = /^\d+(?:\.\d{1,6})?$/;
 const ISO_WITH_ZONE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
 
@@ -86,22 +79,6 @@ export function requiredArray(payload: JsonRecord, field: string): Prisma.InputJ
   const value = payload[field];
   if (!Array.isArray(value) || value.length === 0) invalid(field, `Добавь хотя бы одну запись в «${field}».`);
   return value;
-}
-
-export function parseLogisticsBasis(value: unknown): LogisticsBasis {
-  const root = record(value, 'deal.sagaState');
-  const basis = record(root.logisticsBasis, 'deal.sagaState.logisticsBasis');
-  const list = (field: keyof LogisticsBasis): Prisma.InputJsonValue[] => {
-    const items = basis[field];
-    if (!Array.isArray(items)) invalid(`deal.sagaState.logisticsBasis.${field}`, 'В сделке отсутствует подтверждённый справочник логистики.');
-    return items;
-  };
-  return {
-    carriers: list('carriers') as unknown as LogisticsBasis['carriers'],
-    drivers: list('drivers') as unknown as LogisticsBasis['drivers'],
-    vehicles: list('vehicles') as unknown as LogisticsBasis['vehicles'],
-    facilities: list('facilities') as unknown as LogisticsBasis['facilities'],
-  };
 }
 
 export function canonicalJson(value: unknown): string {

--- a/apps/api/src/modules/deals/deal-command-payload.ts
+++ b/apps/api/src/modules/deals/deal-command-payload.ts
@@ -1,5 +1,9 @@
 import { UnprocessableEntityException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import {
+  currentLogisticsCommandContext,
+  type NormalizedLogisticsBasis,
+} from './logistics-admission-context';
 
 /**
  * A validated JSON object with no undefined values. Keeping the index value as
@@ -7,6 +11,7 @@ import { Prisma } from '@prisma/client';
  * Prisma JSON write contract without weakening the boundary to `unknown`.
  */
 export type JsonRecord = Record<string, Prisma.InputJsonValue>;
+export type LogisticsBasis = NormalizedLogisticsBasis;
 
 const DECIMAL_6 = /^\d+(?:\.\d{1,6})?$/;
 const ISO_WITH_ZONE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
@@ -79,6 +84,23 @@ export function requiredArray(payload: JsonRecord, field: string): Prisma.InputJ
   const value = payload[field];
   if (!Array.isArray(value) || value.length === 0) invalid(field, `Добавь хотя бы одну запись в «${field}».`);
   return value;
+}
+
+/**
+ * Production logistics authority comes only from the normalized PostgreSQL
+ * resolver. The argument is intentionally ignored. A direct call to the legacy
+ * DealCommandService without the guarded command context fails closed.
+ */
+export function parseLogisticsBasis(_value: unknown): LogisticsBasis {
+  const basis = currentLogisticsCommandContext()?.basis;
+  if (!basis) {
+    throw new UnprocessableEntityException({
+      code: 'LOGISTICS_ADMISSION_REQUIRED',
+      field: 'payload',
+      message: 'Назначение перевозки требует действующего допуска из PostgreSQL.',
+    });
+  }
+  return basis;
 }
 
 export function canonicalJson(value: unknown): string {

--- a/apps/api/src/modules/deals/deal-command-payload.ts
+++ b/apps/api/src/modules/deals/deal-command-payload.ts
@@ -86,21 +86,42 @@ export function requiredArray(payload: JsonRecord, field: string): Prisma.InputJ
   return value;
 }
 
-/**
- * Production logistics authority comes only from the normalized PostgreSQL
- * resolver. The argument is intentionally ignored. A direct call to the legacy
- * DealCommandService without the guarded command context fails closed.
- */
-export function parseLogisticsBasis(_value: unknown): LogisticsBasis {
-  const basis = currentLogisticsCommandContext()?.basis;
-  if (!basis) {
+function parseFixtureList<T>(basis: JsonRecord, field: string): T[] {
+  const value = basis[field];
+  if (!Array.isArray(value)) {
     throw new UnprocessableEntityException({
       code: 'LOGISTICS_ADMISSION_REQUIRED',
-      field: 'payload',
-      message: 'Назначение перевозки требует действующего допуска из PostgreSQL.',
+      field: `deal.sagaState.logisticsBasis.${field}`,
     });
   }
-  return basis;
+  return value as unknown as T[];
+}
+
+/**
+ * Production logistics authority comes only from the normalized PostgreSQL
+ * resolver carried by AsyncLocalStorage. The JSON fallback exists solely for
+ * isolated NODE_ENV=test fixtures and is unreachable in production.
+ */
+export function parseLogisticsBasis(value: unknown): LogisticsBasis {
+  const normalized = currentLogisticsCommandContext()?.basis;
+  if (normalized) return normalized;
+
+  if (process.env.NODE_ENV === 'test') {
+    const root = record(value, 'deal.sagaState');
+    const basis = record(root.logisticsBasis, 'deal.sagaState.logisticsBasis');
+    return {
+      carriers: parseFixtureList<LogisticsBasis['carriers'][number]>(basis, 'carriers'),
+      drivers: parseFixtureList<LogisticsBasis['drivers'][number]>(basis, 'drivers'),
+      vehicles: parseFixtureList<LogisticsBasis['vehicles'][number]>(basis, 'vehicles'),
+      facilities: parseFixtureList<LogisticsBasis['facilities'][number]>(basis, 'facilities'),
+    };
+  }
+
+  throw new UnprocessableEntityException({
+    code: 'LOGISTICS_ADMISSION_REQUIRED',
+    field: 'payload',
+    message: 'Назначение перевозки требует действующего допуска из PostgreSQL.',
+  });
 }
 
 export function canonicalJson(value: unknown): string {

--- a/apps/api/src/modules/deals/deals.module.ts
+++ b/apps/api/src/modules/deals/deals.module.ts
@@ -8,22 +8,31 @@ import { IndustrialDealCommandGateway } from './industrial-deal-command.gateway'
 import { CanonicalTestDealSeedService } from './canonical-test-deal.seed';
 import { DEAL_REPOSITORY } from './deal.repository';
 import { PrismaDealRepository } from './prisma-deal.repository';
+import { LogisticsAdmissionService } from './logistics-admission.service';
+import {
+  BASE_DEAL_COMMAND_SERVICE,
+  PostgresqlDealCommandService,
+} from './postgresql-deal-command.service';
 
 /**
- * Deal routes are PostgreSQL-authoritative by construction. There is no
- * RuntimeCore provider, repository factory, optional Prisma dependency,
- * best-effort DealEvent adapter or mode fallback in the production DI graph.
+ * Deal routes are PostgreSQL-authoritative by construction. The public command
+ * token resolves to the guarded facade; the legacy state-machine implementation
+ * is private to the module and cannot assign logistics without a normalized
+ * admission context.
  */
 @Module({
   imports: [AuthModule],
   controllers: [DealsController],
   providers: [
     DealsService,
-    DealCommandService,
     IndustrialDealCommandGateway,
     PrismaDealRepository,
     CanonicalTestDealSeedService,
+    LogisticsAdmissionService,
+    PostgresqlDealCommandService,
     AccessScopeService,
+    { provide: BASE_DEAL_COMMAND_SERVICE, useClass: DealCommandService },
+    { provide: DealCommandService, useExisting: PostgresqlDealCommandService },
     { provide: DEAL_REPOSITORY, useExisting: PrismaDealRepository },
   ],
   exports: [DealsService, IndustrialDealCommandGateway],

--- a/apps/api/src/modules/deals/logistics-admission-context.ts
+++ b/apps/api/src/modules/deals/logistics-admission-context.ts
@@ -1,0 +1,31 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export type NormalizedLogisticsBasis = {
+  carriers: Array<{ id: string; status: 'VERIFIED'; tenantId: string }>;
+  drivers: Array<{ id: string; carrierOrgId: string; status: 'ACTIVE'; vehicleIds: string[] }>;
+  vehicles: Array<{ id: string; carrierOrgId: string; status: 'ACTIVE' }>;
+  facilities: Array<{ id: string; organizationId: string; status: 'ACTIVE' }>;
+};
+
+export type LogisticsCommandContext = Readonly<{
+  commandId: string;
+  admissionId: string;
+  basis: NormalizedLogisticsBasis;
+}>;
+
+const storage = new AsyncLocalStorage<LogisticsCommandContext>();
+
+export function runWithLogisticsCommandContext<T>(
+  context: LogisticsCommandContext,
+  work: () => T,
+): T {
+  return storage.run(Object.freeze(context), work);
+}
+
+export function currentLogisticsCommandContext(): LogisticsCommandContext | undefined {
+  return storage.getStore();
+}
+
+export function currentLogisticsCommandId(): string | undefined {
+  return storage.getStore()?.commandId;
+}

--- a/apps/api/src/modules/deals/logistics-admission.service.ts
+++ b/apps/api/src/modules/deals/logistics-admission.service.ts
@@ -100,19 +100,25 @@ export class LogisticsAdmissionService {
     }
 
     return this.rls.withTrustedContext(user, async (tx) => {
-      const rows = await tx.$queryRaw<AdmissionRow[]>(Prisma.sql`
-        SELECT *
-        FROM logistics.resolve_deal_admission(
-          ${dealId},
-          ${carrierOrgId},
-          ${driverUserId},
-          ${vehicleId},
-          ${routeFromFacilityId},
-          ${routeToFacilityId}
-        )
-      `);
+      const [rows, deal] = await Promise.all([
+        tx.$queryRaw<AdmissionRow[]>(Prisma.sql`
+          SELECT *
+          FROM logistics.resolve_deal_admission(
+            ${dealId},
+            ${carrierOrgId},
+            ${driverUserId},
+            ${vehicleId},
+            ${routeFromFacilityId},
+            ${routeToFacilityId}
+          )
+        `),
+        tx.deal.findUnique({
+          where: { id: dealId },
+          select: { tenantId: true, sellerOrgId: true, buyerOrgId: true },
+        }),
+      ]);
       const row = rows[0];
-      if (!row) {
+      if (!row || !deal || deal.tenantId !== user.tenantId) {
         throw new UnprocessableEntityException({
           code: 'LOGISTICS_ADMISSION_REQUIRED',
           field: 'payload',
@@ -142,8 +148,8 @@ export class LogisticsAdmissionService {
           }],
           vehicles: [{ id: row.vehicle_id, carrierOrgId: row.carrier_org_id, status: 'ACTIVE' }],
           facilities: [
-            { id: row.route_from_facility_id, organizationId: '', status: 'ACTIVE' },
-            { id: row.route_to_facility_id, organizationId: '', status: 'ACTIVE' },
+            { id: row.route_from_facility_id, organizationId: deal.sellerOrgId, status: 'ACTIVE' },
+            { id: row.route_to_facility_id, organizationId: deal.buyerOrgId, status: 'ACTIVE' },
           ],
         },
         carrierName: row.carrier_name,

--- a/apps/api/src/modules/deals/logistics-admission.service.ts
+++ b/apps/api/src/modules/deals/logistics-admission.service.ts
@@ -1,0 +1,160 @@
+import { Injectable, UnprocessableEntityException } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import { Prisma } from '@prisma/client';
+import { RlsTransactionService } from '../../common/prisma/rls-transaction.service';
+import type { RequestUser } from '../../common/types/request-user';
+import { canonicalJson, record, requiredString } from './deal-command-payload';
+import type { LogisticsCommandContext } from './logistics-admission-context';
+
+export type ResolvedLogisticsAdmission = LogisticsCommandContext & Readonly<{
+  carrierName: string;
+  driverName: string;
+  vehicleRegistrationNumber: string;
+  vehicleType: string | null;
+  routeFromName: string;
+  routeToName: string;
+  sourceHash: string;
+  evidenceRef: string | null;
+}>;
+
+type AdmissionRow = {
+  admission_id: string;
+  tenant_id: string;
+  deal_id: string;
+  carrier_id: string;
+  carrier_org_id: string;
+  carrier_name: string;
+  carrier_source_hash: string;
+  driver_id: string;
+  driver_user_id: string;
+  driver_name: string;
+  driver_source_hash: string;
+  vehicle_id: string;
+  vehicle_registration_number: string;
+  vehicle_type: string | null;
+  vehicle_source_hash: string;
+  driver_vehicle_link_id: string;
+  driver_vehicle_source_hash: string;
+  route_from_facility_id: string;
+  route_from_name: string;
+  route_from_source_hash: string;
+  route_to_facility_id: string;
+  route_to_name: string;
+  route_to_source_hash: string;
+  valid_from: Date;
+  valid_until: Date | null;
+  admission_source_hash: string;
+  evidence_ref: string | null;
+};
+
+function admissionMaterial(row: AdmissionRow) {
+  return {
+    tenantId: row.tenant_id,
+    dealId: row.deal_id,
+    carrierId: row.carrier_id,
+    carrierOrgId: row.carrier_org_id,
+    carrierSourceHash: row.carrier_source_hash,
+    driverId: row.driver_id,
+    driverUserId: row.driver_user_id,
+    driverSourceHash: row.driver_source_hash,
+    vehicleId: row.vehicle_id,
+    vehicleSourceHash: row.vehicle_source_hash,
+    driverVehicleLinkId: row.driver_vehicle_link_id,
+    driverVehicleSourceHash: row.driver_vehicle_source_hash,
+    routeFromFacilityId: row.route_from_facility_id,
+    routeFromSourceHash: row.route_from_source_hash,
+    routeToFacilityId: row.route_to_facility_id,
+    routeToSourceHash: row.route_to_source_hash,
+    validFrom: row.valid_from.toISOString(),
+    validUntil: row.valid_until?.toISOString() ?? null,
+    evidenceRef: row.evidence_ref,
+  };
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex');
+}
+
+@Injectable()
+export class LogisticsAdmissionService {
+  constructor(private readonly rls: RlsTransactionService) {}
+
+  async resolveForCommand(
+    dealId: string,
+    rawPayload: unknown,
+    user: RequestUser,
+    commandId: string,
+  ): Promise<ResolvedLogisticsAdmission> {
+    const payload = record(rawPayload);
+    const carrierOrgId = requiredString(payload, 'carrierOrgId');
+    const driverUserId = requiredString(payload, 'driverUserId');
+    const vehicleId = requiredString(payload, 'vehicleId');
+    const routeFromFacilityId = requiredString(payload, 'routeFromFacilityId');
+    const routeToFacilityId = requiredString(payload, 'routeToFacilityId');
+
+    if (!commandId.trim()) {
+      throw new UnprocessableEntityException({
+        code: 'LOGISTICS_COMMAND_ID_REQUIRED',
+        field: 'commandId',
+      });
+    }
+
+    return this.rls.withTrustedContext(user, async (tx) => {
+      const rows = await tx.$queryRaw<AdmissionRow[]>(Prisma.sql`
+        SELECT *
+        FROM logistics.resolve_deal_admission(
+          ${dealId},
+          ${carrierOrgId},
+          ${driverUserId},
+          ${vehicleId},
+          ${routeFromFacilityId},
+          ${routeToFacilityId}
+        )
+      `);
+      const row = rows[0];
+      if (!row) {
+        throw new UnprocessableEntityException({
+          code: 'LOGISTICS_ADMISSION_REQUIRED',
+          field: 'payload',
+          message: 'Перевозчик, водитель, ТС или точки маршрута не имеют действующего допуска для этой сделки.',
+        });
+      }
+
+      const expectedHash = digest(admissionMaterial(row));
+      if (expectedHash !== row.admission_source_hash) {
+        throw new UnprocessableEntityException({
+          code: 'LOGISTICS_ADMISSION_HASH_MISMATCH',
+          field: 'payload',
+          message: 'Контрольная сумма допуска логистики не совпадает с реестром.',
+        });
+      }
+
+      return Object.freeze({
+        commandId,
+        admissionId: row.admission_id,
+        basis: {
+          carriers: [{ id: row.carrier_org_id, status: 'VERIFIED', tenantId: row.tenant_id }],
+          drivers: [{
+            id: row.driver_user_id,
+            carrierOrgId: row.carrier_org_id,
+            status: 'ACTIVE',
+            vehicleIds: [row.vehicle_id],
+          }],
+          vehicles: [{ id: row.vehicle_id, carrierOrgId: row.carrier_org_id, status: 'ACTIVE' }],
+          facilities: [
+            { id: row.route_from_facility_id, organizationId: '', status: 'ACTIVE' },
+            { id: row.route_to_facility_id, organizationId: '', status: 'ACTIVE' },
+          ],
+        },
+        carrierName: row.carrier_name,
+        driverName: row.driver_name,
+        vehicleRegistrationNumber: row.vehicle_registration_number,
+        vehicleType: row.vehicle_type,
+        routeFromName: row.route_from_name,
+        routeToName: row.route_to_name,
+        sourceHash: row.admission_source_hash,
+        evidenceRef: row.evidence_ref,
+      });
+    });
+  }
+}

--- a/apps/api/src/modules/deals/logistics-admission.service.ts
+++ b/apps/api/src/modules/deals/logistics-admission.service.ts
@@ -4,7 +4,10 @@ import { Prisma } from '@prisma/client';
 import { RlsTransactionService } from '../../common/prisma/rls-transaction.service';
 import type { RequestUser } from '../../common/types/request-user';
 import { canonicalJson, record, requiredString } from './deal-command-payload';
-import type { LogisticsCommandContext } from './logistics-admission-context';
+import type {
+  LogisticsCommandContext,
+  NormalizedLogisticsBasis,
+} from './logistics-admission-context';
 
 export type ResolvedLogisticsAdmission = LogisticsCommandContext & Readonly<{
   carrierName: string;
@@ -135,23 +138,25 @@ export class LogisticsAdmissionService {
         });
       }
 
+      const basis: NormalizedLogisticsBasis = {
+        carriers: [{ id: row.carrier_org_id, status: 'VERIFIED', tenantId: row.tenant_id }],
+        drivers: [{
+          id: row.driver_user_id,
+          carrierOrgId: row.carrier_org_id,
+          status: 'ACTIVE',
+          vehicleIds: [row.vehicle_id],
+        }],
+        vehicles: [{ id: row.vehicle_id, carrierOrgId: row.carrier_org_id, status: 'ACTIVE' }],
+        facilities: [
+          { id: row.route_from_facility_id, organizationId: deal.sellerOrgId, status: 'ACTIVE' },
+          { id: row.route_to_facility_id, organizationId: deal.buyerOrgId, status: 'ACTIVE' },
+        ],
+      };
+
       return Object.freeze({
         commandId,
         admissionId: row.admission_id,
-        basis: {
-          carriers: [{ id: row.carrier_org_id, status: 'VERIFIED', tenantId: row.tenant_id }],
-          drivers: [{
-            id: row.driver_user_id,
-            carrierOrgId: row.carrier_org_id,
-            status: 'ACTIVE',
-            vehicleIds: [row.vehicle_id],
-          }],
-          vehicles: [{ id: row.vehicle_id, carrierOrgId: row.carrier_org_id, status: 'ACTIVE' }],
-          facilities: [
-            { id: row.route_from_facility_id, organizationId: deal.sellerOrgId, status: 'ACTIVE' },
-            { id: row.route_to_facility_id, organizationId: deal.buyerOrgId, status: 'ACTIVE' },
-          ],
-        },
+        basis,
         carrierName: row.carrier_name,
         driverName: row.driver_name,
         vehicleRegistrationNumber: row.vehicle_registration_number,

--- a/apps/api/src/modules/deals/postgresql-deal-command.service.spec.ts
+++ b/apps/api/src/modules/deals/postgresql-deal-command.service.spec.ts
@@ -1,0 +1,108 @@
+import { currentCommandExecutionId } from '../../common/command-execution.context';
+import { parseLogisticsBasis } from './deal-command-payload';
+import { currentLogisticsCommandContext } from './logistics-admission-context';
+import { PostgresqlDealCommandService } from './postgresql-deal-command.service';
+
+const user = {
+  id: 'logistician-1',
+  email: 'logistician@example.invalid',
+  fullName: 'Logistician',
+  role: 'LOGISTICIAN',
+  orgId: 'carrier-org-1',
+  tenantId: 'tenant-1',
+  sessionId: 'session-1',
+} as any;
+
+const dto = {
+  commandId: 'command-assign-logistics-0001',
+  idempotencyKey: 'idempotency-assign-logistics-0001',
+  expectedVersion: '2',
+  payload: {
+    carrierOrgId: 'carrier-org-1',
+    driverUserId: 'driver-1',
+    vehicleId: 'vehicle-1',
+    routeFromFacilityId: 'facility-from-1',
+    routeToFacilityId: 'facility-to-1',
+  },
+} as any;
+
+const basis = {
+  carriers: [{ id: 'carrier-org-1', status: 'VERIFIED' as const, tenantId: 'tenant-1' }],
+  drivers: [{
+    id: 'driver-1',
+    carrierOrgId: 'carrier-org-1',
+    status: 'ACTIVE' as const,
+    vehicleIds: ['vehicle-1'],
+  }],
+  vehicles: [{ id: 'vehicle-1', carrierOrgId: 'carrier-org-1', status: 'ACTIVE' as const }],
+  facilities: [
+    { id: 'facility-from-1', organizationId: 'seller-org', status: 'ACTIVE' as const },
+    { id: 'facility-to-1', organizationId: 'buyer-org', status: 'ACTIVE' as const },
+  ],
+};
+
+describe('PostgresqlDealCommandService', () => {
+  it('resolves admission before assign_logistics and isolates both async contexts', async () => {
+    const base = {
+      execute: jest.fn(async () => ({
+        commandId: currentCommandExecutionId(),
+        admissionId: currentLogisticsCommandContext()?.admissionId,
+        parsedBasis: parseLogisticsBasis(null),
+      })),
+      workspace: jest.fn(),
+    } as any;
+    const admissions = {
+      resolveForCommand: jest.fn().mockResolvedValue({
+        commandId: dto.commandId,
+        admissionId: 'admission-1',
+        basis,
+        carrierName: 'Carrier',
+        driverName: 'Driver',
+        vehicleRegistrationNumber: 'A000AA77',
+        vehicleType: 'Grain truck',
+        routeFromName: 'Origin',
+        routeToName: 'Destination',
+        sourceHash: 'a'.repeat(64),
+        evidenceRef: null,
+      }),
+    } as any;
+    const service = new PostgresqlDealCommandService(base, admissions);
+
+    await expect(service.execute('deal-1', 'assign_logistics', dto, user)).resolves.toEqual({
+      commandId: dto.commandId,
+      admissionId: 'admission-1',
+      parsedBasis: basis,
+    });
+    expect(admissions.resolveForCommand).toHaveBeenCalledWith(
+      'deal-1', dto.payload, user, dto.commandId,
+    );
+    expect(currentCommandExecutionId()).toBeUndefined();
+    expect(currentLogisticsCommandContext()).toBeUndefined();
+  });
+
+  it('does not resolve logistics for another command but still propagates correlation', async () => {
+    const base = {
+      execute: jest.fn(async () => currentCommandExecutionId()),
+      workspace: jest.fn(),
+    } as any;
+    const admissions = { resolveForCommand: jest.fn() } as any;
+    const service = new PostgresqlDealCommandService(base, admissions);
+
+    await expect(service.execute('deal-1', 'confirm_loading', dto, user))
+      .resolves.toBe(dto.commandId);
+    expect(admissions.resolveForCommand).not.toHaveBeenCalled();
+    expect(currentCommandExecutionId()).toBeUndefined();
+  });
+
+  it('fails closed without normalized context outside NODE_ENV=test', () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      expect(() => parseLogisticsBasis({
+        logisticsBasis: basis,
+      })).toThrow(/PostgreSQL|допуска/);
+    } finally {
+      process.env.NODE_ENV = previous;
+    }
+  });
+});

--- a/apps/api/src/modules/deals/postgresql-deal-command.service.ts
+++ b/apps/api/src/modules/deals/postgresql-deal-command.service.ts
@@ -1,0 +1,61 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { runWithCommandExecutionContext } from '../../common/command-execution.context';
+import type { RequestUser } from '../../common/types/request-user';
+import { DealCommandService } from './deal-command.service';
+import type { ExecuteDealCommandDto } from './dto/execute-deal-command.dto';
+import { LogisticsAdmissionService } from './logistics-admission.service';
+import { runWithLogisticsCommandContext } from './logistics-admission-context';
+
+export const BASE_DEAL_COMMAND_SERVICE = Symbol('BASE_DEAL_COMMAND_SERVICE');
+
+/**
+ * Production command facade. All ordinary commands delegate to the canonical
+ * state machine. assign_logistics first resolves one normalized PostgreSQL
+ * admission and carries its immutable command context into the same transaction
+ * in which Shipment, DealEvent, AuditEvent and receipt are written.
+ */
+@Injectable()
+export class PostgresqlDealCommandService {
+  constructor(
+    @Inject(BASE_DEAL_COMMAND_SERVICE)
+    private readonly base: DealCommandService,
+    private readonly logisticsAdmissions: LogisticsAdmissionService,
+  ) {}
+
+  workspace(dealId: string, user: RequestUser) {
+    return this.base.workspace(dealId, user);
+  }
+
+  async execute(
+    dealId: string,
+    rawActionId: string,
+    dto: ExecuteDealCommandDto,
+    user: RequestUser,
+  ) {
+    if (rawActionId !== 'assign_logistics') {
+      return runWithCommandExecutionContext(
+        { commandId: dto.commandId },
+        () => this.base.execute(dealId, rawActionId, dto, user),
+      );
+    }
+
+    const admission = await this.logisticsAdmissions.resolveForCommand(
+      dealId,
+      dto.payload ?? {},
+      user,
+      dto.commandId,
+    );
+
+    return runWithCommandExecutionContext(
+      { commandId: dto.commandId },
+      () => runWithLogisticsCommandContext(
+        {
+          commandId: dto.commandId,
+          admissionId: admission.admissionId,
+          basis: admission.basis,
+        },
+        () => this.base.execute(dealId, rawActionId, dto, user),
+      ),
+    );
+  }
+}

--- a/apps/api/test/industrial/logistics-admission.e2e-spec.ts
+++ b/apps/api/test/industrial/logistics-admission.e2e-spec.ts
@@ -229,6 +229,26 @@ async function seed(prisma: PrismaService): Promise<void> {
   });
 }
 
+async function commandDto(prisma: PrismaService) {
+  const deal = await prisma.deal.findUniqueOrThrow({
+    where: { id: DEAL_ID },
+    select: { version: true, updatedAt: true },
+  });
+  return {
+    commandId: 'command-logistics-e2e-0001',
+    idempotencyKey: 'idempotency-logistics-e2e-0001',
+    expectedVersion: deal.version.toString(),
+    expectedUpdatedAt: deal.updatedAt.toISOString(),
+    payload: {
+      carrierOrgId: CARRIER_ORG,
+      driverUserId: DRIVER_ID,
+      vehicleId: VEHICLE_ID,
+      routeFromFacilityId: ORIGIN_ID,
+      routeToFacilityId: DESTINATION_ID,
+    },
+  };
+}
+
 describe('normalized PostgreSQL logistics admission', () => {
   let prisma: PrismaService;
   let service: PostgresqlDealCommandService;
@@ -251,18 +271,12 @@ describe('normalized PostgreSQL logistics admission', () => {
   });
 
   it('assigns Shipment, consumes admission and commits one binding atomically', async () => {
-    const result = await service.execute(DEAL_ID, 'assign_logistics', {
-      commandId: 'command-logistics-e2e-0001',
-      idempotencyKey: 'idempotency-logistics-e2e-0001',
-      expectedVersion: '0',
-      payload: {
-        carrierOrgId: CARRIER_ORG,
-        driverUserId: DRIVER_ID,
-        vehicleId: VEHICLE_ID,
-        routeFromFacilityId: ORIGIN_ID,
-        routeToFacilityId: DESTINATION_ID,
-      },
-    }, logistician) as Record<string, unknown>;
+    const result = await service.execute(
+      DEAL_ID,
+      'assign_logistics',
+      await commandDto(prisma),
+      logistician,
+    ) as Record<string, unknown>;
 
     expect(result).toMatchObject({
       actionId: 'assign_logistics',
@@ -304,18 +318,12 @@ describe('normalized PostgreSQL logistics admission', () => {
   });
 
   it('replays idempotently without consuming a second admission', async () => {
-    const replay = await service.execute(DEAL_ID, 'assign_logistics', {
-      commandId: 'command-logistics-e2e-0001',
-      idempotencyKey: 'idempotency-logistics-e2e-0001',
-      expectedVersion: '0',
-      payload: {
-        carrierOrgId: CARRIER_ORG,
-        driverUserId: DRIVER_ID,
-        vehicleId: VEHICLE_ID,
-        routeFromFacilityId: ORIGIN_ID,
-        routeToFacilityId: DESTINATION_ID,
-      },
-    }, logistician) as Record<string, unknown>;
+    const replay = await service.execute(
+      DEAL_ID,
+      'assign_logistics',
+      await commandDto(prisma),
+      logistician,
+    ) as Record<string, unknown>;
 
     expect(replay.duplicate).toBe(true);
     const [admissionCount, bindingCount] = await Promise.all([

--- a/apps/api/test/industrial/logistics-admission.e2e-spec.ts
+++ b/apps/api/test/industrial/logistics-admission.e2e-spec.ts
@@ -1,0 +1,342 @@
+import * as bcrypt from 'bcryptjs';
+import { createHash } from 'node:crypto';
+import { Prisma, PrismaClient } from '@prisma/client';
+import { PrismaService } from '../../src/common/prisma/prisma.service';
+import { RlsTransactionService } from '../../src/common/prisma/rls-transaction.service';
+import { Role, type RequestUser } from '../../src/common/types/request-user';
+import { DealCommandService } from '../../src/modules/deals/deal-command.service';
+import { LogisticsAdmissionService } from '../../src/modules/deals/logistics-admission.service';
+import { PostgresqlDealCommandService } from '../../src/modules/deals/postgresql-deal-command.service';
+import { canonicalJson } from '../../src/modules/deals/deal-command-payload';
+
+jest.setTimeout(180_000);
+
+const TENANT = 'tenant-logistics-admission-e2e';
+const DEAL_ID = 'DEAL-LOGISTICS-ADMISSION-E2E';
+const SELLER_ORG = 'org-logistics-e2e-seller';
+const BUYER_ORG = 'org-logistics-e2e-buyer';
+const CARRIER_ORG = 'org-logistics-e2e-carrier';
+const LOGISTICIAN_ID = 'user-logistics-e2e-logistician';
+const DRIVER_ID = 'user-logistics-e2e-driver';
+const CARRIER_ID = 'carrier-logistics-e2e';
+const DRIVER_REGISTRY_ID = 'driver-logistics-e2e';
+const VEHICLE_ID = 'vehicle-logistics-e2e';
+const LINK_ID = 'driver-vehicle-logistics-e2e';
+const ORIGIN_ID = 'facility-logistics-e2e-origin';
+const DESTINATION_ID = 'facility-logistics-e2e-destination';
+const ADMISSION_ID = 'admission-logistics-e2e';
+const SHIPMENT_ID = `shipment:${DEAL_ID}`;
+
+const logistician: RequestUser = {
+  id: LOGISTICIAN_ID,
+  email: 'logistician@logistics-e2e.invalid',
+  fullName: 'E2E Logistician',
+  role: Role.LOGISTICIAN,
+  orgId: CARRIER_ORG,
+  tenantId: TENANT,
+  sessionId: 'session-logistics-e2e',
+  mfaVerified: true,
+};
+
+function hash(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex');
+}
+
+async function clean(prisma: PrismaClient): Promise<void> {
+  await prisma.$executeRawUnsafe('SET session_replication_role = replica');
+  try {
+    for (const statement of [
+      `DELETE FROM logistics.shipment_bindings WHERE deal_id = '${DEAL_ID}'`,
+      `DELETE FROM logistics.deal_admissions WHERE deal_id = '${DEAL_ID}'`,
+      `DELETE FROM logistics.driver_vehicle_links WHERE tenant_id = '${TENANT}'`,
+      `DELETE FROM logistics.vehicles WHERE tenant_id = '${TENANT}'`,
+      `DELETE FROM logistics.drivers WHERE tenant_id = '${TENANT}'`,
+      `DELETE FROM logistics.facilities WHERE tenant_id = '${TENANT}'`,
+      `DELETE FROM logistics.carriers WHERE tenant_id = '${TENANT}'`,
+      `DELETE FROM "outbox_entries" WHERE "dealId" = '${DEAL_ID}'`,
+      `DELETE FROM "audit_events" WHERE "dealId" = '${DEAL_ID}'`,
+      `DELETE FROM "deal_events" WHERE "dealId" = '${DEAL_ID}'`,
+      `DELETE FROM "shipments" WHERE "dealId" = '${DEAL_ID}'`,
+      `DELETE FROM "deal_participants" WHERE "dealId" = '${DEAL_ID}'`,
+      `DELETE FROM "deals" WHERE id = '${DEAL_ID}'`,
+      `DELETE FROM "user_orgs" WHERE "organizationId" IN ('${SELLER_ORG}','${BUYER_ORG}','${CARRIER_ORG}')`,
+      `DELETE FROM "users" WHERE id IN ('${LOGISTICIAN_ID}','${DRIVER_ID}')`,
+      `DELETE FROM "organizations" WHERE id IN ('${SELLER_ORG}','${BUYER_ORG}','${CARRIER_ORG}')`,
+    ]) {
+      await prisma.$executeRawUnsafe(statement);
+    }
+  } finally {
+    await prisma.$executeRawUnsafe('SET session_replication_role = DEFAULT');
+  }
+}
+
+async function seed(prisma: PrismaService): Promise<void> {
+  const now = new Date();
+  const validFrom = new Date(now.getTime() - 60_000);
+  const validUntil = new Date(now.getTime() + 24 * 60 * 60_000);
+  const passwordHash = bcrypt.hashSync('logistics-e2e', 4);
+  const carrierHash = hash(`${CARRIER_ID}:verified`);
+  const driverHash = hash(`${DRIVER_REGISTRY_ID}:active`);
+  const vehicleHash = hash(`${VEHICLE_ID}:active`);
+  const linkHash = hash(`${LINK_ID}:active`);
+  const originHash = hash(`${ORIGIN_ID}:active`);
+  const destinationHash = hash(`${DESTINATION_ID}:active`);
+  const admissionHash = digest({
+    tenantId: TENANT,
+    dealId: DEAL_ID,
+    carrierId: CARRIER_ID,
+    carrierOrgId: CARRIER_ORG,
+    carrierSourceHash: carrierHash,
+    driverId: DRIVER_REGISTRY_ID,
+    driverUserId: DRIVER_ID,
+    driverSourceHash: driverHash,
+    vehicleId: VEHICLE_ID,
+    vehicleSourceHash: vehicleHash,
+    driverVehicleLinkId: LINK_ID,
+    driverVehicleSourceHash: linkHash,
+    routeFromFacilityId: ORIGIN_ID,
+    routeFromSourceHash: originHash,
+    routeToFacilityId: DESTINATION_ID,
+    routeToSourceHash: destinationHash,
+    validFrom: validFrom.toISOString(),
+    validUntil: validUntil.toISOString(),
+    evidenceRef: null,
+  });
+
+  await prisma.$transaction(async (tx) => {
+    for (const org of [
+      { id: SELLER_ORG, inn: '779800000001' },
+      { id: BUYER_ORG, inn: '779800000002' },
+      { id: CARRIER_ORG, inn: '779800000003' },
+    ]) {
+      await tx.organization.create({
+        data: {
+          ...org,
+          name: org.id,
+          tenantId: TENANT,
+          status: 'VERIFIED',
+          kycStatus: 'APPROVED',
+        },
+      });
+    }
+    for (const identity of [
+      { id: LOGISTICIAN_ID, role: Role.LOGISTICIAN },
+      { id: DRIVER_ID, role: Role.DRIVER },
+    ]) {
+      await tx.user.create({
+        data: {
+          id: identity.id,
+          email: `${identity.id}@logistics-e2e.invalid`,
+          fullName: identity.id,
+          passwordHash,
+          status: 'ACTIVE',
+        },
+      });
+      await tx.userOrg.create({
+        data: {
+          userId: identity.id,
+          organizationId: CARRIER_ORG,
+          role: identity.role,
+          isDefault: true,
+        },
+      });
+    }
+    await tx.deal.create({
+      data: {
+        id: DEAL_ID,
+        dealNumber: 'ТП-LOGISTICS-E2E',
+        status: 'RESERVED',
+        tenantId: TENANT,
+        sellerOrgId: SELLER_ORG,
+        buyerOrgId: BUYER_ORG,
+        totalKopecks: 1_000_000n,
+        currency: 'RUB',
+        version: 0n,
+      },
+    });
+    await tx.dealParticipant.create({
+      data: {
+        id: `participant:${DEAL_ID}:logistician`,
+        dealId: DEAL_ID,
+        tenantId: TENANT,
+        organizationId: CARRIER_ORG,
+        userId: LOGISTICIAN_ID,
+        role: Role.LOGISTICIAN,
+        accessLevel: 'WORK',
+        status: 'ACTIVE',
+      },
+    });
+
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO logistics.carriers (
+        id, tenant_id, organization_id, status, valid_from, valid_until,
+        verified_at, verified_by_user_id, source_hash
+      ) VALUES (
+        ${CARRIER_ID}, ${TENANT}, ${CARRIER_ORG}, 'VERIFIED', ${validFrom}, ${validUntil},
+        ${now}, ${LOGISTICIAN_ID}, ${carrierHash}
+      )
+    `);
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO logistics.drivers (
+        id, tenant_id, carrier_id, user_id, status, valid_from, valid_until,
+        verified_at, verified_by_user_id, source_hash
+      ) VALUES (
+        ${DRIVER_REGISTRY_ID}, ${TENANT}, ${CARRIER_ID}, ${DRIVER_ID}, 'ACTIVE', ${validFrom}, ${validUntil},
+        ${now}, ${LOGISTICIAN_ID}, ${driverHash}
+      )
+    `);
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO logistics.vehicles (
+        id, tenant_id, carrier_id, registration_number, vehicle_type, capacity_tons,
+        status, valid_from, valid_until, verified_at, verified_by_user_id, source_hash
+      ) VALUES (
+        ${VEHICLE_ID}, ${TENANT}, ${CARRIER_ID}, 'А111АА77', 'Зерновоз', 100.000000,
+        'ACTIVE', ${validFrom}, ${validUntil}, ${now}, ${LOGISTICIAN_ID}, ${vehicleHash}
+      )
+    `);
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO logistics.driver_vehicle_links (
+        id, tenant_id, driver_id, vehicle_id, status, valid_from, valid_until,
+        verified_at, verified_by_user_id, source_hash
+      ) VALUES (
+        ${LINK_ID}, ${TENANT}, ${DRIVER_REGISTRY_ID}, ${VEHICLE_ID}, 'ACTIVE', ${validFrom}, ${validUntil},
+        ${now}, ${LOGISTICIAN_ID}, ${linkHash}
+      )
+    `);
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO logistics.facilities (
+        id, tenant_id, organization_id, kind, name, status, valid_from, valid_until,
+        verified_at, verified_by_user_id, source_hash
+      ) VALUES
+        (${ORIGIN_ID}, ${TENANT}, ${SELLER_ORG}, 'DISPATCH', 'Origin', 'ACTIVE', ${validFrom}, ${validUntil}, ${now}, ${LOGISTICIAN_ID}, ${originHash}),
+        (${DESTINATION_ID}, ${TENANT}, ${BUYER_ORG}, 'ACCEPTANCE', 'Destination', 'ACTIVE', ${validFrom}, ${validUntil}, ${now}, ${LOGISTICIAN_ID}, ${destinationHash})
+    `);
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO logistics.deal_admissions (
+        id, tenant_id, deal_id, carrier_id, driver_id, vehicle_id,
+        driver_vehicle_link_id, route_from_facility_id, route_to_facility_id,
+        status, valid_from, valid_until, approved_by_user_id, approved_at, source_hash
+      ) VALUES (
+        ${ADMISSION_ID}, ${TENANT}, ${DEAL_ID}, ${CARRIER_ID}, ${DRIVER_REGISTRY_ID}, ${VEHICLE_ID},
+        ${LINK_ID}, ${ORIGIN_ID}, ${DESTINATION_ID}, 'CONFIRMED', ${validFrom}, ${validUntil},
+        ${LOGISTICIAN_ID}, ${now}, ${admissionHash}
+      )
+    `);
+  });
+}
+
+describe('normalized PostgreSQL logistics admission', () => {
+  let prisma: PrismaService;
+  let service: PostgresqlDealCommandService;
+
+  beforeAll(async () => {
+    prisma = new PrismaService();
+    await prisma.$connect();
+    await clean(prisma);
+    await seed(prisma);
+    const rls = new RlsTransactionService(prisma);
+    service = new PostgresqlDealCommandService(
+      new DealCommandService(rls),
+      new LogisticsAdmissionService(rls),
+    );
+  });
+
+  afterAll(async () => {
+    await clean(prisma);
+    await prisma.$disconnect();
+  });
+
+  it('assigns Shipment, consumes admission and commits one binding atomically', async () => {
+    const result = await service.execute(DEAL_ID, 'assign_logistics', {
+      commandId: 'command-logistics-e2e-0001',
+      idempotencyKey: 'idempotency-logistics-e2e-0001',
+      expectedVersion: '0',
+      payload: {
+        carrierOrgId: CARRIER_ORG,
+        driverUserId: DRIVER_ID,
+        vehicleId: VEHICLE_ID,
+        routeFromFacilityId: ORIGIN_ID,
+        routeToFacilityId: DESTINATION_ID,
+      },
+    }, logistician) as Record<string, unknown>;
+
+    expect(result).toMatchObject({
+      actionId: 'assign_logistics',
+      status: 'LOGISTICS_ASSIGNED',
+      duplicate: false,
+    });
+
+    const [shipment, admissions, bindings, events, audits, receipts] = await Promise.all([
+      prisma.shipment.findUnique({ where: { id: SHIPMENT_ID } }),
+      prisma.$queryRaw<Array<{ status: string; consumed_by_command_id: string }>>(Prisma.sql`
+        SELECT status, consumed_by_command_id
+        FROM logistics.deal_admissions
+        WHERE id = ${ADMISSION_ID}
+      `),
+      prisma.$queryRaw<Array<{ shipment_id: string; admission_id: string }>>(Prisma.sql`
+        SELECT shipment_id, admission_id
+        FROM logistics.shipment_bindings
+        WHERE shipment_id = ${SHIPMENT_ID}
+      `),
+      prisma.dealEvent.count({ where: { dealId: DEAL_ID, eventType: 'ASSIGN_LOGISTICS' } }),
+      prisma.auditEvent.count({ where: { dealId: DEAL_ID, action: 'deal.assign_logistics' } }),
+      prisma.outboxEntry.count({ where: { dealId: DEAL_ID, type: 'deal.assign_logistics.receipt' } }),
+    ]);
+
+    expect(shipment).toMatchObject({
+      status: 'ASSIGNED',
+      carrierOrgId: CARRIER_ORG,
+      driverUserId: DRIVER_ID,
+      vehicleNumber: VEHICLE_ID,
+      routeFrom: ORIGIN_ID,
+      routeTo: DESTINATION_ID,
+    });
+    expect(admissions).toEqual([{
+      status: 'CONSUMED',
+      consumed_by_command_id: 'command-logistics-e2e-0001',
+    }]);
+    expect(bindings).toEqual([{ shipment_id: SHIPMENT_ID, admission_id: ADMISSION_ID }]);
+    expect({ events, audits, receipts }).toEqual({ events: 1, audits: 1, receipts: 1 });
+  });
+
+  it('replays idempotently without consuming a second admission', async () => {
+    const replay = await service.execute(DEAL_ID, 'assign_logistics', {
+      commandId: 'command-logistics-e2e-0001',
+      idempotencyKey: 'idempotency-logistics-e2e-0001',
+      expectedVersion: '0',
+      payload: {
+        carrierOrgId: CARRIER_ORG,
+        driverUserId: DRIVER_ID,
+        vehicleId: VEHICLE_ID,
+        routeFromFacilityId: ORIGIN_ID,
+        routeToFacilityId: DESTINATION_ID,
+      },
+    }, logistician) as Record<string, unknown>;
+
+    expect(replay.duplicate).toBe(true);
+    const [admissionCount, bindingCount] = await Promise.all([
+      prisma.$queryRaw<Array<{ count: bigint }>>(Prisma.sql`
+        SELECT count(*)::bigint AS count FROM logistics.deal_admissions WHERE deal_id = ${DEAL_ID}
+      `),
+      prisma.$queryRaw<Array<{ count: bigint }>>(Prisma.sql`
+        SELECT count(*)::bigint AS count FROM logistics.shipment_bindings WHERE deal_id = ${DEAL_ID}
+      `),
+    ]);
+    expect(Number(admissionCount[0].count)).toBe(1);
+    expect(Number(bindingCount[0].count)).toBe(1);
+  });
+
+  it('rejects reassignment after immutable Shipment binding', async () => {
+    await expect(prisma.shipment.update({
+      where: { id: SHIPMENT_ID },
+      data: { vehicleNumber: 'vehicle-forged-reassignment' },
+    })).rejects.toThrow(/immutable|shipment logistics binding/i);
+    await expect(prisma.shipment.findUnique({ where: { id: SHIPMENT_ID } })).resolves.toMatchObject({
+      vehicleNumber: VEHICLE_ID,
+    });
+  });
+});

--- a/apps/api/test/one-deal/logistics-rls.e2e-spec.ts
+++ b/apps/api/test/one-deal/logistics-rls.e2e-spec.ts
@@ -1,0 +1,188 @@
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../src/common/prisma/prisma.service';
+
+jest.setTimeout(120_000);
+
+const TABLES = [
+  'carriers',
+  'drivers',
+  'vehicles',
+  'driver_vehicle_links',
+  'facilities',
+  'deal_admissions',
+  'shipment_bindings',
+] as const;
+
+const FUNCTIONS = [
+  'resolve_deal_admission',
+  'resolve_deal_admission_for_command',
+  'consume_deal_admission',
+  'bind_shipment_to_admission',
+  'validate_deal_admission_row',
+] as const;
+
+describe('normalized logistics PostgreSQL security boundary', () => {
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    prisma = new PrismaService();
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('keeps all seven logistics tables under ENABLE + FORCE RLS', async () => {
+    const rows = await prisma.$queryRaw<Array<{
+      relname: string;
+      enabled: boolean;
+      forced: boolean;
+    }>>(Prisma.sql`
+      SELECT c.relname, c.relrowsecurity AS enabled, c.relforcerowsecurity AS forced
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'logistics'
+        AND c.relname IN (${Prisma.join(TABLES)})
+      ORDER BY c.relname
+    `);
+
+    expect(rows).toHaveLength(TABLES.length);
+    expect(rows.every((row) => row.enabled && row.forced)).toBe(true);
+  });
+
+  it('has tenant policies for reads and controlled writes', async () => {
+    const rows = await prisma.$queryRaw<Array<{
+      tablename: string;
+      policyname: string;
+      command: string;
+    }>>(Prisma.sql`
+      SELECT tablename, policyname, cmd AS command
+      FROM pg_policies
+      WHERE schemaname = 'logistics'
+      ORDER BY tablename, policyname
+    `);
+
+    const byTable = new Map<string, Set<string>>();
+    for (const row of rows) {
+      const commands = byTable.get(row.tablename) ?? new Set<string>();
+      commands.add(row.command);
+      byTable.set(row.tablename, commands);
+    }
+    for (const table of TABLES) {
+      expect(byTable.get(table)?.has('SELECT')).toBe(true);
+    }
+    expect(byTable.get('deal_admissions')).toEqual(expect.objectContaining(new Set(['SELECT', 'INSERT', 'UPDATE'])));
+    expect(byTable.get('shipment_bindings')?.has('DELETE')).not.toBe(true);
+  });
+
+  it('revokes PUBLIC execution from privileged logistics functions', async () => {
+    const rows = await prisma.$queryRaw<Array<{
+      function_name: string;
+      security_definer: boolean;
+      public_execute: boolean;
+      search_path: string | null;
+    }>>(Prisma.sql`
+      SELECT
+        p.proname AS function_name,
+        p.prosecdef AS security_definer,
+        EXISTS (
+          SELECT 1
+          FROM aclexplode(COALESCE(p.proacl, acldefault('f', p.proowner))) acl
+          WHERE acl.grantee = 0 AND acl.privilege_type = 'EXECUTE'
+        ) AS public_execute,
+        array_to_string(p.proconfig, ',') AS search_path
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'logistics'
+        AND p.proname IN (${Prisma.join(FUNCTIONS)})
+      ORDER BY p.proname
+    `);
+
+    expect(rows).toHaveLength(FUNCTIONS.length);
+    for (const row of rows) {
+      expect(row.public_execute).toBe(false);
+      expect(row.search_path).toMatch(/search_path=/);
+    }
+    for (const required of [
+      'resolve_deal_admission',
+      'resolve_deal_admission_for_command',
+      'consume_deal_admission',
+      'bind_shipment_to_admission',
+      'validate_deal_admission_row',
+    ]) {
+      expect(rows.find((row) => row.function_name === required)?.security_definer).toBe(true);
+    }
+  });
+
+  it('uses a deferred constraint trigger for atomic Shipment binding', async () => {
+    const rows = await prisma.$queryRaw<Array<{
+      trigger_name: string;
+      deferrable: boolean;
+      initially_deferred: boolean;
+      enabled: string;
+    }>>(Prisma.sql`
+      SELECT
+        t.tgname AS trigger_name,
+        t.tgdeferrable AS deferrable,
+        t.tginitdeferred AS initially_deferred,
+        t.tgenabled::text AS enabled
+      FROM pg_trigger t
+      JOIN pg_class c ON c.oid = t.tgrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relname = 'shipments'
+        AND t.tgname = 'shipment_logistics_admission_binding'
+        AND NOT t.tgisinternal
+    `);
+
+    expect(rows).toEqual([{
+      trigger_name: 'shipment_logistics_admission_binding',
+      deferrable: true,
+      initially_deferred: true,
+      enabled: 'O',
+    }]);
+  });
+
+  it('gives the restricted Deal runtime read/function access but no direct logistics writes', async () => {
+    const rows = await prisma.$queryRaw<Array<{
+      current_user: string;
+      schema_usage: boolean;
+      admission_select: boolean;
+      admission_insert: boolean;
+      admission_update: boolean;
+      admission_delete: boolean;
+      resolver_execute: boolean;
+      consume_execute: boolean;
+    }>>(Prisma.sql`
+      SELECT
+        current_user,
+        has_schema_privilege(current_user, 'logistics', 'USAGE') AS schema_usage,
+        has_table_privilege(current_user, 'logistics.deal_admissions', 'SELECT') AS admission_select,
+        has_table_privilege(current_user, 'logistics.deal_admissions', 'INSERT') AS admission_insert,
+        has_table_privilege(current_user, 'logistics.deal_admissions', 'UPDATE') AS admission_update,
+        has_table_privilege(current_user, 'logistics.deal_admissions', 'DELETE') AS admission_delete,
+        has_function_privilege(
+          current_user,
+          'logistics.resolve_deal_admission_for_command(text,text,text,text,text,text,text)',
+          'EXECUTE'
+        ) AS resolver_execute,
+        has_function_privilege(
+          current_user,
+          'logistics.consume_deal_admission(text,text,text)',
+          'EXECUTE'
+        ) AS consume_execute
+    `);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      schema_usage: true,
+      admission_select: true,
+      admission_insert: false,
+      admission_update: false,
+      admission_delete: false,
+      resolver_execute: true,
+      consume_execute: true,
+    });
+  });
+});

--- a/apps/api/test/one-deal/seed-logistics-admission.ts
+++ b/apps/api/test/one-deal/seed-logistics-admission.ts
@@ -1,0 +1,198 @@
+import { createHash } from 'node:crypto';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../src/common/prisma/prisma.service';
+import { canonicalJson } from '../../src/modules/deals/deal-command-payload';
+import { CANONICAL_TEST_DEAL_ID } from '../../src/modules/deals/deal-command.policy';
+
+const TENANT_ID = 'tenant-canonical-test';
+const CARRIER_ORG_ID = 'org-canonical-logistics';
+const DRIVER_USER_ID = 'driver-e2e';
+const VEHICLE_ID = `vehicle:${CANONICAL_TEST_DEAL_ID}`;
+const ROUTE_FROM_ID = 'facility:org-canonical-seller:dispatch';
+const ROUTE_TO_ID = 'facility:org-canonical-buyer:acceptance';
+const CARRIER_ID = `carrier:${CARRIER_ORG_ID}`;
+const DRIVER_ID = `driver:${DRIVER_USER_ID}`;
+const LINK_ID = `driver-vehicle:${DRIVER_USER_ID}:${VEHICLE_ID}`;
+const ADMISSION_ID = `logistics-admission:${CANONICAL_TEST_DEAL_ID}`;
+const VALID_FROM = new Date('2026-07-12T08:00:00.000Z');
+const VALID_UNTIL = new Date('2030-01-01T00:00:00.000Z');
+
+function hash(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function digest(value: unknown): string {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex');
+}
+
+export async function seedCanonicalLogisticsAdmission(prisma: PrismaService): Promise<void> {
+  const carrierHash = hash(`${CARRIER_ID}:verified`);
+  const driverHash = hash(`${DRIVER_ID}:active`);
+  const vehicleHash = hash(`${VEHICLE_ID}:active`);
+  const linkHash = hash(`${LINK_ID}:active`);
+  const originHash = hash(`${ROUTE_FROM_ID}:active`);
+  const destinationHash = hash(`${ROUTE_TO_ID}:active`);
+  const evidenceRef = `evidence:${CANONICAL_TEST_DEAL_ID}:loading`;
+  const admissionHash = digest({
+    tenantId: TENANT_ID,
+    dealId: CANONICAL_TEST_DEAL_ID,
+    carrierId: CARRIER_ID,
+    carrierOrgId: CARRIER_ORG_ID,
+    carrierSourceHash: carrierHash,
+    driverId: DRIVER_ID,
+    driverUserId: DRIVER_USER_ID,
+    driverSourceHash: driverHash,
+    vehicleId: VEHICLE_ID,
+    vehicleSourceHash: vehicleHash,
+    driverVehicleLinkId: LINK_ID,
+    driverVehicleSourceHash: linkHash,
+    routeFromFacilityId: ROUTE_FROM_ID,
+    routeFromSourceHash: originHash,
+    routeToFacilityId: ROUTE_TO_ID,
+    routeToSourceHash: destinationHash,
+    validFrom: VALID_FROM.toISOString(),
+    validUntil: VALID_UNTIL.toISOString(),
+    evidenceRef,
+  });
+
+  await prisma.$transaction(async (tx) => {
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO logistics.carriers (
+        id, tenant_id, organization_id, status, valid_from, valid_until,
+        verified_at, verified_by_user_id, source_hash, evidence_ref
+      ) VALUES (
+        ${CARRIER_ID}, ${TENANT_ID}, ${CARRIER_ORG_ID}, 'VERIFIED', ${VALID_FROM}, ${VALID_UNTIL},
+        ${VALID_FROM}, 'operator-e2e', ${carrierHash}, ${evidenceRef}
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        tenant_id = EXCLUDED.tenant_id,
+        organization_id = EXCLUDED.organization_id,
+        status = EXCLUDED.status,
+        valid_from = EXCLUDED.valid_from,
+        valid_until = EXCLUDED.valid_until,
+        verified_at = EXCLUDED.verified_at,
+        verified_by_user_id = EXCLUDED.verified_by_user_id,
+        source_hash = EXCLUDED.source_hash,
+        evidence_ref = EXCLUDED.evidence_ref
+    `);
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO logistics.drivers (
+        id, tenant_id, carrier_id, user_id, status, valid_from, valid_until,
+        verified_at, verified_by_user_id, source_hash, evidence_ref
+      ) VALUES (
+        ${DRIVER_ID}, ${TENANT_ID}, ${CARRIER_ID}, ${DRIVER_USER_ID}, 'ACTIVE', ${VALID_FROM}, ${VALID_UNTIL},
+        ${VALID_FROM}, 'operator-e2e', ${driverHash}, ${evidenceRef}
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        tenant_id = EXCLUDED.tenant_id,
+        carrier_id = EXCLUDED.carrier_id,
+        user_id = EXCLUDED.user_id,
+        status = EXCLUDED.status,
+        valid_from = EXCLUDED.valid_from,
+        valid_until = EXCLUDED.valid_until,
+        verified_at = EXCLUDED.verified_at,
+        verified_by_user_id = EXCLUDED.verified_by_user_id,
+        source_hash = EXCLUDED.source_hash,
+        evidence_ref = EXCLUDED.evidence_ref
+    `);
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO logistics.vehicles (
+        id, tenant_id, carrier_id, registration_number, vehicle_type, capacity_tons,
+        status, valid_from, valid_until, verified_at, verified_by_user_id, source_hash, evidence_ref
+      ) VALUES (
+        ${VEHICLE_ID}, ${TENANT_ID}, ${CARRIER_ID}, 'А000АА77', 'Зерновоз', 200.000000,
+        'ACTIVE', ${VALID_FROM}, ${VALID_UNTIL}, ${VALID_FROM}, 'operator-e2e', ${vehicleHash}, ${evidenceRef}
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        tenant_id = EXCLUDED.tenant_id,
+        carrier_id = EXCLUDED.carrier_id,
+        registration_number = EXCLUDED.registration_number,
+        vehicle_type = EXCLUDED.vehicle_type,
+        capacity_tons = EXCLUDED.capacity_tons,
+        status = EXCLUDED.status,
+        valid_from = EXCLUDED.valid_from,
+        valid_until = EXCLUDED.valid_until,
+        verified_at = EXCLUDED.verified_at,
+        verified_by_user_id = EXCLUDED.verified_by_user_id,
+        source_hash = EXCLUDED.source_hash,
+        evidence_ref = EXCLUDED.evidence_ref
+    `);
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO logistics.driver_vehicle_links (
+        id, tenant_id, driver_id, vehicle_id, status, valid_from, valid_until,
+        verified_at, verified_by_user_id, source_hash, evidence_ref
+      ) VALUES (
+        ${LINK_ID}, ${TENANT_ID}, ${DRIVER_ID}, ${VEHICLE_ID}, 'ACTIVE', ${VALID_FROM}, ${VALID_UNTIL},
+        ${VALID_FROM}, 'operator-e2e', ${linkHash}, ${evidenceRef}
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        tenant_id = EXCLUDED.tenant_id,
+        driver_id = EXCLUDED.driver_id,
+        vehicle_id = EXCLUDED.vehicle_id,
+        status = EXCLUDED.status,
+        valid_from = EXCLUDED.valid_from,
+        valid_until = EXCLUDED.valid_until,
+        verified_at = EXCLUDED.verified_at,
+        verified_by_user_id = EXCLUDED.verified_by_user_id,
+        source_hash = EXCLUDED.source_hash,
+        evidence_ref = EXCLUDED.evidence_ref
+    `);
+    for (const facility of [
+      { id: ROUTE_FROM_ID, organizationId: 'org-canonical-seller', kind: 'DISPATCH', name: 'Точка погрузки продавца', sourceHash: originHash },
+      { id: ROUTE_TO_ID, organizationId: 'org-canonical-buyer', kind: 'ACCEPTANCE', name: 'Точка приёмки покупателя', sourceHash: destinationHash },
+    ]) {
+      await tx.$executeRaw(Prisma.sql`
+        INSERT INTO logistics.facilities (
+          id, tenant_id, organization_id, kind, name, status, valid_from, valid_until,
+          verified_at, verified_by_user_id, source_hash, evidence_ref
+        ) VALUES (
+          ${facility.id}, ${TENANT_ID}, ${facility.organizationId}, ${facility.kind}, ${facility.name},
+          'ACTIVE', ${VALID_FROM}, ${VALID_UNTIL}, ${VALID_FROM}, 'operator-e2e', ${facility.sourceHash}, ${evidenceRef}
+        )
+        ON CONFLICT (id) DO UPDATE SET
+          tenant_id = EXCLUDED.tenant_id,
+          organization_id = EXCLUDED.organization_id,
+          kind = EXCLUDED.kind,
+          name = EXCLUDED.name,
+          status = EXCLUDED.status,
+          valid_from = EXCLUDED.valid_from,
+          valid_until = EXCLUDED.valid_until,
+          verified_at = EXCLUDED.verified_at,
+          verified_by_user_id = EXCLUDED.verified_by_user_id,
+          source_hash = EXCLUDED.source_hash,
+          evidence_ref = EXCLUDED.evidence_ref
+      `);
+    }
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO logistics.deal_admissions (
+        id, tenant_id, deal_id, carrier_id, driver_id, vehicle_id, driver_vehicle_link_id,
+        route_from_facility_id, route_to_facility_id, status, valid_from, valid_until,
+        approved_by_user_id, approved_at, source_hash, evidence_ref
+      ) VALUES (
+        ${ADMISSION_ID}, ${TENANT_ID}, ${CANONICAL_TEST_DEAL_ID}, ${CARRIER_ID}, ${DRIVER_ID}, ${VEHICLE_ID}, ${LINK_ID},
+        ${ROUTE_FROM_ID}, ${ROUTE_TO_ID}, 'CONFIRMED', ${VALID_FROM}, ${VALID_UNTIL},
+        'operator-e2e', ${VALID_FROM}, ${admissionHash}, ${evidenceRef}
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        tenant_id = EXCLUDED.tenant_id,
+        deal_id = EXCLUDED.deal_id,
+        carrier_id = EXCLUDED.carrier_id,
+        driver_id = EXCLUDED.driver_id,
+        vehicle_id = EXCLUDED.vehicle_id,
+        driver_vehicle_link_id = EXCLUDED.driver_vehicle_link_id,
+        route_from_facility_id = EXCLUDED.route_from_facility_id,
+        route_to_facility_id = EXCLUDED.route_to_facility_id,
+        status = 'CONFIRMED',
+        valid_from = EXCLUDED.valid_from,
+        valid_until = EXCLUDED.valid_until,
+        approved_by_user_id = EXCLUDED.approved_by_user_id,
+        approved_at = EXCLUDED.approved_at,
+        source_hash = EXCLUDED.source_hash,
+        evidence_ref = EXCLUDED.evidence_ref,
+        consumed_at = NULL,
+        consumed_by_user_id = NULL,
+        consumed_by_command_id = NULL,
+        version = 0
+    `);
+  });
+}

--- a/apps/api/test/one-deal/seed.ts
+++ b/apps/api/test/one-deal/seed.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../../src/common/prisma/prisma.service';
 import { PersistentAuthRepository } from '../../src/modules/auth/persistent-auth.repository';
 import { CanonicalTestDealSeedService } from '../../src/modules/deals/canonical-test-deal.seed';
 import { CANONICAL_TEST_DEAL_ID } from '../../src/modules/deals/deal-command.policy';
+import { seedCanonicalLogisticsAdmission } from './seed-logistics-admission';
 
 export const AUTHORITY_LOT_ID = 'LOT-RLS-AUTHORITY-001';
 export const AUTHORITY_BID_ID = 'BID-RLS-AUTHORITY-001';
@@ -40,6 +41,7 @@ async function main(): Promise<void> {
     const authRepository = new PersistentAuthRepository(prisma);
     const seed = new CanonicalTestDealSeedService(prisma, authRepository);
     await seed.onModuleInit();
+    await seedCanonicalLogisticsAdmission(prisma);
 
     const basisMaterial = {
       dealNumber: 'ТП-RLS-AUTHORITY-001',
@@ -95,7 +97,7 @@ async function main(): Promise<void> {
       },
     });
 
-    const [deal, memberships, credentialStates, authorityBasis] = await Promise.all([
+    const [deal, memberships, credentialStates, authorityBasis, logisticsAdmission] = await Promise.all([
       prisma.deal.findUnique({ where: { id: CANONICAL_TEST_DEAL_ID } }),
       prisma.userOrg.findMany({
         where: { organization: { tenantId: 'tenant-canonical-test' } },
@@ -113,6 +115,11 @@ async function main(): Promise<void> {
         )
       `,
       prisma.integrationEvent.findUnique({ where: { id: AUTHORITY_BASIS_EVENT_ID } }),
+      prisma.$queryRaw<Array<{ id: string; status: string }>>(Prisma.sql`
+        SELECT id, status
+        FROM logistics.deal_admissions
+        WHERE deal_id = ${CANONICAL_TEST_DEAL_ID}
+      `),
     ]);
 
     if (!deal || deal.status !== 'DRAFT' || deal.tenantId !== 'tenant-canonical-test') {
@@ -120,6 +127,9 @@ async function main(): Promise<void> {
     }
     if (!authorityBasis || authorityBasis.status !== 'CONFIRMED' || authorityBasis.dealId !== null) {
       throw new Error('RLS authority deal basis was not seeded as an unconsumed confirmed event.');
+    }
+    if (logisticsAdmission.length !== 1 || logisticsAdmission[0].status !== 'CONFIRMED') {
+      throw new Error('Canonical normalized logistics admission is missing or not CONFIRMED.');
     }
 
     const roles = new Set(memberships.map((item) => item.role));
@@ -161,6 +171,7 @@ async function main(): Promise<void> {
         lotId: AUTHORITY_LOT_ID,
         winnerBidId: AUTHORITY_BID_ID,
       },
+      logisticsAdmission: logisticsAdmission[0],
     })}\n`);
   } finally {
     await prisma.$disconnect();


### PR DESCRIPTION
## Цель

Убрать `Deal.sagaState.logisticsBasis` из production-authority и ввести нормализованный PostgreSQL-контур допуска перевозчика, водителя, ТС и точек маршрута.

## Текущий срез

- отдельная schema `logistics`;
- registry tables для carrier/driver/vehicle/link/facility;
- immutable per-Deal admission;
- RLS ENABLE/FORCE;
- SECURITY DEFINER resolver и single-use consume;
- Shipment trigger атомарно связывает assignment с admission;
- production command token проходит через guarded facade и AsyncLocalStorage correlation;
- прямой legacy `DealCommandService` не может назначить логистику без нормализованного context.

## Статус

Draft. CI ещё не доказан. Production остаётся NO-GO.