### PR TITLE
Add PostgreSQL authority for auction reads

### DIFF
--- a/.github/workflows/codeql-platform-v7-report.yml
+++ b/.github/workflows/codeql-platform-v7-report.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/codeql-platform-v7-report.yml"
+      - "apps/api/**"
       - "apps/web/app/platform-v7/**"
       - "apps/web/components/platform-v7/**"
       - "apps/web/components/v7r/**"

--- a/.github/workflows/qodana-platform-v7-report.yml
+++ b/.github/workflows/qodana-platform-v7-report.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/qodana-platform-v7-report.yml"
       - "qodana.yaml"
+      - "apps/api/**"
       - "apps/web/app/platform-v7/**"
       - "apps/web/components/platform-v7/**"
       - "apps/web/components/v7r/**"

--- a/apps/api/prisma/migrations/20260713210000_auction_postgresql_authority/migration.sql
+++ b/apps/api/prisma/migrations/20260713210000_auction_postgresql_authority/migration.sql
@@ -1,9 +1,12 @@
 -- Auction facts are PostgreSQL-authoritative. This migration intentionally creates
--- no fixture lots, bids, awards or Deals. Application users receive SELECT-only
--- access through tenant FORCE-RLS; future mutations must use separately reviewed
--- canonical command functions and cannot be introduced through the read API.
+-- no fixture lots, bids, awards or Deals. The bounded auction schema is outside
+-- Prisma's public-schema ownership while remaining migration-managed, FORCE-RLS
+-- protected and available to the application through explicit SELECT-only grants.
 
-CREATE TABLE public.auction_lots (
+CREATE SCHEMA IF NOT EXISTS auction;
+REVOKE ALL ON SCHEMA auction FROM PUBLIC;
+
+CREATE TABLE auction.lots (
   id text PRIMARY KEY,
   tenant_id text NOT NULL,
   seller_org_id text NOT NULL,
@@ -40,7 +43,7 @@ CREATE TABLE public.auction_lots (
   )
 );
 
-CREATE TABLE public.auction_bids (
+CREATE TABLE auction.bids (
   id text PRIMARY KEY,
   tenant_id text NOT NULL,
   lot_id text NOT NULL,
@@ -55,10 +58,10 @@ CREATE TABLE public.auction_bids (
   updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
   CONSTRAINT auction_bids_tenant_lot_id_key UNIQUE (tenant_id, lot_id, id),
   CONSTRAINT auction_bids_lot_fkey FOREIGN KEY (tenant_id, lot_id)
-    REFERENCES public.auction_lots (tenant_id, id) ON DELETE RESTRICT ON UPDATE CASCADE
+    REFERENCES auction.lots (tenant_id, id) ON DELETE RESTRICT ON UPDATE CASCADE
 );
 
-CREATE TABLE public.auction_awards (
+CREATE TABLE auction.awards (
   id text PRIMARY KEY,
   tenant_id text NOT NULL,
   lot_id text NOT NULL,
@@ -72,9 +75,9 @@ CREATE TABLE public.auction_awards (
   updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
   CONSTRAINT auction_awards_tenant_lot_key UNIQUE (tenant_id, lot_id),
   CONSTRAINT auction_awards_lot_fkey FOREIGN KEY (tenant_id, lot_id)
-    REFERENCES public.auction_lots (tenant_id, id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    REFERENCES auction.lots (tenant_id, id) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT auction_awards_winning_bid_fkey FOREIGN KEY (tenant_id, lot_id, winning_bid_id)
-    REFERENCES public.auction_bids (tenant_id, lot_id, id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    REFERENCES auction.bids (tenant_id, lot_id, id) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT auction_awards_deal_fkey FOREIGN KEY (deal_id)
     REFERENCES public.deals (id) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT auction_awards_deal_state_check CHECK (
@@ -84,21 +87,21 @@ CREATE TABLE public.auction_awards (
 );
 
 CREATE INDEX auction_lots_tenant_status_idx
-  ON public.auction_lots (tenant_id, status, auction_ends_at DESC, id);
+  ON auction.lots (tenant_id, status, auction_ends_at DESC, id);
 CREATE INDEX auction_lots_seller_idx
-  ON public.auction_lots (tenant_id, seller_org_id, updated_at DESC);
+  ON auction.lots (tenant_id, seller_org_id, updated_at DESC);
 CREATE INDEX auction_bids_lot_amount_idx
-  ON public.auction_bids (tenant_id, lot_id, amount_rub_per_ton DESC, placed_at ASC, id);
+  ON auction.bids (tenant_id, lot_id, amount_rub_per_ton DESC, placed_at ASC, id);
 CREATE INDEX auction_bids_buyer_idx
-  ON public.auction_bids (tenant_id, buyer_org_id, placed_at DESC);
+  ON auction.bids (tenant_id, buyer_org_id, placed_at DESC);
 CREATE INDEX auction_awards_deal_idx
-  ON public.auction_awards (tenant_id, deal_id);
+  ON auction.awards (tenant_id, deal_id);
 
-CREATE OR REPLACE FUNCTION public.app_auction_touch_version()
+CREATE OR REPLACE FUNCTION auction.touch_version()
 RETURNS trigger
 LANGUAGE plpgsql
 SECURITY INVOKER
-SET search_path = pg_catalog, public
+SET search_path = pg_catalog, public, auction
 AS $function$
 BEGIN
   NEW.updated_at := transaction_timestamp();
@@ -108,28 +111,28 @@ END
 $function$;
 
 CREATE TRIGGER auction_lots_touch_version
-BEFORE UPDATE ON public.auction_lots
-FOR EACH ROW EXECUTE FUNCTION public.app_auction_touch_version();
+BEFORE UPDATE ON auction.lots
+FOR EACH ROW EXECUTE FUNCTION auction.touch_version();
 
 CREATE TRIGGER auction_bids_touch_version
-BEFORE UPDATE ON public.auction_bids
-FOR EACH ROW EXECUTE FUNCTION public.app_auction_touch_version();
+BEFORE UPDATE ON auction.bids
+FOR EACH ROW EXECUTE FUNCTION auction.touch_version();
 
 CREATE TRIGGER auction_awards_touch_version
-BEFORE UPDATE ON public.auction_awards
-FOR EACH ROW EXECUTE FUNCTION public.app_auction_touch_version();
+BEFORE UPDATE ON auction.awards
+FOR EACH ROW EXECUTE FUNCTION auction.touch_version();
 
-CREATE OR REPLACE FUNCTION public.app_auction_bid_guard()
+CREATE OR REPLACE FUNCTION auction.bid_guard()
 RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, public
+SET search_path = pg_catalog, public, auction
 AS $function$
 DECLARE
-  lot_record public.auction_lots%ROWTYPE;
+  lot_record auction.lots%ROWTYPE;
 BEGIN
   SELECT * INTO lot_record
-  FROM public.auction_lots
+  FROM auction.lots
   WHERE tenant_id = NEW.tenant_id
     AND id = NEW.lot_id
   FOR KEY SHARE;
@@ -156,23 +159,23 @@ END
 $function$;
 
 CREATE TRIGGER auction_bids_authority_guard
-BEFORE INSERT OR UPDATE ON public.auction_bids
-FOR EACH ROW EXECUTE FUNCTION public.app_auction_bid_guard();
+BEFORE INSERT OR UPDATE ON auction.bids
+FOR EACH ROW EXECUTE FUNCTION auction.bid_guard();
 
-CREATE OR REPLACE FUNCTION public.app_auction_award_guard()
+CREATE OR REPLACE FUNCTION auction.award_guard()
 RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, public
+SET search_path = pg_catalog, public, auction
 AS $function$
 DECLARE
-  lot_record public.auction_lots%ROWTYPE;
+  lot_record auction.lots%ROWTYPE;
   bid_status text;
   deal_tenant_id text;
   deal_source_lot_id text;
 BEGIN
   SELECT * INTO lot_record
-  FROM public.auction_lots
+  FROM auction.lots
   WHERE tenant_id = NEW.tenant_id
     AND id = NEW.lot_id
   FOR UPDATE;
@@ -182,7 +185,7 @@ BEGIN
   END IF;
 
   SELECT status INTO bid_status
-  FROM public.auction_bids
+  FROM auction.bids
   WHERE tenant_id = NEW.tenant_id
     AND lot_id = NEW.lot_id
     AND id = NEW.winning_bid_id
@@ -216,50 +219,55 @@ END
 $function$;
 
 CREATE TRIGGER auction_awards_authority_guard
-BEFORE INSERT OR UPDATE ON public.auction_awards
-FOR EACH ROW EXECUTE FUNCTION public.app_auction_award_guard();
+BEFORE INSERT OR UPDATE ON auction.awards
+FOR EACH ROW EXECUTE FUNCTION auction.award_guard();
 
-ALTER TABLE public.auction_lots ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.auction_lots FORCE ROW LEVEL SECURITY;
-ALTER TABLE public.auction_bids ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.auction_bids FORCE ROW LEVEL SECURITY;
-ALTER TABLE public.auction_awards ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.auction_awards FORCE ROW LEVEL SECURITY;
+ALTER TABLE auction.lots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE auction.lots FORCE ROW LEVEL SECURITY;
+ALTER TABLE auction.bids ENABLE ROW LEVEL SECURITY;
+ALTER TABLE auction.bids FORCE ROW LEVEL SECURITY;
+ALTER TABLE auction.awards ENABLE ROW LEVEL SECURITY;
+ALTER TABLE auction.awards FORCE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS auction_lots_tenant_select ON public.auction_lots;
+DROP POLICY IF EXISTS auction_lots_tenant_select ON auction.lots;
 CREATE POLICY auction_lots_tenant_select
-ON public.auction_lots
+ON auction.lots
 FOR SELECT
 USING (
   NULLIF(current_setting('app.current_tenant_id', true), '') IS NOT NULL
   AND tenant_id = current_setting('app.current_tenant_id', true)
 );
 
-DROP POLICY IF EXISTS auction_bids_tenant_select ON public.auction_bids;
+DROP POLICY IF EXISTS auction_bids_tenant_select ON auction.bids;
 CREATE POLICY auction_bids_tenant_select
-ON public.auction_bids
+ON auction.bids
 FOR SELECT
 USING (
   NULLIF(current_setting('app.current_tenant_id', true), '') IS NOT NULL
   AND tenant_id = current_setting('app.current_tenant_id', true)
 );
 
-DROP POLICY IF EXISTS auction_awards_tenant_select ON public.auction_awards;
+DROP POLICY IF EXISTS auction_awards_tenant_select ON auction.awards;
 CREATE POLICY auction_awards_tenant_select
-ON public.auction_awards
+ON auction.awards
 FOR SELECT
 USING (
   NULLIF(current_setting('app.current_tenant_id', true), '') IS NOT NULL
   AND tenant_id = current_setting('app.current_tenant_id', true)
 );
+
+REVOKE ALL ON FUNCTION auction.touch_version() FROM PUBLIC;
+REVOKE ALL ON FUNCTION auction.bid_guard() FROM PUBLIC;
+REVOKE ALL ON FUNCTION auction.award_guard() FROM PUBLIC;
 
 DO $auction_authority_grants$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_deal') THEN
-    GRANT SELECT ON public.auction_lots, public.auction_bids, public.auction_awards TO app_deal;
-    GRANT EXECUTE ON FUNCTION public.app_auction_bid_guard() TO app_deal;
-    GRANT EXECUTE ON FUNCTION public.app_auction_award_guard() TO app_deal;
-    GRANT EXECUTE ON FUNCTION public.app_auction_touch_version() TO app_deal;
+    GRANT USAGE ON SCHEMA auction TO app_deal;
+    GRANT SELECT ON auction.lots, auction.bids, auction.awards TO app_deal;
+    GRANT EXECUTE ON FUNCTION auction.bid_guard() TO app_deal;
+    GRANT EXECUTE ON FUNCTION auction.award_guard() TO app_deal;
+    GRANT EXECUTE ON FUNCTION auction.touch_version() TO app_deal;
   END IF;
 END
 $auction_authority_grants$;

--- a/apps/api/prisma/migrations/20260713210000_auction_postgresql_authority/migration.sql
+++ b/apps/api/prisma/migrations/20260713210000_auction_postgresql_authority/migration.sql
@@ -1,0 +1,265 @@
+-- Auction facts are PostgreSQL-authoritative. This migration intentionally creates
+-- no fixture lots, bids, awards or Deals. Application users receive SELECT-only
+-- access through tenant FORCE-RLS; future mutations must use separately reviewed
+-- canonical command functions and cannot be introduced through the read API.
+
+CREATE TABLE public.auction_lots (
+  id text PRIMARY KEY,
+  tenant_id text NOT NULL,
+  seller_org_id text NOT NULL,
+  title text NOT NULL,
+  culture text NOT NULL,
+  grade text,
+  volume_tons numeric(20, 6) NOT NULL CHECK (volume_tons > 0),
+  start_price_rub_per_ton bigint NOT NULL CHECK (start_price_rub_per_ton >= 0),
+  step_price_rub_per_ton bigint NOT NULL CHECK (step_price_rub_per_ton > 0),
+  region text NOT NULL,
+  address text,
+  status text NOT NULL CHECK (status IN ('DRAFT', 'OPEN', 'BIDDING', 'MATCHED', 'IN_DEAL', 'CLOSED', 'CANCELLED')),
+  auction_ends_at timestamptz NOT NULL,
+  source_type text NOT NULL CHECK (source_type IN ('FGIS', 'ERP', 'MANUAL_VERIFIED', 'OTHER')),
+  source_external_id text,
+  source_certificate_id text,
+  source_verified_at timestamptz,
+  admission_status text NOT NULL DEFAULT 'PENDING' CHECK (admission_status IN ('PENDING', 'REVIEW', 'ADMITTED', 'BLOCKED')),
+  auto_extend_enabled boolean NOT NULL DEFAULT true,
+  auto_extend_window_minutes integer NOT NULL DEFAULT 10 CHECK (auto_extend_window_minutes BETWEEN 0 AND 120),
+  auto_extend_minutes integer NOT NULL DEFAULT 10 CHECK (auto_extend_minutes BETWEEN 0 AND 120),
+  version bigint NOT NULL DEFAULT 1 CHECK (version > 0),
+  created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  CONSTRAINT auction_lots_tenant_id_key UNIQUE (tenant_id, id),
+  CONSTRAINT auction_lots_live_source_check CHECK (
+    status NOT IN ('BIDDING', 'MATCHED', 'IN_DEAL', 'CLOSED')
+    OR (
+      source_external_id IS NOT NULL
+      AND btrim(source_external_id) <> ''
+      AND source_verified_at IS NOT NULL
+      AND admission_status = 'ADMITTED'
+    )
+  )
+);
+
+CREATE TABLE public.auction_bids (
+  id text PRIMARY KEY,
+  tenant_id text NOT NULL,
+  lot_id text NOT NULL,
+  buyer_org_id text NOT NULL,
+  buyer_name text NOT NULL,
+  amount_rub_per_ton bigint NOT NULL CHECK (amount_rub_per_ton > 0),
+  volume_tons numeric(20, 6) NOT NULL CHECK (volume_tons > 0),
+  status text NOT NULL CHECK (status IN ('PLACED', 'LEADING', 'OUTBID', 'ACCEPTED', 'REJECTED', 'CANCELLED', 'WINNING')),
+  placed_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  version bigint NOT NULL DEFAULT 1 CHECK (version > 0),
+  created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  CONSTRAINT auction_bids_tenant_lot_id_key UNIQUE (tenant_id, lot_id, id),
+  CONSTRAINT auction_bids_lot_fkey FOREIGN KEY (tenant_id, lot_id)
+    REFERENCES public.auction_lots (tenant_id, id) ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE public.auction_awards (
+  id text PRIMARY KEY,
+  tenant_id text NOT NULL,
+  lot_id text NOT NULL,
+  winning_bid_id text NOT NULL,
+  deal_id text,
+  status text NOT NULL DEFAULT 'AWARDED' CHECK (status IN ('AWARDED', 'DEAL_CREATED', 'REVOKED')),
+  awarded_by_actor_id text NOT NULL,
+  awarded_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  version bigint NOT NULL DEFAULT 1 CHECK (version > 0),
+  created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+  CONSTRAINT auction_awards_tenant_lot_key UNIQUE (tenant_id, lot_id),
+  CONSTRAINT auction_awards_lot_fkey FOREIGN KEY (tenant_id, lot_id)
+    REFERENCES public.auction_lots (tenant_id, id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT auction_awards_winning_bid_fkey FOREIGN KEY (tenant_id, lot_id, winning_bid_id)
+    REFERENCES public.auction_bids (tenant_id, lot_id, id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT auction_awards_deal_fkey FOREIGN KEY (deal_id)
+    REFERENCES public.deals (id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT auction_awards_deal_state_check CHECK (
+    (status = 'DEAL_CREATED' AND deal_id IS NOT NULL)
+    OR (status <> 'DEAL_CREATED' AND deal_id IS NULL)
+  )
+);
+
+CREATE INDEX auction_lots_tenant_status_idx
+  ON public.auction_lots (tenant_id, status, auction_ends_at DESC, id);
+CREATE INDEX auction_lots_seller_idx
+  ON public.auction_lots (tenant_id, seller_org_id, updated_at DESC);
+CREATE INDEX auction_bids_lot_amount_idx
+  ON public.auction_bids (tenant_id, lot_id, amount_rub_per_ton DESC, placed_at ASC, id);
+CREATE INDEX auction_bids_buyer_idx
+  ON public.auction_bids (tenant_id, buyer_org_id, placed_at DESC);
+CREATE INDEX auction_awards_deal_idx
+  ON public.auction_awards (tenant_id, deal_id);
+
+CREATE OR REPLACE FUNCTION public.app_auction_touch_version()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $function$
+BEGIN
+  NEW.updated_at := transaction_timestamp();
+  NEW.version := OLD.version + 1;
+  RETURN NEW;
+END
+$function$;
+
+CREATE TRIGGER auction_lots_touch_version
+BEFORE UPDATE ON public.auction_lots
+FOR EACH ROW EXECUTE FUNCTION public.app_auction_touch_version();
+
+CREATE TRIGGER auction_bids_touch_version
+BEFORE UPDATE ON public.auction_bids
+FOR EACH ROW EXECUTE FUNCTION public.app_auction_touch_version();
+
+CREATE TRIGGER auction_awards_touch_version
+BEFORE UPDATE ON public.auction_awards
+FOR EACH ROW EXECUTE FUNCTION public.app_auction_touch_version();
+
+CREATE OR REPLACE FUNCTION public.app_auction_bid_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $function$
+DECLARE
+  lot_record public.auction_lots%ROWTYPE;
+BEGIN
+  SELECT * INTO lot_record
+  FROM public.auction_lots
+  WHERE tenant_id = NEW.tenant_id
+    AND id = NEW.lot_id
+  FOR KEY SHARE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'auction lot does not exist in the same tenant' USING ERRCODE = '23503';
+  END IF;
+
+  IF lot_record.status <> 'BIDDING'
+     OR lot_record.admission_status <> 'ADMITTED'
+     OR lot_record.source_verified_at IS NULL
+     OR lot_record.source_external_id IS NULL
+     OR btrim(lot_record.source_external_id) = ''
+  THEN
+    RAISE EXCEPTION 'auction lot is not open for authoritative bidding' USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.volume_tons > lot_record.volume_tons THEN
+    RAISE EXCEPTION 'bid volume exceeds authoritative lot volume' USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END
+$function$;
+
+CREATE TRIGGER auction_bids_authority_guard
+BEFORE INSERT OR UPDATE ON public.auction_bids
+FOR EACH ROW EXECUTE FUNCTION public.app_auction_bid_guard();
+
+CREATE OR REPLACE FUNCTION public.app_auction_award_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $function$
+DECLARE
+  lot_record public.auction_lots%ROWTYPE;
+  bid_status text;
+  deal_tenant_id text;
+  deal_source_lot_id text;
+BEGIN
+  SELECT * INTO lot_record
+  FROM public.auction_lots
+  WHERE tenant_id = NEW.tenant_id
+    AND id = NEW.lot_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'auction lot does not exist in the same tenant' USING ERRCODE = '23503';
+  END IF;
+
+  SELECT status INTO bid_status
+  FROM public.auction_bids
+  WHERE tenant_id = NEW.tenant_id
+    AND lot_id = NEW.lot_id
+    AND id = NEW.winning_bid_id
+  FOR KEY SHARE;
+
+  IF NOT FOUND OR bid_status NOT IN ('ACCEPTED', 'WINNING') THEN
+    RAISE EXCEPTION 'award requires an accepted winning bid from the same tenant and lot' USING ERRCODE = '23514';
+  END IF;
+
+  IF lot_record.status NOT IN ('MATCHED', 'IN_DEAL', 'CLOSED') THEN
+    RAISE EXCEPTION 'award requires a matched authoritative lot' USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.deal_id IS NOT NULL THEN
+    SELECT "tenantId", COALESCE("sourceLotId", "lotId")
+      INTO deal_tenant_id, deal_source_lot_id
+    FROM public.deals
+    WHERE id = NEW.deal_id
+    FOR KEY SHARE;
+
+    IF NOT FOUND
+       OR deal_tenant_id IS DISTINCT FROM NEW.tenant_id
+       OR deal_source_lot_id IS DISTINCT FROM NEW.lot_id
+    THEN
+      RAISE EXCEPTION 'server-issued Deal must match auction tenant and lot' USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END
+$function$;
+
+CREATE TRIGGER auction_awards_authority_guard
+BEFORE INSERT OR UPDATE ON public.auction_awards
+FOR EACH ROW EXECUTE FUNCTION public.app_auction_award_guard();
+
+ALTER TABLE public.auction_lots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.auction_lots FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.auction_bids ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.auction_bids FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.auction_awards ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.auction_awards FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS auction_lots_tenant_select ON public.auction_lots;
+CREATE POLICY auction_lots_tenant_select
+ON public.auction_lots
+FOR SELECT
+USING (
+  NULLIF(current_setting('app.current_tenant_id', true), '') IS NOT NULL
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+
+DROP POLICY IF EXISTS auction_bids_tenant_select ON public.auction_bids;
+CREATE POLICY auction_bids_tenant_select
+ON public.auction_bids
+FOR SELECT
+USING (
+  NULLIF(current_setting('app.current_tenant_id', true), '') IS NOT NULL
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+
+DROP POLICY IF EXISTS auction_awards_tenant_select ON public.auction_awards;
+CREATE POLICY auction_awards_tenant_select
+ON public.auction_awards
+FOR SELECT
+USING (
+  NULLIF(current_setting('app.current_tenant_id', true), '') IS NOT NULL
+  AND tenant_id = current_setting('app.current_tenant_id', true)
+);
+
+DO $auction_authority_grants$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_deal') THEN
+    GRANT SELECT ON public.auction_lots, public.auction_bids, public.auction_awards TO app_deal;
+    GRANT EXECUTE ON FUNCTION public.app_auction_bid_guard() TO app_deal;
+    GRANT EXECUTE ON FUNCTION public.app_auction_award_guard() TO app_deal;
+    GRANT EXECUTE ON FUNCTION public.app_auction_touch_version() TO app_deal;
+  END IF;
+END
+$auction_authority_grants$;

--- a/apps/api/prisma/migrations/20260713211000_auction_single_winner_guard/migration.sql
+++ b/apps/api/prisma/migrations/20260713211000_auction_single_winner_guard/migration.sql
@@ -1,0 +1,5 @@
+-- A lot can have at most one persisted accepted/winning bid. The application read
+-- model treats any winner without a matching award as contradictory and fails closed.
+CREATE UNIQUE INDEX auction_bids_single_winner_idx
+ON public.auction_bids (tenant_id, lot_id)
+WHERE status IN ('ACCEPTED', 'WINNING');

--- a/apps/api/prisma/migrations/20260713211000_auction_single_winner_guard/migration.sql
+++ b/apps/api/prisma/migrations/20260713211000_auction_single_winner_guard/migration.sql
@@ -1,5 +1,5 @@
 -- A lot can have at most one persisted accepted/winning bid. The application read
 -- model treats any winner without a matching award as contradictory and fails closed.
 CREATE UNIQUE INDEX auction_bids_single_winner_idx
-ON public.auction_bids (tenant_id, lot_id)
+ON auction.bids (tenant_id, lot_id)
 WHERE status IN ('ACCEPTED', 'WINNING');

--- a/apps/api/src/modules/auctions/auction-authority.service.ts
+++ b/apps/api/src/modules/auctions/auction-authority.service.ts
@@ -1,0 +1,577 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import {
+  RlsTransactionService,
+  type TrustedRlsContext,
+} from '../../common/prisma/rls-transaction.service';
+import { Role, type RequestUser } from '../../common/types/request-user';
+
+const LOT_ID_PATTERN = /^[^\u0000-\u001F\u007F]{1,200}$/;
+const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const LOT_PAGE_LIMIT = 500;
+
+type DatabaseClockRow = Readonly<{
+  observed_at: Date;
+  tx_id: bigint;
+  database_name: string;
+}>;
+
+type AuctionLotRow = Readonly<{
+  id: string;
+  tenant_id: string;
+  seller_org_id: string;
+  title: string;
+  culture: string;
+  grade: string | null;
+  volume_tons: string;
+  start_price_rub_per_ton: string;
+  step_price_rub_per_ton: string;
+  region: string;
+  address: string | null;
+  status: string;
+  auction_ends_at: Date;
+  source_type: string;
+  source_external_id: string | null;
+  source_certificate_id: string | null;
+  source_verified_at: Date | null;
+  admission_status: string;
+  auto_extend_enabled: boolean;
+  auto_extend_window_minutes: number;
+  auto_extend_minutes: number;
+  version: bigint;
+  updated_at: Date;
+}>;
+
+type AuctionBidRow = Readonly<{
+  id: string;
+  buyer_org_id: string;
+  buyer_name: string;
+  amount_rub_per_ton: string;
+  status: string;
+  version: bigint;
+}>;
+
+type AuctionBidSummaryRow = Readonly<{
+  active_count: bigint;
+  winner_count: bigint;
+  max_version: bigint | null;
+}>;
+
+type AuctionAwardRow = Readonly<{
+  id: string;
+  winning_bid_id: string;
+  deal_id: string | null;
+  award_status: string;
+  award_version: bigint;
+  deal_exists: string | null;
+  deal_tenant_id: string | null;
+  deal_source_lot_id: string | null;
+  deal_version: bigint | null;
+}>;
+
+type OriginModeRow = Readonly<{
+  source_type: string;
+  lot_count: bigint;
+  version: bigint;
+}>;
+
+type AuctionAuthorityProof = Readonly<{
+  source: 'POSTGRESQL';
+  scope: 'AUCTION';
+  tenantId: string;
+  actorId: string;
+  observedAt: string;
+  version: number;
+  transactionId: string;
+  database: string;
+}>;
+
+@Injectable()
+export class AuctionAuthorityService {
+  constructor(private readonly rls: RlsTransactionService) {}
+
+  async listAccessibleLots(user: RequestUser) {
+    return this.rls.withTrustedContext(user, async (tx, context) => {
+      const clock = await readDatabaseClock(tx);
+      const scope = lotVisibilityScope(user, context);
+      const rows = await tx.$queryRaw<AuctionLotRow[]>(Prisma.sql`
+        SELECT
+          l.id,
+          l.tenant_id,
+          l.seller_org_id,
+          l.title,
+          l.culture,
+          l.grade,
+          l.volume_tons::text AS volume_tons,
+          l.start_price_rub_per_ton::text AS start_price_rub_per_ton,
+          l.step_price_rub_per_ton::text AS step_price_rub_per_ton,
+          l.region,
+          l.address,
+          l.status,
+          l.auction_ends_at,
+          l.source_type,
+          l.source_external_id,
+          l.source_certificate_id,
+          l.source_verified_at,
+          l.admission_status,
+          l.auto_extend_enabled,
+          l.auto_extend_window_minutes,
+          l.auto_extend_minutes,
+          l.version,
+          l.updated_at
+        FROM public.auction_lots l
+        WHERE l.tenant_id = ${context.tenantId}
+          AND (${scope})
+        ORDER BY l.updated_at DESC, l.id ASC
+        LIMIT ${LOT_PAGE_LIMIT + 1}
+      `);
+      const hasMore = rows.length > LOT_PAGE_LIMIT;
+      const page = rows.slice(0, LOT_PAGE_LIMIT);
+
+      return {
+        authority: authorityProof(context, clock, page.map((row) => row.version)),
+        items: page.map(toAccessibleLot),
+        pageInfo: {
+          limit: LOT_PAGE_LIMIT,
+          returned: page.length,
+          hasMore,
+        },
+      };
+    });
+  }
+
+  async listOriginModes(user: RequestUser) {
+    return this.rls.withTrustedContext(user, async (tx, context) => {
+      const clock = await readDatabaseClock(tx);
+      const scope = lotVisibilityScope(user, context);
+      const rows = await tx.$queryRaw<OriginModeRow[]>(Prisma.sql`
+        SELECT
+          l.source_type,
+          count(*)::bigint AS lot_count,
+          max(l.version)::bigint AS version
+        FROM public.auction_lots l
+        WHERE l.tenant_id = ${context.tenantId}
+          AND (${scope})
+        GROUP BY l.source_type
+        ORDER BY l.source_type ASC
+      `);
+
+      return {
+        authority: authorityProof(context, clock, rows.map((row) => row.version)),
+        items: rows.map((row) => ({
+          id: row.source_type,
+          title: row.source_type,
+          description: 'Server-persisted auction lot source',
+          nextStep: null,
+          lotCount: safeInteger(row.lot_count, 'origin lot count'),
+        })),
+      };
+    });
+  }
+
+  async getWorkspace(lotIdInput: string, user: RequestUser) {
+    const lotId = normalizeLotId(lotIdInput);
+
+    return this.rls.withTrustedContext(user, async (tx, context) => {
+      const clock = await readDatabaseClock(tx);
+      const scope = lotVisibilityScope(user, context);
+      const lots = await tx.$queryRaw<AuctionLotRow[]>(Prisma.sql`
+        SELECT
+          l.id,
+          l.tenant_id,
+          l.seller_org_id,
+          l.title,
+          l.culture,
+          l.grade,
+          l.volume_tons::text AS volume_tons,
+          l.start_price_rub_per_ton::text AS start_price_rub_per_ton,
+          l.step_price_rub_per_ton::text AS step_price_rub_per_ton,
+          l.region,
+          l.address,
+          l.status,
+          l.auction_ends_at,
+          l.source_type,
+          l.source_external_id,
+          l.source_certificate_id,
+          l.source_verified_at,
+          l.admission_status,
+          l.auto_extend_enabled,
+          l.auto_extend_window_minutes,
+          l.auto_extend_minutes,
+          l.version,
+          l.updated_at
+        FROM public.auction_lots l
+        WHERE l.tenant_id = ${context.tenantId}
+          AND l.id = ${lotId}
+          AND (${scope})
+        LIMIT 1
+      `);
+      const lot = lots[0];
+      if (!lot) {
+        throw new NotFoundException({ code: 'AUCTION_LOT_NOT_ACCESSIBLE' });
+      }
+
+      const awards = await tx.$queryRaw<AuctionAwardRow[]>(Prisma.sql`
+        SELECT
+          a.id,
+          a.winning_bid_id,
+          a.deal_id,
+          a.status AS award_status,
+          a.version AS award_version,
+          d.id AS deal_exists,
+          d."tenantId" AS deal_tenant_id,
+          COALESCE(d."sourceLotId", d."lotId") AS deal_source_lot_id,
+          d.version AS deal_version
+        FROM public.auction_awards a
+        LEFT JOIN public.deals d ON d.id = a.deal_id
+        WHERE a.tenant_id = ${context.tenantId}
+          AND a.lot_id = ${lotId}
+          AND a.status <> 'REVOKED'
+        LIMIT 1
+      `);
+      const award = awards[0] ?? null;
+
+      const summaries = await tx.$queryRaw<AuctionBidSummaryRow[]>(Prisma.sql`
+        SELECT
+          count(*) FILTER (
+            WHERE b.status NOT IN ('REJECTED', 'CANCELLED')
+          )::bigint AS active_count,
+          count(*) FILTER (
+            WHERE b.status IN ('WINNING', 'ACCEPTED')
+          )::bigint AS winner_count,
+          max(b.version) FILTER (
+            WHERE b.status NOT IN ('REJECTED', 'CANCELLED')
+          )::bigint AS max_version
+        FROM public.auction_bids b
+        WHERE b.tenant_id = ${context.tenantId}
+          AND b.lot_id = ${lotId}
+      `);
+      const summary = summaries[0];
+      if (!summary) {
+        throw new InternalServerErrorException({ code: 'AUCTION_BID_SUMMARY_UNAVAILABLE' });
+      }
+      const bidCount = safeInteger(summary.active_count, 'auction bid count');
+      const winnerCount = safeInteger(summary.winner_count, 'auction winner count');
+
+      const selectedBidFilter = award
+        ? Prisma.sql`AND b.id = ${award.winning_bid_id}`
+        : Prisma.empty;
+      const selectedBids = await tx.$queryRaw<AuctionBidRow[]>(Prisma.sql`
+        SELECT
+          b.id,
+          b.buyer_org_id,
+          b.buyer_name,
+          b.amount_rub_per_ton::text AS amount_rub_per_ton,
+          b.status,
+          b.version
+        FROM public.auction_bids b
+        WHERE b.tenant_id = ${context.tenantId}
+          AND b.lot_id = ${lotId}
+          AND b.status NOT IN ('REJECTED', 'CANCELLED')
+          ${selectedBidFilter}
+        ORDER BY b.amount_rub_per_ton DESC, b.placed_at ASC, b.id ASC
+        LIMIT 1
+      `);
+      const bestBid = selectedBids[0] ?? null;
+
+      assertPersistedAuctionConsistency(
+        lot,
+        bidCount,
+        winnerCount,
+        bestBid,
+        award,
+        context,
+      );
+
+      const dealCreated = Boolean(
+        award?.deal_id
+          && award.award_status === 'DEAL_CREATED'
+          && award.deal_exists
+          && award.deal_tenant_id === context.tenantId
+          && award.deal_source_lot_id === lot.id,
+      );
+      const observedAt = clock.observed_at;
+      const blockers = workspaceBlockers(lot, award, dealCreated, observedAt);
+      const liveStatus = lot.status === 'OPEN' || lot.status === 'BIDDING';
+      const readyForLive = liveStatus
+        && lot.auction_ends_at.getTime() > observedAt.getTime()
+        && blockers.length === 0;
+      const minutesToEnd = Math.max(
+        0,
+        Math.floor((lot.auction_ends_at.getTime() - observedAt.getTime()) / 60_000),
+      );
+      const nextRequiredMilestones = requiredMilestones(lot, bidCount, award, dealCreated);
+      const versions = [
+        lot.version,
+        summary.max_version,
+        award?.award_version,
+        award?.deal_version,
+      ].filter((value): value is bigint => typeof value === 'bigint');
+
+      return {
+        authority: authorityProof(context, clock, versions),
+        workspace: {
+          lotId: lot.id,
+          title: lot.title,
+          lotStatus: lot.status,
+          originMode: {
+            id: lot.source_type,
+            title: lot.source_type,
+            description: lot.source_verified_at
+              ? 'Source verified and persisted by the server'
+              : 'Source verification is required',
+            nextStep: originNextStep(lot),
+          },
+          readiness: {
+            score: Math.max(0, 100 - blockers.length * 20),
+            band: blockers.length === 0
+              ? (readyForLive ? 'READY' : 'COMPLETE')
+              : blockers.length <= 2
+                ? 'REVIEW'
+                : 'BLOCKED',
+            blockers,
+            readyForLive,
+            bestBid: bestBid ? finiteNumber(bestBid.amount_rub_per_ton, 'best bid') : null,
+            nextAction: nextAction(lot, bidCount, award, dealCreated),
+          },
+          timer: {
+            auctionEndsAt: lot.auction_ends_at.toISOString(),
+            minutesToEnd,
+            shouldAutoExtend: Boolean(
+              readyForLive
+                && lot.auto_extend_enabled
+                && minutesToEnd <= lot.auto_extend_window_minutes,
+            ),
+            autoExtendMinutes: lot.auto_extend_minutes,
+          },
+          bestBid: bestBid
+            ? {
+                id: bestBid.id,
+                amount: finiteNumber(bestBid.amount_rub_per_ton, 'best bid'),
+                buyerName: bestBid.buyer_name,
+                buyerOrgId: bestBid.buyer_org_id,
+                status: bestBid.status,
+              }
+            : null,
+          bidCount,
+          executionBridge: {
+            dealCreated,
+            dealId: dealCreated ? award?.deal_id ?? null : null,
+            nextRequiredMilestones,
+          },
+        },
+      };
+    });
+  }
+}
+
+function normalizeLotId(value: string): string {
+  const normalized = value?.trim();
+  if (!normalized || !LOT_ID_PATTERN.test(normalized)) {
+    throw new BadRequestException({ code: 'INVALID_AUCTION_LOT_ID' });
+  }
+  return normalized;
+}
+
+function lotVisibilityScope(user: RequestUser, context: TrustedRlsContext): Prisma.Sql {
+  switch (user.role) {
+    case Role.FARMER:
+      return Prisma.sql`l.seller_org_id = ${context.orgId}`;
+    case Role.BUYER:
+      return Prisma.sql`l.status IN ('OPEN', 'BIDDING', 'MATCHED', 'IN_DEAL')`;
+    case Role.SUPPORT_MANAGER:
+    case Role.ADMIN:
+    case Role.COMPLIANCE_OFFICER:
+    case Role.EXECUTIVE:
+      return Prisma.sql`TRUE`;
+    default:
+      return Prisma.sql`FALSE`;
+  }
+}
+
+async function readDatabaseClock(
+  tx: Prisma.TransactionClient,
+): Promise<DatabaseClockRow> {
+  const rows = await tx.$queryRaw<DatabaseClockRow[]>(Prisma.sql`
+    SELECT
+      transaction_timestamp() AS observed_at,
+      txid_current() AS tx_id,
+      current_database() AS database_name
+  `);
+  const row = rows[0];
+  if (!row?.observed_at || typeof row.database_name !== 'string') {
+    throw new InternalServerErrorException({ code: 'AUCTION_POSTGRESQL_CLOCK_UNAVAILABLE' });
+  }
+  return row;
+}
+
+function authorityProof(
+  context: TrustedRlsContext,
+  clock: DatabaseClockRow,
+  versions: readonly bigint[],
+): AuctionAuthorityProof {
+  const version = versions.length > 0
+    ? Math.max(...versions.map((value) => safeVersion(value)))
+    : 1;
+  return Object.freeze({
+    source: 'POSTGRESQL',
+    scope: 'AUCTION',
+    tenantId: context.tenantId,
+    actorId: context.userId,
+    observedAt: clock.observed_at.toISOString(),
+    version,
+    transactionId: clock.tx_id.toString(),
+    database: clock.database_name,
+  });
+}
+
+function toAccessibleLot(row: AuctionLotRow) {
+  return {
+    id: row.id,
+    title: row.title,
+    culture: row.culture,
+    grade: row.grade,
+    volumeTons: finiteNumber(row.volume_tons, 'lot volume'),
+    startPrice: finiteNumber(row.start_price_rub_per_ton, 'lot start price'),
+    stepPrice: finiteNumber(row.step_price_rub_per_ton, 'lot price step'),
+    region: row.region,
+    address: row.address,
+    status: row.status,
+    auctionEndsAt: row.auction_ends_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+}
+
+function workspaceBlockers(
+  lot: AuctionLotRow,
+  award: AuctionAwardRow | null,
+  dealCreated: boolean,
+  observedAt: Date,
+): string[] {
+  const blockers: string[] = [];
+  if (!lot.source_external_id?.trim()) blockers.push('source_external_id_required');
+  if (!lot.source_verified_at) blockers.push('source_verification_required');
+  if (lot.admission_status !== 'ADMITTED') {
+    blockers.push(`admission_${lot.admission_status.toLowerCase()}`);
+  }
+  if (lot.status === 'DRAFT' || lot.status === 'CANCELLED') {
+    blockers.push(`lot_status_${lot.status.toLowerCase()}`);
+  }
+  if (
+    (lot.status === 'OPEN' || lot.status === 'BIDDING')
+    && lot.auction_ends_at.getTime() <= observedAt.getTime()
+  ) {
+    blockers.push('auction_window_closed');
+  }
+  if (lot.status === 'MATCHED' || lot.status === 'IN_DEAL' || lot.status === 'CLOSED') {
+    if (!award) blockers.push('server_award_required');
+    else if (!dealCreated) blockers.push('server_deal_creation_pending');
+  }
+  return blockers;
+}
+
+function requiredMilestones(
+  lot: AuctionLotRow,
+  bidCount: number,
+  award: AuctionAwardRow | null,
+  dealCreated: boolean,
+): string[] {
+  const milestones: string[] = [];
+  if (!lot.source_external_id?.trim() || !lot.source_verified_at) milestones.push('verify_lot_source');
+  if (lot.admission_status !== 'ADMITTED') milestones.push('complete_admission');
+  if (bidCount === 0) milestones.push('receive_server_bid');
+  if (bidCount > 0 && !award) milestones.push('issue_server_award');
+  if (award && !dealCreated) milestones.push('create_canonical_deal');
+  return milestones;
+}
+
+function originNextStep(lot: AuctionLotRow): string | null {
+  if (!lot.source_external_id?.trim() || !lot.source_verified_at) return 'VERIFY_SOURCE';
+  if (lot.admission_status !== 'ADMITTED') return 'COMPLETE_ADMISSION';
+  return null;
+}
+
+function nextAction(
+  lot: AuctionLotRow,
+  bidCount: number,
+  award: AuctionAwardRow | null,
+  dealCreated: boolean,
+): string {
+  if (!lot.source_external_id?.trim() || !lot.source_verified_at) return 'VERIFY_SOURCE';
+  if (lot.admission_status !== 'ADMITTED') return 'COMPLETE_ADMISSION';
+  if (dealCreated) return 'OPEN_CANONICAL_DEAL';
+  if (award) return 'CREATE_CANONICAL_DEAL_SERVER_SIDE';
+  if (bidCount > 0) return 'WAIT_FOR_SERVER_AWARD';
+  if (lot.status === 'OPEN' || lot.status === 'BIDDING') return 'WAIT_FOR_SERVER_BIDS';
+  return 'REVIEW_AUCTION_STATE';
+}
+
+function assertPersistedAuctionConsistency(
+  lot: AuctionLotRow,
+  bidCount: number,
+  winnerCount: number,
+  bestBid: AuctionBidRow | null,
+  award: AuctionAwardRow | null,
+  context: TrustedRlsContext,
+): void {
+  if (lot.tenant_id !== context.tenantId) {
+    throw new InternalServerErrorException({ code: 'AUCTION_TENANT_AUTHORITY_MISMATCH' });
+  }
+  if ((bidCount === 0) !== (bestBid === null)) {
+    throw new InternalServerErrorException({ code: 'AUCTION_BID_AGGREGATE_MISMATCH' });
+  }
+  if (!award && winnerCount > 0) {
+    throw new InternalServerErrorException({ code: 'AUCTION_WINNER_WITHOUT_AWARD' });
+  }
+  if (award) {
+    if (
+      !bestBid
+      || bestBid.id !== award.winning_bid_id
+      || !['WINNING', 'ACCEPTED'].includes(bestBid.status)
+      || winnerCount !== 1
+    ) {
+      throw new InternalServerErrorException({ code: 'AUCTION_AWARD_BID_MISMATCH' });
+    }
+    if (!['MATCHED', 'IN_DEAL', 'CLOSED'].includes(lot.status)) {
+      throw new InternalServerErrorException({ code: 'AUCTION_AWARD_LOT_STATE_MISMATCH' });
+    }
+    if (
+      award.deal_id
+      && (
+        award.award_status !== 'DEAL_CREATED'
+        || award.deal_tenant_id !== context.tenantId
+        || award.deal_source_lot_id !== lot.id
+        || !award.deal_exists
+      )
+    ) {
+      throw new InternalServerErrorException({ code: 'AUCTION_DEAL_AUTHORITY_MISMATCH' });
+    }
+  }
+}
+
+function finiteNumber(value: string, field: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || Math.abs(parsed) > Number.MAX_SAFE_INTEGER) {
+    throw new InternalServerErrorException({ code: 'AUCTION_NUMERIC_OUT_OF_RANGE', field });
+  }
+  return parsed;
+}
+
+function safeVersion(value: bigint): number {
+  if (value < 1n || value > MAX_SAFE_BIGINT) {
+    throw new InternalServerErrorException({ code: 'AUCTION_VERSION_OUT_OF_RANGE' });
+  }
+  return Number(value);
+}
+
+function safeInteger(value: bigint, field: string): number {
+  if (value < 0n || value > MAX_SAFE_BIGINT) {
+    throw new InternalServerErrorException({ code: 'AUCTION_INTEGER_OUT_OF_RANGE', field });
+  }
+  return Number(value);
+}

--- a/apps/api/src/modules/auctions/auction-authority.service.ts
+++ b/apps/api/src/modules/auctions/auction-authority.service.ts
@@ -124,7 +124,7 @@ export class AuctionAuthorityService {
           l.auto_extend_minutes,
           l.version,
           l.updated_at
-        FROM public.auction_lots l
+        FROM auction.lots l
         WHERE l.tenant_id = ${context.tenantId}
           AND (${scope})
         ORDER BY l.updated_at DESC, l.id ASC
@@ -154,7 +154,7 @@ export class AuctionAuthorityService {
           l.source_type,
           count(*)::bigint AS lot_count,
           max(l.version)::bigint AS version
-        FROM public.auction_lots l
+        FROM auction.lots l
         WHERE l.tenant_id = ${context.tenantId}
           AND (${scope})
         GROUP BY l.source_type
@@ -205,7 +205,7 @@ export class AuctionAuthorityService {
           l.auto_extend_minutes,
           l.version,
           l.updated_at
-        FROM public.auction_lots l
+        FROM auction.lots l
         WHERE l.tenant_id = ${context.tenantId}
           AND l.id = ${lotId}
           AND (${scope})
@@ -227,7 +227,7 @@ export class AuctionAuthorityService {
           d."tenantId" AS deal_tenant_id,
           COALESCE(d."sourceLotId", d."lotId") AS deal_source_lot_id,
           d.version AS deal_version
-        FROM public.auction_awards a
+        FROM auction.awards a
         LEFT JOIN public.deals d ON d.id = a.deal_id
         WHERE a.tenant_id = ${context.tenantId}
           AND a.lot_id = ${lotId}
@@ -247,7 +247,7 @@ export class AuctionAuthorityService {
           max(b.version) FILTER (
             WHERE b.status NOT IN ('REJECTED', 'CANCELLED')
           )::bigint AS max_version
-        FROM public.auction_bids b
+        FROM auction.bids b
         WHERE b.tenant_id = ${context.tenantId}
           AND b.lot_id = ${lotId}
       `);
@@ -269,7 +269,7 @@ export class AuctionAuthorityService {
           b.amount_rub_per_ton::text AS amount_rub_per_ton,
           b.status,
           b.version
-        FROM public.auction_bids b
+        FROM auction.bids b
         WHERE b.tenant_id = ${context.tenantId}
           AND b.lot_id = ${lotId}
           AND b.status NOT IN ('REJECTED', 'CANCELLED')

--- a/apps/api/src/modules/auctions/auction-postgresql-authority.spec.ts
+++ b/apps/api/src/modules/auctions/auction-postgresql-authority.spec.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '../../../../..');
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+const migrationPath =
+  'apps/api/prisma/migrations/20260713210000_auction_postgresql_authority/migration.sql';
+const servicePath = 'apps/api/src/modules/auctions/auction-authority.service.ts';
+const controllerPath = 'apps/api/src/modules/auctions/auctions.controller.ts';
+const lotsControllerPath = 'apps/api/src/modules/lots/lots.controller.ts';
+
+describe('auction PostgreSQL authority', () => {
+  it('creates no hard-coded auction or Deal facts', () => {
+    const implementation = [read(migrationPath), read(servicePath)].join('\n');
+
+    expect(implementation).not.toMatch(/INSERT\s+INTO\s+public\.auction_/i);
+    expect(implementation).not.toContain('LOT-001');
+    expect(implementation).not.toContain('BID-001');
+    expect(implementation).not.toContain('DL-2607-014');
+    expect(implementation).not.toContain('FGIS-LOT-2607-014');
+    expect(implementation).not.toContain('Math.random');
+    expect(implementation).not.toContain('Date.now');
+  });
+
+  it('enforces tenant FORCE-RLS for every auction authority table', () => {
+    const migration = read(migrationPath);
+
+    for (const table of ['auction_lots', 'auction_bids', 'auction_awards']) {
+      expect(migration).toContain(`ALTER TABLE public.${table} ENABLE ROW LEVEL SECURITY`);
+      expect(migration).toContain(`ALTER TABLE public.${table} FORCE ROW LEVEL SECURITY`);
+      expect(migration).toContain(`ON public.${table}\nFOR SELECT`);
+    }
+    expect(migration).toContain("current_setting('app.current_tenant_id', true)");
+    expect(migration).not.toMatch(/CREATE\s+POLICY[\s\S]+FOR\s+(?:INSERT|UPDATE|DELETE|ALL)/i);
+  });
+
+  it('binds lot, bid, award and server-issued Deal to one tenant and lot', () => {
+    const migration = read(migrationPath);
+
+    expect(migration).toContain('FOREIGN KEY (tenant_id, lot_id)');
+    expect(migration).toContain('FOREIGN KEY (tenant_id, lot_id, winning_bid_id)');
+    expect(migration).toContain('server-issued Deal must match auction tenant and lot');
+    expect(migration).toContain('deal_tenant_id IS DISTINCT FROM NEW.tenant_id');
+    expect(migration).toContain('deal_source_lot_id IS DISTINCT FROM NEW.lot_id');
+    expect(migration).toContain("bid_status NOT IN ('ACCEPTED', 'WINNING')");
+  });
+
+  it('uses a trusted PostgreSQL transaction to issue the authority proof', () => {
+    const service = read(servicePath);
+
+    expect(service).toContain('this.rls.withTrustedContext');
+    expect(service).toContain("source: 'POSTGRESQL'");
+    expect(service).toContain("scope: 'AUCTION'");
+    expect(service).toContain('transaction_timestamp() AS observed_at');
+    expect(service).toContain('txid_current() AS tx_id');
+    expect(service).toContain('current_database() AS database_name');
+    expect(service).toContain('tenantId: context.tenantId');
+    expect(service).toContain('actorId: context.userId');
+  });
+
+  it('exposes only read endpoints and does not create bids, awards or Deals', () => {
+    const controller = read(controllerPath);
+
+    expect(controller).toContain("@Get('origin-modes')");
+    expect(controller).toContain("@Get('lots/:lotId/workspace')");
+    expect(controller).not.toMatch(/@(Post|Patch|Put|Delete)\(/);
+    expect(controller).not.toContain('createDeal');
+    expect(controller).not.toContain('selectWinner');
+  });
+
+  it('replaces the authenticated lot registry with the PostgreSQL authority envelope', () => {
+    const controller = read(lotsControllerPath);
+
+    expect(controller).toContain("@Get('my')");
+    expect(controller).toContain('this.auctionAuthority.listAccessibleLots(user)');
+    expect(controller).not.toMatch(/my\([^)]*\)[\s\S]{0,120}this\.lots\.list/);
+  });
+
+  it('fails closed on contradictory award and Deal state', () => {
+    const service = read(servicePath);
+
+    expect(service).toContain('AUCTION_WINNER_WITHOUT_AWARD');
+    expect(service).toContain('AUCTION_AWARD_BID_MISMATCH');
+    expect(service).toContain('AUCTION_AWARD_LOT_STATE_MISMATCH');
+    expect(service).toContain('AUCTION_DEAL_AUTHORITY_MISMATCH');
+    expect(service).toContain("award.award_status === 'DEAL_CREATED'");
+    expect(service).toContain('award.deal_source_lot_id === lot.id');
+  });
+});

--- a/apps/api/src/modules/auctions/auction-postgresql-authority.spec.ts
+++ b/apps/api/src/modules/auctions/auction-postgresql-authority.spec.ts
@@ -17,7 +17,7 @@ describe('auction PostgreSQL authority', () => {
   it('creates no hard-coded auction or Deal facts', () => {
     const implementation = [read(migrationPath), read(servicePath)].join('\n');
 
-    expect(implementation).not.toMatch(/INSERT\s+INTO\s+public\.auction_/i);
+    expect(implementation).not.toMatch(/INSERT\s+INTO\s+auction\./i);
     expect(implementation).not.toContain('LOT-001');
     expect(implementation).not.toContain('BID-001');
     expect(implementation).not.toContain('DL-2607-014');
@@ -26,13 +26,16 @@ describe('auction PostgreSQL authority', () => {
     expect(implementation).not.toContain('Date.now');
   });
 
-  it('enforces tenant FORCE-RLS for every auction authority table', () => {
+  it('isolates the bounded context and enforces tenant FORCE-RLS on every authority table', () => {
     const migration = read(migrationPath);
 
-    for (const table of ['auction_lots', 'auction_bids', 'auction_awards']) {
-      expect(migration).toContain(`ALTER TABLE public.${table} ENABLE ROW LEVEL SECURITY`);
-      expect(migration).toContain(`ALTER TABLE public.${table} FORCE ROW LEVEL SECURITY`);
-      expect(migration).toContain(`ON public.${table}\nFOR SELECT`);
+    expect(migration).toContain('CREATE SCHEMA IF NOT EXISTS auction');
+    expect(migration).toContain('REVOKE ALL ON SCHEMA auction FROM PUBLIC');
+    expect(migration).toContain('GRANT USAGE ON SCHEMA auction TO app_deal');
+    for (const table of ['lots', 'bids', 'awards']) {
+      expect(migration).toContain(`ALTER TABLE auction.${table} ENABLE ROW LEVEL SECURITY`);
+      expect(migration).toContain(`ALTER TABLE auction.${table} FORCE ROW LEVEL SECURITY`);
+      expect(migration).toContain(`ON auction.${table}\nFOR SELECT`);
     }
     expect(migration).toContain("current_setting('app.current_tenant_id', true)");
     expect(migration).not.toMatch(/CREATE\s+POLICY[\s\S]+FOR\s+(?:INSERT|UPDATE|DELETE|ALL)/i);
@@ -60,6 +63,9 @@ describe('auction PostgreSQL authority', () => {
     expect(service).toContain('current_database() AS database_name');
     expect(service).toContain('tenantId: context.tenantId');
     expect(service).toContain('actorId: context.userId');
+    expect(service).toContain('FROM auction.lots l');
+    expect(service).toContain('FROM auction.bids b');
+    expect(service).toContain('FROM auction.awards a');
   });
 
   it('exposes only read endpoints and does not create bids, awards or Deals', () => {

--- a/apps/api/src/modules/auctions/auctions.controller.ts
+++ b/apps/api/src/modules/auctions/auctions.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import type { RequestUser } from '../../common/types/request-user';
+import { AuctionAuthorityService } from './auction-authority.service';
+
+@UseGuards(RolesGuard)
+@Roles('FARMER', 'BUYER', 'SUPPORT_MANAGER', 'ADMIN', 'COMPLIANCE_OFFICER', 'EXECUTIVE')
+@Controller('auctions')
+export class AuctionsController {
+  constructor(private readonly authority: AuctionAuthorityService) {}
+
+  @Get('origin-modes')
+  originModes(@CurrentUser() user: RequestUser) {
+    return this.authority.listOriginModes(user);
+  }
+
+  @Get('lots/:lotId/workspace')
+  workspace(
+    @Param('lotId') lotId: string,
+    @CurrentUser() user: RequestUser,
+  ) {
+    return this.authority.getWorkspace(lotId, user);
+  }
+}

--- a/apps/api/src/modules/auctions/auctions.module.ts
+++ b/apps/api/src/modules/auctions/auctions.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuctionAuthorityService } from './auction-authority.service';
+import { AuctionsController } from './auctions.controller';
+
+@Module({
+  controllers: [AuctionsController],
+  providers: [AuctionAuthorityService],
+  exports: [AuctionAuthorityService],
+})
+export class AuctionsModule {}

--- a/apps/api/src/modules/lots/lots.controller.ts
+++ b/apps/api/src/modules/lots/lots.controller.ts
@@ -4,6 +4,8 @@ import { UseGuards } from '@nestjs/common';
 import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { Public } from '../../common/decorators/public.decorator';
+import type { RequestUser } from '../../common/types/request-user';
+import { AuctionAuthorityService } from '../auctions/auction-authority.service';
 import { LotsService } from './lots.service';
 import { CreateLotDto } from './dto/create-lot.dto';
 
@@ -11,7 +13,10 @@ import { CreateLotDto } from './dto/create-lot.dto';
 @Roles('FARMER', 'BUYER', 'SUPPORT_MANAGER')
 @Controller('lots')
 export class LotsController {
-  constructor(private readonly lots: LotsService) {}
+  constructor(
+    private readonly lots: LotsService,
+    private readonly auctionAuthority: AuctionAuthorityService,
+  ) {}
 
   @Public()
   @Get()
@@ -31,9 +36,10 @@ export class LotsController {
     return this.lots.getReport(id, user);
   }
 
+  @Roles('FARMER', 'BUYER', 'SUPPORT_MANAGER', 'ADMIN', 'COMPLIANCE_OFFICER', 'EXECUTIVE')
   @Get('my')
-  my(@CurrentUser() user: any) {
-    return this.lots.list(user);
+  my(@CurrentUser() user: RequestUser) {
+    return this.auctionAuthority.listAccessibleLots(user);
   }
 
   @Post()

--- a/apps/api/src/modules/lots/lots.module.ts
+++ b/apps/api/src/modules/lots/lots.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { AccessScopeService } from '../../common/security/access.service';
 import { ObjectPolicyService } from '../../common/security/object-policy.service';
 import { AuditModule } from '../audit/audit.module';
+import { AuctionsModule } from '../auctions/auctions.module';
 import { SearchModule } from '../search/search.module';
 import { LotsController } from './lots.controller';
 import { LotsService } from './lots.service';
 
 @Module({
-  imports: [AuditModule, SearchModule],
+  imports: [AuditModule, SearchModule, AuctionsModule],
   controllers: [LotsController],
   providers: [LotsService, AccessScopeService, ObjectPolicyService],
   exports: [LotsService]


### PR DESCRIPTION
## What changed

- added a dedicated PostgreSQL `auction` bounded schema for lots, bids and awards without seed data;
- added tenant FORCE-RLS, explicit schema grants and SELECT-only application access;
- added database constraints and triggers binding lot, single winning bid, award and server-issued Deal to the same tenant and lot;
- added `GET /auctions/origin-modes` and `GET /auctions/lots/:lotId/workspace`;
- switched authenticated `GET /lots/my` from the process-memory lot store to the PostgreSQL authority envelope;
- added strict contradiction checks and auction authority regressions;
- kept workspace reads scalable by using PostgreSQL aggregates plus one authoritative best/winning bid;
- extended CodeQL and Qodana path coverage to `apps/api/**` so API authority changes receive exact-head analysis.

## Dependency already in main

PR #2470 is merged at `3b33097623acfd664132d57d3ac92c2ed4f059e1`. The Design System v8 auction UI is read-only, uses one `AuctionPostgresAuthorityWorkspace`, and fails closed without the endpoints supplied by this PR.

## Safety boundary

- no fixture lots, bids, winners, prices or Deals;
- no live FGIS claim;
- no bid placement, cancellation, winner selection or Deal creation endpoint;
- no application INSERT/UPDATE/DELETE policy for auction tables;
- tenant and actor come from trusted session/RLS context;
- incompatible winner, award or Deal envelopes fail closed;
- Deal linkage is exposed only when a persisted award references a canonical Deal with matching `tenantId` and source `lotId`.

## Exact-head validation

Verified head: `b51717a90af6a62af3ebcb06170c07d6b6b7bf81`

Green on the exact head:

- Node CI: typecheck, tests and build;
- web-unit and production web build;
- 12 roles / 19 commands / PostgreSQL RLS / DR restore;
- industrial core / races / outbox / reconciliation / load proof;
- persistent sessions / rotation / MFA / revoke and Prisma drift proof;
- Security Scan;
- Security Quality Gate;
- Dependency Review;
- CodeQL report;
- Qodana report.

The implementation proves PostgreSQL-authoritative read envelopes and fail-closed UI integration. It does not prove live FGIS connectivity, live bid/award processing or production-scale auction traffic.