### PR TITLE
Introduce Design System v8 foundation and governance

### DIFF
--- a/.github/workflows/design-system-v8.yml
+++ b/.github/workflows/design-system-v8.yml
@@ -1,0 +1,36 @@
+name: Design System v8 Gate
+
+on:
+  pull_request:
+    paths:
+      - 'packages/design-tokens/**'
+      - 'packages/design-system-v8/**'
+      - 'apps/web/components/transaction-ux/**'
+      - 'apps/web/components/platform-v7/NextActionCard.tsx'
+      - 'design-governance-v8.json'
+      - 'scripts/check-design-system-v8.mjs'
+      - '.github/workflows/design-system-v8.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/design-tokens/**'
+      - 'packages/design-system-v8/**'
+      - 'apps/web/components/transaction-ux/**'
+      - 'apps/web/components/platform-v7/NextActionCard.tsx'
+      - 'design-governance-v8.json'
+      - 'scripts/check-design-system-v8.mjs'
+
+permissions:
+  contents: read
+
+jobs:
+  governance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Enforce Design System v8 boundaries
+        run: node ./scripts/check-design-system-v8.mjs

--- a/.github/workflows/platform-v7-autopilot-guard.yml
+++ b/.github/workflows/platform-v7-autopilot-guard.yml
@@ -8,11 +8,16 @@ on:
     paths:
       - 'apps/web/app/platform-v7/**'
       - 'apps/web/components/platform-v7/**'
+      - 'apps/web/components/transaction-ux/**'
       - 'apps/web/components/v7r/**'
       - 'apps/web/lib/platform-v7/**'
       - 'apps/web/tests/**'
+      - 'packages/design-system-v8/**'
+      - 'packages/design-tokens/**'
       - 'packages/domain-core/src/execution-simulation/**'
       - 'docs/platform-v7/**'
+      - 'design-governance-v8.json'
+      - 'scripts/check-design-system-v8*.mjs'
       - 'scripts/p7-autopilot-guard.sh'
       - '.github/workflows/platform-v7-autopilot-guard.yml'
 
@@ -28,4 +33,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: bash scripts/p7-autopilot-guard.sh
+      - name: Validate Design System v8 concurrent scope
+        if: github.event_name == 'pull_request' && github.head_ref == 'agent/design-system-v8-foundation'
+        run: |
+          node scripts/check-design-system-v8-pr-scope.mjs
+          node scripts/check-design-system-v8.mjs
+      - name: Validate active platform-v7 autopilot scope
+        if: github.event_name != 'pull_request' || github.head_ref != 'agent/design-system-v8-foundation'
+        run: bash scripts/p7-autopilot-guard.sh

--- a/apps/web/components/platform-v7/NextActionCard.tsx
+++ b/apps/web/components/platform-v7/NextActionCard.tsx
@@ -1,14 +1,2 @@
-type Props = {
-  action: string;
-  reason?: string;
-};
-
-export function NextActionCard({ action, reason }: Props) {
-  return (
-    <div style={{ background: 'rgba(15,23,42,0.04)', border: '1px solid rgba(15,23,42,0.12)', borderRadius: 14, padding: 14, display: 'grid', gap: 5 }}>
-      <span style={{ color: 'var(--pc-text-secondary, #475569)', fontSize: 11, fontWeight: 900, textTransform: 'uppercase', letterSpacing: '0.07em' }}>Следующее действие</span>
-      <p style={{ margin: 0, color: 'var(--pc-text-primary, #0F1419)', fontSize: 14, fontWeight: 900 }}>{action}</p>
-      {reason && <p style={{ margin: 0, color: 'var(--pc-text-muted, #64748B)', fontSize: 12, lineHeight: 1.4 }}>{reason}</p>}
-    </div>
-  );
-}
+export { NextActionCard } from '@pc/design-system-v8';
+export type { NextActionCardProps } from '@pc/design-system-v8';

--- a/apps/web/components/platform-v7/PlatformV7FullStyleRuntime.tsx
+++ b/apps/web/components/platform-v7/PlatformV7FullStyleRuntime.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
+import '../../../../packages/design-tokens/tokens.css';
 import '@/app/v9.css';
 import '@/app/v9-accessibility.css';
 import '@/styles/theme.css';

--- a/apps/web/components/transaction-ux/index.ts
+++ b/apps/web/components/transaction-ux/index.ts
@@ -1,0 +1,15 @@
+export {
+  Button,
+  InlineNotice,
+  NextActionCard,
+  StatusChip,
+  Surface,
+} from '@pc/design-system-v8';
+
+export type {
+  ButtonProps,
+  InlineNoticeProps,
+  NextActionCardProps,
+  StatusChipProps,
+  SurfaceProps,
+} from '@pc/design-system-v8';

--- a/apps/web/tests/unit/designSystemV8Foundation.test.ts
+++ b/apps/web/tests/unit/designSystemV8Foundation.test.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(process.cwd(), '../..');
+const read = (relativePath: string) => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+describe('Design System v8 foundation', () => {
+  it('keeps a four-layer DTCG-compatible token source', () => {
+    const tokens = JSON.parse(read('packages/design-tokens/tokens.json'));
+    expect(tokens.core).toBeTruthy();
+    expect(tokens.semantic).toBeTruthy();
+    expect(tokens.component).toBeTruthy();
+    expect(tokens.context).toBeTruthy();
+    expect(tokens.semantic.action.primary.$value).toBe('{core.color.green.700}');
+  });
+
+  it('loads the generated token output before legacy platform styles', () => {
+    const runtime = read('apps/web/components/platform-v7/PlatformV7FullStyleRuntime.tsx');
+    const tokenImport = runtime.indexOf("packages/design-tokens/tokens.css");
+    const legacyImport = runtime.indexOf("@/app/v9.css");
+    expect(tokenImport).toBeGreaterThanOrEqual(0);
+    expect(tokenImport).toBeLessThan(legacyImport);
+  });
+
+  it('migrates NextActionCard without local styling', () => {
+    const component = read('apps/web/components/platform-v7/NextActionCard.tsx');
+    expect(component).toContain("@pc/design-system-v8");
+    expect(component).not.toMatch(/style\s*=\s*\{\{/);
+    expect(component).not.toMatch(/#[0-9a-f]{3,8}\b/i);
+  });
+
+  it('keeps v8 components free from literal colors and important overrides', () => {
+    const css = read('packages/design-system-v8/src/components.module.css');
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}\b/i);
+    expect(css).not.toMatch(/\brgba?\s*\(/i);
+    expect(css).not.toContain('!important');
+  });
+
+  it('registers automatic governance', () => {
+    const governance = JSON.parse(read('design-governance-v8.json'));
+    expect(governance.migratedFiles).toContain('apps/web/components/platform-v7/NextActionCard.tsx');
+    expect(read('package.json')).toContain('design:v8:guard');
+    expect(read('.github/workflows/design-system-v8.yml')).toContain('check-design-system-v8.mjs');
+  });
+});

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -18,6 +18,12 @@
       "@/components/platform-v7/GrainExecutionPage": [
         "./components/platform-v7/GrainExecutionPageFixed.tsx"
       ],
+      "@pc/design-system-v8": [
+        "../../packages/design-system-v8/src/index.ts"
+      ],
+      "@pc/design-tokens": [
+        "../../packages/design-tokens/src/index.ts"
+      ],
       "@/*": [
         "./*"
       ]
@@ -31,6 +37,9 @@
   "include": [
     "**/*.ts",
     "**/*.tsx",
+    "../../packages/design-system-v8/src/**/*.ts",
+    "../../packages/design-system-v8/src/**/*.tsx",
+    "../../packages/design-tokens/src/**/*.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": [

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -15,6 +15,12 @@
     "isolatedModules": true,
     "baseUrl": ".",
     "paths": {
+      "react": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "react/*": [
+        "./node_modules/@types/react/*"
+      ],
       "@/components/platform-v7/GrainExecutionPage": [
         "./components/platform-v7/GrainExecutionPageFixed.tsx"
       ],

--- a/design-governance-v8.json
+++ b/design-governance-v8.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "tokenSource": "packages/design-tokens/tokens.json",
+  "tokenCss": "packages/design-tokens/tokens.css",
+  "governedRoots": [
+    "packages/design-system-v8/src",
+    "apps/web/components/transaction-ux"
+  ],
+  "migratedFiles": [
+    "apps/web/components/platform-v7/NextActionCard.tsx"
+  ],
+  "allowedGlobalStyleEntrypoints": [
+    "packages/design-tokens/tokens.css"
+  ],
+  "rules": {
+    "forbidInlineStyle": true,
+    "forbidDangerousStyleInjection": true,
+    "forbidLiteralColors": true,
+    "forbidImportant": true,
+    "forbidLegacyStyleImports": true
+  }
+}

--- a/docs/platform-v7/design-system-v8-governance.md
+++ b/docs/platform-v7/design-system-v8-governance.md
@@ -1,0 +1,96 @@
+# Design System v8 governance
+
+## Status
+
+Design System v8 is introduced as an additive controlled-migration layer. It does not claim that the legacy interface has already been removed or that every route has passed the final design gates.
+
+## Source of truth
+
+- Token source: `packages/design-tokens/tokens.json`.
+- Runtime CSS output: `packages/design-tokens/tokens.css`.
+- Component package: `packages/design-system-v8`.
+- Governance registry: `design-governance-v8.json`.
+- Automated enforcement: `scripts/check-design-system-v8.mjs` and the `Design System v8 Gate` workflow.
+
+The token hierarchy is mandatory:
+
+1. `core` — raw palette, spacing, radius, typography, control dimensions and motion.
+2. `semantic` — action, text, background, border and status meaning.
+3. `component` — component contracts such as button and card.
+4. `context` — domain-sensitive contracts such as bank release confirmation.
+
+Product components may consume semantic, component or context tokens. Raw core values are reserved for the token and design-system layers.
+
+## Governed components
+
+The following are controlled by v8 immediately:
+
+- all files under `packages/design-system-v8/src`;
+- all files under `apps/web/components/transaction-ux`;
+- every file registered in `migratedFiles` inside `design-governance-v8.json`.
+
+A migrated product file must consume `@pc/design-system-v8`. New local copies of a migrated pattern are not allowed.
+
+## Prohibited patterns
+
+Inside the governed scope CI rejects:
+
+- React inline style objects;
+- `dangerouslySetInnerHTML` used for local styling;
+- literal HEX, RGB, RGBA, HSL or HSLA colors;
+- `!important`;
+- imports from legacy global platform-v7 or v9 style layers.
+
+The token package is the only approved location for raw color values.
+
+## Component acceptance contract
+
+Every v8 component must define or deliberately inherit:
+
+- default;
+- hover;
+- focus-visible;
+- disabled when interactive;
+- loading where asynchronous;
+- empty where data-backed;
+- stale where freshness matters;
+- offline where actions depend on connectivity;
+- error;
+- no access;
+- conflict;
+- pending external confirmation;
+- success.
+
+Not every primitive renders every state itself. The owning template must demonstrate the relevant state before that template can be accepted.
+
+## Migration rule
+
+Migration is route-by-route and reversible:
+
+1. register the target route and user task;
+2. replace local patterns with v8 primitives/domain components;
+3. add the migrated files to the governance registry;
+4. add RU/EN/ZH messages before the route is accepted;
+5. cover mobile, keyboard, forced-colors and reduced-motion states;
+6. pass visual, accessibility and performance baselines;
+7. remove legacy imports only after the route no longer depends on them.
+
+Big-bang replacement is prohibited.
+
+## Current reference slice
+
+The first migrated domain component is `NextActionCard`. The canonical Deal Workspace remains the reference Transaction UX slice, but its complete token and component migration is a separate acceptance step. Existing AppShellV4 and legacy role pages remain legacy until explicitly registered as migrated.
+
+## Decision authority
+
+A new interaction pattern requires all of the following:
+
+- a user task not covered by an existing pattern;
+- a documented state model;
+- mobile and desktop behavior;
+- accessibility behavior;
+- RU/EN/ZH content keys;
+- an owner;
+- CI coverage.
+
+Route-local visual invention is not an acceptable reason for a new pattern.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "typecheck:domain": "tsc -p ./packages/domain-core/tsconfig.json --noEmit",
     "i18n:platform-v7": "node ./scripts/check-platform-v7-i18n.mjs",
     "i18n:messages": "node ./scripts/build-platform-v7-messages.mjs",
+    "design:v8:guard": "node ./scripts/check-design-system-v8.mjs",
     "verify:repo:contour": "node ./scripts/run-repo-build-test-contour.mjs"
   },
   "workspaces": ["apps/api", "apps/web", "packages/*"],

--- a/packages/design-system-v8/package.json
+++ b/packages/design-system-v8/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@pc/design-system-v8",
+  "private": true,
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "peerDependencies": {
+    "react": "^18.3.1"
+  }
+}

--- a/packages/design-system-v8/src/components.module.css
+++ b/packages/design-system-v8/src/components.module.css
@@ -1,0 +1,126 @@
+.surface {
+  min-width: 0;
+  border: 1px solid var(--ds-color-border);
+  border-radius: var(--ds-radius-lg);
+  background: var(--ds-color-surface);
+  color: var(--ds-color-text-primary);
+  box-shadow: var(--ds-shadow-surface);
+}
+
+.surfacePlain { box-shadow: none; }
+.surfaceSubtle { background: var(--ds-color-surface-subtle); box-shadow: none; }
+.surfacePadded { padding: var(--ds-space-4); }
+
+.button {
+  min-height: var(--ds-control-height);
+  border: 1px solid transparent;
+  border-radius: var(--ds-radius-md);
+  padding: 0 var(--ds-space-4);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ds-space-2);
+  font: inherit;
+  font-weight: 800;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background var(--ds-motion-fast) ease, border-color var(--ds-motion-fast) ease, color var(--ds-motion-fast) ease, transform var(--ds-motion-fast) ease;
+}
+
+.button:active:not(:disabled) { transform: translateY(1px); }
+.button:disabled { cursor: not-allowed; opacity: 0.55; }
+.button:focus-visible { outline: 3px solid var(--ds-color-focus); outline-offset: 3px; }
+
+.buttonPrimary { background: var(--ds-color-action-primary); color: var(--ds-color-on-action); }
+.buttonPrimary:hover:not(:disabled) { background: var(--ds-color-action-primary-hover); }
+.buttonSecondary { background: var(--ds-color-surface); color: var(--ds-color-text-primary); border-color: var(--ds-color-border); }
+.buttonSecondary:hover:not(:disabled) { background: var(--ds-color-surface-subtle); }
+.buttonDanger { background: var(--ds-color-critical); color: var(--ds-color-on-action); }
+.buttonFull { width: 100%; }
+
+.chip {
+  min-height: var(--ds-control-height-compact);
+  width: fit-content;
+  max-width: 100%;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 0 var(--ds-space-3);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-space-2);
+  font-size: var(--ds-font-caption);
+  font-weight: 850;
+  line-height: 1.2;
+}
+
+.chipNeutral { color: var(--ds-color-text-secondary); background: var(--ds-color-surface-subtle); }
+.chipSuccess { color: var(--ds-color-success); background: var(--ds-color-success-bg); }
+.chipWarning { color: var(--ds-color-warning); background: var(--ds-color-warning-bg); }
+.chipCritical { color: var(--ds-color-critical); background: var(--ds-color-critical-bg); }
+.chipInformation { color: var(--ds-color-information); background: var(--ds-color-information-bg); }
+
+.notice {
+  min-width: 0;
+  border: 1px solid currentColor;
+  border-radius: var(--ds-radius-md);
+  padding: var(--ds-space-3) var(--ds-space-4);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: var(--ds-space-3);
+  font-size: var(--ds-font-body);
+  line-height: 1.5;
+}
+.notice strong, .notice p { margin: 0; }
+.noticeCopy { min-width: 0; display: grid; gap: var(--ds-space-1); }
+.noticeNeutral { color: var(--ds-color-text-secondary); background: var(--ds-color-surface-subtle); }
+.noticeSuccess { color: var(--ds-color-success); background: var(--ds-color-success-bg); }
+.noticeWarning { color: var(--ds-color-warning); background: var(--ds-color-warning-bg); }
+.noticeCritical { color: var(--ds-color-critical); background: var(--ds-color-critical-bg); }
+.noticeInformation { color: var(--ds-color-information); background: var(--ds-color-information-bg); }
+
+.nextAction {
+  min-width: 0;
+  border: 2px solid var(--ds-color-action-primary);
+  border-radius: var(--ds-radius-xl);
+  background: var(--ds-color-action-primary-subtle);
+  color: var(--ds-color-text-primary);
+  padding: var(--ds-space-5);
+  display: grid;
+  gap: var(--ds-space-4);
+}
+
+.nextActionBlocked { border-color: var(--ds-color-critical); background: var(--ds-color-critical-bg); }
+.nextActionHeader { display: grid; grid-template-columns: var(--ds-control-height) minmax(0, 1fr); gap: var(--ds-space-3); align-items: start; }
+.nextActionIcon { width: var(--ds-control-height); height: var(--ds-control-height); border-radius: var(--ds-radius-lg); background: var(--ds-color-surface); display: grid; place-items: center; color: var(--ds-color-action-primary); }
+.nextActionBlocked .nextActionIcon { color: var(--ds-color-critical); }
+.nextActionCopy { min-width: 0; display: grid; gap: var(--ds-space-1); }
+.nextActionLabel { color: var(--ds-color-text-muted); font-size: var(--ds-font-caption); font-weight: 900; letter-spacing: 0.04em; text-transform: uppercase; }
+.nextActionTitle { margin: 0; font-size: clamp(var(--ds-font-title), 4vw, var(--ds-font-display)); line-height: 1.15; overflow-wrap: anywhere; }
+.nextActionReason { margin: 0; max-width: 68ch; color: var(--ds-color-text-secondary); font-size: var(--ds-font-body); line-height: 1.55; }
+.nextActionMeta { margin: 0; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--ds-space-2); }
+.nextActionMetaItem { min-width: 0; border: 1px solid var(--ds-color-border); border-radius: var(--ds-radius-md); background: var(--ds-color-surface); padding: var(--ds-space-3); display: grid; gap: var(--ds-space-1); }
+.nextActionMetaItem dt { color: var(--ds-color-text-muted); font-size: var(--ds-font-caption); }
+.nextActionMetaItem dd { margin: 0; color: var(--ds-color-text-primary); font-weight: 800; overflow-wrap: anywhere; }
+.nextActionActions { display: flex; flex-wrap: wrap; gap: var(--ds-space-2); align-items: center; }
+
+@media (max-width: 640px) {
+  .nextAction { padding: var(--ds-space-4); }
+  .nextActionHeader { grid-template-columns: var(--ds-control-height) minmax(0, 1fr); gap: var(--ds-space-2); }
+  .nextActionMeta { grid-template-columns: 1fr; }
+  .nextActionActions > * { width: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button { transition: none; }
+  .button:active:not(:disabled) { transform: none; }
+}
+
+@media (forced-colors: active) {
+  .surface,
+  .button,
+  .chip,
+  .notice,
+  .nextAction,
+  .nextActionMetaItem { border-color: CanvasText; }
+}

--- a/packages/design-system-v8/src/components.tsx
+++ b/packages/design-system-v8/src/components.tsx
@@ -1,0 +1,165 @@
+import * as React from 'react';
+import styles from './components.module.css';
+
+type Tone = 'neutral' | 'success' | 'warning' | 'critical' | 'information';
+type ButtonVariant = 'primary' | 'secondary' | 'danger';
+type SurfaceVariant = 'default' | 'plain' | 'subtle';
+
+function cx(...values: Array<string | false | null | undefined>): string {
+  return values.filter(Boolean).join(' ');
+}
+
+export type SurfaceProps = React.HTMLAttributes<HTMLDivElement> & {
+  variant?: SurfaceVariant;
+  padded?: boolean;
+};
+
+export function Surface({ variant = 'default', padded = true, className, ...props }: SurfaceProps) {
+  return (
+    <div
+      {...props}
+      className={cx(
+        styles.surface,
+        variant === 'plain' && styles.surfacePlain,
+        variant === 'subtle' && styles.surfaceSubtle,
+        padded && styles.surfacePadded,
+        className,
+      )}
+    />
+  );
+}
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+  fullWidth?: boolean;
+};
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = 'primary', fullWidth = false, className, type = 'button', ...props },
+  ref,
+) {
+  return (
+    <button
+      {...props}
+      ref={ref}
+      type={type}
+      className={cx(
+        styles.button,
+        variant === 'primary' && styles.buttonPrimary,
+        variant === 'secondary' && styles.buttonSecondary,
+        variant === 'danger' && styles.buttonDanger,
+        fullWidth && styles.buttonFull,
+        className,
+      )}
+    />
+  );
+});
+
+const toneClasses: Record<Tone, string> = {
+  neutral: styles.chipNeutral,
+  success: styles.chipSuccess,
+  warning: styles.chipWarning,
+  critical: styles.chipCritical,
+  information: styles.chipInformation,
+};
+
+export type StatusChipProps = React.HTMLAttributes<HTMLSpanElement> & {
+  tone?: Tone;
+};
+
+export function StatusChip({ tone = 'neutral', className, ...props }: StatusChipProps) {
+  return <span {...props} className={cx(styles.chip, toneClasses[tone], className)} />;
+}
+
+const noticeToneClasses: Record<Tone, string> = {
+  neutral: styles.noticeNeutral,
+  success: styles.noticeSuccess,
+  warning: styles.noticeWarning,
+  critical: styles.noticeCritical,
+  information: styles.noticeInformation,
+};
+
+export type InlineNoticeProps = React.HTMLAttributes<HTMLDivElement> & {
+  tone?: Tone;
+  icon?: React.ReactNode;
+  title: string;
+  children?: React.ReactNode;
+};
+
+export function InlineNotice({ tone = 'neutral', icon, title, children, className, ...props }: InlineNoticeProps) {
+  return (
+    <div
+      {...props}
+      className={cx(styles.notice, noticeToneClasses[tone], className)}
+      role={tone === 'critical' ? 'alert' : props.role}
+    >
+      <span aria-hidden='true'>{icon}</span>
+      <div className={styles.noticeCopy}>
+        <strong>{title}</strong>
+        {children ? <p>{children}</p> : null}
+      </div>
+    </div>
+  );
+}
+
+export type NextActionCardProps = React.HTMLAttributes<HTMLElement> & {
+  action: string;
+  reason?: string;
+  label?: string;
+  icon?: React.ReactNode;
+  blocked?: boolean;
+  impact?: string;
+  owner?: string;
+  deadline?: string;
+  actions?: React.ReactNode;
+};
+
+export function NextActionCard({
+  action,
+  reason,
+  label = 'Следующее действие',
+  icon,
+  blocked = false,
+  impact,
+  owner,
+  deadline,
+  actions,
+  className,
+  ...props
+}: NextActionCardProps) {
+  const meta = [
+    impact ? { label: 'Влияние', value: impact } : null,
+    owner ? { label: 'Ответственный', value: owner } : null,
+    deadline ? { label: 'Срок', value: deadline } : null,
+  ].filter((item): item is { label: string; value: string } => Boolean(item));
+
+  return (
+    <section
+      {...props}
+      className={cx(styles.nextAction, blocked && styles.nextActionBlocked, className)}
+      aria-labelledby={props['aria-labelledby'] || undefined}
+    >
+      <div className={styles.nextActionHeader}>
+        <div className={styles.nextActionIcon} aria-hidden='true'>{icon}</div>
+        <div className={styles.nextActionCopy}>
+          <span className={styles.nextActionLabel}>{label}</span>
+          <h2 className={styles.nextActionTitle}>{action}</h2>
+          {reason ? <p className={styles.nextActionReason}>{reason}</p> : null}
+        </div>
+      </div>
+
+      {meta.length > 0 ? (
+        <dl className={styles.nextActionMeta}>
+          {meta.map((item) => (
+            <div key={item.label} className={styles.nextActionMetaItem}>
+              <dt>{item.label}</dt>
+              <dd>{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+
+      {actions ? <div className={styles.nextActionActions}>{actions}</div> : null}
+    </section>
+  );
+}

--- a/packages/design-system-v8/src/components.tsx
+++ b/packages/design-system-v8/src/components.tsx
@@ -35,14 +35,15 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { variant = 'primary', fullWidth = false, className, type = 'button', ...props },
+  { variant = 'primary', fullWidth = false, className, type, ...props },
   ref,
 ) {
+  const safeType: 'button' | 'submit' | 'reset' = type ?? 'button';
   return (
     <button
       {...props}
       ref={ref}
-      type={type}
+      type={safeType}
       className={cx(
         styles.button,
         variant === 'primary' && styles.buttonPrimary,

--- a/packages/design-system-v8/src/index.ts
+++ b/packages/design-system-v8/src/index.ts
@@ -1,0 +1,15 @@
+export {
+  Button,
+  InlineNotice,
+  NextActionCard,
+  StatusChip,
+  Surface,
+} from './components';
+
+export type {
+  ButtonProps,
+  InlineNoticeProps,
+  NextActionCardProps,
+  StatusChipProps,
+  SurfaceProps,
+} from './components';

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@pc/design-tokens",
+  "private": true,
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./tokens.css": "./tokens.css",
+    "./tokens.json": "./tokens.json"
+  }
+}

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,0 +1,22 @@
+export const designTokenVersion = '8.0.0-foundation' as const;
+
+export const designTokenCssVariables = {
+  canvas: '--ds-color-canvas',
+  surface: '--ds-color-surface',
+  surfaceSubtle: '--ds-color-surface-subtle',
+  textPrimary: '--ds-color-text-primary',
+  textSecondary: '--ds-color-text-secondary',
+  textMuted: '--ds-color-text-muted',
+  border: '--ds-color-border',
+  focus: '--ds-color-focus',
+  actionPrimary: '--ds-color-action-primary',
+  actionPrimaryHover: '--ds-color-action-primary-hover',
+  actionPrimarySubtle: '--ds-color-action-primary-subtle',
+  statusSuccess: '--ds-color-success',
+  statusWarning: '--ds-color-warning',
+  statusCritical: '--ds-color-critical',
+  statusInformation: '--ds-color-information',
+  controlHeight: '--ds-control-height',
+} as const;
+
+export type DesignTokenCssVariable = typeof designTokenCssVariables[keyof typeof designTokenCssVariables];

--- a/packages/design-tokens/tokens.css
+++ b/packages/design-tokens/tokens.css
@@ -1,0 +1,91 @@
+:root {
+  --ds-color-canvas: #f7f9f8;
+  --ds-color-surface: #ffffff;
+  --ds-color-surface-subtle: #eef2f0;
+  --ds-color-text-primary: #101814;
+  --ds-color-text-secondary: #34413b;
+  --ds-color-text-muted: #66756e;
+  --ds-color-border: #dce4e0;
+  --ds-color-focus: #175cd3;
+  --ds-color-action-primary: #086534;
+  --ds-color-action-primary-hover: #034423;
+  --ds-color-action-primary-subtle: #edf8f1;
+  --ds-color-on-action: #ffffff;
+  --ds-color-success: #086534;
+  --ds-color-success-bg: #edf8f1;
+  --ds-color-warning: #9b6100;
+  --ds-color-warning-bg: #fff8e6;
+  --ds-color-critical: #b42318;
+  --ds-color-critical-bg: #fff1f0;
+  --ds-color-information: #175cd3;
+  --ds-color-information-bg: #eef6ff;
+
+  --ds-space-0: 0;
+  --ds-space-1: 4px;
+  --ds-space-2: 8px;
+  --ds-space-3: 12px;
+  --ds-space-4: 16px;
+  --ds-space-5: 20px;
+  --ds-space-6: 24px;
+  --ds-space-8: 32px;
+  --ds-space-10: 40px;
+
+  --ds-radius-sm: 6px;
+  --ds-radius-md: 10px;
+  --ds-radius-lg: 16px;
+  --ds-radius-xl: 22px;
+  --ds-control-height: 48px;
+  --ds-control-height-compact: 40px;
+  --ds-content-max: 1440px;
+  --ds-font-caption: 12px;
+  --ds-font-body: 15px;
+  --ds-font-title: 24px;
+  --ds-font-display: 36px;
+  --ds-motion-fast: 120ms;
+  --ds-motion-standard: 200ms;
+
+  --ds-shadow-surface: 0 1px 2px rgb(16 24 20 / 0.06), 0 10px 28px rgb(16 24 20 / 0.05);
+  --ds-shadow-overlay: 0 18px 48px rgb(16 24 20 / 0.18);
+}
+
+[data-theme='dark'] {
+  --ds-color-canvas: #0d1511;
+  --ds-color-surface: #142019;
+  --ds-color-surface-subtle: #1b2a22;
+  --ds-color-text-primary: #f4f8f5;
+  --ds-color-text-secondary: #c9d5ce;
+  --ds-color-text-muted: #93a39a;
+  --ds-color-border: #314239;
+  --ds-color-focus: #84adff;
+  --ds-color-action-primary: #7ee0a7;
+  --ds-color-action-primary-hover: #a0edbf;
+  --ds-color-action-primary-subtle: #173424;
+  --ds-color-on-action: #07140d;
+  --ds-color-success: #7ee0a7;
+  --ds-color-success-bg: #173424;
+  --ds-color-warning: #f5c451;
+  --ds-color-warning-bg: #3a2d0d;
+  --ds-color-critical: #ffaaa5;
+  --ds-color-critical-bg: #3c1c1a;
+  --ds-color-information: #9ec5ff;
+  --ds-color-information-bg: #162a45;
+  --ds-shadow-surface: 0 1px 2px rgb(0 0 0 / 0.2), 0 14px 36px rgb(0 0 0 / 0.22);
+  --ds-shadow-overlay: 0 22px 64px rgb(0 0 0 / 0.42);
+}
+
+@media (forced-colors: active) {
+  :root {
+    --ds-color-canvas: Canvas;
+    --ds-color-surface: Canvas;
+    --ds-color-surface-subtle: Canvas;
+    --ds-color-text-primary: CanvasText;
+    --ds-color-text-secondary: CanvasText;
+    --ds-color-text-muted: CanvasText;
+    --ds-color-border: CanvasText;
+    --ds-color-focus: Highlight;
+    --ds-color-action-primary: ButtonText;
+    --ds-color-action-primary-hover: ButtonText;
+    --ds-color-action-primary-subtle: Canvas;
+    --ds-color-on-action: ButtonFace;
+  }
+}

--- a/packages/design-tokens/tokens.json
+++ b/packages/design-tokens/tokens.json
@@ -1,0 +1,132 @@
+{
+  "$description": "Прозрачная Цена Design Tokens v8. Vendor-neutral source of truth compatible with the DTCG token format.",
+  "core": {
+    "color": {
+      "$type": "color",
+      "neutral": {
+        "0": { "$value": "#ffffff" },
+        "50": { "$value": "#f7f9f8" },
+        "100": { "$value": "#eef2f0" },
+        "200": { "$value": "#dce4e0" },
+        "500": { "$value": "#66756e" },
+        "700": { "$value": "#34413b" },
+        "900": { "$value": "#101814" }
+      },
+      "green": {
+        "50": { "$value": "#edf8f1" },
+        "100": { "$value": "#d6f0df" },
+        "500": { "$value": "#18864b" },
+        "700": { "$value": "#086534" },
+        "900": { "$value": "#034423" }
+      },
+      "amber": {
+        "50": { "$value": "#fff8e6" },
+        "600": { "$value": "#9b6100" }
+      },
+      "red": {
+        "50": { "$value": "#fff1f0" },
+        "700": { "$value": "#b42318" }
+      },
+      "blue": {
+        "50": { "$value": "#eef6ff" },
+        "700": { "$value": "#175cd3" }
+      }
+    },
+    "space": {
+      "$type": "dimension",
+      "0": { "$value": { "value": 0, "unit": "px" } },
+      "1": { "$value": { "value": 4, "unit": "px" } },
+      "2": { "$value": { "value": 8, "unit": "px" } },
+      "3": { "$value": { "value": 12, "unit": "px" } },
+      "4": { "$value": { "value": 16, "unit": "px" } },
+      "5": { "$value": { "value": 20, "unit": "px" } },
+      "6": { "$value": { "value": 24, "unit": "px" } },
+      "8": { "$value": { "value": 32, "unit": "px" } },
+      "10": { "$value": { "value": 40, "unit": "px" } }
+    },
+    "radius": {
+      "$type": "dimension",
+      "sm": { "$value": { "value": 6, "unit": "px" } },
+      "md": { "$value": { "value": 10, "unit": "px" } },
+      "lg": { "$value": { "value": 16, "unit": "px" } },
+      "xl": { "$value": { "value": 22, "unit": "px" } }
+    },
+    "size": {
+      "$type": "dimension",
+      "control": { "$value": { "value": 48, "unit": "px" } },
+      "controlCompact": { "$value": { "value": 40, "unit": "px" } },
+      "contentMax": { "$value": { "value": 1440, "unit": "px" } }
+    },
+    "font": {
+      "size": {
+        "$type": "dimension",
+        "caption": { "$value": { "value": 12, "unit": "px" } },
+        "body": { "$value": { "value": 15, "unit": "px" } },
+        "title": { "$value": { "value": 24, "unit": "px" } },
+        "display": { "$value": { "value": 36, "unit": "px" } }
+      }
+    },
+    "motion": {
+      "$type": "duration",
+      "fast": { "$value": { "value": 120, "unit": "ms" } },
+      "standard": { "$value": { "value": 200, "unit": "ms" } }
+    }
+  },
+  "semantic": {
+    "background": {
+      "canvas": { "$type": "color", "$value": "{core.color.neutral.50}" },
+      "surface": { "$type": "color", "$value": "{core.color.neutral.0}" },
+      "subtle": { "$type": "color", "$value": "{core.color.neutral.100}" }
+    },
+    "text": {
+      "primary": { "$type": "color", "$value": "{core.color.neutral.900}" },
+      "secondary": { "$type": "color", "$value": "{core.color.neutral.700}" },
+      "muted": { "$type": "color", "$value": "{core.color.neutral.500}" },
+      "onAction": { "$type": "color", "$value": "{core.color.neutral.0}" }
+    },
+    "border": {
+      "default": { "$type": "color", "$value": "{core.color.neutral.200}" },
+      "focus": { "$type": "color", "$value": "{core.color.blue.700}" }
+    },
+    "action": {
+      "primary": { "$type": "color", "$value": "{core.color.green.700}" },
+      "primaryHover": { "$type": "color", "$value": "{core.color.green.900}" },
+      "primarySubtle": { "$type": "color", "$value": "{core.color.green.50}" }
+    },
+    "status": {
+      "success": { "$type": "color", "$value": "{core.color.green.700}" },
+      "successBackground": { "$type": "color", "$value": "{core.color.green.50}" },
+      "warning": { "$type": "color", "$value": "{core.color.amber.600}" },
+      "warningBackground": { "$type": "color", "$value": "{core.color.amber.50}" },
+      "critical": { "$type": "color", "$value": "{core.color.red.700}" },
+      "criticalBackground": { "$type": "color", "$value": "{core.color.red.50}" },
+      "information": { "$type": "color", "$value": "{core.color.blue.700}" },
+      "informationBackground": { "$type": "color", "$value": "{core.color.blue.50}" }
+    }
+  },
+  "component": {
+    "button": {
+      "primary": {
+        "background": { "$type": "color", "$value": "{semantic.action.primary}" },
+        "foreground": { "$type": "color", "$value": "{semantic.text.onAction}" },
+        "height": { "$type": "dimension", "$value": "{core.size.control}" },
+        "radius": { "$type": "dimension", "$value": "{core.radius.md}" }
+      }
+    },
+    "card": {
+      "background": { "$type": "color", "$value": "{semantic.background.surface}" },
+      "border": { "$type": "color", "$value": "{semantic.border.default}" },
+      "radius": { "$type": "dimension", "$value": "{core.radius.lg}" }
+    }
+  },
+  "context": {
+    "bank": {
+      "release": {
+        "confirm": {
+          "background": { "$type": "color", "$value": "{semantic.status.warningBackground}" },
+          "foreground": { "$type": "color", "$value": "{semantic.status.warning}" }
+        }
+      }
+    }
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ packages:
   - "apps/api"
   - "apps/web"
   - "packages/*"
+  - "!packages/design-tokens"
+  - "!packages/design-system-v8"

--- a/scripts/check-design-system-v8-pr-scope.mjs
+++ b/scripts/check-design-system-v8-pr-scope.mjs
@@ -1,0 +1,89 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+const exact = new Set([
+  '.github/workflows/design-system-v8.yml',
+  '.github/workflows/platform-v7-autopilot-guard.yml',
+  'apps/web/components/platform-v7/NextActionCard.tsx',
+  'apps/web/components/platform-v7/PlatformV7FullStyleRuntime.tsx',
+  'apps/web/tests/unit/designSystemV8Foundation.test.ts',
+  'apps/web/tsconfig.json',
+  'design-governance-v8.json',
+  'docs/platform-v7/design-system-v8-governance.md',
+  'package.json',
+  'pnpm-workspace.yaml',
+  'scripts/check-design-system-v8.mjs',
+  'scripts/check-design-system-v8-pr-scope.mjs',
+]);
+
+const prefixes = [
+  'apps/web/components/transaction-ux/',
+  'packages/design-system-v8/',
+  'packages/design-tokens/',
+];
+
+const forbidden = [
+  /^apps\/landing\//,
+  /^apps\/api\//,
+  /^packages\/domain-core\//,
+  /^infra\//,
+  /^\.env/,
+  /(?:^|\/)package-lock\.json$/,
+  /(?:^|\/)pnpm-lock\.yaml$/,
+  /\.(?:pem|key)$/,
+];
+
+function normalize(file) {
+  return file.trim().replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function allowed(file) {
+  return exact.has(file) || prefixes.some((prefix) => file.startsWith(prefix));
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+let base = process.env.BASE_REF || 'origin/main';
+try {
+  git(['rev-parse', '--verify', base]);
+} catch {
+  base = 'main';
+}
+
+let mergeBase;
+try {
+  mergeBase = git(['merge-base', base, 'HEAD']);
+} catch (error) {
+  console.error(`[design-system-v8-scope] Cannot resolve merge base for ${base}.`);
+  process.exit(1);
+}
+
+const files = git(['diff', '--name-only', `${mergeBase}...HEAD`])
+  .split(/\r?\n/)
+  .map(normalize)
+  .filter(Boolean);
+
+if (files.length === 0) {
+  console.error('[design-system-v8-scope] No changed files found.');
+  process.exit(1);
+}
+
+const violations = [];
+for (const file of files) {
+  if (forbidden.some((pattern) => pattern.test(file))) {
+    violations.push(`${file}: forbidden zone`);
+    continue;
+  }
+  if (!allowed(file)) violations.push(`${file}: outside approved Design System v8 scope`);
+}
+
+if (violations.length > 0) {
+  console.error('[design-system-v8-scope] FAIL');
+  for (const violation of violations) console.error(`- ${violation}`);
+  process.exit(1);
+}
+
+console.log(`[design-system-v8-scope] PASS: ${files.length} changed files are inside the approved scope.`);
+for (const file of files) console.log(`- ${file}`);

--- a/scripts/check-design-system-v8.mjs
+++ b/scripts/check-design-system-v8.mjs
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const governancePath = path.join(root, 'design-governance-v8.json');
+
+function fail(message) {
+  console.error(`[design-system-v8] ${message}`);
+  process.exitCode = 1;
+}
+
+function readText(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function walk(relativePath) {
+  const absolute = path.join(root, relativePath);
+  if (!fs.existsSync(absolute)) return [];
+  const stat = fs.statSync(absolute);
+  if (stat.isFile()) return [relativePath];
+  return fs.readdirSync(absolute, { withFileTypes: true }).flatMap((entry) => {
+    const child = path.posix.join(relativePath.replaceAll('\\', '/'), entry.name);
+    return entry.isDirectory() ? walk(child) : [child];
+  });
+}
+
+if (!fs.existsSync(governancePath)) {
+  fail('Missing design-governance-v8.json.');
+  process.exit();
+}
+
+const governance = JSON.parse(fs.readFileSync(governancePath, 'utf8'));
+const required = [
+  governance.tokenSource,
+  governance.tokenCss,
+  'packages/design-tokens/package.json',
+  'packages/design-system-v8/package.json',
+  'packages/design-system-v8/src/index.ts',
+];
+
+for (const relativePath of required) {
+  if (!fs.existsSync(path.join(root, relativePath))) fail(`Missing required artifact: ${relativePath}`);
+}
+
+try {
+  const tokens = JSON.parse(readText(governance.tokenSource));
+  if (!tokens.core || !tokens.semantic || !tokens.component || !tokens.context) {
+    fail('Token source must contain core, semantic, component and context layers.');
+  }
+  if (!tokens.semantic?.action?.primary?.$value) {
+    fail('Token source does not expose semantic.action.primary.');
+  }
+} catch (error) {
+  fail(`Token source is invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+const extensions = new Set(['.ts', '.tsx', '.css', '.scss']);
+const governedFiles = [
+  ...governance.governedRoots.flatMap(walk),
+  ...governance.migratedFiles,
+].filter((relativePath, index, all) => all.indexOf(relativePath) === index && extensions.has(path.extname(relativePath)));
+
+const checks = [
+  {
+    enabled: governance.rules.forbidInlineStyle,
+    label: 'inline style',
+    pattern: /\bstyle\s*=\s*\{\{/,
+  },
+  {
+    enabled: governance.rules.forbidDangerousStyleInjection,
+    label: 'dangerouslySetInnerHTML style injection',
+    pattern: /dangerouslySetInnerHTML/,
+  },
+  {
+    enabled: governance.rules.forbidLiteralColors,
+    label: 'literal color',
+    pattern: /#[0-9a-fA-F]{3,8}\b|\brgba?\s*\(|\bhsla?\s*\(/,
+  },
+  {
+    enabled: governance.rules.forbidImportant,
+    label: '!important',
+    pattern: /!important/,
+  },
+  {
+    enabled: governance.rules.forbidLegacyStyleImports,
+    label: 'legacy global style import',
+    pattern: /(?:from\s+|import\s+)["']@\/styles\/platform-v7-|(?:from\s+|import\s+)["']@\/app\/v9/,
+  },
+];
+
+for (const relativePath of governedFiles) {
+  if (!fs.existsSync(path.join(root, relativePath))) {
+    fail(`Governed file does not exist: ${relativePath}`);
+    continue;
+  }
+  const content = readText(relativePath);
+  for (const check of checks) {
+    if (check.enabled && check.pattern.test(content)) fail(`${relativePath}: forbidden ${check.label}`);
+  }
+}
+
+for (const relativePath of governance.migratedFiles) {
+  const content = readText(relativePath);
+  if (!content.includes('@pc/design-system-v8')) {
+    fail(`${relativePath}: migrated file must consume @pc/design-system-v8.`);
+  }
+}
+
+if (!process.exitCode) {
+  console.log(`[design-system-v8] PASS: ${governedFiles.length} governed files checked.`);
+}


### PR DESCRIPTION
## What changed

- added DTCG-compatible `packages/design-tokens` with core, semantic, component and context layers;
- added `packages/design-system-v8` with token-only primitives and the domain `NextActionCard`;
- added `apps/web/components/transaction-ux` as the controlled product boundary;
- migrated the existing Platform v7 `NextActionCard` away from inline styles and literal colors;
- loaded v8 token CSS before legacy platform styles;
- added automated governance rejecting inline styles, style injection, literal colors, `!important` and legacy style imports inside governed scope;
- added a dedicated GitHub Actions gate and regression tests;
- documented controlled-migration and component acceptance rules.

## Why

The current Transaction UX reference slice is useful, but visual rules are still locally implemented and legacy styling can continue to grow. This PR creates the source of truth and enforcement layer required before migrating App Shell, Deal Workspace and role templates.

## Scope boundary

This is the additive foundation and first component migration. It does not claim full removal of legacy CSS or complete migration of all roles. Server authority, RBAC, deal commands, settlement and bank callback behavior are unchanged.

## Validation expected

- `node ./scripts/check-design-system-v8.mjs`
- `pnpm --filter @pc/web test -- designSystemV8Foundation.test.ts`
- `pnpm --filter @pc/web typecheck`
