### PR TITLE
Classify public legal, demo and grain SEO routes

### DIFF
--- a/apps/web/app/platform-v7/layout.tsx
+++ b/apps/web/app/platform-v7/layout.tsx
@@ -51,13 +51,21 @@ const PUBLIC_EXACT_PATHS = new Set([
   '/platform-v7/contact',
   '/platform-v7/request',
   '/platform-v7/docs',
+  '/platform-v7/about',
+  '/platform-v7/oferta',
+  '/platform-v7/privacy',
+  '/platform-v7/roles',
+  '/platform-v7/terms',
 ]);
 const PUBLIC_HEADERLESS_PATHS = new Set([
   '/platform-v7/help',
   '/platform-v7/pricing',
   '/platform-v7/roadmap',
 ]);
-const PUBLIC_PREFIX_PATHS = ['/platform-v7/role-preview'];
+const PUBLIC_PREFIX_PATHS = [
+  '/platform-v7/role-preview',
+  '/platform-v7/demo',
+];
 
 type ShellLocale = 'ru' | 'en' | 'zh';
 

--- a/apps/web/app/platform-v7/layout.tsx
+++ b/apps/web/app/platform-v7/layout.tsx
@@ -56,6 +56,12 @@ const PUBLIC_EXACT_PATHS = new Set([
   '/platform-v7/privacy',
   '/platform-v7/roles',
   '/platform-v7/terms',
+  '/platform-v7/secure-grain-deal',
+  '/platform-v7/grain-logistics',
+  '/platform-v7/grain-quality',
+  '/platform-v7/grain-documents',
+  '/platform-v7/grain-payment',
+  '/platform-v7/fgis-zerno',
 ]);
 const PUBLIC_HEADERLESS_PATHS = new Set([
   '/platform-v7/help',


### PR DESCRIPTION
## Что изменено

- `/platform-v7/about`, `/oferta`, `/privacy`, `/roles`, `/terms` зарегистрированы как публичные exact routes;
- весь `/platform-v7/demo/*` зарегистрирован как public prefix;
- публичные SEO landing pages `/secure-grain-deal`, `/grain-logistics`, `/grain-quality`, `/grain-documents`, `/grain-payment`, `/fgis-zerno` зарегистрированы как public exact routes;
- страницы сохраняют существующий публичный runtime и больше не требуют cabinet session/RBAC из-за ошибки route policy;
- protected business routes, роли, tenant scope, Deal state, деньги и интеграции не меняются.

## Почему это не фиктивное закрытие inventory

Все поверхности уже являются публичными по назначению и структуре: legal/about/roles объясняют проект и условия; `/demo/*` содержит публичный proof-of-flow; шесть grain pages используют общий `SeoLandingPage` и связаны из публичной `/about`. PR не заменяет их универсальным экраном, не вводит redirects и не меняет бизнес-семантику — исправляется только ошибочная классификация layout policy.

## Exact-head evidence

Route inventory artifact `platform-v7-route-inventory-ceaeb904...` подтверждает:
- `pageFiles=206`;
- `public 14 → 29`;
- `alias-redirect 68 → 67` — ранее redirect-классифицированная вложенная demo-поверхность корректно относится к public family;
- `protected-legacy 63 → 49`;
- `legacyRouteFiles=49`.

Дополнительно: Design System v8 scope/governance, autopilot guard, web-unit, Dependency Review, Qodana и Security Scan уже зелёные; полный Node CI/CI/security-quality/CodeQL обязателен до merge.

Продолжение #2516.