### PR TITLE
Consolidate cabinet help and utilities into one clear menu

### DIFF
--- a/apps/web/components/platform-v7/HeaderUtilityMenu.module.css
+++ b/apps/web/components/platform-v7/HeaderUtilityMenu.module.css
@@ -1,3 +1,5 @@
+.simplifiedShell {}
+
 .root {
   position: relative;
   display: inline-flex;
@@ -256,12 +258,16 @@
 }
 
 /* Native shell actions remain functional and are activated from this single menu. */
-:global(.pc-v4-actions > .pc-v4-search),
-:global(.pc-v4-actions > .pc-v4-theme-toggle),
-:global(.pc-v4-actions button[aria-label='Открыть уведомления']),
-:global(.pc-v4-actions button[aria-label='Открыть калькулятор']),
-:global(.pc-v4-actions .p7-note-widget),
-:global(.pc-v4-actions .p7-role-support) {
+.simplifiedShell :global(.pc-v4-actions > .pc-v4-search),
+.simplifiedShell :global(.pc-v4-actions > .pc-v4-theme-toggle),
+.simplifiedShell :global(.pc-v4-actions button[aria-label='Открыть уведомления']),
+.simplifiedShell :global(.pc-v4-actions button[aria-label='Открыть калькулятор']),
+.simplifiedShell :global(.pc-v4-actions .p7-note-widget),
+.simplifiedShell :global(.pc-v4-actions .p7-role-support),
+.simplifiedShell :global(.pc-v7-role-dock a[href='/platform-v7/ai']),
+.simplifiedShell :global(.pc-v7-safe-drawer-link[href='/platform-v7/ai']),
+.simplifiedShell :global(.pc-v4-bottomnav a[href='/platform-v7/ai']),
+.simplifiedShell :global(.pc-v7-role-dock button.pc-v7-role-dock-item) {
   display: none !important;
 }
 

--- a/apps/web/components/platform-v7/HeaderUtilityMenu.module.css
+++ b/apps/web/components/platform-v7/HeaderUtilityMenu.module.css
@@ -259,7 +259,7 @@
 :global(.pc-v4-actions > .pc-v4-search),
 :global(.pc-v4-actions > .pc-v4-theme-toggle),
 :global(.pc-v4-actions button[aria-label='Открыть уведомления']),
-:global(.pc-v4-actions .p7-calc-trigger),
+:global(.pc-v4-actions button[aria-label='Открыть калькулятор']),
 :global(.pc-v4-actions .p7-note-widget),
 :global(.pc-v4-actions .p7-role-support) {
   display: none !important;

--- a/apps/web/components/platform-v7/HeaderUtilityMenu.module.css
+++ b/apps/web/components/platform-v7/HeaderUtilityMenu.module.css
@@ -1,0 +1,326 @@
+.root {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.trigger {
+  min-height: 42px;
+  border: 1px solid var(--pc-border);
+  border-radius: 14px;
+  background: var(--pc-bg-elevated);
+  color: var(--pc-text-primary);
+  padding: 0 13px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.trigger[data-open='true'] {
+  border-color: var(--pc-accent-border);
+  background: var(--pc-accent-bg);
+  color: var(--pc-accent-strong);
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 5000;
+  border: 0;
+  background: rgba(3, 8, 7, 0.34);
+  padding: 0;
+  cursor: default;
+}
+
+.panel {
+  position: fixed;
+  top: calc(env(safe-area-inset-top) + 66px);
+  right: 14px;
+  z-index: 5010;
+  width: min(420px, calc(100dvw - 28px));
+  max-height: calc(100dvh - env(safe-area-inset-top) - 82px);
+  overflow: auto;
+  border: 1px solid var(--pc-border);
+  border-radius: 22px;
+  background: var(--pc-bg-card);
+  color: var(--pc-text-primary);
+  box-shadow: var(--pc-shadow-lg);
+  padding: 14px;
+  display: grid;
+  gap: 14px;
+}
+
+.panelHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panelTitle {
+  display: grid;
+  gap: 3px;
+}
+
+.panelTitle strong {
+  font-size: 16px;
+  line-height: 1.2;
+  font-weight: 950;
+}
+
+.panelTitle span {
+  color: var(--pc-text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+  font-weight: 700;
+}
+
+.closeButton,
+.backButton {
+  min-width: 42px;
+  min-height: 42px;
+  border: 1px solid var(--pc-border);
+  border-radius: 13px;
+  background: var(--pc-bg-elevated);
+  color: var(--pc-text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.section {
+  display: grid;
+  gap: 8px;
+}
+
+.sectionTitle {
+  margin: 0;
+  color: var(--pc-text-muted);
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.actionGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.action,
+.linkAction {
+  min-width: 0;
+  min-height: 66px;
+  border: 1px solid var(--pc-border);
+  border-radius: 16px;
+  background: var(--pc-bg-elevated);
+  color: var(--pc-text-primary);
+  padding: 10px 11px;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  align-items: center;
+  gap: 9px;
+  text-align: left;
+  text-decoration: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+.action:hover,
+.linkAction:hover {
+  border-color: var(--pc-accent-border);
+  background: var(--pc-accent-bg);
+}
+
+.actionIcon {
+  width: 34px;
+  height: 34px;
+  border-radius: 11px;
+  background: var(--pc-bg-card);
+  color: var(--pc-accent-strong);
+  display: grid;
+  place-items: center;
+}
+
+.actionCopy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.actionCopy strong {
+  font-size: 13px;
+  line-height: 1.25;
+  font-weight: 900;
+}
+
+.actionCopy span {
+  color: var(--pc-text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.logout {
+  min-height: 48px;
+  border: 1px solid color-mix(in srgb, var(--pc-danger, #b42318) 28%, var(--pc-border));
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--pc-danger-bg, #fff3f2) 72%, var(--pc-bg-card));
+  color: var(--pc-danger, #b42318);
+  padding: 0 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.notePanel {
+  display: grid;
+  gap: 12px;
+}
+
+.notePanel textarea {
+  width: 100%;
+  min-height: 240px;
+  resize: vertical;
+  border: 1px solid var(--pc-border);
+  border-radius: 16px;
+  background: var(--pc-bg-elevated);
+  color: var(--pc-text-primary);
+  padding: 13px;
+  font: inherit;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.notePanel textarea:focus-visible {
+  border-color: var(--pc-accent);
+  outline: 3px solid color-mix(in srgb, var(--pc-accent) 28%, transparent);
+  outline-offset: 2px;
+}
+
+.noteFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--pc-text-muted);
+  font-size: 11px;
+  font-weight: 750;
+}
+
+.clearNote {
+  min-height: 42px;
+  border: 1px solid var(--pc-border);
+  border-radius: 13px;
+  background: var(--pc-bg-elevated);
+  color: var(--pc-text-secondary);
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.clearNote:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.trigger:focus-visible,
+.closeButton:focus-visible,
+.backButton:focus-visible,
+.action:focus-visible,
+.linkAction:focus-visible,
+.logout:focus-visible,
+.clearNote:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--pc-accent) 36%, transparent);
+  outline-offset: 3px;
+}
+
+/* Native shell actions remain functional and are activated from this single menu. */
+:global(.pc-v4-actions > .pc-v4-search),
+:global(.pc-v4-actions > .pc-v4-theme-toggle),
+:global(.pc-v4-actions button[aria-label='Открыть уведомления']),
+:global(.pc-v4-actions .p7-calc-trigger),
+:global(.pc-v4-actions .p7-note-widget),
+:global(.pc-v4-actions .p7-role-support) {
+  display: none !important;
+}
+
+@media (max-width: 767px) {
+  .trigger {
+    width: 42px;
+    min-width: 42px;
+    max-width: 42px;
+    height: 42px;
+    padding: 0;
+  }
+
+  .triggerText {
+    display: none;
+  }
+
+  .panel {
+    top: calc(env(safe-area-inset-top) + 58px);
+    left: 10px;
+    right: 10px;
+    width: auto;
+    max-height: calc(100dvh - env(safe-area-inset-top) - 72px);
+    border-radius: 20px;
+    padding: 12px;
+  }
+
+  .actionGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .action,
+  .linkAction {
+    min-height: 58px;
+  }
+}
+
+@media (max-width: 374px) {
+  .trigger {
+    width: 38px;
+    min-width: 38px;
+    max-width: 38px;
+    height: 38px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel { scroll-behavior: auto; }
+}
+
+@media (forced-colors: active) {
+  .trigger,
+  .panel,
+  .closeButton,
+  .backButton,
+  .action,
+  .linkAction,
+  .logout,
+  .notePanel textarea,
+  .clearNote {
+    border: 1px solid CanvasText;
+  }
+}

--- a/apps/web/components/platform-v7/HeaderUtilityMenu.tsx
+++ b/apps/web/components/platform-v7/HeaderUtilityMenu.tsx
@@ -37,7 +37,6 @@ const ACTIVE_ROLE_KEY = 'pc-v7-active-role';
 const STORE_KEY = 'pc-session-v10';
 const NOTE_STORAGE_KEY = 'platform-v7-header-notepad';
 const LOGOUT_TARGET = '/platform-v7/login?logout=1';
-const CALCULATOR_EVENT = 'platform-v7:open-calculator';
 
 type Panel = 'menu' | 'notepad' | null;
 
@@ -115,6 +114,7 @@ export function HeaderUtilityMenu() {
   const bodyMount = useMount('body');
   const [panel, setPanel] = React.useState<Panel>(null);
   const [note, setNote] = React.useState('');
+  const [noteReady, setNoteReady] = React.useState(false);
   const [savedAt, setSavedAt] = React.useState('');
   const closeButtonRef = React.useRef<HTMLButtonElement>(null);
 
@@ -123,6 +123,8 @@ export function HeaderUtilityMenu() {
       setNote(window.localStorage.getItem(NOTE_STORAGE_KEY) || '');
     } catch {
       setNote('');
+    } finally {
+      setNoteReady(true);
     }
   }, []);
 
@@ -142,28 +144,20 @@ export function HeaderUtilityMenu() {
   React.useEffect(() => setPanel(null), [path]);
 
   React.useEffect(() => {
+    if (!noteReady) return;
     try {
       window.localStorage.setItem(NOTE_STORAGE_KEY, note);
-      if (note || savedAt) {
-        setSavedAt(new Date().toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' }));
-      }
+      setSavedAt(new Date().toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' }));
     } catch {
       setSavedAt('локальное сохранение недоступно');
     }
-    // savedAt deliberately excluded: it is output, not input.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [note]);
+  }, [note, noteReady]);
 
   if (PUBLIC_PATHS.has(path) || !headerMount || !bodyMount) return null;
 
   const runNativeAction = (selector: string) => {
     setPanel(null);
     window.requestAnimationFrame(() => activateNativeAction(selector));
-  };
-
-  const openCalculator = () => {
-    setPanel(null);
-    window.requestAnimationFrame(() => window.dispatchEvent(new CustomEvent(CALCULATOR_EVENT)));
   };
 
   const logout = () => {
@@ -238,7 +232,7 @@ export function HeaderUtilityMenu() {
             <section className={styles.section} aria-labelledby='utility-tools-title'>
               <h2 className={styles.sectionTitle} id='utility-tools-title'>Дополнительно</h2>
               <div className={styles.actionGrid}>
-                <ActionCard icon={<Calculator size={18} aria-hidden='true' />} title='Калькулятор' description='Обычный и ролевой расчёт' onClick={openCalculator} />
+                <ActionCard icon={<Calculator size={18} aria-hidden='true' />} title='Калькулятор' description='Обычный и ролевой расчёт' onClick={() => runNativeAction("button[aria-label='Открыть калькулятор']")} />
                 <ActionCard icon={<FileText size={18} aria-hidden='true' />} title='Блокнот' description='Записать вес, сумму или задачу' onClick={() => setPanel('notepad')} />
                 <ActionCard icon={<Moon size={18} aria-hidden='true' />} title='Сменить тему' description='Светлый или тёмный экран' onClick={() => runNativeAction('.pc-v4-theme-toggle')} />
               </div>

--- a/apps/web/components/platform-v7/HeaderUtilityMenu.tsx
+++ b/apps/web/components/platform-v7/HeaderUtilityMenu.tsx
@@ -118,6 +118,13 @@ export function HeaderUtilityMenu() {
   const closeButtonRef = React.useRef<HTMLButtonElement>(null);
 
   React.useEffect(() => {
+    const shell = headerMount?.closest('.pc-shell-root-v4');
+    if (!shell) return;
+    shell.classList.add(styles.simplifiedShell);
+    return () => shell.classList.remove(styles.simplifiedShell);
+  }, [headerMount]);
+
+  React.useEffect(() => {
     try {
       setNote(window.localStorage.getItem(NOTE_STORAGE_KEY) || '');
     } catch {

--- a/apps/web/components/platform-v7/HeaderUtilityMenu.tsx
+++ b/apps/web/components/platform-v7/HeaderUtilityMenu.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import {
+  Bell,
+  Calculator,
+  CircleHelp,
+  FileSearch2,
+  FileText,
+  LogOut,
+  Menu,
+  Moon,
+  Search,
+  Trash2,
+  X,
+} from 'lucide-react';
+import { createPortal } from 'react-dom';
+import { PLATFORM_V7_AI_ROUTE } from '@/lib/platform-v7/routes';
+import { usePlatformV7RStore, type PlatformRole } from '@/stores/usePlatformV7RStore';
+import { SESSION_COOKIE } from '@/lib/auth-cookies';
+import styles from './HeaderUtilityMenu.module.css';
+
+const PUBLIC_PATHS = new Set([
+  '/platform-v7',
+  '/platform-v7/open',
+  '/platform-v7/login',
+  '/platform-v7/register',
+  '/platform-v7/docs',
+  '/platform-v7/demo',
+  '/platform-v7/contact',
+  '/platform-v7/request',
+  '/platform-v7/deal-flow',
+]);
+const ACTIVE_ROLE_KEY = 'pc-v7-active-role';
+const STORE_KEY = 'pc-session-v10';
+const NOTE_STORAGE_KEY = 'platform-v7-header-notepad';
+const LOGOUT_TARGET = '/platform-v7/login?logout=1';
+const CALCULATOR_EVENT = 'platform-v7:open-calculator';
+
+type Panel = 'menu' | 'notepad' | null;
+
+type ActionCardProps = {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  onClick: () => void;
+};
+
+const ROLE_HELP: Record<PlatformRole, string> = {
+  operator: 'Помощь оператору',
+  buyer: 'Помощь покупателю',
+  seller: 'Помощь продавцу',
+  logistics: 'Помощь логистике',
+  driver: 'Помощь водителю',
+  surveyor: 'Помощь сюрвейеру',
+  elevator: 'Помощь при приёмке',
+  lab: 'Помощь лаборатории',
+  bank: 'Помощь банковской проверке',
+  arbitrator: 'Помощь арбитру',
+  compliance: 'Помощь комплаенсу',
+  executive: 'Помощь руководителю',
+};
+
+function normalize(pathname: string | null): string {
+  if (!pathname) return '/platform-v7';
+  return pathname.split('?')[0].replace(/\/$/, '') || '/platform-v7';
+}
+
+function useMount(selector: string): Element | null {
+  const [mount, setMount] = React.useState<Element | null>(null);
+
+  React.useEffect(() => {
+    const sync = () => setMount(document.querySelector(selector));
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [selector]);
+
+  return mount;
+}
+
+function clearCookie(name: string) {
+  document.cookie = `${name}=; Max-Age=0; Path=/; SameSite=Lax`;
+}
+
+function activateNativeAction(selector: string): boolean {
+  const control = document.querySelector<HTMLElement>(selector);
+  if (!control) return false;
+  control.click();
+  return true;
+}
+
+function ActionCard({ icon, title, description, onClick }: ActionCardProps) {
+  return (
+    <button className={styles.action} type='button' onClick={onClick}>
+      <span className={styles.actionIcon}>{icon}</span>
+      <span className={styles.actionCopy}>
+        <strong>{title}</strong>
+        <span>{description}</span>
+      </span>
+    </button>
+  );
+}
+
+export function HeaderUtilityMenu() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const path = normalize(pathname);
+  const role = usePlatformV7RStore((state) => state.role) || 'operator';
+  const clearRoleSelection = usePlatformV7RStore((state) => state.clearRoleSelection);
+  const headerMount = useMount('.pc-v4-actions');
+  const bodyMount = useMount('body');
+  const [panel, setPanel] = React.useState<Panel>(null);
+  const [note, setNote] = React.useState('');
+  const [savedAt, setSavedAt] = React.useState('');
+  const closeButtonRef = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    try {
+      setNote(window.localStorage.getItem(NOTE_STORAGE_KEY) || '');
+    } catch {
+      setNote('');
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (panel) closeButtonRef.current?.focus();
+  }, [panel]);
+
+  React.useEffect(() => {
+    if (!panel) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setPanel(null);
+    };
+    window.addEventListener('keydown', closeOnEscape);
+    return () => window.removeEventListener('keydown', closeOnEscape);
+  }, [panel]);
+
+  React.useEffect(() => setPanel(null), [path]);
+
+  React.useEffect(() => {
+    try {
+      window.localStorage.setItem(NOTE_STORAGE_KEY, note);
+      if (note || savedAt) {
+        setSavedAt(new Date().toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' }));
+      }
+    } catch {
+      setSavedAt('локальное сохранение недоступно');
+    }
+    // savedAt deliberately excluded: it is output, not input.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [note]);
+
+  if (PUBLIC_PATHS.has(path) || !headerMount || !bodyMount) return null;
+
+  const runNativeAction = (selector: string) => {
+    setPanel(null);
+    window.requestAnimationFrame(() => activateNativeAction(selector));
+  };
+
+  const openCalculator = () => {
+    setPanel(null);
+    window.requestAnimationFrame(() => window.dispatchEvent(new CustomEvent(CALCULATOR_EVENT)));
+  };
+
+  const logout = () => {
+    setPanel(null);
+    clearRoleSelection();
+    window.sessionStorage.removeItem(ACTIVE_ROLE_KEY);
+    window.localStorage.removeItem(STORE_KEY);
+    clearCookie('pc-role');
+    clearCookie(SESSION_COOKIE);
+    router.replace(LOGOUT_TARGET, { scroll: true });
+    window.requestAnimationFrame(() => {
+      window.scrollTo(0, 0);
+      if (!window.location.pathname.startsWith('/platform-v7/login')) window.location.assign(LOGOUT_TARGET);
+    });
+  };
+
+  const trigger = (
+    <div className={styles.root}>
+      <button
+        className={styles.trigger}
+        type='button'
+        aria-label='Открыть помощь и инструменты'
+        aria-expanded={panel !== null}
+        aria-haspopup='dialog'
+        data-open={panel ? 'true' : 'false'}
+        onClick={() => setPanel((current) => current ? null : 'menu')}
+      >
+        <Menu size={18} aria-hidden='true' />
+        <span className={styles.triggerText}>Помощь</span>
+      </button>
+    </div>
+  );
+
+  const panelNode = panel ? (
+    <>
+      <button className={styles.backdrop} type='button' aria-label='Закрыть помощь и инструменты' onClick={() => setPanel(null)} />
+      <section className={styles.panel} role='dialog' aria-modal='true' aria-label={panel === 'notepad' ? 'Блокнот' : 'Помощь и инструменты'}>
+        <header className={styles.panelHeader}>
+          <div className={styles.panelTitle}>
+            <strong>{panel === 'notepad' ? 'Блокнот' : 'Помощь и инструменты'}</strong>
+            <span>{panel === 'notepad' ? 'Личная заметка сохраняется только на этом устройстве.' : 'Все дополнительные функции собраны в одном месте.'}</span>
+          </div>
+          <button ref={closeButtonRef} className={styles.closeButton} type='button' aria-label='Закрыть' onClick={() => setPanel(null)}>
+            <X size={18} aria-hidden='true' />
+          </button>
+        </header>
+
+        {panel === 'menu' ? (
+          <>
+            <section className={styles.section} aria-labelledby='utility-work-title'>
+              <h2 className={styles.sectionTitle} id='utility-work-title'>Работа</h2>
+              <div className={styles.actionGrid}>
+                <ActionCard icon={<Search size={18} aria-hidden='true' />} title='Найти' description='Открыть поиск по платформе' onClick={() => runNativeAction('.pc-v4-search')} />
+                <ActionCard icon={<Bell size={18} aria-hidden='true' />} title='Уведомления' description='Посмотреть реальные события' onClick={() => runNativeAction("button[aria-label='Открыть уведомления']")} />
+              </div>
+            </section>
+
+            <section className={styles.section} aria-labelledby='utility-help-title'>
+              <h2 className={styles.sectionTitle} id='utility-help-title'>Нужна помощь</h2>
+              <div className={styles.actionGrid}>
+                <Link className={styles.linkAction} href={PLATFORM_V7_AI_ROUTE} onClick={() => setPanel(null)}>
+                  <span className={styles.actionIcon}><FileSearch2 size={18} aria-hidden='true' /></span>
+                  <span className={styles.actionCopy}><strong>Разобрать шаг</strong><span>Объяснить текущую задачу</span></span>
+                </Link>
+                <Link className={styles.linkAction} href={`/platform-v7/status?role=${role}`} onClick={() => setPanel(null)}>
+                  <span className={styles.actionIcon}><CircleHelp size={18} aria-hidden='true' /></span>
+                  <span className={styles.actionCopy}><strong>{ROLE_HELP[role]}</strong><span>Статус, инструкция и поддержка</span></span>
+                </Link>
+              </div>
+            </section>
+
+            <section className={styles.section} aria-labelledby='utility-tools-title'>
+              <h2 className={styles.sectionTitle} id='utility-tools-title'>Дополнительно</h2>
+              <div className={styles.actionGrid}>
+                <ActionCard icon={<Calculator size={18} aria-hidden='true' />} title='Калькулятор' description='Обычный и ролевой расчёт' onClick={openCalculator} />
+                <ActionCard icon={<FileText size={18} aria-hidden='true' />} title='Блокнот' description='Записать вес, сумму или задачу' onClick={() => setPanel('notepad')} />
+                <ActionCard icon={<Moon size={18} aria-hidden='true' />} title='Сменить тему' description='Светлый или тёмный экран' onClick={() => runNativeAction('.pc-v4-theme-toggle')} />
+              </div>
+            </section>
+
+            <button className={styles.logout} type='button' onClick={logout}>
+              <LogOut size={18} aria-hidden='true' />Выйти из платформы
+            </button>
+          </>
+        ) : (
+          <section className={styles.notePanel}>
+            <button className={styles.backButton} type='button' onClick={() => setPanel('menu')}>
+              Вернуться к инструментам
+            </button>
+            <textarea
+              aria-label='Текст блокнота'
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+              placeholder='Запиши вес, сумму, телефон или следующую задачу.'
+              spellCheck={false}
+            />
+            <div className={styles.noteFooter}>
+              <span>{note.length} знаков{savedAt ? ` · сохранено ${savedAt}` : ''}</span>
+              <button className={styles.clearNote} type='button' disabled={!note.trim()} onClick={() => setNote('')}>
+                <Trash2 size={16} aria-hidden='true' />Очистить
+              </button>
+            </div>
+          </section>
+        )}
+      </section>
+    </>
+  ) : null;
+
+  return (
+    <>
+      {createPortal(trigger, headerMount)}
+      {createPortal(panelNode, bodyMount)}
+    </>
+  );
+}

--- a/apps/web/components/platform-v7/HeaderUtilityMenu.tsx
+++ b/apps/web/components/platform-v7/HeaderUtilityMenu.tsx
@@ -10,7 +10,6 @@ import {
   FileSearch2,
   FileText,
   LogOut,
-  Menu,
   Moon,
   Search,
   Trash2,
@@ -185,7 +184,7 @@ export function HeaderUtilityMenu() {
         data-open={panel ? 'true' : 'false'}
         onClick={() => setPanel((current) => current ? null : 'menu')}
       >
-        <Menu size={18} aria-hidden='true' />
+        <CircleHelp size={18} aria-hidden='true' />
         <span className={styles.triggerText}>Помощь</span>
       </button>
     </div>

--- a/apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx
+++ b/apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx
@@ -8,12 +8,10 @@ import { RbacCabinetGuard } from '@/components/platform-v7/RbacCabinetGuard';
 import { PlatformV7SingleEntryGuard } from '@/components/platform-v7/PlatformV7SingleEntryGuard';
 import { PlatformV7ShellUxController } from '@/components/platform-v7/PlatformV7ShellUxController';
 import { CalculatorHeaderWidget } from '@/components/platform-v7/CalculatorHeaderWidget';
-import { MobileHeaderActionRail } from '@/components/platform-v7/MobileHeaderActionRail';
-import { NotepadHeaderWidget } from '@/components/platform-v7/NotepadHeaderWidget';
+import { HeaderUtilityMenu } from '@/components/platform-v7/HeaderUtilityMenu';
 import { RoleAssistantWidget } from '@/components/platform-v7/RoleAssistantWidget';
 import { PlatformFooter } from '@/components/platform-v7/PlatformFooter';
 import { OnboardingTour } from '@/components/platform-v7/OnboardingTour';
-import { SupportHeaderIcon } from '@/components/platform-v7/SupportHeaderIcon';
 import { HeaderLanguageSwitch } from '@/components/platform-v7/HeaderLanguageSwitch';
 import { StaffControlCenterEntry } from '@/components/platform-v7/StaffControlCenterEntry';
 import { RoleIntentDashboard } from '@/components/platform-v7/RoleIntentDashboard';
@@ -205,9 +203,7 @@ export function PlatformV7ProtectedShell({ pathname, children }: { pathname: str
             <StaffControlCenterEntry />
           </React.Suspense>
           <CalculatorHeaderWidget />
-          <NotepadHeaderWidget />
-          <SupportHeaderIcon />
-          <MobileHeaderActionRail />
+          <HeaderUtilityMenu />
           <RoleAssistantWidget />
           {workSurface}
           {showPlatformFooter ? <PlatformFooter /> : null}

--- a/apps/web/components/platform-v7/RoleAssistantWidget.module.css
+++ b/apps/web/components/platform-v7/RoleAssistantWidget.module.css
@@ -1,16 +1,13 @@
-:global(.pc-v7-role-dock a[href='/platform-v7/ai']),
-:global(.pc-v7-safe-drawer-link[href='/platform-v7/ai']),
-:global(.pc-v4-bottomnav a[href='/platform-v7/ai']),
-:global(.pc-v7-role-dock button.pc-v7-role-dock-item) {
-  display: none !important;
+.scope {
+  display: contents;
 }
 
-:global([data-testid='platform-v7-work-step-guide']) {
+.scope :global([data-testid='platform-v7-work-step-guide']) {
   padding: 8px !important;
   border-radius: 16px !important;
 }
 
-:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row) {
+.scope :global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row) {
   display: flex !important;
   align-items: center !important;
   gap: 7px !important;
@@ -18,13 +15,13 @@
   min-width: 0 !important;
 }
 
-:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:first-child) {
+.scope :global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:first-child) {
   min-width: 86px !important;
   max-width: 148px !important;
   flex: 0 1 auto !important;
 }
 
-:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:last-child) {
+.scope :global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:last-child) {
   display: flex !important;
   flex-wrap: nowrap !important;
   overflow-x: auto !important;
@@ -32,27 +29,27 @@
   scrollbar-width: none !important;
 }
 
-:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:last-child::-webkit-scrollbar) {
+.scope :global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:last-child::-webkit-scrollbar) {
   display: none !important;
 }
 
-:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row a) {
+.scope :global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row a) {
   width: auto !important;
   min-height: 32px !important;
   flex: 0 0 auto !important;
   justify-content: center !important;
 }
 
-:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row span) {
+.scope :global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row span) {
   flex: 0 0 auto !important;
 }
 
 @media (max-width: 640px) {
-  :global([data-testid='platform-v7-work-step-guide']) {
+  .scope :global([data-testid='platform-v7-work-step-guide']) {
     padding: 7px !important;
   }
 
-  :global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:first-child) {
+  .scope :global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:first-child) {
     min-width: 70px !important;
     max-width: 104px !important;
     font-size: 11px !important;

--- a/apps/web/components/platform-v7/RoleAssistantWidget.module.css
+++ b/apps/web/components/platform-v7/RoleAssistantWidget.module.css
@@ -1,0 +1,60 @@
+:global(.pc-v7-role-dock a[href='/platform-v7/ai']),
+:global(.pc-v7-safe-drawer-link[href='/platform-v7/ai']),
+:global(.pc-v4-bottomnav a[href='/platform-v7/ai']),
+:global(.pc-v7-role-dock button.pc-v7-role-dock-item) {
+  display: none !important;
+}
+
+:global([data-testid='platform-v7-work-step-guide']) {
+  padding: 8px !important;
+  border-radius: 16px !important;
+}
+
+:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row) {
+  display: flex !important;
+  align-items: center !important;
+  gap: 7px !important;
+  grid-template-columns: none !important;
+  min-width: 0 !important;
+}
+
+:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:first-child) {
+  min-width: 86px !important;
+  max-width: 148px !important;
+  flex: 0 1 auto !important;
+}
+
+:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:last-child) {
+  display: flex !important;
+  flex-wrap: nowrap !important;
+  overflow-x: auto !important;
+  min-width: 0 !important;
+  scrollbar-width: none !important;
+}
+
+:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:last-child::-webkit-scrollbar) {
+  display: none !important;
+}
+
+:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row a) {
+  width: auto !important;
+  min-height: 32px !important;
+  flex: 0 0 auto !important;
+  justify-content: center !important;
+}
+
+:global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row span) {
+  flex: 0 0 auto !important;
+}
+
+@media (max-width: 640px) {
+  :global([data-testid='platform-v7-work-step-guide']) {
+    padding: 7px !important;
+  }
+
+  :global([data-testid='platform-v7-work-step-guide'] .p7-work-actions-row > div:first-child) {
+    min-width: 70px !important;
+    max-width: 104px !important;
+    font-size: 11px !important;
+  }
+}

--- a/apps/web/components/platform-v7/RoleAssistantWidget.tsx
+++ b/apps/web/components/platform-v7/RoleAssistantWidget.tsx
@@ -3,7 +3,7 @@
 import { usePathname } from 'next/navigation';
 import { UxFinalQuietLayer } from '@/components/platform-v7/UxFinalQuietLayer';
 import { WorkStepGuide } from '@/components/platform-v7/WorkStepGuide';
-import './RoleAssistantWidget.module.css';
+import styles from './RoleAssistantWidget.module.css';
 
 const PUBLIC_PATHS = new Set([
   '/platform-v7',
@@ -32,9 +32,9 @@ export function RoleAssistantWidget() {
   if (PUBLIC_PATHS.has(path) || path.startsWith('/platform-v7/role-preview')) return null;
 
   return (
-    <>
+    <div className={styles.scope}>
       <UxFinalQuietLayer />
       <WorkStepGuide />
-    </>
+    </div>
   );
 }

--- a/apps/web/components/platform-v7/RoleAssistantWidget.tsx
+++ b/apps/web/components/platform-v7/RoleAssistantWidget.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { FileSearch2 } from 'lucide-react';
 import { UxFinalQuietLayer } from '@/components/platform-v7/UxFinalQuietLayer';
 import { WorkStepGuide } from '@/components/platform-v7/WorkStepGuide';
-import { PLATFORM_V7_AI_ROUTE } from '@/lib/platform-v7/routes';
+import './RoleAssistantWidget.module.css';
 
 const PUBLIC_PATHS = new Set([
   '/platform-v7',
@@ -35,35 +33,8 @@ export function RoleAssistantWidget() {
 
   return (
     <>
-      <style>{`
-        .pc-v7-role-dock a[href='/platform-v7/ai'],
-        .pc-v7-safe-drawer-link[href='/platform-v7/ai'],
-        .pc-v4-bottomnav a[href='/platform-v7/ai'],
-        .pc-v7-role-dock button.pc-v7-role-dock-item{display:none!important}
-        .pc-v7-assistant-widget{position:fixed;right:16px;bottom:calc(env(safe-area-inset-bottom) + 92px);z-index:104;display:inline-flex;align-items:center;gap:8px;min-height:44px;max-width:min(240px,calc(100dvw - 32px));padding:0 14px;border-radius:999px;border:1px solid var(--pc-accent-border);background:var(--pc-accent-bg);color:var(--pc-accent-strong);box-shadow:var(--pc-shadow-lg);text-decoration:none;font-size:12px;font-weight:950;line-height:1;backdrop-filter:blur(18px)}
-        .pc-v7-assistant-widget[data-active='true']{background:var(--pc-accent);border-color:var(--pc-accent);color:white}
-        .pc-v7-assistant-widget svg{width:17px;height:17px;flex:0 0 auto}
-        @media(max-width:640px){.pc-v7-assistant-widget{right:12px;bottom:calc(env(safe-area-inset-bottom) + 82px);min-height:42px;padding:0 12px;font-size:11px}.pc-v7-assistant-widget span{max-width:136px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}}
-      `}</style>
       <UxFinalQuietLayer />
       <WorkStepGuide />
-      <style>{`
-        [data-testid="platform-v7-work-step-guide"]{padding:8px!important;border-radius:16px!important}
-        [data-testid="platform-v7-work-step-guide"] .p7-work-actions-row{display:flex!important;align-items:center!important;gap:7px!important;grid-template-columns:none!important;min-width:0!important}
-        [data-testid="platform-v7-work-step-guide"] .p7-work-actions-row>div:first-child{min-width:86px!important;max-width:148px!important;flex:0 1 auto!important}
-        [data-testid="platform-v7-work-step-guide"] .p7-work-actions-row>div:last-child{display:flex!important;flex-wrap:nowrap!important;overflow-x:auto!important;min-width:0!important;scrollbar-width:none!important}
-        [data-testid="platform-v7-work-step-guide"] .p7-work-actions-row>div:last-child::-webkit-scrollbar{display:none!important}
-        [data-testid="platform-v7-work-step-guide"] .p7-work-actions-row a{width:auto!important;min-height:32px!important;flex:0 0 auto!important;justify-content:center!important}
-        [data-testid="platform-v7-work-step-guide"] .p7-work-actions-row span{flex:0 0 auto}
-        @media(max-width:640px){
-          [data-testid="platform-v7-work-step-guide"]{padding:7px!important}
-          [data-testid="platform-v7-work-step-guide"] .p7-work-actions-row>div:first-child{min-width:70px!important;max-width:104px!important;font-size:11px!important}
-        }
-      `}</style>
-      <Link className="pc-v7-assistant-widget" href={PLATFORM_V7_AI_ROUTE} data-active={path === PLATFORM_V7_AI_ROUTE ? 'true' : 'false'} aria-label="Открыть разбор рабочего шага" title="Разбор рабочего шага">
-        <FileSearch2 aria-hidden="true" />
-        <span>Разбор шага</span>
-      </Link>
     </>
   );
 }

--- a/apps/web/tests/unit/platformV7CanonicalDealWorkspace.test.ts
+++ b/apps/web/tests/unit/platformV7CanonicalDealWorkspace.test.ts
@@ -16,6 +16,9 @@ describe('platform-v7 canonical one-deal workspace', () => {
   const dashboard = source('components/platform-v7/RoleIntentDashboard.tsx');
   const dashboardStyles = source('components/platform-v7/RoleIntentDashboard.module.css');
   const shell = source('components/platform-v7/PlatformV7ProtectedShell.tsx');
+  const utilityMenu = source('components/platform-v7/HeaderUtilityMenu.tsx');
+  const utilityStyles = source('components/platform-v7/HeaderUtilityMenu.module.css');
+  const assistant = source('components/platform-v7/RoleAssistantWidget.tsx');
   const proxy = source('app/api/proxy/[...path]/route.ts');
   const loginPage = source('app/platform-v7/login/page.tsx');
   const loginClient = source('app/platform-v7/login/LoginFormClient.tsx');
@@ -63,6 +66,29 @@ describe('platform-v7 canonical one-deal workspace', () => {
     expect(workspace).toContain("values.acceptanceId = acceptanceId");
     expect(commandFormStyles).toContain('min-height: 48px');
     expect(commandFormStyles).toContain('@media (max-width: 560px)');
+  });
+
+  it('keeps header complexity behind one clearly labelled utility menu', () => {
+    expect(shell).toContain('<HeaderUtilityMenu />');
+    expect(shell).toContain('<CalculatorHeaderWidget />');
+    expect(shell).not.toContain('<MobileHeaderActionRail />');
+    expect(shell).not.toContain('<NotepadHeaderWidget />');
+    expect(shell).not.toContain('<SupportHeaderIcon />');
+    expect(utilityMenu).toContain('Помощь и инструменты');
+    expect(utilityMenu).toContain('Все дополнительные функции собраны в одном месте');
+    expect(utilityMenu).toContain("runNativeAction('.pc-v4-search')");
+    expect(utilityMenu).toContain("button[aria-label='Открыть уведомления']");
+    expect(utilityMenu).toContain("button[aria-label='Открыть калькулятор']");
+    expect(utilityMenu).toContain('PLATFORM_V7_AI_ROUTE');
+    expect(utilityMenu).toContain('Статус, инструкция и поддержка');
+    expect(utilityMenu).toContain('Выйти из платформы');
+    expect(utilityMenu).not.toContain('ROLE_NOTICE');
+    expect(utilityMenu).not.toContain('Есть действие');
+    expect(utilityStyles).toContain("button[aria-label='Открыть калькулятор']");
+    expect(utilityStyles).toContain('min-height: 48px');
+    expect(utilityStyles).toContain('@media (max-width: 767px)');
+    expect(assistant).not.toContain('pc-v7-assistant-widget');
+    expect(assistant).toContain('<WorkStepGuide />');
   });
 
   it('submits only user-entered payload through real task-first forms', () => {

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -168,6 +168,14 @@
       "apps/web/components/platform-v7/DealCommandForm.tsx",
       "apps/web/components/platform-v7/DealCommandForm.module.css",
       "apps/web/tests/unit/platformV7CanonicalDealWorkspace.test.ts"
+    ],
+    "agent/cognitive-app-shell-utilities": [
+      "apps/web/components/platform-v7/HeaderUtilityMenu.tsx",
+      "apps/web/components/platform-v7/HeaderUtilityMenu.module.css",
+      "apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx",
+      "apps/web/components/platform-v7/RoleAssistantWidget.tsx",
+      "apps/web/components/platform-v7/RoleAssistantWidget.module.css",
+      "apps/web/tests/unit/platformV7CanonicalDealWorkspace.test.ts"
     ]
   },
   "currentAcceptance": [


### PR DESCRIPTION
## Цель

Снизить выбор и визуальный шум до начала основной работы. Пользователь должен видеть в шапке навигацию, язык, подтверждённый staff-доступ и один понятный вход «Помощь», а не ряд несвязанных технических и вспомогательных иконок.

## Что изменено

- поиск, реальные уведомления, калькулятор, блокнот, смена темы, разбор шага, ролевая помощь и выход собраны в единое меню «Помощь и инструменты»;
- существующие search, notification, theme и calculator механизмы не дублируются: меню активирует действующие контролы AppShell;
- отдельные кнопки блокнота и поддержки больше не монтируются в защищённой оболочке;
- плавающая кнопка AI-разбора убрана, но сам разбор доступен через единое меню, а WorkStepGuide сохранён;
- статические псевдоуведомления не используются: пункт уведомлений открывает фактический notification panel AppShell;
- staff entry остаётся отдельным и появляется только после серверно подтверждённого назначения;
- язык остаётся отдельным контекстным контролом;
- меню работает на mobile и desktop, имеет крупные цели, Escape/overlay-close, focus-visible, forced-colors и reduced-motion;
- личный блокнот сохраняется локально только после безопасной гидратации состояния.

## Проверки

Добавлены regression gates на:

- один utility entry вместо MobileHeaderActionRail + NotepadHeaderWidget + SupportHeaderIcon;
- сохранение существующего калькулятора и native shell actions;
- отсутствие fake notification copy;
- сохранение WorkStepGuide;
- mobile layout и крупные интерактивные цели.

## Честная граница

Это упрощение оболочки защищённых кабинетов. Полная миграция AppShellV4 с удалением legacy inline styles и DOM-переводчика остаётся отдельной работой; данный PR не заявляет завершение всей визуальной программы.