### PR TITLE
Retry serializable PostgreSQL conflicts in industrial core

### DIFF
--- a/apps/api/src/common/prisma/rls-transaction.service.spec.ts
+++ b/apps/api/src/common/prisma/rls-transaction.service.spec.ts
@@ -7,6 +7,7 @@ import { Role } from '../types/request-user';
 import { PrismaService } from './prisma.service';
 import {
   deriveTrustedRlsContext,
+  isRetryableTransactionConflict,
   RlsContextError,
   RlsTransactionService,
   type TrustedRlsContext,
@@ -139,6 +140,62 @@ describe('RlsTransactionService', () => {
       timeout: 2_000,
       isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
     });
+  });
+
+  it('retries a serializable callback after bounded PostgreSQL P2034 conflicts', async () => {
+    const test = fixture();
+    let attempt = 0;
+    test.transaction.mockImplementation(async (callback) => {
+      const result = await callback(test.tx);
+      attempt += 1;
+      if (attempt < 3) throw Object.assign(new Error('write conflict'), { code: 'P2034' });
+      return result;
+    });
+    const work = jest.fn(async () => 'persisted');
+
+    await expect(test.service.withTrustedContext(
+      TRUSTED_USER,
+      work,
+      {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+        retryDelayMs: 0,
+      },
+    )).resolves.toBe('persisted');
+
+    expect(test.transaction).toHaveBeenCalledTimes(3);
+    expect(test.queryRaw).toHaveBeenCalledTimes(3);
+    expect(work).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry ReadCommitted work unless retries are explicitly enabled', async () => {
+    const test = fixture();
+    const conflict = Object.assign(new Error('write conflict'), { code: 'P2034' });
+    test.transaction.mockRejectedValue(conflict);
+
+    await expect(test.service.withTrustedContext(
+      TRUSTED_USER,
+      async () => 'unreachable',
+      { retryDelayMs: 0 },
+    )).rejects.toBe(conflict);
+    expect(test.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('recognizes Prisma and PostgreSQL serialization/deadlock codes only', () => {
+    expect(isRetryableTransactionConflict({ code: 'P2034' })).toBe(true);
+    expect(isRetryableTransactionConflict({ code: 'P2010', meta: { sqlState: '40001' } })).toBe(true);
+    expect(isRetryableTransactionConflict({ meta: { database_error_code: '40P01' } })).toBe(true);
+    expect(isRetryableTransactionConflict({ code: 'P2002' })).toBe(false);
+    expect(isRetryableTransactionConflict(new Error('ordinary failure'))).toBe(false);
+  });
+
+  it('rejects unsafe retry settings before opening a transaction', async () => {
+    const test = fixture();
+    await expect(test.service.withTrustedContext(
+      TRUSTED_USER,
+      async () => 'unreachable',
+      { maxConflictRetries: 6 },
+    )).rejects.toBeInstanceOf(RangeError);
+    expect(test.transaction).not.toHaveBeenCalled();
   });
 
   it('does not execute business work when RLS context initialization fails', async () => {

--- a/apps/api/src/common/prisma/rls-transaction.service.ts
+++ b/apps/api/src/common/prisma/rls-transaction.service.ts
@@ -31,9 +31,10 @@ export type RlsTransactionOptions = Readonly<{
   timeout?: number;
   isolationLevel?: Prisma.TransactionIsolationLevel;
   /**
-   * Explicit opt-in retry count for PostgreSQL serialization failures and deadlocks.
-   * Keep this disabled for work that performs non-transactional side effects inside
-   * the callback. A retried callback must be database-only and idempotent.
+   * Override the retry count for PostgreSQL serialization failures and deadlocks.
+   * Serializable transactions default to three retries; other isolation levels
+   * default to none. Callbacks must keep non-database side effects outside the
+   * transaction because PostgreSQL can require the callback to execute again.
    */
   maxConflictRetries?: number;
   retryDelayMs?: number;
@@ -75,12 +76,19 @@ export class RlsTransactionService {
     options: RlsTransactionOptions = {},
   ): Promise<T> {
     const context = deriveTrustedRlsContext(user);
-    const maxConflictRetries = boundedInteger(options.maxConflictRetries, 0, 5, 0);
+    const isolationLevel = options.isolationLevel ?? Prisma.TransactionIsolationLevel.ReadCommitted;
+    const defaultConflictRetries = isolationLevel === Prisma.TransactionIsolationLevel.Serializable ? 3 : 0;
+    const maxConflictRetries = boundedInteger(
+      options.maxConflictRetries,
+      0,
+      5,
+      defaultConflictRetries,
+    );
     const retryDelayMs = boundedInteger(options.retryDelayMs, 0, 1_000, 10);
     const transactionOptions = {
       maxWait: options.maxWait ?? 5_000,
       timeout: options.timeout ?? 15_000,
-      isolationLevel: options.isolationLevel ?? Prisma.TransactionIsolationLevel.ReadCommitted,
+      isolationLevel,
     };
 
     for (let attempt = 0; ; attempt += 1) {

--- a/apps/api/src/common/prisma/rls-transaction.service.ts
+++ b/apps/api/src/common/prisma/rls-transaction.service.ts
@@ -30,6 +30,13 @@ export type RlsTransactionOptions = Readonly<{
   maxWait?: number;
   timeout?: number;
   isolationLevel?: Prisma.TransactionIsolationLevel;
+  /**
+   * Explicit opt-in retry count for PostgreSQL serialization failures and deadlocks.
+   * Keep this disabled for work that performs non-transactional side effects inside
+   * the callback. A retried callback must be database-only and idempotent.
+   */
+  maxConflictRetries?: number;
+  retryDelayMs?: number;
 }>;
 
 export function deriveTrustedRlsContext(user: RequestUser | undefined): TrustedRlsContext {
@@ -68,27 +75,79 @@ export class RlsTransactionService {
     options: RlsTransactionOptions = {},
   ): Promise<T> {
     const context = deriveTrustedRlsContext(user);
+    const maxConflictRetries = boundedInteger(options.maxConflictRetries, 0, 5, 0);
+    const retryDelayMs = boundedInteger(options.retryDelayMs, 0, 1_000, 10);
+    const transactionOptions = {
+      maxWait: options.maxWait ?? 5_000,
+      timeout: options.timeout ?? 15_000,
+      isolationLevel: options.isolationLevel ?? Prisma.TransactionIsolationLevel.ReadCommitted,
+    };
 
-    return this.prisma.$transaction(
-      async (tx) => {
-        await tx.$queryRaw(
-          Prisma.sql`
-            SELECT
-              set_config('app.current_user_id', ${context.userId}, true),
-              set_config('app.current_org_id', ${context.orgId}, true),
-              set_config('app.current_tenant_id', ${context.tenantId}, true),
-              set_config('app.current_role', ${context.role}, true),
-              set_config('app.current_session_id', ${context.sessionId}, true)
-          `,
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        return await this.prisma.$transaction(
+          async (tx) => {
+            await tx.$queryRaw(
+              Prisma.sql`
+                SELECT
+                  set_config('app.current_user_id', ${context.userId}, true),
+                  set_config('app.current_org_id', ${context.orgId}, true),
+                  set_config('app.current_tenant_id', ${context.tenantId}, true),
+                  set_config('app.current_role', ${context.role}, true),
+                  set_config('app.current_session_id', ${context.sessionId}, true)
+              `,
+            );
+
+            return work(tx, context);
+          },
+          transactionOptions,
         );
-
-        return work(tx, context);
-      },
-      {
-        maxWait: options.maxWait ?? 5_000,
-        timeout: options.timeout ?? 15_000,
-        isolationLevel: options.isolationLevel ?? Prisma.TransactionIsolationLevel.ReadCommitted,
-      },
-    );
+      } catch (error) {
+        if (!isRetryableTransactionConflict(error) || attempt >= maxConflictRetries) throw error;
+        await conflictBackoff(retryDelayMs, attempt);
+      }
+    }
   }
+}
+
+export function isRetryableTransactionConflict(error: unknown): boolean {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    if (error.code === 'P2034') return true;
+    const databaseCode = readDatabaseCode(error.meta);
+    return databaseCode === '40001' || databaseCode === '40P01';
+  }
+  if (!error || typeof error !== 'object') return false;
+  const candidate = error as { code?: unknown; meta?: unknown };
+  if (candidate.code === 'P2034' || candidate.code === '40001' || candidate.code === '40P01') return true;
+  const databaseCode = readDatabaseCode(candidate.meta);
+  return databaseCode === '40001' || databaseCode === '40P01';
+}
+
+function readDatabaseCode(meta: unknown): string | null {
+  if (!meta || typeof meta !== 'object') return null;
+  const record = meta as Record<string, unknown>;
+  for (const key of ['code', 'database_error_code', 'dbErrorCode', 'sqlState']) {
+    if (typeof record[key] === 'string') return record[key];
+  }
+  return null;
+}
+
+async function conflictBackoff(baseDelayMs: number, attempt: number): Promise<void> {
+  if (baseDelayMs <= 0) return;
+  const exponential = Math.min(baseDelayMs * 2 ** attempt, 1_000);
+  const jitter = Math.floor(Math.random() * Math.max(1, baseDelayMs));
+  await new Promise((resolve) => setTimeout(resolve, exponential + jitter));
+}
+
+function boundedInteger(
+  value: number | undefined,
+  minimum: number,
+  maximum: number,
+  fallback: number,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new RangeError(`Transaction option must be an integer between ${minimum} and ${maximum}.`);
+  }
+  return value;
 }

--- a/apps/api/test/industrial/load-proof.e2e-spec.ts
+++ b/apps/api/test/industrial/load-proof.e2e-spec.ts
@@ -139,6 +139,24 @@ async function bankConfirm(
   }
 }
 
+async function runDealCycle(fixture: DealFixture, index: number): Promise<void> {
+  for (let step = 0; step < USER_STEPS.length; step += 1) {
+    const instance = (index + step) % 2 === 0 ? alpha : beta;
+    await runStep(instance, fixture, USER_STEPS[step].actionId, USER_STEPS[step].userKey);
+  }
+  await bankConfirm(index % 2 === 0 ? alpha : beta, fixture, 'RESERVE');
+  for (let step = 0; step < POST_RESERVE_STEPS.length; step += 1) {
+    const instance = (index + step) % 2 === 0 ? beta : alpha;
+    const currentStep = POST_RESERVE_STEPS[step];
+    if (currentStep.actionId === 'finalize_lab') {
+      await prepareLaboratoryLifecycle(instance, fixture);
+    }
+    await runStep(instance, fixture, currentStep.actionId, currentStep.userKey);
+  }
+  await bankConfirm(index % 2 === 0 ? beta : alpha, fixture, 'RELEASE');
+  await runStep(alpha, fixture, 'close_deal', 'operator');
+}
+
 describe('Industrial core load proof on two instances', () => {
   it(`drives ${DEALS} deals through full concurrent cycles with zero duplicate money`, async () => {
     latenciesMs.length = 0;
@@ -148,25 +166,16 @@ describe('Industrial core load proof on two instances', () => {
     }
 
     const startedAt = Date.now();
-    await Promise.all(
-      fixtures.map(async (fixture, index) => {
-        for (let step = 0; step < USER_STEPS.length; step += 1) {
-          const instance = (index + step) % 2 === 0 ? alpha : beta;
-          await runStep(instance, fixture, USER_STEPS[step].actionId, USER_STEPS[step].userKey);
-        }
-        await bankConfirm(index % 2 === 0 ? alpha : beta, fixture, 'RESERVE');
-        for (let step = 0; step < POST_RESERVE_STEPS.length; step += 1) {
-          const instance = (index + step) % 2 === 0 ? beta : alpha;
-          const currentStep = POST_RESERVE_STEPS[step];
-          if (currentStep.actionId === 'finalize_lab') {
-            await prepareLaboratoryLifecycle(instance, fixture);
-          }
-          await runStep(instance, fixture, currentStep.actionId, currentStep.userKey);
-        }
-        await bankConfirm(index % 2 === 0 ? beta : alpha, fixture, 'RELEASE');
-        await runStep(alpha, fixture, 'close_deal', 'operator');
-      }),
+    const outcomes = await Promise.allSettled(
+      fixtures.map((fixture, index) => runDealCycle(fixture, index)),
     );
+    const failures = outcomes.filter((outcome): outcome is PromiseRejectedResult => outcome.status === 'rejected');
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        `${failures.length} of ${fixtures.length} concurrent Deal cycles failed`,
+      );
+    }
     const wallMs = Date.now() - startedAt;
 
     for (const fixture of fixtures) {


### PR DESCRIPTION
## What changed

- added bounded retries for PostgreSQL serialization failures and deadlocks in trusted RLS transactions;
- Serializable transactions default to three retries, while ReadCommitted remains non-retrying unless explicitly configured;
- retry support recognizes Prisma `P2034` and PostgreSQL SQLSTATE `40001` / `40P01` only;
- every retry re-establishes transaction-local user, organization, tenant, role and session context;
- added unit coverage for retry limits, isolation defaults and non-retryable errors;
- changed the industrial concurrent Deal proof to await every Deal cycle with `Promise.allSettled` before surfacing failures, preventing unfinished cycles from contaminating later PostgreSQL suites.

## Why

The acceptance UI PR exposed a real industrial-gate defect under concurrent laboratory evidence preparation: a Serializable RLS transaction could fail with `P2034` and was not retried. The load proof also rejected on the first failed promise while other Deal cycles continued, allowing residual outbox writes to affect subsequent suites.

## Safety boundary

- retries are bounded to a maximum of five;
- non-Serializable transactions do not retry by default;
- uniqueness, idempotency and RLS constraints remain authoritative;
- no business error, validation error or duplicate-key error is retried;
- non-database side effects must remain outside retryable callbacks;
- this is CI-scale concurrency correctness, not a production-scale throughput claim.

## Required exact-head checks

- API typecheck and unit tests;
- industrial core, races, outbox, reconciliation and load proof;
- 12-role / RLS / DR;
- persistent auth / MFA;
- production build and full Node CI;
- Security Scan, Security Quality Gate, Dependency Review, CodeQL and Qodana.