### PR TITLE
Scale the Today workspace without hiding deal functions

### DIFF
--- a/apps/web/components/platform-v7/RoleIntentDashboard.module.css
+++ b/apps/web/components/platform-v7/RoleIntentDashboard.module.css
@@ -118,7 +118,8 @@
   color: var(--pc-accent-strong);
 }
 
-.retryButton {
+.retryButton,
+.loadMoreButton {
   min-height: 48px;
   border: 1px solid var(--pc-accent);
   border-radius: 14px;
@@ -132,6 +133,16 @@
   font: inherit;
   font-weight: 850;
   cursor: pointer;
+}
+
+.loadMoreButton {
+  width: 100%;
+}
+
+.retryButton:disabled,
+.loadMoreButton:disabled {
+  opacity: 0.62;
+  cursor: wait;
 }
 
 .otherDeals {
@@ -157,11 +168,16 @@
   background: var(--pc-bg-elevated);
 }
 
+.dealListBody {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
 .dealLinks {
   max-height: min(440px, 55dvh);
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: 12px;
   display: grid;
   gap: 8px;
 }
@@ -213,7 +229,20 @@
   line-height: 1.35;
 }
 
+.loadMoreError {
+  margin: 0;
+  border: 1px solid color-mix(in srgb, var(--pc-danger, #b42318) 28%, var(--pc-border));
+  border-radius: 13px;
+  background: color-mix(in srgb, var(--pc-danger-bg, #fff3f2) 72%, var(--pc-bg-card));
+  color: var(--pc-danger, #b42318);
+  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.45;
+  font-weight: 800;
+}
+
 .retryButton:focus-visible,
+.loadMoreButton:focus-visible,
 .dealLink:focus-visible,
 .otherDeals summary:focus-visible {
   outline: 3px solid color-mix(in srgb, var(--pc-accent) 42%, transparent);
@@ -267,7 +296,7 @@
     padding: 20px 16px;
   }
 
-  .dealLinks {
+  .dealListBody {
     padding: 9px;
   }
 
@@ -288,7 +317,9 @@
   .stateCard,
   .otherDeals,
   .dealLink,
-  .retryButton {
+  .retryButton,
+  .loadMoreButton,
+  .loadMoreError {
     border: 1px solid CanvasText;
   }
 }

--- a/apps/web/components/platform-v7/RoleIntentDashboard.tsx
+++ b/apps/web/components/platform-v7/RoleIntentDashboard.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import { AlertTriangle, ArrowRight, CheckCircle2, RefreshCw } from 'lucide-react';
+import { AlertTriangle, ArrowRight, CheckCircle2, Loader2, RefreshCw } from 'lucide-react';
 import { CanonicalDealWorkspace } from '@/components/platform-v7/CanonicalDealWorkspace';
 import type { PlatformRole } from '@/stores/usePlatformV7RStore';
 import styles from './RoleIntentDashboard.module.css';
@@ -14,11 +14,19 @@ type AccessibleDealRef = {
   nextAction: string | null;
 };
 
+type AccessibleDealsPage = {
+  deals: AccessibleDealRef[];
+  nextCursor: string | null;
+  total: number | null;
+};
+
 type LoadState =
   | { kind: 'loading' }
-  | { kind: 'ready'; deals: AccessibleDealRef[] }
+  | { kind: 'ready'; deals: AccessibleDealRef[]; nextCursor: string | null; total: number | null; loadingMore: boolean; loadMoreError: string }
   | { kind: 'empty' }
   | { kind: 'error'; message: string };
+
+const PAGE_SIZE = 20;
 
 const ROLE_FOCUS: Record<PlatformRole, string> = {
   operator: 'Управление исполнением сделок',
@@ -42,11 +50,19 @@ function optionalString(value: unknown): string | null | undefined {
   return normalized || null;
 }
 
-function validDeals(payload: unknown): AccessibleDealRef[] | null {
-  if (!payload || typeof payload !== 'object' || !Array.isArray((payload as { items?: unknown }).items)) return null;
+function optionalNonNegativeInteger(value: unknown): number | null | undefined {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) return undefined;
+  return value;
+}
+
+function validDealsPage(payload: unknown): AccessibleDealsPage | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const root = payload as Record<string, unknown>;
+  if (!Array.isArray(root.items)) return null;
 
   const deals: AccessibleDealRef[] = [];
-  for (const item of (payload as { items: unknown[] }).items) {
+  for (const item of root.items) {
     if (!item || typeof item !== 'object') return null;
 
     const row = item as Record<string, unknown>;
@@ -59,7 +75,14 @@ function validDeals(payload: unknown): AccessibleDealRef[] | null {
     deals.push({ id, dealNumber, status, nextAction });
   }
 
-  return deals;
+  const pagination = root.pagination && typeof root.pagination === 'object'
+    ? root.pagination as Record<string, unknown>
+    : null;
+  const nextCursor = optionalString(root.nextCursor ?? pagination?.nextCursor);
+  const total = optionalNonNegativeInteger(root.total ?? pagination?.total);
+  if (nextCursor === undefined || total === undefined) return null;
+
+  return { deals, nextCursor, total };
 }
 
 function prioritizeDeals(deals: AccessibleDealRef[]): AccessibleDealRef[] {
@@ -71,6 +94,13 @@ function prioritizeDeals(deals: AccessibleDealRef[]): AccessibleDealRef[] {
   }
 
   return [...actionable, ...waiting];
+}
+
+function mergeDeals(current: AccessibleDealRef[], incoming: AccessibleDealRef[]): AccessibleDealRef[] {
+  const byId = new Map<string, AccessibleDealRef>();
+  for (const deal of current) byId.set(deal.id, deal);
+  for (const deal of incoming) byId.set(deal.id, deal);
+  return prioritizeDeals([...byId.values()]);
 }
 
 function actionCountLabel(count: number): string {
@@ -87,18 +117,31 @@ function dealTitle(deal: AccessibleDealRef): string {
   return deal.dealNumber || deal.id;
 }
 
+function pageUrl(cursor: string | null): string {
+  const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
+  if (cursor) params.set('cursor', cursor);
+  return `/api/proxy/deals/accessible?${params.toString()}`;
+}
+
 export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
   const [state, setState] = React.useState<LoadState>({ kind: 'loading' });
   const requestRef = React.useRef(0);
 
-  const load = React.useCallback(async () => {
+  const load = React.useCallback(async (cursor: string | null = null, append = false) => {
     const requestId = ++requestRef.current;
-    setState({ kind: 'loading' });
+    if (append) {
+      setState((current) => current.kind === 'ready'
+        ? { ...current, loadingMore: true, loadMoreError: '' }
+        : current);
+    } else {
+      setState({ kind: 'loading' });
+    }
+
     const controller = new AbortController();
     const timeout = window.setTimeout(() => controller.abort(), 12_000);
 
     try {
-      const response = await fetch('/api/proxy/deals/accessible?limit=20', {
+      const response = await fetch(pageUrl(cursor), {
         cache: 'no-store',
         headers: { Accept: 'application/json' },
         signal: controller.signal,
@@ -107,30 +150,67 @@ export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
       if (requestId !== requestRef.current) return;
 
       if (!response.ok) {
-        setState({
-          kind: 'error',
-          message: response.status === 401 || response.status === 403
-            ? 'Доступ к сделкам не подтверждён. Войди заново.'
-            : 'Не удалось загрузить сделки.',
-        });
+        const message = response.status === 401 || response.status === 403
+          ? 'Доступ к сделкам не подтверждён. Войди заново.'
+          : 'Не удалось загрузить сделки.';
+        if (append) {
+          setState((current) => current.kind === 'ready'
+            ? { ...current, loadingMore: false, loadMoreError: message }
+            : current);
+        } else {
+          setState({ kind: 'error', message });
+        }
         return;
       }
 
-      const deals = validDeals(payload);
-      if (!deals) {
-        setState({ kind: 'error', message: 'Сервер вернул некорректный список сделок.' });
+      const page = validDealsPage(payload);
+      if (!page) {
+        const message = 'Сервер вернул некорректный список сделок.';
+        if (append) {
+          setState((current) => current.kind === 'ready'
+            ? { ...current, loadingMore: false, loadMoreError: message }
+            : current);
+        } else {
+          setState({ kind: 'error', message });
+        }
         return;
       }
 
-      setState(deals.length === 0 ? { kind: 'empty' } : { kind: 'ready', deals: prioritizeDeals(deals) });
+      if (append) {
+        setState((current) => current.kind === 'ready'
+          ? {
+              kind: 'ready',
+              deals: mergeDeals(current.deals, page.deals),
+              nextCursor: page.nextCursor,
+              total: page.total ?? current.total,
+              loadingMore: false,
+              loadMoreError: '',
+            }
+          : current);
+      } else {
+        setState(page.deals.length === 0
+          ? { kind: 'empty' }
+          : {
+              kind: 'ready',
+              deals: prioritizeDeals(page.deals),
+              nextCursor: page.nextCursor,
+              total: page.total,
+              loadingMore: false,
+              loadMoreError: '',
+            });
+      }
     } catch (error) {
       if (requestId !== requestRef.current) return;
-      setState({
-        kind: 'error',
-        message: error instanceof DOMException && error.name === 'AbortError'
-          ? 'Сервер не ответил вовремя. Повтори загрузку.'
-          : 'Не удалось загрузить сделки.',
-      });
+      const message = error instanceof DOMException && error.name === 'AbortError'
+        ? 'Сервер не ответил вовремя. Повтори загрузку.'
+        : 'Не удалось загрузить сделки.';
+      if (append) {
+        setState((current) => current.kind === 'ready'
+          ? { ...current, loadingMore: false, loadMoreError: message }
+          : current);
+      } else {
+        setState({ kind: 'error', message });
+      }
     } finally {
       window.clearTimeout(timeout);
     }
@@ -185,6 +265,9 @@ export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
 
   const [current, ...otherDeals] = state.deals;
   const actionableCount = state.deals.filter((deal) => deal.nextAction).length;
+  const loadedCountLabel = state.total === null
+    ? `Загружено активных сделок: ${state.deals.length}`
+    : `Загружено ${state.deals.length} из ${state.total}`;
 
   return (
     <div className={styles.todayWorkspace}>
@@ -196,24 +279,42 @@ export function RoleIntentDashboard({ role }: { role: PlatformRole }) {
         </div>
         <div className={styles.todayFacts} aria-label='Сводка задач на сегодня'>
           <strong>{actionCountLabel(actionableCount)}</strong>
-          <span>Показано активных сделок: {state.deals.length}</span>
+          <span>{loadedCountLabel}</span>
         </div>
       </section>
 
-      {otherDeals.length > 0 ? (
+      {otherDeals.length > 0 || state.nextCursor ? (
         <details className={styles.otherDeals}>
-          <summary>Другие показанные сделки: {otherDeals.length}</summary>
-          <nav className={styles.dealLinks} aria-label='Другие показанные сделки'>
-            {otherDeals.map((deal) => (
-              <Link className={styles.dealLink} key={deal.id} href={`/platform-v7/deals/${encodeURIComponent(deal.id)}/execution`}>
-                <span className={styles.dealCopy}>
-                  <strong>{dealTitle(deal)}</strong>
-                  <small>{deal.nextAction || 'Сейчас действие не требуется'}</small>
-                </span>
-                <ArrowRight size={18} aria-hidden='true' />
-              </Link>
-            ))}
-          </nav>
+          <summary>Все загруженные сделки: {state.deals.length}</summary>
+          <div className={styles.dealListBody}>
+            {otherDeals.length > 0 ? (
+              <nav className={styles.dealLinks} aria-label='Другие загруженные сделки'>
+                {otherDeals.map((deal) => (
+                  <Link className={styles.dealLink} key={deal.id} href={`/platform-v7/deals/${encodeURIComponent(deal.id)}/execution`}>
+                    <span className={styles.dealCopy}>
+                      <strong>{dealTitle(deal)}</strong>
+                      <small>{deal.nextAction || 'Сейчас действие не требуется'}</small>
+                    </span>
+                    <ArrowRight size={18} aria-hidden='true' />
+                  </Link>
+                ))}
+              </nav>
+            ) : null}
+
+            {state.nextCursor ? (
+              <button
+                className={styles.loadMoreButton}
+                type='button'
+                disabled={state.loadingMore}
+                onClick={() => void load(state.nextCursor, true)}
+              >
+                {state.loadingMore ? <Loader2 className={styles.spin} size={18} aria-hidden='true' /> : <ArrowRight size={18} aria-hidden='true' />}
+                {state.loadingMore ? 'Загружаем ещё' : 'Показать ещё сделки'}
+              </button>
+            ) : null}
+
+            {state.loadMoreError ? <p className={styles.loadMoreError} role='alert'>{state.loadMoreError}</p> : null}
+          </div>
         </details>
       ) : null}
 

--- a/apps/web/tests/unit/platformV7RoleIntentDashboard.test.ts
+++ b/apps/web/tests/unit/platformV7RoleIntentDashboard.test.ts
@@ -31,7 +31,8 @@ describe('platform-v7 role intent dashboard', () => {
     const shell = read('apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx');
 
     expect(model).toContain('ROLE_INTENT_ACTIONS');
-    expect(dashboard).toContain('/api/proxy/deals/accessible?limit=20');
+    expect(dashboard).toContain('const PAGE_SIZE = 20');
+    expect(dashboard).toContain("params.set('cursor', cursor)");
     expect(dashboard).toContain('function prioritizeDeals');
     expect(dashboard).toContain('(deal.nextAction ? actionable : waiting).push(deal)');
     expect(dashboard).toContain('Сначала показана сделка, где от вас уже требуется действие');
@@ -57,6 +58,20 @@ describe('platform-v7 role intent dashboard', () => {
     ]) {
       expect(shell).toContain(route);
     }
+  });
+
+  it('scales the Today queue without hiding or replacing the primary deal', () => {
+    const dashboard = read('apps/web/components/platform-v7/RoleIntentDashboard.tsx');
+    const dashboardStyles = read('apps/web/components/platform-v7/RoleIntentDashboard.module.css');
+
+    expect(dashboard).toContain('nextCursor: string | null');
+    expect(dashboard).toContain('mergeDeals(current.deals, page.deals)');
+    expect(dashboard).toContain('const byId = new Map<string, AccessibleDealRef>()');
+    expect(dashboard).toContain('Показать ещё сделки');
+    expect(dashboard).toContain('loadMoreError: message');
+    expect(dashboard).toContain('<CanonicalDealWorkspace role={role} dealId={current.id} />');
+    expect(dashboardStyles).toContain('.loadMoreButton');
+    expect(dashboardStyles).toContain('overscroll-behavior: contain');
   });
 
   it('keeps all twelve owner cabinet routes, organizations and page implementations connected', () => {

--- a/apps/web/tests/unit/platformV7TodayWorkspace.test.ts
+++ b/apps/web/tests/unit/platformV7TodayWorkspace.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function source(path: string): string {
+  return readFileSync(join(process.cwd(), path), 'utf8');
+}
+
+describe('platform-v7 Today workspace scale and cognitive safety', () => {
+  const dashboard = source('components/platform-v7/RoleIntentDashboard.tsx');
+  const styles = source('components/platform-v7/RoleIntentDashboard.module.css');
+
+  it('keeps one primary deal while supporting server cursor pagination', () => {
+    expect(dashboard).toContain('const PAGE_SIZE = 20');
+    expect(dashboard).toContain("params.set('cursor', cursor)");
+    expect(dashboard).toContain('nextCursor: string | null');
+    expect(dashboard).toContain('mergeDeals(current.deals, page.deals)');
+    expect(dashboard).toContain('Показать ещё сделки');
+    expect(dashboard).toContain('<CanonicalDealWorkspace role={role} dealId={current.id} />');
+  });
+
+  it('deduplicates pages and never replaces an already usable screen with a load-more failure', () => {
+    expect(dashboard).toContain("const byId = new Map<string, AccessibleDealRef>()");
+    expect(dashboard).toContain("current.kind === 'ready'");
+    expect(dashboard).toContain('loadMoreError: message');
+    expect(dashboard).toContain("role='alert'");
+  });
+
+  it('keeps large touch targets and mobile-safe scrolling', () => {
+    expect(styles).toContain('.loadMoreButton');
+    expect(styles).toContain('min-height: 48px');
+    expect(styles).toContain('overscroll-behavior: contain');
+    expect(styles).toContain('@media (max-width: 430px)');
+    expect(styles).toContain('@media (forced-colors: active)');
+  });
+});


### PR DESCRIPTION
## Цель

Сделать первый экран понятным пользователю с низкой цифровой грамотностью и одновременно пригодным для крупных портфелей сделок.

## Что изменено

- одна приоритетная сделка остаётся главным рабочим местом;
- дополнительные сделки загружаются серверными страницами по 20 записей;
- поддержан cursor pagination без загрузки всего портфеля в браузер;
- повторяющиеся сделки между страницами удаляются по `deal.id`;
- ошибка дозагрузки не уничтожает уже открытое рабочее место;
- количество показывается честно: общее число используется только когда его вернул сервер;
- добавлены крупные touch targets, bounded scrolling, forced-colors и reduced-motion;
- сохранены все существующие маршруты, команды, RBAC, state machine, деньги, аудит и интеграционные границы.

## Граница зрелости

Изменение подготавливает UI к большим портфелям. Оно не является доказательством production capacity без отдельных нагрузочных и операционных gates.