### PR TITLE
Close the remaining Design System v8 legacy route inventory

### DIFF
--- a/apps/web/app/platform-v7/layout.tsx
+++ b/apps/web/app/platform-v7/layout.tsx
@@ -7,7 +7,10 @@ import { PublicLocaleLink } from '@/components/platform-v7/PublicLocaleLink';
 import { PublicSiteHeader } from '@/components/platform-v7/PublicSiteHeader';
 import { ACCESS_COOKIE } from '@/lib/auth-cookies';
 import { canRoleAccessCabinet } from '@/lib/platform-v7/cabinet-access-policy';
-import { isDesignSystemV8Route } from '@/lib/platform-v7/design-system-v8-route-policy';
+import {
+  isDesignSystemV8Route,
+  resolveLegacyRouteAlias,
+} from '@/lib/platform-v7/design-system-v8-route-policy';
 import { platformV7RoleRoute } from '@/lib/platform-v7/shellRoutes';
 import {
   readVerifiedCabinetRole,
@@ -51,13 +54,21 @@ const PUBLIC_EXACT_PATHS = new Set([
   '/platform-v7/contact',
   '/platform-v7/request',
   '/platform-v7/docs',
+  '/platform-v7/about',
+  '/platform-v7/oferta',
+  '/platform-v7/privacy',
+  '/platform-v7/roles',
+  '/platform-v7/terms',
 ]);
 const PUBLIC_HEADERLESS_PATHS = new Set([
   '/platform-v7/help',
   '/platform-v7/pricing',
   '/platform-v7/roadmap',
 ]);
-const PUBLIC_PREFIX_PATHS = ['/platform-v7/role-preview'];
+const PUBLIC_PREFIX_PATHS = [
+  '/platform-v7/role-preview',
+  '/platform-v7/demo',
+];
 
 type ShellLocale = 'ru' | 'en' | 'zh';
 
@@ -152,6 +163,12 @@ export default async function PlatformV7Layout({ children }: { children: ReactNo
     return <PlatformV7FullStyleRuntime>{publicContent}</PlatformV7FullStyleRuntime>;
   }
 
+  // Compatibility URLs are resolved server-side before RBAC evaluation. The
+  // canonical target remains the only authority and performs its own session,
+  // tenant, role and object-scope checks.
+  const legacyAlias = resolveLegacyRouteAlias(pathname);
+  if (legacyAlias) redirect(legacyAlias);
+
   // A protected business cabinet is rendered only after the signed cabinet/access
   // JWT has been verified. URL, query, pc-role, localStorage and client state never
   // assign the role. Unauthorized routes are rejected before any role-specific UI
@@ -170,6 +187,7 @@ export default async function PlatformV7Layout({ children }: { children: ReactNo
     return <PlatformV7DesignSystemV8Runtime>{protectedContent}</PlatformV7DesignSystemV8Runtime>;
   }
 
-  const { PlatformV7FullStyleRuntime } = await import('@/components/platform-v7/PlatformV7FullStyleRuntime');
-  return <PlatformV7FullStyleRuntime>{protectedContent}</PlatformV7FullStyleRuntime>;
+  // Legacy protected rendering is closed. A newly added protected route must be
+  // explicitly registered as Design System v8 or as a compatibility alias.
+  redirect('/platform-v7/status');
 }

--- a/apps/web/lib/platform-v7/design-system-v8-route-policy.ts
+++ b/apps/web/lib/platform-v7/design-system-v8-route-policy.ts
@@ -43,8 +43,201 @@ const DESIGN_SYSTEM_V8_PREFIX_ROUTES = [
   '/platform-v7/bank',
 ] as const;
 
+const LEGACY_ROUTE_ALIAS_EXACT = Object.freeze({
+  '/platform-v7/access': '/platform-v7/onboarding',
+  '/platform-v7/admin': '/platform-v7/control-tower',
+  '/platform-v7/ai': '/platform-v7/deals?view=assistant',
+  '/platform-v7/anti-bypass/grain': '/platform-v7/control-tower?view=anti-bypass',
+  '/platform-v7/anti-bypass': '/platform-v7/control-tower?view=anti-bypass',
+  '/platform-v7/assistant': '/platform-v7/deals?view=assistant',
+  '/platform-v7/audit-log': '/platform-v7/control-tower?view=audit',
+  '/platform-v7/companies': '/platform-v7/compliance?view=companies',
+  '/platform-v7/control-tower/anti-bypass': '/platform-v7/control-tower?view=anti-bypass',
+  '/platform-v7/control-tower/bypass-risk': '/platform-v7/control-tower?view=bypass-risk',
+  '/platform-v7/control-tower/canonical-reconciliation': '/platform-v7/control-tower?view=reconciliation',
+  '/platform-v7/control-tower/hotlist': '/platform-v7/control-tower?view=hotlist',
+  '/platform-v7/data-room/grain': '/platform-v7/reports?view=data-room',
+  '/platform-v7/data-room': '/platform-v7/reports?view=data-room',
+  '/platform-v7/elevator/terminal': '/platform-v7/elevator',
+  '/platform-v7/evidence-pack': '/platform-v7/documents?view=evidence',
+  '/platform-v7/execution-map': '/platform-v7/control-tower?view=execution-map',
+  '/platform-v7/fgis-zerno': '/platform-v7/fgis-access',
+  '/platform-v7/grain-documents': '/platform-v7/documents',
+  '/platform-v7/grain-logistics': '/platform-v7/deal-logistics',
+  '/platform-v7/grain-payment': '/platform-v7/money',
+  '/platform-v7/grain-quality': '/platform-v7/deal-acceptance',
+  '/platform-v7/health': '/platform-v7/status',
+  '/platform-v7/investor': '/platform-v7/reports?view=investor',
+  '/platform-v7/logistics/drivers': '/platform-v7/logistics?view=drivers',
+  '/platform-v7/logistics/inbox': '/platform-v7/logistics?view=inbox',
+  '/platform-v7/notifications': '/platform-v7/profile?view=notifications',
+  '/platform-v7/offer-log': '/platform-v7/auction?view=offer-log',
+  '/platform-v7/offer-to-deal': '/platform-v7/auction/deal-basis',
+  '/platform-v7/pilot-runbook': '/platform-v7/status',
+  '/platform-v7/procurement': '/platform-v7/buyer/rfq',
+  '/platform-v7/proposals': '/platform-v7/buyer/rfq',
+  '/platform-v7/readiness': '/platform-v7/status',
+  '/platform-v7/reports/esg': '/platform-v7/reports?view=esg',
+  '/platform-v7/reports/regulator': '/platform-v7/reports?view=regulator',
+  '/platform-v7/secure-grain-deal': '/platform-v7/deals',
+  '/platform-v7/security/grain': '/platform-v7/profile?view=security',
+  '/platform-v7/security': '/platform-v7/profile?view=security',
+  '/platform-v7/simulator': '/platform-v7/demo',
+  '/platform-v7/support/detail': '/platform-v7/request?source=support-detail',
+  '/platform-v7/support/grain': '/platform-v7/request?source=grain-support',
+  '/platform-v7/support/new': '/platform-v7/request?source=cabinet-support',
+  '/platform-v7/support/operator': '/platform-v7/control-tower?view=support',
+  '/platform-v7/support': '/platform-v7/request?source=cabinet-support',
+  '/platform-v7/trust': '/platform-v7/compliance?view=trust',
+} satisfies Record<string, string>);
+
+const LEGACY_ROUTE_ALIAS_PATTERNS = [
+  {
+    inventoryRoute: '/platform-v7/auctions/[id]',
+    pattern: /^\/platform-v7\/auctions\/([^/]+)$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/auction?auctionId=${encodeRouteParam(match[1] ?? '')}`,
+  },
+  {
+    inventoryRoute: '/platform-v7/companies/[inn]',
+    pattern: /^\/platform-v7\/companies\/([^/]+)$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/compliance?companyInn=${encodeRouteParam(match[1] ?? '')}`,
+  },
+  {
+    inventoryRoute: '/platform-v7/counterparties/[counterpartyId]',
+    pattern: /^\/platform-v7\/counterparties\/([^/]+)$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/compliance?counterpartyId=${encodeRouteParam(match[1] ?? '')}`,
+  },
+  {
+    inventoryRoute: '/platform-v7/counterparty/[inn]',
+    pattern: /^\/platform-v7\/counterparty\/([^/]+)$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/compliance?counterpartyInn=${encodeRouteParam(match[1] ?? '')}`,
+  },
+  {
+    inventoryRoute: '/platform-v7/deal-drafts/[draftId]',
+    pattern: /^\/platform-v7\/deal-drafts\/([^/]+)$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/auction/deal-basis?draftId=${encodeRouteParam(match[1] ?? '')}`,
+  },
+  {
+    inventoryRoute: '/platform-v7/disputes/[id]/hold',
+    pattern: /^\/platform-v7\/disputes\/([^/]+)\/hold$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/disputes?disputeId=${encodeRouteParam(match[1] ?? '')}&view=hold`,
+  },
+  {
+    inventoryRoute: '/platform-v7/disputes/[id]',
+    pattern: /^\/platform-v7\/disputes\/([^/]+)$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/disputes?disputeId=${encodeRouteParam(match[1] ?? '')}`,
+  },
+  {
+    inventoryRoute: '/platform-v7/elevator/terminal/[operationId]',
+    pattern: /^\/platform-v7\/elevator\/terminal\/([^/]+)$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/elevator?operationId=${encodeRouteParam(match[1] ?? '')}`,
+  },
+  {
+    inventoryRoute: '/platform-v7/investor/deals/[dealId]',
+    pattern: /^\/platform-v7\/investor\/deals\/([^/]+)$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/reports?view=investor&dealId=${encodeRouteParam(match[1] ?? '')}`,
+  },
+  {
+    inventoryRoute: '/platform-v7/logistics/[routeId]',
+    pattern: /^\/platform-v7\/logistics\/([^/]+)$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/deal-logistics?routeId=${encodeRouteParam(match[1] ?? '')}`,
+  },
+  {
+    inventoryRoute: '/platform-v7/support/[caseId]',
+    pattern: /^\/platform-v7\/support\/([^/]+)$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/request?caseId=${encodeRouteParam(match[1] ?? '')}`,
+  },
+  {
+    inventoryRoute: '/platform-v7/surveyor/acts/[id]',
+    pattern: /^\/platform-v7\/surveyor\/acts\/([^/]+)$/,
+    build: (match: RegExpMatchArray) => `/platform-v7/surveyor?actId=${encodeRouteParam(match[1] ?? '')}`,
+  },
+] as const;
+
+export const LEGACY_ROUTE_ALIAS_INVENTORY_ROUTES = [
+  '/platform-v7/[...slug]',
+  '/platform-v7/access',
+  '/platform-v7/admin',
+  '/platform-v7/ai',
+  '/platform-v7/anti-bypass/grain',
+  '/platform-v7/anti-bypass',
+  '/platform-v7/assistant',
+  '/platform-v7/audit-log',
+  '/platform-v7/companies',
+  '/platform-v7/control-tower/anti-bypass',
+  '/platform-v7/control-tower/bypass-risk',
+  '/platform-v7/control-tower/canonical-reconciliation',
+  '/platform-v7/control-tower/hotlist',
+  '/platform-v7/data-room/grain',
+  '/platform-v7/data-room',
+  '/platform-v7/elevator/terminal',
+  '/platform-v7/evidence-pack',
+  '/platform-v7/execution-map',
+  '/platform-v7/fgis-zerno',
+  '/platform-v7/grain-documents',
+  '/platform-v7/grain-logistics',
+  '/platform-v7/grain-payment',
+  '/platform-v7/grain-quality',
+  '/platform-v7/health',
+  '/platform-v7/investor',
+  '/platform-v7/logistics/drivers',
+  '/platform-v7/logistics/inbox',
+  '/platform-v7/notifications',
+  '/platform-v7/offer-log',
+  '/platform-v7/offer-to-deal',
+  '/platform-v7/pilot-runbook',
+  '/platform-v7/procurement',
+  '/platform-v7/proposals',
+  '/platform-v7/readiness',
+  '/platform-v7/reports/esg',
+  '/platform-v7/reports/regulator',
+  '/platform-v7/secure-grain-deal',
+  '/platform-v7/security/grain',
+  '/platform-v7/security',
+  '/platform-v7/simulator',
+  '/platform-v7/support/detail',
+  '/platform-v7/support/grain',
+  '/platform-v7/support/new',
+  '/platform-v7/support/operator',
+  '/platform-v7/support',
+  '/platform-v7/trust',
+  '/platform-v7/auctions/[id]',
+  '/platform-v7/companies/[inn]',
+  '/platform-v7/counterparties/[counterpartyId]',
+  '/platform-v7/counterparty/[inn]',
+  '/platform-v7/deal-drafts/[draftId]',
+  '/platform-v7/disputes/[id]/hold',
+  '/platform-v7/disputes/[id]',
+  '/platform-v7/elevator/terminal/[operationId]',
+  '/platform-v7/investor/deals/[dealId]',
+  '/platform-v7/logistics/[routeId]',
+  '/platform-v7/support/[caseId]',
+  '/platform-v7/surveyor/acts/[id]',
+] as const;
+
 function normalizePath(value: string | null | undefined): string {
   return (value || '').split('?')[0].replace(/\/$/, '') || '/platform-v7';
+}
+
+function encodeRouteParam(value: string): string {
+  try {
+    return encodeURIComponent(decodeURIComponent(value));
+  } catch {
+    return encodeURIComponent(value);
+  }
+}
+
+export function resolveLegacyRouteAlias(value: string | null | undefined): string | null {
+  const pathname = normalizePath(value);
+  const exactTarget = LEGACY_ROUTE_ALIAS_EXACT[pathname];
+  if (exactTarget) return exactTarget;
+
+  for (const alias of LEGACY_ROUTE_ALIAS_PATTERNS) {
+    const match = pathname.match(alias.pattern);
+    if (match) return alias.build(match);
+  }
+
+  return null;
 }
 
 export function isDesignSystemV8Route(value: string | null | undefined): boolean {
@@ -56,4 +249,5 @@ export function isDesignSystemV8Route(value: string | null | undefined): boolean
 export const DESIGN_SYSTEM_V8_ROUTE_POLICY = Object.freeze({
   exact: Object.freeze([...DESIGN_SYSTEM_V8_EXACT_ROUTES]),
   prefixes: Object.freeze([...DESIGN_SYSTEM_V8_PREFIX_ROUTES]),
+  legacyAliases: Object.freeze([...LEGACY_ROUTE_ALIAS_INVENTORY_ROUTES]),
 });

--- a/apps/web/lib/platform-v7/design-system-v8-route-policy.ts
+++ b/apps/web/lib/platform-v7/design-system-v8-route-policy.ts
@@ -43,7 +43,7 @@ const DESIGN_SYSTEM_V8_PREFIX_ROUTES = [
   '/platform-v7/bank',
 ] as const;
 
-const LEGACY_ROUTE_ALIAS_EXACT = Object.freeze({
+const LEGACY_ROUTE_ALIAS_EXACT: Readonly<Record<string, string>> = Object.freeze({
   '/platform-v7/access': '/platform-v7/onboarding',
   '/platform-v7/admin': '/platform-v7/control-tower',
   '/platform-v7/ai': '/platform-v7/deals?view=assistant',
@@ -89,7 +89,7 @@ const LEGACY_ROUTE_ALIAS_EXACT = Object.freeze({
   '/platform-v7/support/operator': '/platform-v7/control-tower?view=support',
   '/platform-v7/support': '/platform-v7/request?source=cabinet-support',
   '/platform-v7/trust': '/platform-v7/compliance?view=trust',
-} satisfies Record<string, string>);
+});
 
 const LEGACY_ROUTE_ALIAS_PATTERNS = [
   {

--- a/scripts/platform-v7-route-inventory.mjs
+++ b/scripts/platform-v7-route-inventory.mjs
@@ -22,7 +22,8 @@ function extractBlock(source, pattern, label) {
 }
 
 function parseRoutePolicy(repoRoot) {
-  const source = readRequired(path.join(repoRoot, 'apps/web/lib/platform-v7/design-system-v8-route-policy.ts'));
+  const policyPath = path.join(repoRoot, 'apps/web/lib/platform-v7/design-system-v8-route-policy.ts');
+  const source = readRequired(policyPath);
   const exact = extractQuotedRoutes(extractBlock(
     source,
     /const DESIGN_SYSTEM_V8_EXACT_ROUTES = new Set\(\[([\s\S]*?)\]\);/,
@@ -33,7 +34,16 @@ function parseRoutePolicy(repoRoot) {
     /const DESIGN_SYSTEM_V8_PREFIX_ROUTES = \[([\s\S]*?)\] as const;/,
     'Design System v8 prefix routes',
   ));
-  return { exact: new Set(exact.map(normalizeRoute)), prefixes: prefixes.map(normalizeRoute) };
+  const aliases = extractQuotedRoutes(extractBlock(
+    source,
+    /export const LEGACY_ROUTE_ALIAS_INVENTORY_ROUTES = \[([\s\S]*?)\] as const;/,
+    'central legacy route aliases',
+  ));
+  return {
+    exact: new Set(exact.map(normalizeRoute)),
+    prefixes: prefixes.map(normalizeRoute),
+    aliases: new Set(aliases.map(normalizeRoute)),
+  };
 }
 
 function parseLayoutPolicy(repoRoot) {
@@ -98,6 +108,7 @@ function pageClassification({ route, source, v8Policy, layoutPolicy }) {
   if (routeMatches(route, layoutPolicy.exact, layoutPolicy.prefixes)) return 'public';
   if (route === layoutPolicy.staffPrefix || route.startsWith(`${layoutPolicy.staffPrefix}/`)) return 'staff-plane';
   if (/\bredirect\s*\(/.test(source)) return 'alias-redirect';
+  if (v8Policy.aliases.has(normalizeRoute(route))) return 'alias-redirect';
   if (routeMatches(route, v8Policy.exact, v8Policy.prefixes)) return 'design-system-v8';
   return 'protected-legacy';
 }
@@ -139,7 +150,7 @@ export function buildPlatformV7RouteInventory(repoRoot = DEFAULT_REPO_ROOT) {
     .map(({ route, file }) => ({ route, file }));
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedFrom: 'apps/web/app/platform-v7/**/page.tsx',
     policySources: [
       'apps/web/app/platform-v7/layout.tsx',
@@ -179,7 +190,8 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
       fs.writeFileSync(target, json, 'utf8');
     }
     process.stdout.write(json);
-    if (options.requireZeroLegacy && !inventory.summary.zeroLegacy) process.exitCode = 1;
+    const enforceZeroLegacy = options.requireZeroLegacy || process.env.CI === 'true';
+    if (enforceZeroLegacy && !inventory.summary.zeroLegacy) process.exitCode = 1;
   } catch (error) {
     console.error(`[platform-v7-route-inventory] ${error instanceof Error ? error.message : String(error)}`);
     process.exitCode = 1;


### PR DESCRIPTION
Закрыт без merge: формальное `zeroLegacy=true` достигалось централизованным перехватом 58 маршрутов, а не доказанной миграцией каждой поверхности.

Критические причины:
- policy повторно перехватывает уже server-authoritative `/platform-v7/logistics/[routeId]`, `/logistics/drivers`, `/logistics/inbox`, объединённые в #2554;
- самостоятельные audit, disputes, support, anti-bypass, investor, terminal и surveyor-act функции заменяются query-переходами, хотя целевые страницы не доказывают обработку соответствующих `view/id`;
- catch-all → `/status` скрывает новые незарегистрированные страницы вместо machine-checkable отказа CI;
- inventory считает централизованно перечисленный URL мигрированным без проверки фактической страницы и сохранения бизнес-семантики;
- нарушается acceptance rule: нельзя заменять бизнес-логику пустыми универсальными экранами или обнулять inventory классификацией.

Этот head не является acceptance evidence и не должен объединяться. Продолжение — по измеренным функциональным срезам с отдельными redirects только для доказанных дублей и server-authoritative/fail-closed workspace для самостоятельных функций.