### PR TITLE
Make role home a server-prioritized Today workspace

### DIFF
--- a/apps/web/components/platform-v7/RoleIntentDashboard.module.css
+++ b/apps/web/components/platform-v7/RoleIntentDashboard.module.css
@@ -1,7 +1,86 @@
-.stateCard {
-  min-height: 180px;
+.todayWorkspace {
+  display: grid;
+  gap: 14px;
+}
+
+.todayHeader {
+  border: 1px solid var(--pc-accent-border);
+  border-radius: 22px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--pc-accent-bg) 86%, var(--pc-bg-card)), var(--pc-bg-card));
+  padding: 18px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  box-shadow: var(--pc-shadow-sm);
+}
+
+.todayCopy {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.todayLabel {
+  width: fit-content;
+  min-height: 28px;
+  border: 1px solid var(--pc-accent-border);
+  border-radius: 999px;
+  background: var(--pc-bg-card);
+  color: var(--pc-accent-strong);
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  font-size: 11px;
+  font-weight: 950;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.todayCopy h1 {
+  margin: 0;
+  color: var(--pc-text-primary);
+  font-size: clamp(22px, 4vw, 30px);
+  line-height: 1.12;
+  letter-spacing: -0.025em;
+}
+
+.todayCopy p {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--pc-text-secondary);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.todayFacts {
+  min-width: 190px;
   border: 1px solid var(--pc-border);
-  border-radius: 20px;
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--pc-bg-card) 94%, transparent);
+  padding: 13px 14px;
+  display: grid;
+  gap: 5px;
+}
+
+.todayFacts strong {
+  color: var(--pc-text-primary);
+  font-size: 14px;
+  line-height: 1.25;
+}
+
+.todayFacts span {
+  color: var(--pc-text-muted);
+  font-size: 12px;
+  line-height: 1.35;
+  font-weight: 750;
+}
+
+.stateCard {
+  min-height: 220px;
+  border: 1px solid var(--pc-border);
+  border-radius: 22px;
   background: var(--pc-shell-surface);
   padding: 24px;
   display: grid;
@@ -11,7 +90,7 @@
 }
 
 .stateContent {
-  width: min(100%, 460px);
+  width: min(100%, 480px);
   display: grid;
   justify-items: center;
   gap: 10px;
@@ -20,19 +99,23 @@
 .stateContent h1 {
   margin: 0;
   color: var(--pc-text-primary);
-  font-size: clamp(20px, 4vw, 26px);
+  font-size: clamp(21px, 4vw, 28px);
   line-height: 1.2;
 }
 
 .stateContent p {
   margin: 0;
-  max-width: 42ch;
+  max-width: 44ch;
   font-size: 14px;
   line-height: 1.55;
 }
 
 .errorIcon {
   color: var(--pc-danger, #b42318);
+}
+
+.emptyIcon {
+  color: var(--pc-accent-strong);
 }
 
 .retryButton {
@@ -47,59 +130,94 @@
   justify-content: center;
   gap: 8px;
   font: inherit;
-  font-weight: 800;
+  font-weight: 850;
   cursor: pointer;
 }
 
-.retryButton:focus-visible,
-.dealLink:focus-visible,
-.otherDeals summary:focus-visible {
-  outline: 3px solid color-mix(in srgb, var(--pc-accent) 45%, transparent);
-  outline-offset: 3px;
-}
-
 .otherDeals {
-  margin: 0 0 12px;
   border: 1px solid var(--pc-border);
-  border-radius: 16px;
+  border-radius: 18px;
   background: var(--pc-shell-surface);
   color: var(--pc-text-secondary);
+  overflow: clip;
 }
 
 .otherDeals summary {
-  min-height: 48px;
+  min-height: 52px;
   padding: 0 16px;
   display: flex;
   align-items: center;
   cursor: pointer;
   font-size: 14px;
-  font-weight: 800;
+  font-weight: 900;
+}
+
+.otherDeals[open] summary {
+  border-bottom: 1px solid var(--pc-border);
+  background: var(--pc-bg-elevated);
 }
 
 .dealLinks {
-  padding: 0 12px 12px;
+  max-height: min(440px, 55dvh);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 12px;
   display: grid;
   gap: 8px;
 }
 
 .dealLink {
-  min-height: 48px;
+  min-height: 58px;
   border: 1px solid var(--pc-border);
-  border-radius: 13px;
+  border-radius: 15px;
+  background: var(--pc-bg-card);
   padding: 10px 12px;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
   color: var(--pc-text-primary);
   text-decoration: none;
-  font-weight: 800;
 }
 
-.dealLink::after {
-  content: 'Открыть';
-  color: var(--pc-accent);
-  font-size: 12px;
+.dealLink:hover {
+  border-color: var(--pc-accent-border);
+  background: var(--pc-accent-bg);
+}
+
+.dealLink svg {
+  color: var(--pc-accent-strong);
+}
+
+.dealCopy {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.dealCopy strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  line-height: 1.25;
+  font-weight: 900;
+}
+
+.dealCopy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--pc-text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.retryButton:focus-visible,
+.dealLink:focus-visible,
+.otherDeals summary:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--pc-accent) 42%, transparent);
+  outline-offset: 3px;
 }
 
 .spin {
@@ -110,18 +228,67 @@
   to { transform: rotate(360deg); }
 }
 
+@media (max-width: 720px) {
+  .todayHeader {
+    grid-template-columns: 1fr;
+    padding: 16px;
+  }
+
+  .todayFacts {
+    width: 100%;
+    min-width: 0;
+  }
+}
+
 @media (max-width: 430px) {
-  .stateCard { padding: 20px 16px; }
-  .dealLink { align-items: flex-start; flex-direction: column; }
+  .todayWorkspace {
+    gap: 10px;
+  }
+
+  .todayHeader,
+  .stateCard {
+    border-radius: 18px;
+  }
+
+  .todayHeader {
+    padding: 14px;
+  }
+
+  .todayCopy h1 {
+    font-size: 22px;
+  }
+
+  .todayCopy p {
+    font-size: 13px;
+  }
+
+  .stateCard {
+    min-height: 200px;
+    padding: 20px 16px;
+  }
+
+  .dealLinks {
+    padding: 9px;
+  }
+
+  .dealLink {
+    min-height: 62px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .spin { animation: none; }
+  .spin {
+    animation: none;
+  }
 }
 
 @media (forced-colors: active) {
+  .todayHeader,
+  .todayFacts,
   .stateCard,
   .otherDeals,
   .dealLink,
-  .retryButton { border: 1px solid CanvasText; }
+  .retryButton {
+    border: 1px solid CanvasText;
+  }
 }

--- a/apps/web/components/platform-v7/RoleIntentDashboard.tsx
+++ b/apps/web/components/platform-v7/RoleIntentDashboard.tsx
@@ -2,30 +2,87 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { AlertTriangle, ArrowRight, CheckCircle2, RefreshCw } from 'lucide-react';
 import { CanonicalDealWorkspace } from '@/components/platform-v7/CanonicalDealWorkspace';
 import type { PlatformRole } from '@/stores/usePlatformV7RStore';
 import styles from './RoleIntentDashboard.module.css';
 
-type AccessibleDealRef = { id: string; dealNumber: string | null };
+type AccessibleDealRef = {
+  id: string;
+  dealNumber: string | null;
+  status: string | null;
+  nextAction: string | null;
+};
+
 type LoadState =
   | { kind: 'loading' }
   | { kind: 'ready'; deals: AccessibleDealRef[] }
   | { kind: 'empty' }
   | { kind: 'error'; message: string };
 
+const ROLE_FOCUS: Record<PlatformRole, string> = {
+  operator: 'Управление исполнением сделок',
+  buyer: 'Покупка, поставка и оплата',
+  seller: 'Продажа, отгрузка и получение оплаты',
+  logistics: 'Рейсы, водители и прибытие',
+  driver: 'Текущий рейс и следующий шаг',
+  surveyor: 'Осмотр и подтверждение фактов',
+  elevator: 'Приёмка, вес и передача в лабораторию',
+  lab: 'Пробы, качество и протокол',
+  bank: 'Платёжное основание и банковское подтверждение',
+  arbitrator: 'Спор, доказательства и решение',
+  compliance: 'Допуск, документы и риски',
+  executive: 'Деньги, блокировки и критические отклонения',
+};
+
+function optionalString(value: unknown): string | null | undefined {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized || null;
+}
+
 function validDeals(payload: unknown): AccessibleDealRef[] | null {
   if (!payload || typeof payload !== 'object' || !Array.isArray((payload as { items?: unknown }).items)) return null;
-  const items = (payload as { items: unknown[] }).items;
+
   const deals: AccessibleDealRef[] = [];
-  for (const item of items) {
+  for (const item of (payload as { items: unknown[] }).items) {
     if (!item || typeof item !== 'object') return null;
-    const id = typeof (item as { id?: unknown }).id === 'string' ? (item as { id: string }).id.trim() : '';
-    const dealNumber = (item as { dealNumber?: unknown }).dealNumber;
-    if (!id || (dealNumber !== null && dealNumber !== undefined && typeof dealNumber !== 'string')) return null;
-    deals.push({ id, dealNumber: typeof dealNumber === 'string' ? dealNumber : null });
+
+    const row = item as Record<string, unknown>;
+    const id = typeof row.id === 'string' ? row.id.trim() : '';
+    const dealNumber = optionalString(row.dealNumber);
+    const status = optionalString(row.status);
+    const nextAction = optionalString(row.nextAction);
+
+    if (!id || dealNumber === undefined || status === undefined || nextAction === undefined) return null;
+    deals.push({ id, dealNumber, status, nextAction });
   }
+
   return deals;
+}
+
+function prioritizeDeals(deals: AccessibleDealRef[]): AccessibleDealRef[] {
+  const actionable: AccessibleDealRef[] = [];
+  const waiting: AccessibleDealRef[] = [];
+
+  for (const deal of deals) {
+    (deal.nextAction ? actionable : waiting).push(deal);
+  }
+
+  return [...actionable, ...waiting];
+}
+
+function actionCountLabel(count: number): string {
+  if (count === 0) return 'Новых действий нет';
+  const mod10 = count % 10;
+  const mod100 = count % 100;
+  const noun = mod10 === 1 && mod100 !== 11 ? 'сделка требует' : 'сделок требуют';
+  return `${count} ${noun} действия`;
+}
+
+function dealTitle(deal: AccessibleDealRef): string {
+  return deal.dealNumber || deal.id;
 }
 
 export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
@@ -37,24 +94,33 @@ export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
     setState({ kind: 'loading' });
     const controller = new AbortController();
     const timeout = window.setTimeout(() => controller.abort(), 12_000);
+
     try {
-      const response = await fetch('/api/proxy/deals/accessible?limit=5', {
+      const response = await fetch('/api/proxy/deals/accessible?limit=20', {
         cache: 'no-store',
         headers: { Accept: 'application/json' },
         signal: controller.signal,
       });
       const payload = await response.json().catch(() => null);
       if (requestId !== requestRef.current) return;
+
       if (!response.ok) {
-        setState({ kind: 'error', message: response.status === 401 || response.status === 403 ? 'Доступ к сделкам не подтверждён. Войди заново.' : 'Не удалось загрузить сделки.' });
+        setState({
+          kind: 'error',
+          message: response.status === 401 || response.status === 403
+            ? 'Доступ к сделкам не подтверждён. Войди заново.'
+            : 'Не удалось загрузить сделки.',
+        });
         return;
       }
+
       const deals = validDeals(payload);
       if (!deals) {
         setState({ kind: 'error', message: 'Сервер вернул некорректный список сделок.' });
         return;
       }
-      setState(deals.length === 0 ? { kind: 'empty' } : { kind: 'ready', deals });
+
+      setState(deals.length === 0 ? { kind: 'empty' } : { kind: 'ready', deals: prioritizeDeals(deals) });
     } catch (error) {
       if (requestId !== requestRef.current) return;
       setState({
@@ -80,8 +146,8 @@ export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
       <section className={styles.stateCard} aria-live='polite'>
         <div className={styles.stateContent}>
           <RefreshCw className={styles.spin} size={24} aria-hidden='true' />
-          <h1>Открываем твою рабочую сделку</h1>
-          <p>Покажем только то, что требует твоего внимания сейчас.</p>
+          <h1>Собираем задачи на сегодня</h1>
+          <p>Покажем только подтверждённые сделки и их следующий шаг.</p>
         </div>
       </section>
     );
@@ -91,8 +157,9 @@ export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
     return (
       <section className={styles.stateCard} data-empty-deals>
         <div className={styles.stateContent}>
-          <h1>У вас пока нет активных сделок</h1>
-          <p>Новая сделка появится здесь после подтверждения вашего участия сервером.</p>
+          <CheckCircle2 className={styles.emptyIcon} size={28} aria-hidden='true' />
+          <h1>Сегодня нет активных сделок</h1>
+          <p>Новая сделка появится здесь только после подтверждения вашего участия сервером.</p>
         </div>
       </section>
     );
@@ -103,7 +170,7 @@ export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
       <section className={styles.stateCard} role='alert' data-deals-error>
         <div className={styles.stateContent}>
           <AlertTriangle className={styles.errorIcon} size={26} aria-hidden='true' />
-          <h1>Не удалось загрузить сделки</h1>
+          <h1>Не удалось загрузить задачи</h1>
           <p>{state.message}</p>
           <button className={styles.retryButton} type='button' onClick={() => void load()}>
             <RefreshCw size={18} aria-hidden='true' />
@@ -115,21 +182,40 @@ export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
   }
 
   const [current, ...otherDeals] = state.deals;
+  const actionableCount = state.deals.filter((deal) => deal.nextAction).length;
+
   return (
-    <>
+    <div className={styles.todayWorkspace}>
+      <section className={styles.todayHeader} aria-labelledby='today-title'>
+        <div className={styles.todayCopy}>
+          <span className={styles.todayLabel}>Сегодня</span>
+          <h1 id='today-title'>{ROLE_FOCUS[role]}</h1>
+          <p>Сначала показана сделка, где от вас уже требуется действие. Остальные сделки и функции не скрыты.</p>
+        </div>
+        <div className={styles.todayFacts} aria-label='Сводка задач на сегодня'>
+          <strong>{actionCountLabel(actionableCount)}</strong>
+          <span>Активных сделок: {state.deals.length}</span>
+        </div>
+      </section>
+
       {otherDeals.length > 0 ? (
         <details className={styles.otherDeals}>
           <summary>Другие активные сделки: {otherDeals.length}</summary>
           <nav className={styles.dealLinks} aria-label='Другие активные сделки'>
             {otherDeals.map((deal) => (
               <Link className={styles.dealLink} key={deal.id} href={`/platform-v7/deals/${encodeURIComponent(deal.id)}/execution`}>
-                {deal.dealNumber || deal.id}
+                <span className={styles.dealCopy}>
+                  <strong>{dealTitle(deal)}</strong>
+                  <small>{deal.nextAction || 'Сейчас действие не требуется'}</small>
+                </span>
+                <ArrowRight size={18} aria-hidden='true' />
               </Link>
             ))}
           </nav>
         </details>
       ) : null}
+
       <CanonicalDealWorkspace role={role} dealId={current.id} />
-    </>
+    </div>
   );
 }

--- a/apps/web/components/platform-v7/RoleIntentDashboard.tsx
+++ b/apps/web/components/platform-v7/RoleIntentDashboard.tsx
@@ -75,10 +75,12 @@ function prioritizeDeals(deals: AccessibleDealRef[]): AccessibleDealRef[] {
 
 function actionCountLabel(count: number): string {
   if (count === 0) return 'Новых действий нет';
+
   const mod10 = count % 10;
   const mod100 = count % 100;
-  const noun = mod10 === 1 && mod100 !== 11 ? 'сделка требует' : 'сделок требуют';
-  return `${count} ${noun} действия`;
+  if (mod10 === 1 && mod100 !== 11) return `${count} сделка требует действия`;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return `${count} сделки требуют действия`;
+  return `${count} сделок требуют действия`;
 }
 
 function dealTitle(deal: AccessibleDealRef): string {
@@ -194,14 +196,14 @@ export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
         </div>
         <div className={styles.todayFacts} aria-label='Сводка задач на сегодня'>
           <strong>{actionCountLabel(actionableCount)}</strong>
-          <span>Активных сделок: {state.deals.length}</span>
+          <span>Показано активных сделок: {state.deals.length}</span>
         </div>
       </section>
 
       {otherDeals.length > 0 ? (
         <details className={styles.otherDeals}>
-          <summary>Другие активные сделки: {otherDeals.length}</summary>
-          <nav className={styles.dealLinks} aria-label='Другие активные сделки'>
+          <summary>Другие показанные сделки: {otherDeals.length}</summary>
+          <nav className={styles.dealLinks} aria-label='Другие показанные сделки'>
             {otherDeals.map((deal) => (
               <Link className={styles.dealLink} key={deal.id} href={`/platform-v7/deals/${encodeURIComponent(deal.id)}/execution`}>
                 <span className={styles.dealCopy}>

--- a/apps/web/components/platform-v7/RoleIntentDashboard.tsx
+++ b/apps/web/components/platform-v7/RoleIntentDashboard.tsx
@@ -161,7 +161,7 @@ export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
         <div className={styles.stateContent}>
           <CheckCircle2 className={styles.emptyIcon} size={28} aria-hidden='true' />
           <h1>Сегодня нет активных сделок</h1>
-          <p>Новая сделка появится здесь только после подтверждения вашего участия сервером.</p>
+          <p>У вас пока нет активных сделок, подтверждённых сервером. Новая сделка появится здесь после подтверждения вашего участия.</p>
         </div>
       </section>
     );

--- a/apps/web/tests/unit/platformV7RoleIntentDashboard.test.ts
+++ b/apps/web/tests/unit/platformV7RoleIntentDashboard.test.ts
@@ -24,21 +24,28 @@ const ownerCabinetMatrix = [
 ] as const;
 
 describe('platform-v7 role intent dashboard', () => {
-  it('opens only a participant-scoped real deal and exposes honest empty/error states', () => {
+  it('opens only participant-scoped real deals and exposes honest Today states', () => {
     const model = read('apps/web/lib/platform-v7/roleIntentActions.ts');
     const dashboard = read('apps/web/components/platform-v7/RoleIntentDashboard.tsx');
+    const dashboardStyles = read('apps/web/components/platform-v7/RoleIntentDashboard.module.css');
     const shell = read('apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx');
 
     expect(model).toContain('ROLE_INTENT_ACTIONS');
-    expect(dashboard).toContain('/api/proxy/deals/accessible?limit=5');
+    expect(dashboard).toContain('/api/proxy/deals/accessible?limit=20');
+    expect(dashboard).toContain('function prioritizeDeals');
+    expect(dashboard).toContain('(deal.nextAction ? actionable : waiting).push(deal)');
+    expect(dashboard).toContain('Сначала показана сделка, где от вас уже требуется действие');
     expect(dashboard).toContain('<CanonicalDealWorkspace role={role} dealId={current.id} />');
     expect(dashboard).not.toContain('<CanonicalDealWorkspace role={role} />');
     expect(dashboard).not.toContain('DEAL-INDUSTRIAL-001');
-    expect(dashboard).toContain('У вас пока нет активных сделок');
-    expect(dashboard).toContain('Не удалось загрузить сделки');
+    expect(dashboard).toContain('Сегодня нет активных сделок');
+    expect(dashboard).toContain('Не удалось загрузить задачи');
     expect(dashboard).toContain('Сервер вернул некорректный список сделок');
     expect(dashboard).toContain('Повторить');
     expect(dashboard).not.toContain('getRoleIntentConfig');
+    expect(dashboardStyles).toContain('min-height: 48px');
+    expect(dashboardStyles).toContain('@media (max-width: 430px)');
+    expect(dashboardStyles).toContain('@media (forced-colors: active)');
     expect(shell).toContain('ROLE_INTENT_ROOT_PATHS');
     expect(shell).toContain(': <RoleIntentDashboard role={initialRole} />');
 

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -210,6 +210,11 @@
       "apps/web/tests/unit/platformV7ShellTouchTargets.test.ts",
       "apps/web/tests/unit/platformV7ShellUxController.test.ts",
       "apps/web/tests/unit/platformV7ShellVisualClutter.test.ts"
+    ],
+    "agent/today-priority-workspace": [
+      "apps/web/components/platform-v7/RoleIntentDashboard.tsx",
+      "apps/web/components/platform-v7/RoleIntentDashboard.module.css",
+      "apps/web/tests/unit/platformV7RoleIntentDashboard.test.ts"
     ]
   },
   "currentAcceptance": [


### PR DESCRIPTION
## Цель

Сделать первый экран кабинета понятным без обучения и без потери функций: пользователь сразу видит, что требует действия сегодня, а не случайную первую сделку из списка.

## Что изменено

- роль получает единый экран «Сегодня» с коротким человеческим фокусом;
- список загружается только из participant-scoped `/api/proxy/deals/accessible`;
- объём ответа ограничен 20 сделками, чтобы не перегружать браузер и сеть;
- сначала показывается сделка, для которой сервер вернул `nextAction`;
- сделки без действия сохраняют исходный серверный порядок и остаются доступны в раскрываемом списке;
- UI честно пишет «показано», а не выдаёт ограниченную выборку за полный объём;
- добавлены реальные loading, empty, error и timeout состояния;
- для 12 ролей используются короткие описания рабочего фокуса, но фактический следующий шаг берётся только из канонического workspace;
- touch targets не менее 48 px, mobile-first layout, bounded scrolling, reduced-motion и forced-colors;
- RBAC, DealParticipant scope, команды сделки, optimistic concurrency, idempotency и банковские callback-only ограничения не менялись.

## Промышленная граница

Этот срез не вводит клиентскую бизнес-приоритизацию по сумме, сроку или риску: таких подтверждённых полей endpoint пока не отдаёт. Клиент делает только стабильное разделение `есть server nextAction / нет server nextAction`. Для полноценной приоритетной очереди нужен отдельный серверный контракт с cursor pagination, priority reason, deadline и money impact.

## Проверки

Обновлены regression gates на bounded load, server-derived nextAction, честные состояния, CSS Modules, mobile и accessibility. Exact-head CI запускается после открытия PR.