### PR TITLE
Migrate four field roles to Design System v8 workbenches

### DIFF
--- a/.github/workflows/design-system-v8.yml
+++ b/.github/workflows/design-system-v8.yml
@@ -9,9 +9,14 @@ on:
       - 'apps/web/components/platform-v7/NextActionCard.tsx'
       - 'apps/web/components/v7r/AppShellV4.tsx'
       - 'apps/web/components/v7r/AppShellV4.module.css'
+      - 'apps/web/app/platform-v7/driver/field/page.tsx'
+      - 'apps/web/app/platform-v7/elevator/page.tsx'
+      - 'apps/web/app/platform-v7/lab/page.tsx'
+      - 'apps/web/app/platform-v7/surveyor/page.tsx'
+      - 'apps/web/tests/unit/designSystemV8*.test.ts'
       - 'apps/web/tests/unit/platformV7MobileNavigation.test.ts'
       - 'design-governance-v8.json'
-      - 'scripts/check-design-system-v8.mjs'
+      - 'scripts/check-design-system-v8*.mjs'
       - '.github/workflows/design-system-v8.yml'
   push:
     branches: [main]
@@ -22,21 +27,42 @@ on:
       - 'apps/web/components/platform-v7/NextActionCard.tsx'
       - 'apps/web/components/v7r/AppShellV4.tsx'
       - 'apps/web/components/v7r/AppShellV4.module.css'
+      - 'apps/web/app/platform-v7/driver/field/page.tsx'
+      - 'apps/web/app/platform-v7/elevator/page.tsx'
+      - 'apps/web/app/platform-v7/lab/page.tsx'
+      - 'apps/web/app/platform-v7/surveyor/page.tsx'
+      - 'apps/web/tests/unit/designSystemV8*.test.ts'
       - 'apps/web/tests/unit/platformV7MobileNavigation.test.ts'
       - 'design-governance-v8.json'
-      - 'scripts/check-design-system-v8.mjs'
+      - 'scripts/check-design-system-v8*.mjs'
 
 permissions:
   contents: read
 
+concurrency:
+  group: design-system-v8-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  governance:
+  governance-and-field-role-integration:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.2.1
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: pnpm
+      - name: Install locked dependencies
+        run: pnpm install --frozen-lockfile
       - name: Enforce Design System v8 boundaries
         run: node ./scripts/check-design-system-v8.mjs
+      - name: Typecheck web integration
+        run: pnpm --filter @pc/web typecheck
+      - name: Run Design System v8 foundation regression
+        run: pnpm --filter @pc/web exec vitest run tests/unit/designSystemV8Foundation.test.ts
+      - name: Run field-role regression
+        run: pnpm --filter @pc/web exec vitest run tests/unit/designSystemV8FieldRoles.test.ts

--- a/.github/workflows/platform-v7-autopilot-guard.yml
+++ b/.github/workflows/platform-v7-autopilot-guard.yml
@@ -38,6 +38,11 @@ jobs:
         run: |
           node scripts/check-design-system-v8-pr-scope.mjs
           node scripts/check-design-system-v8.mjs
+      - name: Validate Design System v8 field-role scope
+        if: github.event_name == 'pull_request' && github.head_ref == 'codex/design-system-v8-field-roles'
+        run: |
+          node scripts/check-design-system-v8-field-roles-scope.mjs
+          node scripts/check-design-system-v8.mjs
       - name: Validate active platform-v7 autopilot scope
-        if: github.event_name != 'pull_request' || (github.head_ref != 'agent/design-system-v8-foundation' && github.head_ref != 'agent/transaction-shell-deal-workspace-v8')
+        if: github.event_name != 'pull_request' || (github.head_ref != 'agent/design-system-v8-foundation' && github.head_ref != 'agent/transaction-shell-deal-workspace-v8' && github.head_ref != 'codex/design-system-v8-field-roles')
         run: bash scripts/p7-autopilot-guard.sh

--- a/apps/web/app/platform-v7/driver/field/page.tsx
+++ b/apps/web/app/platform-v7/driver/field/page.tsx
@@ -1,10 +1,12 @@
-import Link from 'next/link';
+import { NextActionCard, StatusChip, Surface } from '@pc/design-system-v8';
+import { FieldTaskTemplate, KeyFact, KeyFactGrid } from '@/components/transaction-ux/FieldTaskTemplate';
+import workspace from '@/components/transaction-ux/FieldRoleWorkspace.module.css';
 import { RoleRouteHint } from '@/components/platform-v7/RoleRouteHint';
 import { FieldDriverRuntime } from '@/components/v7r/FieldDriverRuntime';
 import { LiveApiStatusBar } from '@/components/platform-v7/LiveApiStatusBar';
 import { DriverMissionRouteCard } from '@/components/platform-v7/DriverMissionRouteCard';
 import { getPlatformV7DriverCockpitState } from '@/lib/platform-v7/runtime/driver-cockpit-state';
-import { CockpitHero, OfflineSyncBanner } from '@/components/platform-v7/premium';
+import { OfflineSyncBanner } from '@/components/platform-v7/premium';
 import { CollapsibleSection } from '@/components/platform-v7/CollapsibleSection';
 import { getShipments, activeShipmentCount, shipmentsWithBlockers } from '@/lib/logistics-server';
 import { DriverOfflineQueue } from '@/components/platform-v7/DriverOfflineQueue';
@@ -17,329 +19,40 @@ export default async function DriverFieldPage() {
   const shipments = await getShipments();
   const shipmentCount = activeShipmentCount(shipments);
   const blockedShipments = shipmentsWithBlockers(shipments);
-  const apiOnline = shipments.some((s) => !s.id.includes('MOCK') && !s.id.includes('STATIC'));
-  const liveBlockers = blockedShipments.map((s) => ({
-    id: s.id,
-    label: `Рейс ${s.id}: ${(s.blockers ?? [])[0] ?? 'блокер'}`,
+  const apiOnline = shipments.some((shipment) => !shipment.id.includes('MOCK') && !shipment.id.includes('STATIC'));
+  const [from = 'Тамбов', to = 'Воронеж'] = (mission.route ?? 'Тамбов → Воронеж').split(' → ');
+  const currentKm = Math.round((mission.progressPercent / 100) * 142);
+
+  const liveBlockers = blockedShipments.map((shipment) => ({
+    id: shipment.id,
+    label: `Рейс ${shipment.id}: ${(shipment.blockers ?? [])[0] ?? 'блокер'}`,
     severity: 'warn' as const,
     responsibleRole: 'DRIVER',
-    nextAction: s.nextAction ?? 'Устранить блокер рейса',
+    nextAction: shipment.nextAction ?? 'Устранить блокер рейса',
   }));
-  return (
-    <main
-      data-testid="platform-v7-driver-field-shell"
-      data-platform-v7-driver-field-pass="true"
-      data-hidden-controls="финансовый контур, ставки и платёжные данные скрыты от водителя"
-      style={{
-        display: 'grid',
-        gap: 14,
-        width: '100%',
-        maxWidth: 760,
-        minWidth: 0,
-        margin: '0 auto',
-        overflowX: 'clip',
-        padding: '6px 0 24px',
-      }}
-    >
-      <LiveApiStatusBar
-        apiOnline={apiOnline}
-        blockers={liveBlockers}
-        activeShipments={shipmentCount}
-        role="DRIVER · Полевой режим"
-        summary={`${shipmentCount} активных рейсов · ${blockedShipments.length} с блокерами`}
-      />
-      <OfflineSyncBanner />
-      <style dangerouslySetInnerHTML={{ __html: `
-        [data-testid='platform-v7-role-route-hint']{display:none!important}
-        [data-testid='platform-v7-driver-field-shell']{max-width:100%!important;overflow-x:hidden!important}
-        [data-testid='platform-v7-driver-field-shell'] *{min-width:0;overflow-wrap:anywhere}
-        [data-testid='platform-v7-driver-field-shell'] img,
-        [data-testid='platform-v7-driver-field-shell'] canvas,
-        [data-testid='platform-v7-driver-field-shell'] video,
-        [data-testid='platform-v7-driver-field-shell'] svg{max-width:100%!important}
-        @media(max-width:767px){
-          [data-testid='platform-v7-driver-field-shell']{gap:10px!important;padding-top:0!important}
-          .driver-field-hero{padding:16px!important;border-radius:24px!important;gap:10px!important;overflow:hidden!important}
-          .driver-field-hero p{display:none!important}
-          .driver-field-hero a{white-space:normal!important}
-          .driver-field-quick-links{grid-template-columns:1fr!important}
-          .driver-field-status-grid{grid-template-columns:1fr 1fr!important;gap:8px!important}
-          .driver-field-first-screen{grid-template-columns:1fr!important;border-radius:22px!important;padding:14px!important;overflow:hidden!important}
-          [data-testid='platform-v7-driver-field-shell'] section[id]{scroll-margin-top:112px!important}
-        }
-        @media(max-width:380px){
-          .driver-field-status-grid{grid-template-columns:1fr!important}
-        }
-      ` }} />
-      <section
-        data-testid='platform-v7-driver-field-first-screen'
-        className="driver-field-first-screen"
-        aria-label="Первый экран водителя"
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit,minmax(156px,1fr))',
-          gap: 10,
-          border: '1px solid var(--pc-border, #E4E6EA)',
-          borderRadius: 24,
-          background: '#fff',
-          padding: 16,
-          boxShadow: '0 14px 30px rgba(15,23,42,0.055)',
-          minWidth: 0,
-          maxWidth: '100%',
-          overflow: 'hidden',
-        }}
-      >
-        <div style={{ ...firstScreenCard, gridColumn: '1 / -1', background: 'transparent', border: 'none', minHeight: 'auto', padding: '0 0 4px' }}>
-          <span style={{ fontSize: 13, fontWeight: 900, color: 'var(--pc-text-primary, #0F1419)', letterSpacing: '-0.01em' }}>Полевой режим</span>
-        </div>
-        <div style={firstScreenCard}>
-          <span style={firstScreenLabel}>Что произошло</span>
-          <strong style={firstScreenValue}>рейс назначен водителю</strong>
-        </div>
-        <div style={firstScreenCard}>
-          <span style={firstScreenLabel}>Что заблокировано</span>
-          <strong style={firstScreenValue}>выгрузка ждёт фото и пломбу</strong>
-        </div>
-        <div style={firstScreenCard}>
-          <span style={firstScreenLabel}>Финансовый доступ</span>
-          <strong style={firstScreenValue}>нет доступа к денежному контуру</strong>
-        </div>
-        <div style={firstScreenCard}>
-          <span style={firstScreenLabel}>Кто отвечает</span>
-          <strong style={firstScreenValue}>водитель · полевой рейс</strong>
-        </div>
-        <div style={firstScreenCard}>
-          <span style={firstScreenLabel}>Следующее действие</span>
-          <strong style={firstScreenValue}>подтвердить прибытие</strong>
-        </div>
-        <div style={{ ...firstScreenCard, gap: 8 }}>
-          <a href="#driver-next-action" style={compactAction}>Открыть действие</a>
-          <a href="#driver-offline-events" style={compactGhostAction}>Проверить очередь</a>
-        </div>
-      </section>
 
-      <CockpitHero
-        className="driver-field-hero"
-        eyebrow="Водитель · один рейс · одно действие"
-        title="Текущий рейс"
-        lead="На экране только маршрут, связь, прибытие, фото, пломба и отклонение. Остальной контекст разложен ниже по разделам."
-        aside={
-          <div style={{ border: '1px solid #CBD5E1', borderRadius: 999, background: '#fff', color: 'var(--pc-text-secondary, #475569)', padding: '6px 10px', fontSize: 12, fontWeight: 900, maxWidth: '100%', overflowWrap: 'anywhere' }}>
-            controlled-pilot / pre-integration
-          </div>
-        }
-      >
-        <Link href="#driver-next-action" style={primaryAction}>
-          Подтвердить следующее действие по рейсу
-        </Link>
+  const liveStatus = <div className={workspace.stack}><LiveApiStatusBar apiOnline={apiOnline} blockers={liveBlockers} activeShipments={shipmentCount} role='DRIVER · Полевой режим' summary={`${shipmentCount} активных рейсов · ${blockedShipments.length} с блокерами`} /><OfflineSyncBanner /></div>;
 
-        <div className="driver-field-quick-links" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(128px,1fr))', gap: 8, minWidth: 0, maxWidth: '100%' }}>
-          <a href="#driver-offline-events" style={secondaryChip}>Связь / очередь</a>
-          <a href="#driver-photo-seal" style={secondaryChip}>Фото / пломба</a>
-          <a href="#driver-route-status" style={secondaryChip}>Статус рейса</a>
-        </div>
-      </CockpitHero>
-
-      <section id="driver-next-action" style={driverFieldSection}>
-        <CollapsibleSection title='Статус рейса' summary='следующее · очередь · доступ' defaultOpen>
-          <section className="driver-field-status-grid" aria-label="Полевой статус рейса" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(150px,1fr))', gap: 8, minWidth: 0, maxWidth: '100%' }}>
-            <div style={miniStatusCard}>
-              <span style={miniLabel}>следующее</span>
-              <strong style={miniValue}>прибытие</strong>
-            </div>
-            <div style={miniStatusCard}>
-              <span style={miniLabel}>очередь</span>
-              <strong style={miniValue}>локально сохранится</strong>
-            </div>
-            <div style={miniStatusCard}>
-              <span style={miniLabel}>доступ</span>
-              <strong style={miniValue}>только свой рейс</strong>
-            </div>
-          </section>
-        </CollapsibleSection>
-      </section>
-
-      <section id="driver-route-status" style={driverFieldSection}>
-        <CollapsibleSection title='Маршрут и прогресс' summary='TRIP · точки · ETA' defaultOpen={false}>
-          <DriverMissionRouteCard
-            tripId={mission.tripId}
-            route={mission.route}
-            progressPercent={mission.progressPercent}
-            stageLabel={mission.stageLabel}
-            photoChecklist={mission.photoChecklist}
-          />
-        </CollapsibleSection>
-      </section>
-
-      <section id="driver-photo-seal" style={driverFieldSection}>
-        <CollapsibleSection title='Фото, пломба и полевые действия' summary='доказательства · следующий факт' defaultOpen={false}>
-          <div style={{ padding: '12px', fontSize: 13, color: 'var(--pc-text-secondary)', minWidth: 0, overflowWrap: 'anywhere' }}>Фото и пломба фиксируются в полевом режиме через мобильное приложение.</div>
-        </CollapsibleSection>
-      </section>
-
-      <section id="driver-map" style={driverFieldSection}>
-        <CollapsibleSection title='Маршрут на карте' summary='прогресс · точки · ETA' defaultOpen={false}>
-          {(() => {
-            const [from, to] = (mission.route ?? 'Тамбов → Воронеж').split(' → ');
-            const currentKm = Math.round((mission.progressPercent / 100) * 142);
-            return (
-              <RouteMapStub
-                from={from ?? 'Тамбов'}
-                to={to ?? 'Воронеж'}
-                currentKm={currentKm}
-                totalKm={142}
-                eta="14:30"
-                vehiclePlate="А234-ВС-68"
-              />
-            );
-          })()}
-        </CollapsibleSection>
-      </section>
-
-      <section id="driver-offline-events" style={driverFieldSection}>
-        <CollapsibleSection title='Фото рейса' summary='камера · галерея · прибытие · весовой талон' defaultOpen>
-          <DriverCameraCapture tripId={mission.tripId} />
-        </CollapsibleSection>
-        <CollapsibleSection title='Офлайн-очередь' summary='IndexedDB · синхронизация при восстановлении сети' defaultOpen={false}>
-          <DriverOfflineQueue tripId={mission.tripId} />
-        </CollapsibleSection>
-        <CollapsibleSection title='PWA Offline · Кэш и очередь действий' summary='Service Worker · IndexedDB · Background Sync · last-write-wins · конфликты' defaultOpen={false}>
-          <PwaOfflinePanel />
-        </CollapsibleSection>
-        <CollapsibleSection title='Полевой runtime' summary='очередь · события · офлайн' defaultOpen={false}>
-          <FieldDriverRuntime compact />
-        </CollapsibleSection>
-      </section>
-
-      <RoleRouteHint role="driver" route="/platform-v7/driver/field" />
-    </main>
+  const primary = (
+    <div className={workspace.stack}>
+      <NextActionCard label='Один рейс · одно действие' action='Подтвердить прибытие' reason='Сначала проверь точку назначения. После прибытия зафиксируй фото, пломбу и документ рейса.' blocked={blockedShipments.length > 0} impact={blockedShipments.length ? `${blockedShipments.length} рейса с блокерами` : 'рейс продолжает исполнение'} owner='назначенный водитель' deadline='текущая точка маршрута' actions={<><a className={workspace.primaryLink} href='#driver-next-action'>Открыть действие</a><a className={workspace.secondaryLink} href='#driver-photo-seal'>Фото и пломба</a></>} />
+      <KeyFactGrid>
+        <KeyFact label='Рейс' value={mission.tripId} hint='доступен только назначенному водителю' />
+        <KeyFact label='Маршрут' value={mission.route} hint={mission.stageLabel} />
+        <KeyFact label='Прогресс' value={`${mission.progressPercent}%`} hint='по текущему маршруту' />
+        <KeyFact label='Доступ' value='только свой рейс' hint='денежный контур скрыт' />
+      </KeyFactGrid>
+      <section id='driver-next-action' className={workspace.sectionAnchor}><CollapsibleSection title='Текущий рейс' summary='маршрут · следующая точка · ETA' defaultOpen><DriverMissionRouteCard tripId={mission.tripId} route={mission.route} progressPercent={mission.progressPercent} stageLabel={mission.stageLabel} photoChecklist={mission.photoChecklist} /></CollapsibleSection></section>
+      <CollapsibleSection title='Маршрут на карте' summary='прогресс · точки · ETA' defaultOpen={false}><RouteMapStub from={from} to={to} currentKm={currentKm} totalKm={142} eta='14:30' vehiclePlate='А234-ВС-68' /></CollapsibleSection>
+      <section id='driver-photo-seal' className={workspace.sectionAnchor}><CollapsibleSection title='Фото, пломба и документ рейса' summary='камера · доказательства · весовой талон' defaultOpen><DriverCameraCapture tripId={mission.tripId} /></CollapsibleSection></section>
+      <section id='driver-runtime' className={workspace.sectionAnchor}><CollapsibleSection title='Полевой runtime' summary='события · конфликт · повтор' defaultOpen={false}><FieldDriverRuntime compact /></CollapsibleSection></section>
+      <RoleRouteHint role='driver' route='/platform-v7/driver/field' />
+    </div>
   );
+
+  const context = <div className={workspace.stack}><StatusChip tone={apiOnline ? 'success' : 'warning'}>{apiOnline ? 'Связь с сервером есть' : 'Сервер недоступен'}</StatusChip><ol className={workspace.contextList}><li><span>Следующая точка</span><strong>{to}</strong><small>подтверди прибытие только на площадке</small></li><li><span>Фото</span><strong>{mission.photoChecklist.length} пункта проверки</strong><small>фото привязываются к рейсу и этапу</small></li><li><span>Проблема</span><strong>зафиксировать факт, не решать спор</strong><small>оператор получит событие и доказательства</small></li></ol></div>;
+
+  const evidence = <section className={workspace.evidenceStack} aria-label='Полевые доказательства и связь'><Surface><div className={workspace.sectionStack}><strong>Работа при нестабильной связи</strong><p className={workspace.muted}>Команды не считаются подтверждёнными, пока сервер не принял их в привязанной сессии. При конфликте пользователь получает явную остановку и повторную проверку.</p></div></Surface><CollapsibleSection title='Очередь полевых событий' summary='защищённая синхронизация · повтор · конфликт' defaultOpen={false}><DriverOfflineQueue tripId={mission.tripId} /></CollapsibleSection><CollapsibleSection title='PWA и локальный кэш' summary='доступность · восстановление · ограничения' defaultOpen={false}><PwaOfflinePanel /></CollapsibleSection></section>;
+
+  return <div data-platform-v7-driver-field-pass='true' data-hidden-controls='финансовый контур, ставки и платёжные данные скрыты от водителя'><FieldTaskTemplate testId='platform-v7-driver-field-shell' eyebrow='Водитель · полевая роль' title='Рейс, следующая точка и доказательства' description='На первом уровне только назначенный рейс, одна CTA, связь, фото, пломба, документ и фиксация проблемы.' statusLabel={blockedShipments.length ? 'Есть блокер' : 'Рейс в работе'} statusTone={blockedShipments.length ? 'warning' : 'success'} liveStatus={liveStatus} primary={primary} context={context} evidence={evidence} /></div>;
 }
-
-const primaryAction = {
-  minHeight: 58,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  borderRadius: 16,
-  border: 'none',
-  background: '#0A7A5F',
-  color: '#fff',
-  fontSize: 16,
-  fontWeight: 950,
-  textAlign: 'center',
-  textDecoration: 'none',
-  boxShadow: '0 14px 28px rgba(10,122,95,0.22)',
-  maxWidth: '100%',
-  minWidth: 0,
-  overflowWrap: 'anywhere',
-} as const;
-
-const secondaryChip = {
-  minHeight: 46,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  borderRadius: 14,
-  border: '1px solid #CBD5E1',
-  background: '#fff',
-  color: 'var(--pc-text-primary, #0F1419)',
-  fontSize: 12,
-  fontWeight: 900,
-  textAlign: 'center',
-  textDecoration: 'none',
-  boxShadow: '0 8px 18px rgba(15,23,42,0.045)',
-  maxWidth: '100%',
-  minWidth: 0,
-  overflowWrap: 'anywhere',
-} as const;
-
-const miniStatusCard = {
-  display: 'grid',
-  gap: 5,
-  minHeight: 74,
-  borderRadius: 18,
-  border: '1px solid var(--pc-border, #E4E6EA)',
-  background: '#fff',
-  padding: 14,
-  boxShadow: '0 10px 22px rgba(15,23,42,0.045)',
-  minWidth: 0,
-  overflow: 'hidden',
-} as const;
-
-const miniLabel = {
-  color: 'var(--pc-text-muted, #64748B)',
-  fontSize: 10,
-  fontWeight: 900,
-  letterSpacing: '0.07em',
-  textTransform: 'uppercase',
-  overflowWrap: 'anywhere',
-} as const;
-
-const miniValue = {
-  color: 'var(--pc-text-primary, #0F1419)',
-  fontSize: 15,
-  lineHeight: 1.25,
-  fontWeight: 950,
-  overflowWrap: 'anywhere',
-} as const;
-
-const firstScreenCard = {
-  display: 'grid',
-  gap: 5,
-  minHeight: 72,
-  alignContent: 'center',
-  borderRadius: 18,
-  border: '1px solid #E2E8F0',
-  background: '#F8FAFC',
-  padding: 12,
-  minWidth: 0,
-  overflow: 'hidden',
-} as const;
-
-const firstScreenLabel = {
-  color: 'var(--pc-text-muted, #64748B)',
-  fontSize: 10,
-  fontWeight: 950,
-  letterSpacing: '0.07em',
-  textTransform: 'uppercase',
-  overflowWrap: 'anywhere',
-} as const;
-
-const firstScreenValue = {
-  color: 'var(--pc-text-primary, #0F1419)',
-  fontSize: 14,
-  lineHeight: 1.25,
-  fontWeight: 950,
-  overflowWrap: 'anywhere',
-} as const;
-
-const compactAction = {
-  minHeight: 46,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  borderRadius: 12,
-  background: '#0A7A5F',
-  color: '#fff',
-  fontSize: 12,
-  fontWeight: 950,
-  textDecoration: 'none',
-  maxWidth: '100%',
-  minWidth: 0,
-  overflowWrap: 'anywhere',
-} as const;
-
-const compactGhostAction = {
-  ...compactAction,
-  border: '1px solid #CBD5E1',
-  background: '#fff',
-  color: 'var(--pc-text-primary, #0F1419)',
-} as const;
-
-const driverFieldSection = {
-  minWidth: 0,
-  maxWidth: '100%',
-  overflow: 'hidden',
-  scrollMarginTop: 92,
-} as const;

--- a/apps/web/app/platform-v7/elevator/page.tsx
+++ b/apps/web/app/platform-v7/elevator/page.tsx
@@ -1,3 +1,6 @@
+import { NextActionCard, StatusChip, Surface } from '@pc/design-system-v8';
+import { IntakeWorkbenchTemplate, KeyFact, KeyFactGrid } from '@/components/transaction-ux/FieldTaskTemplate';
+import workspace from '@/components/transaction-ux/FieldRoleWorkspace.module.css';
 import { getLabSamples, pendingProtocols } from '@/lib/labs-server';
 import { getShipments, activeShipmentCount } from '@/lib/logistics-server';
 import { LiveApiStatusBar } from '@/components/platform-v7/LiveApiStatusBar';
@@ -10,124 +13,54 @@ import { TrustDot } from '@/components/platform-v7/visual/TrustDot';
 import { CauseLine } from '@/components/platform-v7/visual/CauseLine';
 import { SmartSectionSummary } from '@/components/platform-v7/visual/SmartSectionSummary';
 import { WeighStationPanel } from '@/components/platform-v7/WeighStationPanel';
-import { CockpitHero, ProcessStepper } from '@/components/platform-v7/premium';
 import { CollapsibleSection } from '@/components/platform-v7/CollapsibleSection';
 import { DL_9106_ELEVATOR_RECEIVING } from '@/lib/platform-v7/deal-execution-source-of-truth';
 
 const elevatorHandoff: HandoffItem[] = [
   { direction: 'sends', role: 'элеватор → контур документов', requirement: 'акт приёмки и акт расхождения в контур документов', documentImpact: true, moneyImpact: true },
-  { direction: 'sends', role: 'элеватор → лабораторный контур качества', requirement: 'проба и показатели качества — в пилотный протокол качества', documentImpact: true },
+  { direction: 'sends', role: 'элеватор → лабораторный контур качества', requirement: 'проба и показатели качества — в протокол качества', documentImpact: true },
   { direction: 'awaits', role: 'от логистики', requirement: 'рейс с ЭТрН и данными водителя перед началом приёмки', documentImpact: true },
-  { direction: 'blockedBy', requirement: 'отклонение веса -1,2 т — нужен акт расхождения до банковской проверки', documentImpact: true, moneyImpact: true },
-  { direction: 'next', requirement: 'зафиксировать вес, подписать акт приёмки и передать пробу в лабораторный контур качества', entity: 'TRIP-2403-001', documentImpact: true },
+  { direction: 'blockedBy', requirement: 'отклонение веса -1,2 т — нужен акт расхождения до дальнейшей проверки', documentImpact: true, moneyImpact: true },
+  { direction: 'next', requirement: 'зафиксировать вес, подписать акт приёмки и передать пробу в лабораторию', entity: 'TRIP-2403-001', documentImpact: true },
 ];
 
 const receiving = DL_9106_ELEVATOR_RECEIVING.snapshot;
 const quality = DL_9106_ELEVATOR_RECEIVING.quality;
-
-const firstScreen = [
-  { label: 'Что произошло', value: 'TRIP-2403-001 прибыл на приёмку', note: 'Физический факт уже в работе: рейс, партия, вес и лабораторная проба.' },
-  { label: 'Что заблокировано', value: 'акт расхождения и протокол качества', note: 'Отклонение веса и сорная примесь выше допуска не дают передать основание банку.' },
-  { label: 'Деньги под риском', value: '9,65 млн ₽ удержание', note: 'Выплата не должна уходить дальше до закрытия веса, качества и документов.' },
-  { label: 'Кто отвечает', value: 'элеватор · лаборатория · оператор', note: 'Приёмка фиксирует вес, лаборатория закрывает протокол, оператор контролирует передачу основания.' },
-  { label: 'Следующее действие', value: 'зафиксировать вес и передать пробу', note: 'Действия ведут в реальные секции текущего кабинета: #weight и #quality.' },
+const intakeChecklist = [
+  { label: 'Рейс', value: 'TRIP-2403-001 прибыл', note: 'назначение и партия подтверждены' },
+  { label: 'Вес', value: '598,8 т принято', note: 'отклонение -1,2 т требует акта' },
+  { label: 'Проба', value: 'передать в лабораторию', note: 'протокол качества ещё не закрыт' },
+  { label: 'Результат', value: 'акт приёмки', note: 'без него документное основание неполно' },
 ] as const;
-
-const receivingSummary = [
-  { label: 'Что сейчас', value: 'TRIP-2403-001 прибыл на приёмку', note: 'Приёмка фиксирует физический факт: вес, качество, акт и отклонения.' },
-  { label: 'Где груз', value: 'элеватор ВРЖ-08 · партия LOT-2403', note: 'Видна только партия и рейс, без коммерческой цены сделки.' },
-  { label: 'Вес', value: '600 т заявлено · 598,8 т принято', note: 'Отклонение -1,2 т создаёт основание для акта расхождения.' },
-  { label: 'Качество', value: 'сорная примесь выше допуска', note: 'Нужен протокол качества; это может изменить расчёт и открыть спор.' },
-] as const;
-
 const gates = [
-  { title: 'Вес', value: 'отклонение -1,2 т', impact: 'создаёт удержание до акта расхождения', state: 'stop' },
-  { title: 'Качество', value: 'есть превышение по примеси', impact: 'требует протокол качества', state: 'stop' },
-  { title: 'Акт приёмки', value: 'готовится', impact: 'без акта основание не передаётся банку', state: 'wait' },
-  { title: 'Качество', value: 'протокол ожидается', impact: 'качество влияет на расчёт и спор', state: 'wait' },
-] as const;
+  { title: 'Вес', value: 'отклонение -1,2 т', impact: 'создаёт остановку до акта расхождения', tone: 'critical' as const },
+  { title: 'Качество', value: 'превышение по примеси', impact: 'требует протокол качества', tone: 'warning' as const },
+  { title: 'Акт приёмки', value: 'готовится', impact: 'без акта основание не передаётся дальше', tone: 'warning' as const },
+  { title: 'Протокол', value: 'ожидается', impact: 'закрывает качество партии', tone: 'neutral' as const },
+];
 
 export default async function Page() {
   const [samples, shipments] = await Promise.all([getLabSamples(), getShipments()]);
   const pendingSamples = pendingProtocols(samples);
   const shipmentCount = activeShipmentCount(shipments);
-  const apiOnline = samples.some((s) => !s.id.startsWith('SAMPLE-00'));
+  const apiOnline = samples.some((sample) => !sample.id.startsWith('SAMPLE-00'));
+  const liveBlockers = pendingSamples.slice(0, 3).map((sample) => ({ id: sample.id, label: `Проба ${sample.id}: протокол качества ожидается`, severity: 'warn' as const, responsibleRole: 'ELEVATOR', nextAction: 'Передать пробу в лабораторию' }));
 
-  const liveBlockers = pendingSamples.slice(0, 3).map((s) => ({ id: s.id, label: `Проба ${s.id}: протокол качества ожидается`, severity: 'warn' as const, responsibleRole: 'ELEVATOR', nextAction: 'Передать пробу в лабораторию' }));
-
-  return (
-    <main data-testid='platform-v7-elevator-page' style={{ display: 'grid', gap: 14, padding: '4px 0 24px' }}>
-      <LiveApiStatusBar apiOnline={apiOnline} blockers={liveBlockers} activeShipments={shipmentCount} role="ELEVATOR · Приёмка" summary={apiOnline ? `${shipmentCount} рейсов на приёмке · ${pendingSamples.length} проб ожидают протокола` : 'Данные статичные — API недоступен'} />
-      <style dangerouslySetInnerHTML={{ __html: `@media(max-width:767px){[data-testid='platform-v7-elevator-page']{gap:10px!important;padding-top:0!important}.p7-elevator-hero{padding:16px!important;border-radius:24px!important;gap:8px!important}.p7-elevator-hero h1{font-size:clamp(28px,8vw,38px)!important;line-height:1.04!important}.p7-elevator-hero p{display:none!important}.p7-elevator-first-screen{padding:14px!important;border-radius:22px!important;gap:10px!important}.p7-elevator-first-screen h2{font-size:20px!important;line-height:1.1!important}.p7-elevator-first-grid{grid-template-columns:1fr!important;gap:8px!important}.p7-elevator-first-actions{display:grid!important;grid-template-columns:1fr!important}.p7-elevator-first-actions a{width:100%!important;min-height:52px!important}.p7-elevator-active{padding:14px!important;border-radius:22px!important;gap:10px!important}.p7-elevator-active h2{font-size:20px!important;line-height:1.1!important}.p7-elevator-active-grid{grid-template-columns:1fr 1fr!important;gap:8px!important}.p7-elevator-active-actions{display:grid!important;grid-template-columns:1fr!important}.p7-elevator-active-actions a{width:100%!important;min-height:54px!important}.p7-elevator-quality{padding:14px!important;border-radius:22px!important;gap:10px!important}.p7-elevator-quality-grid{grid-template-columns:1fr 1fr!important;gap:8px!important}.p7-elevator-quality .p7-elevator-notice{font-size:12px!important;line-height:1.4!important}}` }} />
-      <QuietIntelligenceHint problem='Отклонение веса -1,2 т и превышение по сорной примеси — акт расхождения не подписан.' action='Зафиксировать вес, подписать акт приёмки и акт расхождения, передать пробу в лабораторию.' outcome='После закрытия актов основание уйдёт в контур документов и банку на проверку выплаты.' />
-      <CockpitHero className='p7-elevator-hero' eyebrow='Кабинет приёмки' title='Вес, качество и основание для проверки выплаты' lead='Приёмка формирует основание для банковской проверки: вес, акт приёмки, качество, отклонения и документы. Деньги, ставки, резерв, кредит и покупательская аналитика не раскрываются.'>
-        <ProcessStepper ariaLabel='Этапы приёмки' steps={[{ label: 'Сделка', state: 'done' }, { label: 'Партия', state: 'done' }, { label: 'Приёмка', state: 'current' }, { label: 'Лаборатория', state: 'upcoming' }, { label: 'Документы', state: 'upcoming' }, { label: 'Готово', state: 'upcoming' }]} />
-      </CockpitHero>
-
-      <section className='p7-elevator-first-screen' data-testid='platform-v7-elevator-first-screen' style={card}>
-        <div style={{ display: 'grid', gap: 6 }}>
-          <div style={micro}>первый экран · контроль сделки</div>
-          <h2 style={h2}>Что важно для приёмки прямо сейчас</h2>
-          <p style={muted}>Экран сначала показывает факт, блокер, деньги под риском, владельца и следующее действие. Данные остаются controlled-pilot / pre-integration — без заявлений о промышленной готовности.</p>
-        </div>
-        <div className='p7-elevator-first-grid' style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(190px,1fr))', gap: 10 }}>{firstScreen.map((item) => <FirstScreenCell key={item.label} item={item} />)}</div>
-        <div className='p7-elevator-first-actions' style={actions}><a href='#weight' style={primaryBtn}>Открыть фиксацию веса</a><a href='#quality' style={ghostBtn}>Открыть качество</a></div>
-      </section>
-
-      <CollapsibleSection title='Обзор приёмки' summary='рейс · вес · качество · следующий шаг' defaultOpen>
-        <section style={darkCard}>
-          <div style={{ display: 'grid', gap: 6 }}><div style={{ ...micro, color: '#FED7AA' }}>контроль приёмки</div><h2 style={{ margin: 0, color: '#fff', fontSize: 'clamp(24px,6vw,36px)', lineHeight: 1.08, letterSpacing: '-0.04em', fontWeight: 950 }}>Что приёмка должна понять за 5 секунд</h2></div>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(210px,1fr))', gap: 10 }}>{receivingSummary.map((item) => <SummaryCard key={item.label} item={item} />)}</div>
-        </section>
-      </CollapsibleSection>
-
-      <CollapsibleSection title='Вес и активная приёмка' summary='598,8 т · отклонение -1,2 т' defaultOpen={false}>
-        <section id='weight' className='p7-elevator-active' style={card}>
-          <div style={micro}>Активная приёмка</div>
-          <div style={rowHead}><div><div style={idText}>{receiving.tripId} · {receiving.dealId}</div><h2 style={h2}>{receiving.crop} · {receiving.declaredWeight}</h2><p style={muted}>{receiving.lotId} · прибыл на элеватор ВРЖ-08</p></div><span style={statusPill}>в работе</span></div>
-          <WeighStationPanel tripId={receiving.tripId} declaredTons={600} acceptedTons={598.8} toleranceTons={0.5} note='Отклонение фиксируется актом расхождения; без него основание не передаётся банку на проверку выплаты.' />
-          <div className='p7-elevator-active-grid' style={grid2}><Cell label='Заявлено' value={receiving.declaredWeight} /><Cell label='На приёмке' value={receiving.arrivedWeight} strong /><Cell label='Отклонение' value={receiving.deviation} danger /><Cell label='Лаборатория' value={receiving.lab} /><Cell label='Документы' value={receiving.docs} /><Cell label='Следующее действие' value={receiving.next} strong /></div>
-          <div className='p7-elevator-active-actions' style={actions}><a href='#weight' style={primaryBtn}>Зафиксировать вес</a><a href='#quality' style={ghostBtn}>Передать пробу в лабораторию</a></div>
-        </section>
-      </CollapsibleSection>
-
-      <CollapsibleSection title='Качество и условия допуска' summary='примесь · акт · протокол' defaultOpen={false}>
-        <div style={{ display: 'grid', gap: 12 }}>
-          <section style={card}><div style={micro}>Условия приёмки, влияющие на банковскую проверку</div><div style={grid2}>{gates.map((gate) => <Gate key={`${gate.title}-${gate.value}`} gate={gate} />)}</div></section>
-          <section id='quality' className='p7-elevator-quality' style={card}><div style={micro}>Качество партии · пилотный протокол качества</div><div className='p7-elevator-quality-grid' style={grid2}>{quality.map((item) => <QualityCell key={item.label} item={item} />)}</div><div className='p7-elevator-notice' style={notice}>При отклонении веса или качества платформа создаёт акт расхождения, удержание и задачу оператору. Передача основания банку на проверку выплаты не продолжается до закрытия акта и протокола.</div></section>
-        </div>
-      </CollapsibleSection>
-
-      <CollapsibleSection title='Доказательства, рекомендации и журнал приёмки' summary='факты · передача · решение' defaultOpen={false}>
-        <div style={{ display: 'grid', gap: 10 }}>
-          <div style={{ display: 'grid', gap: 10 }}><CauseLine cause={{ text: 'Акт расхождения по весу не подписан', tone: 'blocked' }} relation='blocks' effect={{ text: 'Основание не передаётся банку', tone: 'blocked' }} moneyAmount='9,65 млн ₽' moneyTone='hold' /><CauseLine cause={{ text: 'Превышение по сорной примеси (2,4% > 2%)', tone: 'warning' }} relation='requires' effect={{ text: 'Протокол качества до расчёта', tone: 'warning' }} /><TrustDot state='test' size='sm' label='Контур исполнения · Физические данные требуют реальных приёмок' /><SmartSectionSummary label='Статус приёмки' items={[{ text: 'TRIP-2403-001 · Вес 598,8 т · Отклонение -1,2 т · Акт готовится', tone: 'warn' }, { text: 'Сорная примесь 2,4% — выше допуска 2% · Протокол ожидается', tone: 'warn' }]} /></div>
-          <DecisionRecommendationStrip context='elevator' />
-          <EvidenceReadinessMiniMatrix context='elevator' />
-          <RoleExecutionHandoff items={elevatorHandoff} title='исполнение: что приёмка отправляет и ожидает' />
-        </div>
-      </CollapsibleSection>
-
+  const primary = (
+    <div className={workspace.stack}>
+      <NextActionCard label='Текущий объект приёмки' action='Зафиксировать вес и оформить акт расхождения' reason='Рейс прибыл. Фактический вес ниже заявленного на 1,2 т. После фиксации веса передай пробу в лабораторию.' blocked impact='акт расхождения и протокол качества не закрыты' owner='элеватор' deadline='до передачи документного основания' actions={<><a className={workspace.primaryLink} href='#weight'>Открыть фиксацию веса</a><a className={workspace.secondaryLink} href='#quality'>Передать пробу</a></>} />
+      <KeyFactGrid><KeyFact label='Рейс' value={receiving.tripId} hint={receiving.lotId} /><KeyFact label='Заявлено' value={receiving.declaredWeight} hint={receiving.crop} /><KeyFact label='Принято' value={receiving.arrivedWeight} hint={`отклонение ${receiving.deviation}`} /><KeyFact label='Следующий результат' value='акт приёмки' hint='и проба в лабораторию' /></KeyFactGrid>
+      <QuietIntelligenceHint problem='Отклонение веса -1,2 т и превышение по сорной примеси — акт расхождения не подписан.' action='Зафиксировать вес, подписать акт приёмки и акт расхождения, передать пробу в лабораторию.' outcome='После закрытия актов основание перейдёт в контур документов для дальнейшей проверки.' />
+      <section id='weight' className={workspace.sectionAnchor}><CollapsibleSection title='Вес и активная приёмка' summary='598,8 т · отклонение -1,2 т' defaultOpen><div className={workspace.sectionStack}><WeighStationPanel tripId={receiving.tripId} declaredTons={600} acceptedTons={598.8} toleranceTons={0.5} note='Отклонение фиксируется актом расхождения; без него документное основание не передаётся дальше.' /><KeyFactGrid><KeyFact label='Лаборатория' value={receiving.lab} /><KeyFact label='Документы' value={receiving.docs} /><KeyFact label='Отклонение' value={receiving.deviation} /><KeyFact label='Действие' value={receiving.next} /></KeyFactGrid></div></CollapsibleSection></section>
+      <section id='quality' className={workspace.sectionAnchor}><CollapsibleSection title='Качество и условия допуска' summary='примесь · акт · протокол' defaultOpen={false}><div className={workspace.sectionStack}><div className={workspace.twoColumn}>{gates.map((gate) => <Surface key={`${gate.title}-${gate.value}`}><div className={workspace.sectionStack}><StatusChip tone={gate.tone}>{gate.title}</StatusChip><strong>{gate.value}</strong><span className={workspace.muted}>{gate.impact}</span></div></Surface>)}</div><div className={workspace.twoColumn}>{quality.map((item) => <Surface key={item.label}><div className={workspace.sectionStack}><StatusChip tone={item.state === 'stop' ? 'critical' : 'warning'}>{item.label}</StatusChip><strong>{item.value}</strong><span className={workspace.muted}>{item.limit}</span></div></Surface>)}</div><div className={workspace.alert}>При отклонении веса или качества создаётся акт расхождения и задача оператору. Передача документного основания не продолжается до закрытия акта и протокола.</div></div></CollapsibleSection></section>
       <CollapsibleSection title='Runtime приёмки' summary='очередь · акт · действие' defaultOpen={false}><FieldElevatorRuntime /></CollapsibleSection>
-    </main>
+    </div>
   );
+
+  const intakeSummary = <ol className={workspace.contextList}>{intakeChecklist.map((item) => <li key={item.label}><span>{item.label}</span><strong>{item.value}</strong><small>{item.note}</small></li>)}</ol>;
+  const context = <div className={workspace.stack}><StatusChip tone={pendingSamples.length ? 'warning' : 'success'}>{pendingSamples.length ? `${pendingSamples.length} проб ожидают` : 'Пробы закрыты'}</StatusChip><p className={workspace.muted}>Роль приёмки видит рейс, партию, вес, пробу, акт и отклонение. Коммерческая цена и банковские операции не раскрываются.</p></div>;
+  const evidence = <div className={workspace.evidenceStack}><Surface><div className={workspace.sectionStack}><CauseLine cause={{ text: 'Акт расхождения по весу не подписан', tone: 'blocked' }} relation='blocks' effect={{ text: 'Документное основание не передаётся дальше', tone: 'blocked' }} /><CauseLine cause={{ text: 'Превышение по сорной примеси (2,4% > 2%)', tone: 'warning' }} relation='requires' effect={{ text: 'Протокол качества', tone: 'warning' }} /><TrustDot state='test' size='sm' label='Контур исполнения · физические данные требуют реальных приёмок' /><SmartSectionSummary label='Статус приёмки' items={[{ text: 'TRIP-2403-001 · Вес 598,8 т · Отклонение -1,2 т · Акт готовится', tone: 'warn' }, { text: 'Сорная примесь 2,4% — выше допуска 2% · Протокол ожидается', tone: 'warn' }]} /></div></Surface><DecisionRecommendationStrip context='elevator' /><EvidenceReadinessMiniMatrix context='elevator' /><RoleExecutionHandoff items={elevatorHandoff} title='исполнение: что приёмка отправляет и ожидает' /></div>;
+  const liveStatus = <LiveApiStatusBar apiOnline={apiOnline} blockers={liveBlockers} activeShipments={shipmentCount} role='ELEVATOR · Приёмка' summary={apiOnline ? `${shipmentCount} рейсов на приёмке · ${pendingSamples.length} проб ожидают протокола` : 'Данные статичные — API недоступен'} />;
+
+  return <IntakeWorkbenchTemplate testId='platform-v7-elevator-page' eyebrow='Элеватор · полевая приёмка' title='Очередь, текущий рейс, чек-лист и акт' description='Первый уровень показывает физический факт приёмки, блокер и одно действие. Цена сделки и банковские операции скрыты.' statusLabel={pendingSamples.length ? 'Приёмка заблокирована' : 'Можно продолжать'} statusTone={pendingSamples.length ? 'warning' : 'success'} liveStatus={liveStatus} intakeSummary={intakeSummary} primary={primary} context={context} evidence={evidence} />;
 }
-
-const grid2 = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(180px,1fr))', gap: 10 } as const;
-const card = { background: 'var(--pc-bg-card)', border: '1px solid var(--pc-border)', borderRadius: 24, padding: 18, display: 'grid', gap: 14, boxShadow: '0 18px 40px rgba(15,23,42,.08)' } as const;
-const darkCard = { ...card, background: 'linear-gradient(135deg,#7C2D12,#0F766E)' } as const;
-const micro = { color: 'var(--pc-text-muted,#64748B)', fontSize: 11, fontWeight: 950, textTransform: 'uppercase', letterSpacing: '.08em' } as const;
-const h2 = { margin: '4px 0 0', color: 'var(--pc-text-primary)', fontSize: 'clamp(22px,5vw,34px)', lineHeight: 1.08, letterSpacing: '-.035em', fontWeight: 950 } as const;
-const muted = { margin: '4px 0 0', color: 'var(--pc-text-muted)', fontSize: 14, lineHeight: 1.45 } as const;
-const idText = { color: '#B45309', fontSize: 13, fontWeight: 950 } as const;
-const rowHead = { display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'start', flexWrap: 'wrap' } as const;
-const statusPill = { borderRadius: 999, background: '#ECFDF5', border: '1px solid #A7F3D0', color: '#047857', padding: '8px 12px', fontSize: 12, fontWeight: 950 } as const;
-const primaryBtn = { minHeight: 48, display: 'grid', placeItems: 'center', borderRadius: 16, background: '#047857', color: '#fff', fontWeight: 950, textDecoration: 'none', padding: '0 16px' } as const;
-const ghostBtn = { ...primaryBtn, background: 'var(--pc-bg-card)', color: 'var(--pc-text-primary)', border: '1px solid var(--pc-border)' } as const;
-const actions = { display: 'flex', gap: 10, flexWrap: 'wrap' } as const;
-const notice = { border: '1px solid #FECACA', background: 'rgba(220,38,38,0.06)', color: '#B91C1C', borderRadius: 18, padding: 14, fontSize: 13, lineHeight: 1.45, fontWeight: 900 } as const;
-
-function FirstScreenCell({ item }: { item: (typeof firstScreen)[number] }) { return <div style={{ border: '1px solid var(--pc-border)', borderRadius: 18, padding: 14, display: 'grid', gap: 6 }}><span style={micro}>{item.label}</span><strong style={{ color: item.label === 'Деньги под риском' || item.label === 'Что заблокировано' ? '#B91C1C' : 'var(--pc-text-primary)', fontSize: 17, lineHeight: 1.2 }}>{item.value}</strong><span style={{ color: 'var(--pc-text-muted)', fontSize: 12, lineHeight: 1.4 }}>{item.note}</span></div>; }
-function Cell({ label, value, strong, danger }: { label: string; value: string; strong?: boolean; danger?: boolean }) { return <div style={{ border: '1px solid var(--pc-border)', borderRadius: 18, padding: 14, display: 'grid', gap: 6 }}><span style={micro}>{label}</span><strong style={{ color: danger ? '#B91C1C' : strong ? '#047857' : 'var(--pc-text-primary)', fontSize: 18, lineHeight: 1.2 }}>{value}</strong></div>; }
-function Gate({ gate }: { gate: (typeof gates)[number] }) { return <div style={{ border: `1px solid ${gate.state === 'stop' ? '#FECACA' : '#FED7AA'}`, background: gate.state === 'stop' ? 'rgba(220,38,38,0.06)' : '#FFF7ED', borderRadius: 18, padding: 14, display: 'grid', gap: 6 }}><span style={{ ...micro, color: gate.state === 'stop' ? '#B91C1C' : '#C2410C' }}>{gate.title}</span><strong style={{ color: 'var(--pc-text-primary)', fontSize: 16 }}>{gate.value}</strong><span style={{ color: 'var(--pc-text-muted)', fontSize: 12, lineHeight: 1.4 }}>{gate.impact}</span></div>; }
-function QualityCell({ item }: { item: (typeof quality)[number] }) { return <div style={{ border: `1px solid ${item.state === 'stop' ? '#FECACA' : '#FED7AA'}`, background: item.state === 'stop' ? 'rgba(220,38,38,0.06)' : '#FFFBEB', borderRadius: 18, padding: 14, display: 'grid', gap: 6 }}><span style={{ ...micro, color: item.state === 'stop' ? '#B91C1C' : '#B45309' }}>{item.label}</span><strong style={{ color: 'var(--pc-text-primary)', fontSize: 18 }}>{item.value}</strong><span style={{ color: item.state === 'stop' ? '#B91C1C' : '#B45309', fontSize: 12 }}>{item.limit}</span></div>; }
-function SummaryCard({ item }: { item: (typeof receivingSummary)[number] }) { return <div style={{ background: 'rgba(255,255,255,.1)', border: '1px solid rgba(255,255,255,.22)', borderRadius: 18, padding: 14, display: 'grid', gap: 7 }}><span style={{ ...micro, color: '#FED7AA' }}>{item.label}</span><strong style={{ color: '#fff', fontSize: 16, lineHeight: 1.25 }}>{item.value}</strong><span style={{ color: '#FFEDD5', fontSize: 12, lineHeight: 1.4 }}>{item.note}</span></div>; }

--- a/apps/web/app/platform-v7/lab/page.tsx
+++ b/apps/web/app/platform-v7/lab/page.tsx
@@ -1,3 +1,6 @@
+import { NextActionCard, StatusChip, Surface } from '@pc/design-system-v8';
+import { FieldTaskTemplate, KeyFact, KeyFactGrid } from '@/components/transaction-ux/FieldTaskTemplate';
+import workspace from '@/components/transaction-ux/FieldRoleWorkspace.module.css';
 import { RoleExecutionSummary } from '@/components/platform-v7/RoleExecutionSummary';
 import { FieldLabRuntime } from '@/components/v7r/FieldLabRuntime';
 import { RoleContinuityPanel } from '@/components/v7r/RoleContinuityPanel';
@@ -7,7 +10,6 @@ import { LiveApiStatusBar } from '@/components/platform-v7/LiveApiStatusBar';
 import { getLabSamples, pendingProtocols, labMoneyImpactRub } from '@/lib/labs-server';
 import { CauseLine } from '@/components/platform-v7/visual/CauseLine';
 import { QualityDeltaBars } from '@/components/platform-v7/QualityDeltaBars';
-import { CockpitHero } from '@/components/platform-v7/premium';
 import { CollapsibleSection } from '@/components/platform-v7/CollapsibleSection';
 import { GostQualityForm } from '@/components/platform-v7/GostQualityForm';
 import { LabPhotoUpload } from '@/components/platform-v7/LabPhotoUpload';
@@ -23,62 +25,25 @@ export default async function Page() {
   const samples = await getLabSamples();
   const pending = pendingProtocols(samples);
   const moneyImpact = labMoneyImpactRub(samples);
-  const apiOnline = samples.some((s) => !s.id.startsWith('SAMPLE-00'));
+  const apiOnline = samples.some((sample) => !sample.id.startsWith('SAMPLE-00'));
+  const impactLabel = moneyImpact !== 0 ? `${(moneyImpact / 1_000_000).toFixed(2)} млн ₽` : 'нет денежного влияния';
+  const liveBlockers = pending.map((sample) => ({ id: sample.id, label: `Проба ${sample.id}: ${sample.status} · ${sample.culture ?? 'культура не указана'}`, severity: 'warn' as const, responsibleRole: 'LAB', nextAction: 'Провести анализ и финализировать протокол' }));
 
-  const liveBlockers = pending.map((s) => ({
-    id: s.id,
-    label: `Проба ${s.id}: ${s.status} · ${s.culture ?? 'культура не указана'}`,
-    severity: 'warn' as const,
-    responsibleRole: 'LAB',
-    nextAction: 'Провести анализ и финализировать протокол',
-  }));
-
-  return (
-    <div data-testid="platform-v7-lab-page" style={{ display: 'grid', gap: 14 }}>
-      <LiveApiStatusBar
-        apiOnline={apiOnline}
-        blockers={liveBlockers}
-        role="LAB · Лабораторный контур"
-        summary={apiOnline ? `${samples.length} проб · ${pending.length} ожидают финализации · ${moneyImpact !== 0 ? (moneyImpact / 1_000_000).toFixed(2) + ' млн ₽ влияние' : 'нет денежного влияния'}` : 'Данные статичные — API недоступен'}
-      />
-      <style dangerouslySetInnerHTML={{ __html: `@media(max-width:767px){[data-testid='platform-v7-lab-page']{gap:10px!important}.p7-lab-hero{padding:16px!important;border-radius:24px!important;gap:10px!important}.p7-lab-hero h1{font-size:clamp(28px,8vw,38px)!important;line-height:1.04!important}.p7-lab-hero p{display:none!important}.p7-lab-steps{grid-template-columns:1fr 1fr!important;gap:8px!important}.p7-lab-step{padding:13px!important;border-radius:16px!important;gap:5px!important}.p7-lab-step strong{font-size:14px!important;line-height:1.25!important}}` }} />
-      <QuietIntelligenceHint problem="Сорная примесь 2,4% превышает допуск 2% — протокол качества не закрыт." action="Зафиксировать показатели и выдать протокол с допуском или отказом." outcome="Протокол уйдёт в контур документов как основание для дальнейшей проверки." />
-      <CockpitHero className='p7-lab-hero' eyebrow='Лаборатория · качество и протокол' title='Проба, показатели и протокол качества' lead='Лабораторный экран показывает пробу, показатели качества, отклонения и итоговый допуск. Финансовое решение, спор и банковская проверка остаются вне роли лаборатории.'>
-        <div className="p7-lab-steps" style={stepsGrid}>
-          {labSteps.map((item) => (
-            <div key={item.label} className="p7-lab-step" style={stepCard}>
-              <span style={micro}>{item.label}</span>
-              <strong style={{ color: 'var(--pc-text-primary, #0F1419)', fontSize: 15, lineHeight: 1.35 }}>{item.value}</strong>
-              <span style={{ color: 'var(--pc-text-muted, #64748B)', fontSize: 12, lineHeight: 1.4 }}>{item.note}</span>
-            </div>
-          ))}
-        </div>
-      </CockpitHero>
-      <CollapsibleSection title='Показатели качества' summary='влага · клейковина · сорность' defaultOpen>
-        <QualityDeltaBars title='Протокол качества · показатели против допуска' indicators={[{ label: 'Влажность', value: 13.1, unit: '%', max: 14, limitLabel: 'допуск до 14%' }, { label: 'Клейковина', value: 23, unit: '%', min: 21, limitLabel: 'минимум 21%' }, { label: 'Сорная примесь', value: 2.4, unit: '%', max: 2, limitLabel: 'допуск до 2% — превышение требует протокола с допуском или отказом' }]} />
-      </CollapsibleSection>
-      <CollapsibleSection title='Влияние на документы' summary='протокол → пакет качества' defaultOpen={false}>
-        <div style={{ display: 'grid', gap: 12 }}>
-          <CauseLine cause={{ text: 'Протокол качества не выдан', tone: 'blocked' }} relation="blocks" effect={{ text: 'Пакет документов по качеству не закрыт', tone: 'blocked' }} />
-          <TrustDot state="test" size="sm" label="Тестовый контур · внешнее подтверждение требуется отдельно" />
-        </div>
-      </CollapsibleSection>
-      <CollapsibleSection title='Роль и передача результата' summary='ответственный · непрерывность' defaultOpen={false}>
-        <div style={{ display: 'grid', gap: 12 }}><RoleExecutionSummary role="lab" /><RoleContinuityPanel role="lab" compact /></div>
-      </CollapsibleSection>
-      <CollapsibleSection title='Протокол качества по ГОСТ' summary='ГОСТ 9353 · показатели · допуск' defaultOpen>
-        <GostQualityForm defaultCulture="wheat_4" sampleId="SAMPLE-0042" compact={false} />
-      </CollapsibleSection>
-      <CollapsibleSection title='Фото и сканы пробы' summary='загрузка JPG · PNG · PDF · TIFF' defaultOpen={false}>
-        <LabPhotoUpload sampleId="SAMPLE-0042" />
-      </CollapsibleSection>
-      <CollapsibleSection title='Лабораторный runtime' summary='пробы · протокол · действие' defaultOpen={false}>
-        <FieldLabRuntime />
-      </CollapsibleSection>
+  const primary = (
+    <div className={workspace.stack}>
+      <NextActionCard label='Одно следующее действие' action='Финализировать протокол качества' reason='Сорная примесь 2,4% превышает допуск 2%. Нужно зафиксировать показатели и выдать протокол с допуском либо отказом.' blocked={pending.length > 0} impact={impactLabel} owner='лаборатория' deadline='до закрытия пакета качества' actions={<><a className={workspace.primaryLink} href='#quality-protocol'>Открыть протокол</a><a className={workspace.secondaryLink} href='#quality-evidence'>Проверить доказательства</a></>} />
+      <KeyFactGrid><KeyFact label='Проб' value={samples.length} hint='доступно роли лаборатории' /><KeyFact label='Ожидают решения' value={pending.length} hint='требуют финализации' /><KeyFact label='Критическое отклонение' value='2,4% сорной примеси' hint='допуск до 2%' /><KeyFact label='Результат' value='протокол качества' hint='передаётся в документы' /></KeyFactGrid>
+      <QuietIntelligenceHint problem='Сорная примесь 2,4% превышает допуск 2% — протокол качества не закрыт.' action='Зафиксировать показатели и выдать протокол с допуском или отказом.' outcome='Протокол уйдёт в контур документов как основание для дальнейшей проверки.' />
+      <section id='quality-protocol' className={workspace.sectionAnchor}><CollapsibleSection title='Протокол качества по ГОСТ' summary='ГОСТ 9353 · показатели · допуск' defaultOpen><GostQualityForm defaultCulture='wheat_4' sampleId='SAMPLE-0042' compact={false} /></CollapsibleSection></section>
+      <CollapsibleSection title='Показатели качества' summary='влага · клейковина · сорность' defaultOpen><QualityDeltaBars title='Протокол качества · показатели против допуска' indicators={[{ label: 'Влажность', value: 13.1, unit: '%', max: 14, limitLabel: 'допуск до 14%' }, { label: 'Клейковина', value: 23, unit: '%', min: 21, limitLabel: 'минимум 21%' }, { label: 'Сорная примесь', value: 2.4, unit: '%', max: 2, limitLabel: 'допуск до 2% — превышение требует протокола с допуском или отказом' }]} /></CollapsibleSection>
+      <CollapsibleSection title='Фото и сканы пробы' summary='загрузка JPG · PNG · PDF · TIFF' defaultOpen={false}><LabPhotoUpload sampleId='SAMPLE-0042' /></CollapsibleSection>
+      <CollapsibleSection title='Лабораторный runtime' summary='пробы · протокол · действие' defaultOpen={false}><FieldLabRuntime /></CollapsibleSection>
     </div>
   );
-}
 
-const stepsGrid = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))', gap: 10 } as const;
-const stepCard = { background: 'var(--pc-bg-card)', border: '1px solid var(--pc-border, #E4E6EA)', borderRadius: 18, padding: 14, display: 'grid', gap: 7, boxShadow: '0 12px 28px rgba(15,23,42,0.055)' } as const;
-const micro = { color: 'var(--pc-text-muted, #64748B)', fontSize: 11, fontWeight: 900, textTransform: 'uppercase', letterSpacing: '0.07em' } as const;
+  const context = <div className={workspace.stack}><StatusChip tone={pending.length ? 'warning' : 'success'}>{pending.length ? `${pending.length} протокола ожидают` : 'Очередь закрыта'}</StatusChip><ol className={workspace.contextList}>{labSteps.map((item) => <li key={item.label}><span>{item.label}</span><strong>{item.value}</strong><small>{item.note}</small></li>)}</ol></div>;
+  const evidence = <section id='quality-evidence' className={`${workspace.evidenceStack} ${workspace.sectionAnchor}`}><Surface><div className={workspace.sectionStack}><CauseLine cause={{ text: 'Протокол качества не выдан', tone: 'blocked' }} relation='blocks' effect={{ text: 'Пакет документов по качеству не закрыт', tone: 'blocked' }} /><TrustDot state='test' size='sm' label='Тестовый контур · внешнее подтверждение требуется отдельно' /></div></Surface><CollapsibleSection title='Роль и передача результата' summary='ответственный · непрерывность' defaultOpen={false}><div className={workspace.sectionStack}><RoleExecutionSummary role='lab' /><RoleContinuityPanel role='lab' compact /></div></CollapsibleSection></section>;
+  const liveStatus = <LiveApiStatusBar apiOnline={apiOnline} blockers={liveBlockers} role='LAB · Лабораторный контур' summary={apiOnline ? `${samples.length} проб · ${pending.length} ожидают финализации · ${impactLabel} влияние` : 'Данные статичные — API недоступен'} />;
+
+  return <FieldTaskTemplate testId='platform-v7-lab-page' eyebrow='Лаборатория · полевая роль' title='Проба, показатели и протокол качества' description='На первом уровне только отклонение, требуемое решение и результат для сделки. Финансовое решение, спор и банковская проверка остаются вне роли лаборатории.' statusLabel={apiOnline ? 'API доступен' : 'Статичный контур'} statusTone={apiOnline ? 'success' : 'warning'} liveStatus={liveStatus} primary={primary} context={context} evidence={evidence} />;
+}

--- a/apps/web/app/platform-v7/surveyor/page.tsx
+++ b/apps/web/app/platform-v7/surveyor/page.tsx
@@ -1,70 +1,33 @@
+import { NextActionCard, StatusChip, Surface } from '@pc/design-system-v8';
+import { FieldTaskTemplate, KeyFact, KeyFactGrid } from '@/components/transaction-ux/FieldTaskTemplate';
+import workspace from '@/components/transaction-ux/FieldRoleWorkspace.module.css';
 import { RoleExecutionSummary } from '@/components/platform-v7/RoleExecutionSummary';
 import { BatonStrip } from '@/components/platform-v7/BatonStrip';
-import { CockpitHero } from '@/components/platform-v7/premium';
 import { CollapsibleSection } from '@/components/platform-v7/CollapsibleSection';
-import { EmptyState } from '@/components/platform-v7/EmptyState';
 
+type SurveyorAssignment = { id: string; deal: string; cargo: string; location: string; time: string; status: 'Требует акта' | 'Ожидает' };
 const surveyorSteps = [
   { label: 'Осмотр', value: 'фото и состояние', note: 'что видно на площадке без пересказа сторон' },
   { label: 'Расхождение', value: 'причина и место', note: 'где возникло отклонение и чем подтверждается' },
   { label: 'Замечание', value: 'текст и вложения', note: 'кратко, с привязкой к рейсу и партии' },
   { label: 'Заключение', value: 'независимая фиксация', note: 'основание уходит в доказательный контур' },
 ] as const;
-
-export default function Page() {
-  return (
-    <div style={{ display: 'grid', gap: 14 }}>
-      <CockpitHero
-        eyebrow='Независимая фиксация на площадке'
-        title='Осмотр, фото, расхождение и заключение'
-        lead='Роль сюрвейера показывает только независимую проверку: фото, состояние груза, расхождения, замечания по приёмке и заключение для доказательного контура. Деньги, банк и решение спора остаются вне этой роли.'
-      >
-        <div style={stepsGrid}>{surveyorSteps.map((item) => <Step key={item.label} item={item} />)}</div>
-      </CockpitHero>
-
-      <CollapsibleSection title='Передача между ролями' summary='логистика → осмотр → оператор' defaultOpen>
-        <BatonStrip from="логистика — рейс и груз" mine="осмотр, фото, расхождение, акт" to="оператор — доказательный контур" toHref="/platform-v7/disputes" />
-      </CollapsibleSection>
-
-      <CollapsibleSection title='Роль сюрвейера' summary='что видит и что отдаёт' defaultOpen={false}>
-        <RoleExecutionSummary role="surveyor" />
-      </CollapsibleSection>
-
-      <CollapsibleSection title='Назначения на осмотр' summary='акты · площадка · время' defaultOpen={false}>
-        <section style={{ background: 'var(--pc-bg-card, #fff)', border: '1px solid var(--pc-border, #E4E6EA)', borderRadius: 20, padding: 18, display: 'grid', gap: 12 }}>
-          <div style={micro}>Назначения</div>
-          {ASSIGNMENTS.length === 0 ? (
-            <EmptyState
-              title='Назначений на осмотр нет'
-              description='Когда логистика передаст рейс и груз на площадку, назначения на независимый осмотр появятся здесь.'
-            />
-          ) : ASSIGNMENTS.map((a) => (
-            <a key={a.id} href={`/platform-v7/surveyor/acts/${a.id}`} style={assignmentCard}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, flexWrap: 'wrap', alignItems: 'center' }}>
-                <div>
-                  <div style={{ fontFamily: 'JetBrains Mono, monospace', fontWeight: 800, color: '#0A7A5F', fontSize: 13 }}>{a.id}</div>
-                  <div style={{ marginTop: 4, fontSize: 13, color: 'var(--pc-text-primary, #0F1419)', fontWeight: 700 }}>{a.cargo} · {a.location}</div>
-                  <div style={{ marginTop: 2, fontSize: 12, color: 'var(--pc-text-muted, #64748B)' }}>{a.deal} · {a.time}</div>
-                </div>
-                <span style={{ padding: '5px 10px', borderRadius: 999, border: '1px solid rgba(217,119,6,0.24)', background: 'rgba(217,119,6,0.07)', color: '#B45309', fontSize: 11, fontWeight: 900 }}>{a.status}</span>
-              </div>
-            </a>
-          ))}
-        </section>
-      </CollapsibleSection>
-    </div>
-  );
-}
-
-function Step({ item }: { item: (typeof surveyorSteps)[number] }) {
-  return <div style={stepCard}><span style={micro}>{item.label}</span><strong style={{ color: 'var(--pc-text-primary, #0F1419)', fontSize: 15, lineHeight: 1.35 }}>{item.value}</strong><span style={{ color: 'var(--pc-text-muted, #64748B)', fontSize: 12, lineHeight: 1.4 }}>{item.note}</span></div>;
-}
-
-const stepsGrid = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))', gap: 10 } as const;
-const stepCard = { background: 'var(--pc-bg-card)', border: '1px solid var(--pc-border, #E4E6EA)', borderRadius: 18, padding: 14, display: 'grid', gap: 7, boxShadow: '0 12px 28px rgba(15,23,42,0.055)' } as const;
-const micro = { color: 'var(--pc-text-muted, #64748B)', fontSize: 11, fontWeight: 900, textTransform: 'uppercase', letterSpacing: '0.07em' } as const;
-const assignmentCard = { textDecoration: 'none', color: 'inherit', background: 'var(--pc-bg-subtle)', border: '1px solid var(--pc-border, #E4E6EA)', borderRadius: 14, padding: 14, display: 'block' } as const;
-const ASSIGNMENTS = [
+const assignments: SurveyorAssignment[] = [
   { id: 'QC-DL-9102', deal: 'DL-9102', cargo: 'Пшеница 4 кл.', location: 'Элеватор Тамбов', time: '11:00', status: 'Требует акта' },
   { id: 'QC-DL-9108', deal: 'DL-9108', cargo: 'Ячмень 3 кл.', location: 'Склад Курск', time: '14:30', status: 'Ожидает' },
 ];
+
+export default function Page() {
+  const urgent = assignments.filter((assignment) => assignment.status === 'Требует акта');
+  const primary = (
+    <div className={workspace.stack}>
+      <NextActionCard label='Одно следующее действие' action='Оформить независимый акт по QC-DL-9102' reason='Зафиксировать состояние груза, место расхождения, фото и краткое заключение. Решение по деньгам и спору остаётся за уполномоченными ролями.' blocked impact='без акта доказательный контур неполон' owner='назначенный сюрвейер' deadline='осмотр назначен на 11:00' actions={<><a className={workspace.primaryLink} href='/platform-v7/surveyor/acts/QC-DL-9102'>Открыть акт</a><a className={workspace.secondaryLink} href='#surveyor-assignments'>Все назначения</a></>} />
+      <KeyFactGrid><KeyFact label='Назначений' value={assignments.length} hint='на текущую смену' /><KeyFact label='Срочно' value={urgent.length} hint='требует независимого акта' /><KeyFact label='Объект' value='рейс и партия' hint='без финансовых данных' /><KeyFact label='Результат' value='акт + фото' hint='передаётся оператору' /></KeyFactGrid>
+      <CollapsibleSection title='Передача между ролями' summary='логистика → осмотр → оператор' defaultOpen><BatonStrip from='логистика — рейс и груз' mine='осмотр, фото, расхождение, акт' to='оператор — доказательный контур' toHref='/platform-v7/disputes' /></CollapsibleSection>
+      <section id='surveyor-assignments' className={workspace.sectionAnchor}><CollapsibleSection title='Назначения на осмотр' summary='акты · площадка · время' defaultOpen><Surface><div className={workspace.assignmentList}>{assignments.map((assignment) => <a key={assignment.id} href={`/platform-v7/surveyor/acts/${assignment.id}`} className={workspace.assignmentCard}><span className={workspace.assignmentCopy}><strong>{assignment.id} · {assignment.cargo}</strong><span>{assignment.location} · {assignment.deal}</span><small>{assignment.time}</small></span><StatusChip tone={assignment.status === 'Требует акта' ? 'warning' : 'neutral'}>{assignment.status}</StatusChip></a>)}</div></Surface></CollapsibleSection></section>
+    </div>
+  );
+  const context = <ol className={workspace.contextList}>{surveyorSteps.map((item) => <li key={item.label}><span>{item.label}</span><strong>{item.value}</strong><small>{item.note}</small></li>)}</ol>;
+  const evidence = <CollapsibleSection title='Роль сюрвейера' summary='что видит и что отдаёт' defaultOpen={false}><RoleExecutionSummary role='surveyor' /></CollapsibleSection>;
+  return <FieldTaskTemplate testId='platform-v7-surveyor-page' eyebrow='Сюрвейер · независимая фиксация' title='Осмотр, фото, расхождение и заключение' description='Сюрвейер видит только назначенный объект, факты осмотра и доказательства. Банк, деньги и решение спора вне этой роли.' statusLabel={`${assignments.length} назначения`} statusTone={urgent.length ? 'warning' : 'success'} primary={primary} context={context} evidence={evidence} />;
+}

--- a/apps/web/components/transaction-ux/FieldRoleWorkspace.module.css
+++ b/apps/web/components/transaction-ux/FieldRoleWorkspace.module.css
@@ -1,0 +1,20 @@
+.stack,.sectionStack,.evidenceStack{min-width:0;display:grid;gap:var(--ds-space-3)}
+.evidenceStack{gap:var(--ds-space-4)}
+.primaryLink,.secondaryLink{min-height:var(--ds-control-height);border-radius:var(--ds-radius-md);padding:0 var(--ds-space-4);display:inline-flex;align-items:center;justify-content:center;text-align:center;text-decoration:none;font-weight:850}
+.primaryLink{background:var(--ds-color-action-primary);color:var(--ds-color-on-action)}
+.primaryLink:hover{background:var(--ds-color-action-primary-hover)}
+.secondaryLink{border:1px solid var(--ds-color-border);background:var(--ds-color-surface);color:var(--ds-color-text-primary)}
+.primaryLink:focus-visible,.secondaryLink:focus-visible,.assignmentCard:focus-visible{outline:3px solid var(--ds-color-focus);outline-offset:3px}
+.sectionAnchor{scroll-margin-top:calc(var(--ds-control-height) + var(--ds-space-8))}
+.contextList,.assignmentList{margin:0;padding:0;list-style:none;display:grid;gap:var(--ds-space-2)}
+.contextList li{min-width:0;border-bottom:1px solid var(--ds-color-border);padding-bottom:var(--ds-space-3);display:grid;gap:var(--ds-space-1)}
+.contextList li:last-child{border-bottom:0;padding-bottom:0}
+.contextList span,.contextList small,.muted{color:var(--ds-color-text-secondary);line-height:1.45}
+.contextList strong{color:var(--ds-color-text-primary);overflow-wrap:anywhere}
+.twoColumn{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--ds-space-3)}
+.alert{border:1px solid var(--ds-color-critical);border-radius:var(--ds-radius-md);padding:var(--ds-space-3);background:var(--ds-color-critical-bg);color:var(--ds-color-critical);font-weight:800;line-height:1.45}
+.assignmentCard{min-height:var(--ds-control-height);border:1px solid var(--ds-color-border);border-radius:var(--ds-radius-md);padding:var(--ds-space-3);display:flex;align-items:center;justify-content:space-between;gap:var(--ds-space-3);background:var(--ds-color-surface-subtle);color:inherit;text-decoration:none}
+.assignmentCopy{min-width:0;display:grid;gap:var(--ds-space-1)}
+.assignmentCopy span,.assignmentCopy small{color:var(--ds-color-text-secondary)}
+@media(max-width:640px){.twoColumn{grid-template-columns:1fr}.assignmentCard{align-items:flex-start}}
+@media(forced-colors:active){.primaryLink,.secondaryLink,.assignmentCard,.alert{border-color:CanvasText}}

--- a/apps/web/components/transaction-ux/FieldTaskTemplate.module.css
+++ b/apps/web/components/transaction-ux/FieldTaskTemplate.module.css
@@ -1,0 +1,16 @@
+.root{width:min(100%,var(--ds-content-max));margin:0 auto;display:grid;gap:var(--ds-space-4)}
+.header{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--ds-space-4)}
+.headingGroup{min-width:0;display:grid;gap:var(--ds-space-2)}
+.eyebrow{color:var(--ds-color-action-primary);font-size:var(--ds-font-caption);font-weight:900;letter-spacing:.04em;text-transform:uppercase}
+.headingGroup h1{margin:0;color:var(--ds-color-text-primary);font-size:clamp(var(--ds-font-title),5vw,var(--ds-font-display));line-height:1.12;overflow-wrap:anywhere}
+.headingGroup p{margin:0;max-width:76ch;color:var(--ds-color-text-secondary);font-size:var(--ds-font-body);line-height:1.55}
+.workArea{display:grid;grid-template-columns:minmax(0,1fr) minmax(280px,360px);align-items:start;gap:var(--ds-space-4)}
+.primary,.context,.evidence,.contextStack{min-width:0;display:grid;gap:var(--ds-space-4)}
+.factGrid{margin:0;display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:var(--ds-space-3)}
+.fact{min-width:0;border:1px solid var(--ds-color-border);border-radius:var(--ds-radius-md);padding:var(--ds-space-3);background:var(--ds-color-surface-subtle)}
+.fact dt{color:var(--ds-color-text-muted);font-size:var(--ds-font-caption);font-weight:750}
+.fact dd{margin:var(--ds-space-1) 0 0;color:var(--ds-color-text-primary);font-size:var(--ds-font-body);font-weight:900;overflow-wrap:anywhere}
+.fact small{display:block;margin-top:var(--ds-space-1);color:var(--ds-color-text-secondary);line-height:1.4}
+@media(max-width:760px){.header{display:grid}.workArea{grid-template-columns:1fr}.context{order:2}.factGrid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+@media(max-width:420px){.factGrid{grid-template-columns:1fr}}
+@media(forced-colors:active){.fact{border-color:CanvasText}}

--- a/apps/web/components/transaction-ux/FieldTaskTemplate.tsx
+++ b/apps/web/components/transaction-ux/FieldTaskTemplate.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from 'react';
+import { StatusChip, Surface } from '@pc/design-system-v8';
+import styles from './FieldTaskTemplate.module.css';
+
+export type FieldStatusTone = 'neutral' | 'success' | 'warning' | 'critical' | 'information';
+
+export type FieldTaskTemplateProps = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  statusLabel: string;
+  statusTone?: FieldStatusTone;
+  primary: ReactNode;
+  context?: ReactNode;
+  evidence?: ReactNode;
+  liveStatus?: ReactNode;
+  testId?: string;
+};
+
+export function FieldTaskTemplate({ eyebrow, title, description, statusLabel, statusTone = 'neutral', primary, context, evidence, liveStatus, testId }: FieldTaskTemplateProps) {
+  return (
+    <div className={styles.root} data-testid={testId} data-density='field'>
+      {liveStatus}
+      <header className={styles.header}>
+        <div className={styles.headingGroup}>
+          <span className={styles.eyebrow}>{eyebrow}</span>
+          <h1>{title}</h1>
+          <p>{description}</p>
+        </div>
+        <StatusChip tone={statusTone}>{statusLabel}</StatusChip>
+      </header>
+      <section className={styles.workArea} aria-label='Рабочая область'>
+        <div className={styles.primary}>{primary}</div>
+        {context ? <aside className={styles.context} aria-label='Контекст задачи'><Surface>{context}</Surface></aside> : null}
+      </section>
+      {evidence ? <section className={styles.evidence} aria-label='Доказательства'>{evidence}</section> : null}
+    </div>
+  );
+}
+
+export type IntakeWorkbenchTemplateProps = FieldTaskTemplateProps & { intakeSummary: ReactNode };
+
+export function IntakeWorkbenchTemplate({ intakeSummary, context, ...props }: IntakeWorkbenchTemplateProps) {
+  return <FieldTaskTemplate {...props} context={<div className={styles.contextStack}><section aria-label='Сводка приёмки'>{intakeSummary}</section>{context}</div>} />;
+}
+
+export function KeyFactGrid({ children }: { children: ReactNode }) { return <dl className={styles.factGrid}>{children}</dl>; }
+
+export function KeyFact({ label, value, hint }: { label: ReactNode; value: ReactNode; hint?: ReactNode }) {
+  return <div className={styles.fact}><dt>{label}</dt><dd>{value}</dd>{hint ? <small>{hint}</small> : null}</div>;
+}

--- a/apps/web/tests/unit/designSystemV8FieldRoles.test.ts
+++ b/apps/web/tests/unit/designSystemV8FieldRoles.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const cwd = process.cwd();
+const repoRoot = [cwd, path.resolve(cwd, '../..')].find((candidate) => fs.existsSync(path.join(candidate, 'design-governance-v8.json')));
+if (!repoRoot) throw new Error(`Cannot resolve repository root from ${cwd}`);
+const read = (relativePath: string) => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+const fieldRolePages = [
+  'apps/web/app/platform-v7/driver/field/page.tsx',
+  'apps/web/app/platform-v7/elevator/page.tsx',
+  'apps/web/app/platform-v7/lab/page.tsx',
+  'apps/web/app/platform-v7/surveyor/page.tsx',
+];
+
+describe('Design System v8 field-role migration', () => {
+  it('migrates four field roles to reusable transaction templates', () => {
+    for (const page of fieldRolePages) {
+      const source = read(page);
+      expect(source).toContain("from '@pc/design-system-v8'");
+      expect(source).toContain("@/components/transaction-ux/FieldTaskTemplate");
+      expect(source).not.toContain('dangerouslySetInnerHTML');
+      expect(source).not.toMatch(/\bstyle\s*=\s*\{\{/);
+      expect(source).not.toContain('/platform-v7/bank');
+      expect(source).not.toContain('/platform-v7/investor');
+      expect(source).not.toContain('/platform-v7/control-tower');
+    }
+  });
+
+  it('provides Field Task and Intake Workbench reusable templates', () => {
+    const template = read('apps/web/components/transaction-ux/FieldTaskTemplate.tsx');
+    expect(template).toContain('export function FieldTaskTemplate');
+    expect(template).toContain('export function IntakeWorkbenchTemplate');
+    expect(template).toContain('export function KeyFactGrid');
+    expect(template).toContain('export function KeyFact');
+  });
+
+  it('registers all migrated field surfaces in governance', () => {
+    const governance = JSON.parse(read('design-governance-v8.json'));
+    for (const page of fieldRolePages) expect(governance.migratedFiles).toContain(page);
+  });
+});

--- a/design-governance-v8.json
+++ b/design-governance-v8.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "tokenSource": "packages/design-tokens/tokens.json",
   "tokenCss": "packages/design-tokens/tokens.css",
   "governedRoots": [
@@ -9,7 +9,11 @@
     "apps/web/components/v7r/AppShellV4.module.css"
   ],
   "migratedFiles": [
-    "apps/web/components/platform-v7/NextActionCard.tsx"
+    "apps/web/components/platform-v7/NextActionCard.tsx",
+    "apps/web/app/platform-v7/driver/field/page.tsx",
+    "apps/web/app/platform-v7/elevator/page.tsx",
+    "apps/web/app/platform-v7/lab/page.tsx",
+    "apps/web/app/platform-v7/surveyor/page.tsx"
   ],
   "allowedGlobalStyleEntrypoints": [
     "packages/design-tokens/tokens.css"

--- a/scripts/check-design-system-v8-field-roles-scope.mjs
+++ b/scripts/check-design-system-v8-field-roles-scope.mjs
@@ -1,0 +1,32 @@
+import { execFileSync } from 'node:child_process';
+
+const exact = new Set([
+  '.github/workflows/design-system-v8.yml',
+  '.github/workflows/platform-v7-autopilot-guard.yml',
+  'apps/web/app/platform-v7/driver/field/page.tsx',
+  'apps/web/app/platform-v7/elevator/page.tsx',
+  'apps/web/app/platform-v7/lab/page.tsx',
+  'apps/web/app/platform-v7/surveyor/page.tsx',
+  'apps/web/tests/unit/designSystemV8FieldRoles.test.ts',
+  'design-governance-v8.json',
+  'scripts/check-design-system-v8-field-roles-scope.mjs',
+]);
+const prefixes = ['apps/web/components/transaction-ux/'];
+const forbidden = [/^apps\/landing\//, /^apps\/api\//, /^packages\//, /^infra\//, /^\.env/, /(?:^|\/)package-lock\.json$/, /(?:^|\/)pnpm-lock\.yaml$/, /\.(?:pem|key)$/];
+const normalize = (file) => file.trim().replaceAll('\\', '/').replace(/^\.\//, '');
+const allowed = (file) => exact.has(file) || prefixes.some((prefix) => file.startsWith(prefix));
+const git = (args) => execFileSync('git', args, { encoding: 'utf8' }).trim();
+let base = process.env.BASE_REF || 'origin/main';
+try { git(['rev-parse', '--verify', base]); } catch { base = 'main'; }
+let mergeBase;
+try { mergeBase = git(['merge-base', base, 'HEAD']); } catch { console.error(`[design-system-v8-field-roles-scope] Cannot resolve merge base for ${base}.`); process.exit(1); }
+const files = git(['diff', '--name-only', `${mergeBase}...HEAD`]).split(/\r?\n/).map(normalize).filter(Boolean);
+if (files.length === 0) { console.error('[design-system-v8-field-roles-scope] No changed files found.'); process.exit(1); }
+const violations = [];
+for (const file of files) {
+  if (forbidden.some((pattern) => pattern.test(file))) violations.push(`${file}: forbidden zone`);
+  else if (!allowed(file)) violations.push(`${file}: outside approved field-role scope`);
+}
+if (violations.length) { console.error('[design-system-v8-field-roles-scope] FAIL'); for (const violation of violations) console.error(`- ${violation}`); process.exit(1); }
+console.log(`[design-system-v8-field-roles-scope] PASS: ${files.length} changed files are inside the approved scope.`);
+for (const file of files) console.log(`- ${file}`);


### PR DESCRIPTION
## Что изменено

- Driver и Laboratory переведены на reusable `FieldTaskTemplate`;
- Elevator переведён на `IntakeWorkbenchTemplate`;
- Surveyor переведён на независимый field-task workflow;
- первый уровень каждой роли показывает одно действие, четыре ключевых факта, блокер, ответственного и результат;
- сохранены фото, пломба, маршрут, весовая, ГОСТ, акт расхождения, offline/conflict, runtime, handoff и evidence-компоненты;
- финансовые, банковые, инвесторские и control-tower маршруты не добавлены в полевые поверхности;
- четыре страницы внесены в `design-governance-v8.json` и теперь автоматически проверяются на inline styles, style injection, literal colors, `!important` и legacy style imports;
- добавлены focused regression tests и отдельный строгий concurrent-scope gate.

## Основание

Design System v8 foundation и канонический App Shell/Deal Workspace уже объединены через PR #2442 и #2443. Этот PR не перезаписывает их и закрывает только следующий независимый пакет: Driver → Elevator → Laboratory → Surveyor.

## Граница зрелости

После объединения четыре полевые роли будут мигрированы на v8. Seller, Buyer, Bank и остальные бизнес-роли, полное удаление legacy CSS/shell/workspace и общая визуальная приёмка всей платформы останутся отдельными этапами.

## Проверки

- Design System v8 governance;
- strict field-role PR scope;
- web typecheck;
- focused field-role regression;
- Node CI tests/build;
- CI industrial core;
- security, CodeQL, Qodana and dependency gates.