### PR TITLE
Replace the deals page with a real server-backed registry

### DIFF
--- a/apps/web/app/platform-v7/deals/deals.module.css
+++ b/apps/web/app/platform-v7/deals/deals.module.css
@@ -1,0 +1,69 @@
+.page {
+  width: min(100%, 1180px);
+  margin: 0 auto;
+  display: grid;
+  gap: 14px;
+}
+
+.pageHeader {
+  border: 1px solid var(--pc-border);
+  border-radius: 22px;
+  background: linear-gradient(135deg, var(--pc-bg-card), var(--pc-accent-bg));
+  padding: 18px;
+  display: grid;
+  gap: 7px;
+}
+
+.eyebrow {
+  width: fit-content;
+  min-height: 28px;
+  border: 1px solid var(--pc-accent-border);
+  border-radius: 999px;
+  background: var(--pc-bg-card);
+  color: var(--pc-accent-strong);
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.pageHeader h1 {
+  margin: 0;
+  color: var(--pc-text-primary);
+  font-size: clamp(26px, 5vw, 40px);
+  line-height: 1.08;
+  letter-spacing: -0.035em;
+}
+
+.pageHeader p {
+  margin: 0;
+  max-width: 72ch;
+  color: var(--pc-text-secondary);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+@media (max-width: 520px) {
+  .page {
+    gap: 10px;
+  }
+
+  .pageHeader {
+    border-radius: 18px;
+    padding: 14px;
+  }
+
+  .pageHeader p {
+    font-size: 13px;
+  }
+}
+
+@media (forced-colors: active) {
+  .pageHeader,
+  .eyebrow {
+    border: 1px solid CanvasText;
+  }
+}

--- a/apps/web/app/platform-v7/deals/page.tsx
+++ b/apps/web/app/platform-v7/deals/page.tsx
@@ -1,130 +1,18 @@
-import Link from 'next/link';
 import { CanonicalDealsList } from '@/components/platform-v7/CanonicalDealsList';
-import { DEAL360_SCENARIOS } from '@/lib/platform-v7/deal360-source-of-truth';
-import { ExcelExportButton } from '@/components/platform-v7/ExcelExportButton';
-import { SmartSectionSummary } from '@/components/platform-v7/visual/SmartSectionSummary';
-import { CollapsibleSection } from '@/components/platform-v7/CollapsibleSection';
-import { E2EDealSimulationPanel } from '@/components/platform-v7/E2EDealSimulationPanel';
-
-const dealSnapshots = Object.values(DEAL360_SCENARIOS).map((s) => ({
-  id: s.dealId,
-  lot: s.lotId,
-  stage: s.cockpit.currentStage,
-  nextActor: s.cockpit.nextActor,
-  money: s.cockpit.moneyStatus,
-  docs: s.cockpit.docStatus,
-  dispute: s.cockpit.disputeStatus,
-  cannotHappenReason: s.cockpit.cannotHappenReason,
-  href: `/platform-v7/deals/${s.dealId}/clean`,
-}));
-
-const stateColor = {
-  ok: { border: 'rgba(10,122,95,0.18)', bg: 'rgba(10,122,95,0.06)', text: '#0A7A5F' },
-  wait: { border: 'rgba(180,83,9,0.18)', bg: 'rgba(180,83,9,0.06)', text: '#B45309' },
-  stop: { border: 'rgba(220,38,38,0.18)', bg: 'rgba(220,38,38,0.06)', text: '#B91C1C' },
-  manual: { border: 'rgba(100,116,139,0.18)', bg: 'rgba(100,116,139,0.06)', text: 'var(--pc-text-secondary, #475569)' },
-} as const;
+import styles from './deals.module.css';
 
 export default function PlatformV7DealsPage() {
-  const stoppedDeals = dealSnapshots.filter((d) => d.cannotHappenReason || d.money.state === 'stop');
-  const primaryDeal = stoppedDeals.find((deal) => deal.id === 'DL-9106') ?? stoppedDeals[0] ?? dealSnapshots[0];
-
   return (
-    <div data-testid='platform-v7-deals-page' style={{ display: 'grid', gap: 18 }}>
+    <div className={styles.page} data-testid='platform-v7-deals-page'>
+      <header className={styles.pageHeader}>
+        <span className={styles.eyebrow}>Реестр исполнения</span>
+        <h1>Сделки</h1>
+        <p>
+          Здесь показываются только сделки, к которым сервер подтвердил ваше участие.
+          Статические сценарии, демонстрационные суммы и внутренние симуляторы из рабочего реестра удалены.
+        </p>
+      </header>
       <CanonicalDealsList />
-      <style dangerouslySetInnerHTML={{ __html: `
-        @media(max-width:767px){
-          [data-testid='platform-v7-deals-page']{gap:12px!important}
-          .pc-deals-shell{padding:16px!important;border-radius:24px!important;gap:12px!important}
-          .pc-deals-kicker,.pc-deals-summary,.pc-deals-secondary-cta,.pc-deals-gates{display:none!important}
-          .pc-deals-title{font-size:clamp(28px,8vw,38px)!important;line-height:1.04!important}
-          .pc-deals-list{gap:8px!important}
-          .pc-deals-list > a:nth-child(n+6){display:none!important}
-          .pc-deal-row{padding:13px!important;border-radius:16px!important;gap:7px!important}
-          .pc-deal-row-top{align-items:flex-start!important;gap:8px!important}
-          .pc-deal-row-id{font-size:10px!important}
-          .pc-deal-row-stage{font-size:13px!important;line-height:1.25!important}
-          .pc-deal-row-money{font-size:11px!important;padding:4px 9px!important;max-width:48vw;text-align:center}
-          .pc-deal-row-stop{font-size:11px!important;line-height:1.35!important;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
-          .pc-deals-primary-cta{width:100%;justify-content:center;min-height:52px!important}
-        }
-      ` }} />
-
-      <section className='pc-deals-shell' style={{ background: 'linear-gradient(135deg, #FFFFFF 0%, #F8FAFB 60%, #EEF6F3 100%)', border: '1px solid var(--pc-border, #E4E6EA)', borderRadius: 26, padding: 22, display: 'grid', gap: 14 }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, flexWrap: 'wrap', alignItems: 'flex-start' }}>
-          <div style={{ display: 'grid', gap: 8, maxWidth: 860 }}>
-            <div className='pc-deals-kicker' style={{ display: 'inline-flex', width: 'fit-content', padding: '7px 11px', borderRadius: 999, background: 'rgba(10,122,95,0.08)', border: '1px solid rgba(10,122,95,0.18)', color: '#0A7A5F', fontSize: 12, fontWeight: 900 }}>
-              Реестр исполнения · сделки в работе
-            </div>
-            <h1 className='pc-deals-title' style={{ margin: 0, fontSize: 'clamp(26px, 4.2vw, 44px)', lineHeight: 1.06, letterSpacing: '-0.04em', color: 'var(--pc-text-primary, #0F1419)', fontWeight: 950 }}>
-              Сделки: деньги, документы, рейс, спор
-            </h1>
-          </div>
-          <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-            <Link href={primaryDeal.href} className='pc-deals-primary-cta' style={primary}>Открыть {primaryDeal.id}</Link>
-            <Link href='/platform-v7/control-tower' className='pc-deals-secondary-cta' style={secondary}>Центр управления</Link>
-          </div>
-        </div>
-
-        <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '0.25rem' }}>
-          <ExcelExportButton dataset="deals" label="Экспорт Excel" />
-        </div>
-
-        <div className='pc-deals-summary'>
-          <SmartSectionSummary
-            label='Реестр сделок'
-            moneyFact='15,89 млн ₽ в работе'
-            blockers={stoppedDeals.map((d) => `${d.id} · ${d.money.label}`)}
-            facts={[`${dealSnapshots.length} сделок`, `${dealSnapshots.filter((d) => d.dispute.state !== 'ok').length} спора`]}
-          />
-        </div>
-
-        <div className='pc-deals-list' style={{ display: 'grid', gap: 10 }}>
-          {dealSnapshots.map((deal) => (
-            <Link key={deal.id} href={deal.href} className='pc-deal-row' style={{ textDecoration: 'none', background: '#fff', border: '1px solid var(--pc-border, #E4E6EA)', borderRadius: 16, padding: 14, display: 'grid', gap: 10 }}>
-              <div className='pc-deal-row-top' style={{ display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
-                <div>
-                  <span className='pc-deal-row-id' style={{ color: 'var(--pc-text-muted, #64748B)', fontSize: 11, fontWeight: 900, textTransform: 'uppercase', letterSpacing: '0.07em' }}>{deal.id} · {deal.lot}</span>
-                  <p className='pc-deal-row-stage' style={{ margin: '4px 0 0', color: 'var(--pc-text-primary, #0F1419)', fontSize: 14, fontWeight: 900 }}>{deal.stage}</p>
-                </div>
-                <span className='pc-deal-row-money' style={{ fontSize: 11, fontWeight: 900, borderRadius: 999, padding: '4px 10px', border: `1px solid ${stateColor[deal.money.state].border}`, background: stateColor[deal.money.state].bg, color: stateColor[deal.money.state].text }}>
-                  {deal.money.label}
-                </span>
-              </div>
-              <div className='pc-deals-gates' style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(140px,1fr))', gap: 8 }}>
-                <GateChip label='Документы' value={deal.docs.label} state={deal.docs.state} />
-                <GateChip label='Споры' value={deal.dispute.label} state={deal.dispute.state} />
-                <div style={{ background: 'rgba(180,83,9,0.05)', border: '1px solid rgba(180,83,9,0.14)', borderRadius: 10, padding: '7px 10px' }}>
-                  <div style={{ color: 'var(--pc-text-muted, #64748B)', fontSize: 10, fontWeight: 900, textTransform: 'uppercase', letterSpacing: '0.07em' }}>Следующий исполнитель</div>
-                  <div style={{ color: 'var(--pc-text-primary, #0F1419)', fontSize: 12, fontWeight: 900, marginTop: 3 }}>{deal.nextActor}</div>
-                </div>
-              </div>
-              {deal.cannotHappenReason && (
-                <p className='pc-deal-row-stop' style={{ margin: 0, color: '#B91C1C', fontSize: 12, lineHeight: 1.4 }}>Остановлено: {deal.cannotHappenReason}</p>
-              )}
-            </Link>
-          ))}
-        </div>
-      </section>
-
-      <section style={{ background: '#fff', border: '1px solid var(--pc-border, #E4E6EA)', borderRadius: 20, padding: 16 }}>
-        <CollapsibleSection title='E2E прогон сделки · 21 шаг' summary='FARMER+BUYER · KYC · УКЭП · Escrow · GPS · LAB · ЭДО · Evidence Chain · Audit' defaultOpen={false}>
-          <E2EDealSimulationPanel />
-        </CollapsibleSection>
-      </section>
     </div>
   );
 }
-
-function GateChip({ label, value, state }: { label: string; value: string; state: keyof typeof stateColor }) {
-  const c = stateColor[state];
-  return (
-    <div style={{ border: `1px solid ${c.border}`, background: c.bg, borderRadius: 10, padding: '7px 10px' }}>
-      <div style={{ color: 'var(--pc-text-muted, #64748B)', fontSize: 10, fontWeight: 900, textTransform: 'uppercase', letterSpacing: '0.07em' }}>{label}</div>
-      <div style={{ color: c.text, fontSize: 12, fontWeight: 900, marginTop: 3 }}>{value}</div>
-    </div>
-  );
-}
-
-const primary = { textDecoration: 'none', display: 'inline-flex', alignItems: 'center', minHeight: 44, padding: '11px 14px', borderRadius: 14, background: '#0F172A', color: '#fff', fontSize: 14, fontWeight: 850 } as const;
-const secondary = { ...primary, background: '#fff', color: 'var(--pc-text-primary, #0F1419)', border: '1px solid #CBD5E1' } as const;

--- a/apps/web/components/platform-v7/CanonicalDealsList.module.css
+++ b/apps/web/components/platform-v7/CanonicalDealsList.module.css
@@ -1,0 +1,384 @@
+.registry {
+  border: 1px solid var(--pc-border);
+  border-radius: 24px;
+  background: var(--pc-shell-surface);
+  padding: 18px;
+  display: grid;
+  gap: 14px;
+  box-shadow: var(--pc-shadow-sm);
+}
+
+.registryHeader {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 18px;
+}
+
+.registryTitle {
+  min-width: 0;
+  display: grid;
+  gap: 7px;
+}
+
+.kicker {
+  width: fit-content;
+  min-height: 30px;
+  border: 1px solid var(--pc-accent-border);
+  border-radius: 999px;
+  background: var(--pc-accent-bg);
+  color: var(--pc-accent-strong);
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+  font-weight: 900;
+}
+
+.registryTitle h2,
+.stateCard h2 {
+  margin: 0;
+  color: var(--pc-text-primary);
+  font-size: clamp(22px, 4vw, 30px);
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+}
+
+.registryTitle p,
+.stateCard p {
+  margin: 0;
+  max-width: 68ch;
+  color: var(--pc-text-secondary);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.summary {
+  min-width: 170px;
+  border: 1px solid var(--pc-border);
+  border-radius: 18px;
+  background: var(--pc-bg-elevated);
+  padding: 12px 14px;
+  display: grid;
+  gap: 2px;
+}
+
+.summary strong {
+  color: var(--pc-text-primary);
+  font-size: 25px;
+  line-height: 1;
+}
+
+.summary span {
+  color: var(--pc-text-secondary);
+  font-size: 12px;
+  font-weight: 850;
+}
+
+.summary small {
+  margin-top: 4px;
+  color: var(--pc-text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.primaryButton,
+.secondaryButton,
+.iconButton {
+  min-height: 48px;
+  border-radius: 14px;
+  padding: 0 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.primaryButton {
+  border: 1px solid var(--pc-accent);
+  background: var(--pc-accent);
+  color: var(--pc-on-accent, #fff);
+}
+
+.secondaryButton,
+.iconButton {
+  border: 1px solid var(--pc-border);
+  background: var(--pc-bg-card);
+  color: var(--pc-text-primary);
+}
+
+.iconButton {
+  width: 48px;
+  padding: 0;
+}
+
+.primaryButton:disabled,
+.secondaryButton:disabled,
+.iconButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.secondaryButton:not(:disabled):hover,
+.iconButton:not(:disabled):hover {
+  border-color: var(--pc-accent-border);
+  background: var(--pc-accent-bg);
+  color: var(--pc-accent-strong);
+}
+
+.inlineError {
+  margin: 0;
+  border: 1px solid color-mix(in srgb, var(--pc-danger, #b42318) 30%, var(--pc-border));
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--pc-danger-bg, #fff3f2) 72%, var(--pc-bg-card));
+  color: var(--pc-danger, #b42318);
+  padding: 11px 13px;
+  font-size: 13px;
+  line-height: 1.45;
+  font-weight: 800;
+}
+
+.list {
+  display: grid;
+  gap: 9px;
+}
+
+.dealCard {
+  min-height: 82px;
+  border: 1px solid var(--pc-border);
+  border-radius: 18px;
+  background: var(--pc-bg-card);
+  color: var(--pc-text-primary);
+  padding: 13px 14px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  text-decoration: none;
+}
+
+.dealCard:hover {
+  border-color: var(--pc-accent-border);
+  background: color-mix(in srgb, var(--pc-accent-bg) 68%, var(--pc-bg-card));
+}
+
+.dealMain,
+.dealState {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.dealIdentity {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--pc-text-muted);
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.025em;
+}
+
+.dealMain strong,
+.dealState strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  line-height: 1.3;
+  font-weight: 900;
+}
+
+.dealMain > span:last-child,
+.dealState small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--pc-text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.status {
+  width: fit-content;
+  min-height: 26px;
+  border: 1px solid var(--pc-border);
+  border-radius: 999px;
+  background: var(--pc-bg-elevated);
+  color: var(--pc-text-secondary);
+  padding: 0 9px;
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  font-weight: 900;
+}
+
+.openAction {
+  min-height: 44px;
+  border-radius: 13px;
+  background: var(--pc-accent-bg);
+  color: var(--pc-accent-strong);
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 900;
+}
+
+.registryFooter {
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+}
+
+.registryFooter p {
+  margin: 0;
+  max-width: 72ch;
+  color: var(--pc-text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.stateCard {
+  min-height: 240px;
+  border: 1px solid var(--pc-border);
+  border-radius: 24px;
+  background: var(--pc-shell-surface);
+  padding: 24px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 10px;
+  color: var(--pc-text-secondary);
+  text-align: center;
+}
+
+.errorIcon {
+  color: var(--pc-danger, #b42318);
+}
+
+.emptyIcon {
+  color: var(--pc-accent-strong);
+}
+
+.spin {
+  animation: deals-spin 0.85s linear infinite;
+}
+
+@keyframes deals-spin {
+  to { transform: rotate(360deg); }
+}
+
+.primaryButton:focus-visible,
+.secondaryButton:focus-visible,
+.iconButton:focus-visible,
+.dealCard:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--pc-accent) 42%, transparent);
+  outline-offset: 3px;
+}
+
+@media (max-width: 840px) {
+  .registryHeader {
+    grid-template-columns: 1fr;
+  }
+
+  .summary {
+    width: 100%;
+    min-width: 0;
+    grid-template-columns: auto 1fr;
+    align-items: baseline;
+    column-gap: 8px;
+  }
+
+  .summary small {
+    grid-column: 1 / -1;
+  }
+
+  .dealCard {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .dealState {
+    grid-column: 1 / -1;
+    border-top: 1px solid var(--pc-border);
+    padding-top: 10px;
+  }
+
+  .openAction {
+    grid-column: 2;
+    grid-row: 1;
+  }
+}
+
+@media (max-width: 520px) {
+  .registry,
+  .stateCard {
+    border-radius: 20px;
+    padding: 13px;
+  }
+
+  .toolbar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 48px;
+  }
+
+  .secondaryButton {
+    width: 100%;
+  }
+
+  .dealCard {
+    min-height: 0;
+    border-radius: 16px;
+    padding: 12px;
+    grid-template-columns: 1fr;
+  }
+
+  .dealMain strong,
+  .dealState strong,
+  .dealMain > span:last-child,
+  .dealState small {
+    white-space: normal;
+  }
+
+  .openAction {
+    grid-column: 1;
+    grid-row: auto;
+    width: 100%;
+    min-height: 48px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spin {
+    animation: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .registry,
+  .summary,
+  .primaryButton,
+  .secondaryButton,
+  .iconButton,
+  .dealCard,
+  .status,
+  .stateCard {
+    border: 1px solid CanvasText;
+  }
+}

--- a/apps/web/components/platform-v7/CanonicalDealsList.tsx
+++ b/apps/web/components/platform-v7/CanonicalDealsList.tsx
@@ -2,105 +2,380 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import { ArrowRight, Loader2, ShieldCheck, Wheat } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  Download,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+  Wheat,
+} from 'lucide-react';
+import styles from './CanonicalDealsList.module.css';
 
-/**
- * Живой реестр сделок участника из канонического PostgreSQL-контура.
- * Скоуп определяет сервер (DealParticipant + RLS); каждая строка ведёт в
- * исполнительное рабочее место сделки. Никаких демо-данных: если backend
- * недоступен или сессия не подтверждена, блок честно говорит об этом.
- */
+const INITIAL_LIMIT = 20;
+const LIMIT_STEP = 20;
+const MAX_LIMIT = 100;
 
 type AccessibleDeal = {
   id: string;
   dealNumber: string | null;
   status: string;
   culture: string | null;
+  cropClass: string | null;
   region: string | null;
+  volumeTons: string | null;
   totalKopecks: number | null;
+  currency: string;
   nextAction: string | null;
   myRole: string;
+  updatedAt: string;
 };
 
-function money(value: number | null): string {
-  if (value === null) return '—';
-  return new Intl.NumberFormat('ru-RU', { style: 'currency', currency: 'RUB', maximumFractionDigits: 0 }).format(value / 100);
+type RegistryState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; items: AccessibleDeal[]; limit: number }
+  | { kind: 'error'; message: string; limit: number };
+
+function optionalString(value: unknown): string | null | undefined {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized || null;
+}
+
+function requiredString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function parseDeals(payload: unknown): AccessibleDeal[] | null {
+  if (!payload || typeof payload !== 'object' || !Array.isArray((payload as { items?: unknown }).items)) return null;
+
+  const result: AccessibleDeal[] = [];
+  for (const item of (payload as { items: unknown[] }).items) {
+    if (!item || typeof item !== 'object') return null;
+    const row = item as Record<string, unknown>;
+
+    const id = requiredString(row.id);
+    const status = requiredString(row.status);
+    const currency = requiredString(row.currency) || 'RUB';
+    const myRole = requiredString(row.myRole);
+    const updatedAt = requiredString(row.updatedAt);
+    const dealNumber = optionalString(row.dealNumber);
+    const culture = optionalString(row.culture);
+    const cropClass = optionalString(row.cropClass);
+    const region = optionalString(row.region);
+    const volumeTons = optionalString(row.volumeTons);
+    const nextAction = optionalString(row.nextAction);
+    const totalKopecks = row.totalKopecks === null || row.totalKopecks === undefined
+      ? null
+      : typeof row.totalKopecks === 'number' && Number.isFinite(row.totalKopecks)
+        ? row.totalKopecks
+        : undefined;
+
+    if (
+      !id || !status || !myRole || !updatedAt
+      || dealNumber === undefined || culture === undefined || cropClass === undefined
+      || region === undefined || volumeTons === undefined || nextAction === undefined
+      || totalKopecks === undefined
+    ) return null;
+
+    result.push({
+      id,
+      dealNumber,
+      status,
+      culture,
+      cropClass,
+      region,
+      volumeTons,
+      totalKopecks,
+      currency,
+      nextAction,
+      myRole,
+      updatedAt,
+    });
+  }
+
+  return result;
+}
+
+function humanStatus(value: string): string {
+  const known: Record<string, string> = {
+    CREATED: 'Создана',
+    ACTIVE: 'В работе',
+    IN_PROGRESS: 'В работе',
+    IN_TRANSIT: 'Груз в пути',
+    ACCEPTANCE: 'Приёмка',
+    LABORATORY: 'Проверка качества',
+    DOCUMENTS: 'Документы',
+    PAYMENT: 'Расчёты',
+    DISPUTE: 'Открыт спор',
+    COMPLETED: 'Завершена',
+    CLOSED: 'Закрыта',
+    CANCELLED: 'Отменена',
+  };
+  return known[value] || value.toLowerCase().replaceAll('_', ' ').replace(/^./, (letter) => letter.toUpperCase());
+}
+
+function formatMoney(kopecks: number | null, currency: string): string {
+  if (kopecks === null || !Number.isFinite(kopecks)) return 'Сумма не указана';
+  return new Intl.NumberFormat('ru-RU', {
+    style: 'currency',
+    currency: currency || 'RUB',
+    maximumFractionDigits: 0,
+  }).format(kopecks / 100);
+}
+
+function formatUpdatedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'время не указано';
+  return new Intl.DateTimeFormat('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function dealTitle(deal: AccessibleDeal): string {
+  return deal.dealNumber || deal.id;
+}
+
+async function exportVisibleDeals(items: AccessibleDeal[]): Promise<void> {
+  const ExcelJS = (await import('exceljs')).default;
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = 'Прозрачная Цена';
+  workbook.created = new Date();
+
+  const sheet = workbook.addWorksheet('Сделки');
+  sheet.columns = [
+    { header: 'Сделка', key: 'deal', width: 22 },
+    { header: 'Культура', key: 'culture', width: 20 },
+    { header: 'Класс', key: 'cropClass', width: 14 },
+    { header: 'Регион', key: 'region', width: 24 },
+    { header: 'Статус', key: 'status', width: 22 },
+    { header: 'Следующий шаг', key: 'nextAction', width: 36 },
+    { header: 'Сумма', key: 'amount', width: 18 },
+    { header: 'Валюта', key: 'currency', width: 10 },
+    { header: 'Обновлена', key: 'updatedAt', width: 20 },
+  ];
+
+  for (const deal of items) {
+    sheet.addRow({
+      deal: dealTitle(deal),
+      culture: deal.culture || 'Зерно',
+      cropClass: deal.cropClass || '',
+      region: deal.region || '',
+      status: humanStatus(deal.status),
+      nextAction: deal.nextAction || 'Действие не требуется',
+      amount: deal.totalKopecks === null ? null : deal.totalKopecks / 100,
+      currency: deal.currency,
+      updatedAt: new Date(deal.updatedAt),
+    });
+  }
+
+  const header = sheet.getRow(1);
+  header.font = { bold: true, color: { argb: 'FFFFFFFF' } };
+  header.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF17563F' } };
+  header.alignment = { vertical: 'middle' };
+  header.height = 24;
+
+  sheet.getColumn('amount').numFmt = '#,##0.00';
+  sheet.getColumn('updatedAt').numFmt = 'dd.mm.yyyy hh:mm';
+  sheet.views = [{ state: 'frozen', ySplit: 1 }];
+  sheet.autoFilter = { from: 'A1', to: 'I1' };
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `прозрачная-цена-сделки-${new Date().toISOString().slice(0, 10)}.xlsx`;
+  anchor.click();
+  URL.revokeObjectURL(url);
 }
 
 export function CanonicalDealsList() {
-  const [items, setItems] = React.useState<AccessibleDeal[] | null>(null);
-  const [loading, setLoading] = React.useState(true);
-  const [unavailable, setUnavailable] = React.useState('');
+  const [state, setState] = React.useState<RegistryState>({ kind: 'loading' });
+  const [loadingMore, setLoadingMore] = React.useState(false);
+  const [exporting, setExporting] = React.useState(false);
+  const [exportError, setExportError] = React.useState('');
+  const requestRef = React.useRef(0);
 
-  React.useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const response = await fetch('/api/proxy/deals/accessible?limit=20', {
-          cache: 'no-store',
-          headers: { Accept: 'application/json' },
-        });
-        const payload = await response.json().catch(() => ({}));
-        if (cancelled) return;
-        if (!response.ok) {
-          setUnavailable(
-            typeof payload?.message === 'string'
-              ? payload.message
-              : 'Сервер не подтвердил список сделок.',
-          );
-          setItems(null);
-        } else {
-          setItems(Array.isArray(payload?.items) ? (payload.items as AccessibleDeal[]) : []);
-        }
-      } catch {
-        if (!cancelled) {
-          setUnavailable('Нет связи с сервером. Список сделок появится после восстановления сети.');
-          setItems(null);
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
+  const load = React.useCallback(async (limit: number, mode: 'initial' | 'more' | 'retry' = 'initial') => {
+    const boundedLimit = Math.min(Math.max(Math.trunc(limit), INITIAL_LIMIT), MAX_LIMIT);
+    const requestId = ++requestRef.current;
+    if (mode === 'more') setLoadingMore(true);
+    else setState({ kind: 'loading' });
+
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 12_000);
+
+    try {
+      const response = await fetch(`/api/proxy/deals/accessible?limit=${boundedLimit}`, {
+        cache: 'no-store',
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      });
+      const payload = await response.json().catch(() => null);
+      if (requestId !== requestRef.current) return;
+
+      if (!response.ok) {
+        const fallback = response.status === 401 || response.status === 403
+          ? 'Доступ к сделкам не подтверждён. Войди заново.'
+          : 'Не удалось загрузить реестр сделок.';
+        const message = payload && typeof payload === 'object' && typeof (payload as { message?: unknown }).message === 'string'
+          ? String((payload as { message: string }).message)
+          : fallback;
+        setState({ kind: 'error', message, limit: boundedLimit });
+        return;
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
+
+      const items = parseDeals(payload);
+      if (!items) {
+        setState({ kind: 'error', message: 'Сервер вернул некорректный реестр сделок.', limit: boundedLimit });
+        return;
+      }
+
+      setState({ kind: 'ready', items, limit: boundedLimit });
+    } catch (error) {
+      if (requestId !== requestRef.current) return;
+      setState({
+        kind: 'error',
+        limit: boundedLimit,
+        message: error instanceof DOMException && error.name === 'AbortError'
+          ? 'Сервер не ответил вовремя. Повтори загрузку.'
+          : 'Нет связи с сервером. Реестр не был заменён локальными данными.',
+      });
+    } finally {
+      window.clearTimeout(timeout);
+      if (requestId === requestRef.current) setLoadingMore(false);
+    }
   }, []);
 
+  React.useEffect(() => {
+    void load(INITIAL_LIMIT);
+    return () => {
+      requestRef.current += 1;
+    };
+  }, [load]);
+
+  const handleExport = async (items: AccessibleDeal[]) => {
+    setExporting(true);
+    setExportError('');
+    try {
+      await exportVisibleDeals(items);
+    } catch {
+      setExportError('Не удалось сформировать Excel. Повтори действие.');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  if (state.kind === 'loading') {
+    return (
+      <section className={styles.stateCard} aria-live='polite'>
+        <Loader2 className={styles.spin} size={26} aria-hidden='true' />
+        <h2>Загружаем ваши сделки</h2>
+        <p>Список формирует сервер с учётом участия и полномочий.</p>
+      </section>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <section className={styles.stateCard} role='alert'>
+        <AlertTriangle className={styles.errorIcon} size={28} aria-hidden='true' />
+        <h2>Реестр временно недоступен</h2>
+        <p>{state.message}</p>
+        <button className={styles.primaryButton} type='button' onClick={() => void load(state.limit, 'retry')}>
+          <RefreshCw size={18} aria-hidden='true' /> Повторить
+        </button>
+      </section>
+    );
+  }
+
+  const { items, limit } = state;
+  const actionableCount = items.filter((deal) => Boolean(deal.nextAction)).length;
+  const canLoadMore = items.length === limit && limit < MAX_LIMIT;
+  const reachedMaximum = items.length === MAX_LIMIT && limit === MAX_LIMIT;
+
+  if (items.length === 0) {
+    return (
+      <section className={styles.stateCard} data-empty-deals>
+        <CheckCircle2 className={styles.emptyIcon} size={28} aria-hidden='true' />
+        <h2>Активных сделок пока нет</h2>
+        <p>Сделка появится здесь только после подтверждения вашего участия сервером.</p>
+      </section>
+    );
+  }
+
   return (
-    <section data-testid='canonical-deals-list' style={{ border: '1px solid var(--pc-border, #E4E6EA)', borderRadius: 24, padding: 18, display: 'grid', gap: 12, background: 'var(--pc-shell-surface, #fff)' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <ShieldCheck size={17} style={{ color: '#0A7A5F' }} />
-        <strong style={{ fontSize: 15 }}>Мои сделки в исполнении</strong>
-        <span style={{ fontSize: 11, color: 'var(--pc-text-muted, #64748B)', fontWeight: 800 }}>подтверждено сервером</span>
+    <section className={styles.registry} data-testid='canonical-deals-list'>
+      <header className={styles.registryHeader}>
+        <div className={styles.registryTitle}>
+          <span className={styles.kicker}><ShieldCheck size={16} aria-hidden='true' /> Доступ подтверждён сервером</span>
+          <h2>Все показанные сделки</h2>
+          <p>Открывай сделку по следующему действию. Технические идентификаторы и внутренние сценарии не подменяют реальные данные.</p>
+        </div>
+        <div className={styles.summary} aria-label='Сводка показанного реестра'>
+          <strong>{items.length}</strong>
+          <span>показано сделок</span>
+          <small>{actionableCount ? `${actionableCount} требуют действия` : 'новых действий нет'}</small>
+        </div>
+      </header>
+
+      <div className={styles.toolbar}>
+        <button
+          className={styles.secondaryButton}
+          type='button'
+          disabled={exporting}
+          onClick={() => void handleExport(items)}
+        >
+          {exporting ? <Loader2 className={styles.spin} size={18} aria-hidden='true' /> : <Download size={18} aria-hidden='true' />}
+          {exporting ? 'Формируем Excel…' : 'Скачать показанные сделки'}
+        </button>
+        <button className={styles.iconButton} type='button' aria-label='Обновить реестр сделок' onClick={() => void load(limit, 'retry')}>
+          <RefreshCw size={18} aria-hidden='true' />
+        </button>
       </div>
 
-      {loading ? (
-        <p style={{ margin: 0, display: 'flex', alignItems: 'center', gap: 8, color: 'var(--pc-text-secondary, #475569)', fontSize: 13 }}>
-          <Loader2 size={16} className='spin' /> Загружаем сделки…
-        </p>
-      ) : unavailable ? (
-        <p role='status' style={{ margin: 0, fontSize: 13, color: 'var(--pc-text-secondary, #475569)' }}>{unavailable}</p>
-      ) : items && items.length === 0 ? (
-        <p style={{ margin: 0, fontSize: 13, color: 'var(--pc-text-secondary, #475569)' }}>Активных сделок пока нет. Когда вас назначат участником, сделка появится здесь.</p>
-      ) : (
-        <div style={{ display: 'grid', gap: 8 }}>
-          {(items ?? []).map((deal) => (
-            <Link key={deal.id} href={`/platform-v7/deals/${deal.id}/execution`} style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1fr) auto', alignItems: 'center', gap: 10, padding: '12px 14px', borderRadius: 16, border: '1px solid var(--pc-border, #E4E6EA)', textDecoration: 'none', color: 'inherit' }}>
-              <span style={{ display: 'grid', gap: 3, minWidth: 0 }}>
-                <span style={{ display: 'flex', gap: 8, alignItems: 'center', fontSize: 11, color: 'var(--pc-text-muted, #64748B)', fontWeight: 850 }}>
-                  <Wheat size={13} /> {deal.dealNumber || deal.id} · {deal.status}
-                </span>
-                <strong style={{ fontSize: 13, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                  {deal.culture || 'Зерно'}{deal.region ? ` · ${deal.region}` : ''} · {money(deal.totalKopecks)}
-                </strong>
-                {deal.nextAction ? <span style={{ fontSize: 12, color: 'var(--pc-text-secondary, #475569)' }}>{deal.nextAction}</span> : null}
-              </span>
-              <ArrowRight size={17} style={{ color: '#0A7A5F', flex: '0 0 auto' }} />
-            </Link>
-          ))}
-        </div>
-      )}
-      <style jsx>{`.spin{animation:spin .8s linear infinite}@keyframes spin{to{transform:rotate(360deg)}}`}</style>
+      {exportError ? <p className={styles.inlineError} role='alert'>{exportError}</p> : null}
+
+      <div className={styles.list}>
+        {items.map((deal) => (
+          <Link key={deal.id} href={`/platform-v7/deals/${encodeURIComponent(deal.id)}/execution`} className={styles.dealCard}>
+            <div className={styles.dealMain}>
+              <span className={styles.dealIdentity}><Wheat size={15} aria-hidden='true' /> {dealTitle(deal)}</span>
+              <strong>{deal.culture || 'Зерно'}{deal.cropClass ? ` · ${deal.cropClass} класс` : ''}</strong>
+              <span>{deal.region || 'Регион не указан'} · {formatMoney(deal.totalKopecks, deal.currency)}</span>
+            </div>
+            <div className={styles.dealState}>
+              <span className={styles.status}>{humanStatus(deal.status)}</span>
+              <strong>{deal.nextAction || 'Сейчас действие не требуется'}</strong>
+              <small>Обновлена {formatUpdatedAt(deal.updatedAt)}</small>
+            </div>
+            <span className={styles.openAction}>Открыть <ArrowRight size={18} aria-hidden='true' /></span>
+          </Link>
+        ))}
+      </div>
+
+      <footer className={styles.registryFooter}>
+        {canLoadMore ? (
+          <button
+            className={styles.primaryButton}
+            type='button'
+            disabled={loadingMore}
+            onClick={() => void load(Math.min(limit + LIMIT_STEP, MAX_LIMIT), 'more')}
+          >
+            {loadingMore ? <Loader2 className={styles.spin} size={18} aria-hidden='true' /> : null}
+            {loadingMore ? 'Загружаем…' : 'Показать ещё сделки'}
+          </button>
+        ) : (
+          <p>{reachedMaximum ? 'Показаны первые 100 сделок. Полный промышленный реестр требует серверной cursor-пагинации.' : 'Показаны все сделки, возвращённые сервером.'}</p>
+        )}
+      </footer>
     </section>
   );
 }

--- a/apps/web/tests/unit/platformV7RealDealsRegistry.test.ts
+++ b/apps/web/tests/unit/platformV7RealDealsRegistry.test.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+describe('platform-v7 real deals registry', () => {
+  const page = read('apps/web/app/platform-v7/deals/page.tsx');
+  const pageStyles = read('apps/web/app/platform-v7/deals/deals.module.css');
+  const registry = read('apps/web/components/platform-v7/CanonicalDealsList.tsx');
+  const registryStyles = read('apps/web/components/platform-v7/CanonicalDealsList.module.css');
+
+  it('removes synthetic scenarios, money and internal simulation from the working registry', () => {
+    expect(page).toContain('<CanonicalDealsList />');
+    expect(page).not.toContain('DEAL360_SCENARIOS');
+    expect(page).not.toContain('E2EDealSimulationPanel');
+    expect(page).not.toContain('SmartSectionSummary');
+    expect(page).not.toContain('ExcelExportButton');
+    expect(page).not.toContain('15,89 млн');
+    expect(page).not.toContain('DL-9106');
+    expect(page).not.toContain('style={{');
+    expect(page).not.toContain('dangerouslySetInnerHTML');
+  });
+
+  it('loads only participant-scoped server data with bounded growth', () => {
+    expect(registry).toContain("const INITIAL_LIMIT = 20");
+    expect(registry).toContain("const MAX_LIMIT = 100");
+    expect(registry).toContain('/api/proxy/deals/accessible?limit=${boundedLimit}');
+    expect(registry).toContain('Math.min(limit + LIMIT_STEP, MAX_LIMIT)');
+    expect(registry).toContain('Список формирует сервер с учётом участия и полномочий');
+    expect(registry).toContain('Реестр не был заменён локальными данными');
+    expect(registry).not.toContain('DL-9102');
+    expect(registry).not.toContain('LOT-2401');
+    expect(registry).not.toContain("new Date('2024-");
+  });
+
+  it('exports exactly the currently loaded real rows instead of fixture data', () => {
+    expect(registry).toContain('async function exportVisibleDeals(items: AccessibleDeal[])');
+    expect(registry).toContain("workbook.creator = 'Прозрачная Цена'");
+    expect(registry).toContain('for (const deal of items)');
+    expect(registry).toContain('Скачать показанные сделки');
+    expect(registry).toContain('прозрачная-цена-сделки-');
+  });
+
+  it('keeps the registry usable on mobile and accessible without inline style patches', () => {
+    expect(registry).toContain("import styles from './CanonicalDealsList.module.css'");
+    expect(registry).not.toContain('style={{');
+    expect(registry).not.toContain('<style jsx>');
+    expect(registryStyles).toContain('min-height: 48px');
+    expect(registryStyles).toContain('@media (max-width: 520px)');
+    expect(registryStyles).toContain('@media (forced-colors: active)');
+    expect(registryStyles).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(pageStyles).toContain('@media (max-width: 520px)');
+  });
+});

--- a/docs/platform-v7/autopilot/autopilot-state.json
+++ b/docs/platform-v7/autopilot/autopilot-state.json
@@ -215,6 +215,13 @@
       "apps/web/components/platform-v7/RoleIntentDashboard.tsx",
       "apps/web/components/platform-v7/RoleIntentDashboard.module.css",
       "apps/web/tests/unit/platformV7RoleIntentDashboard.test.ts"
+    ],
+    "agent/real-deals-registry": [
+      "apps/web/app/platform-v7/deals/page.tsx",
+      "apps/web/app/platform-v7/deals/deals.module.css",
+      "apps/web/components/platform-v7/CanonicalDealsList.tsx",
+      "apps/web/components/platform-v7/CanonicalDealsList.module.css",
+      "apps/web/tests/unit/platformV7RealDealsRegistry.test.ts"
     ]
   },
   "currentAcceptance": [


### PR DESCRIPTION
## Цель

Удалить из рабочего реестра сделок все демонстрационные и фиктивные данные, сохранив полезные функции на реальных participant-scoped данных.

## Что изменено

- `/platform-v7/deals` больше не использует `DEAL360_SCENARIOS`, статические суммы, демонстрационные карточки и E2E-симулятор;
- реестр загружается только через `/api/proxy/deals/accessible` и проверяет форму ответа до отображения;
- начальная выборка ограничена 20 сделками, увеличение идёт шагами по 20 до жёсткого предела 100;
- порядок сервера сохраняется, клиент не придумывает приоритеты и статусы;
- у каждой сделки показаны культура, регион, сумма, статус, следующий шаг и время обновления;
- добавлены loading, empty, timeout, offline и retry состояния без локальной подмены данных;
- Excel теперь формируется только из фактически загруженных серверных строк, а не из фикстур 2024 года;
- mobile-first layout, цели не менее 48 px, reduced-motion, forced-colors и bounded scrolling;
- бизнес-команды, RBAC, DealParticipant/RLS, аудит, деньги и банковские callback-only ограничения не менялись.

## Промышленная граница

Текущий серверный endpoint ограничен 100 строками и не возвращает cursor/total. UI честно показывает объём текущей выборки и не выдаёт его за полный объём. Следующий backend-срез — cursor pagination и серверные фильтры — нужно проводить после завершения текущей PostgreSQL-authority ветки, чтобы не создавать конфликт в `IndustrialDealCommandGateway`.

## Проверки

Добавлен отдельный regression gate, запрещающий возврат фиктивных сделок, сумм, симулятора и fixture-Excel на рабочую страницу.