### PR TITLE
Harden multilingual account notifications after zero-legacy closure

### DIFF
--- a/.github/workflows/design-system-v8.yml
+++ b/.github/workflows/design-system-v8.yml
@@ -102,6 +102,7 @@ jobs:
             tests/unit/platformV7Dl9106ReleaseReviewPageCurrentMain.test.tsx \
             tests/unit/platformV7FgisAccessFlow.test.ts \
             tests/unit/platformV7LogisticsSecondaryAuthority.test.ts \
+            tests/unit/platformV7NotificationsAuthority.test.ts \
             tests/unit/platformV7OperatorCompatibilityAliases.test.ts \
             tests/unit/platformV7RealDealsRegistry.test.ts \
             tests/unit/platformV7RoleIntentDashboard.test.ts \

--- a/apps/web/app/platform-v7/notifications/notifications.module.css
+++ b/apps/web/app/platform-v7/notifications/notifications.module.css
@@ -2,25 +2,22 @@
   width: min(100%, 900px);
   margin: 0 auto;
   display: grid;
-  gap: 14px;
+  gap: var(--pc-space-4);
 }
 
 .hero {
   min-height: 96px;
-  border: 1px solid var(--pc-border);
-  border-radius: 22px;
-  background: var(--pc-bg-card);
-  padding: 18px;
+  padding: var(--pc-space-5);
   display: grid;
-  grid-template-columns: 52px minmax(0, 1fr);
+  grid-template-columns: 52px minmax(0, 1fr) auto;
   align-items: center;
-  gap: 14px;
+  gap: var(--pc-space-4);
 }
 
 .heroIcon {
   width: 52px;
   height: 52px;
-  border-radius: 16px;
+  border-radius: var(--pc-radius-lg);
   background: var(--pc-accent-bg);
   color: var(--pc-accent-strong);
   display: grid;
@@ -30,6 +27,10 @@
 .heroIcon svg {
   width: 24px;
   height: 24px;
+}
+
+.heroCopy {
+  min-width: 0;
 }
 
 .hero h1,
@@ -45,37 +46,34 @@
 
 .hero h1 {
   color: var(--pc-text-primary);
-  font-size: clamp(24px, 5vw, 32px);
+  font-size: clamp(var(--ds-font-title), 5vw, var(--ds-font-display));
   line-height: 1.1;
-  font-weight: 950;
+  font-weight: 900;
 }
 
 .hero p {
-  margin-top: 5px;
+  margin-top: var(--pc-space-1);
   color: var(--pc-text-muted);
-  font-size: 13px;
+  font-size: var(--ds-font-caption);
   line-height: 1.4;
 }
 
 .controls {
-  border: 1px solid var(--pc-border);
-  border-radius: 18px;
-  background: var(--pc-bg-card);
-  padding: 10px 12px;
+  padding: var(--pc-space-3);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: var(--pc-space-3);
 }
 
 .switchLabel {
-  min-height: 48px;
+  min-height: var(--ds-control-height);
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--pc-space-3);
   color: var(--pc-text-primary);
-  font-size: 13px;
-  font-weight: 850;
+  font-size: var(--ds-font-body);
+  font-weight: 800;
   cursor: pointer;
 }
 
@@ -85,69 +83,19 @@
   accent-color: var(--pc-accent);
 }
 
-.primaryButton,
-.secondaryButton,
-.readButton,
-.primaryLink {
-  min-height: 48px;
-  border-radius: 14px;
-  padding: 0 15px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  font: inherit;
-  font-size: 13px;
-  font-weight: 900;
-  text-decoration: none;
-  cursor: pointer;
-}
-
-.primaryButton,
-.primaryLink {
-  border: 1px solid var(--pc-accent);
-  background: var(--pc-accent);
-  color: var(--pc-on-accent, #fff);
-}
-
-.secondaryButton,
-.readButton {
-  border: 1px solid var(--pc-border);
-  background: var(--pc-bg-elevated);
-  color: var(--pc-text-primary);
-}
-
-.primaryButton svg,
-.secondaryButton svg,
-.readButton svg,
-.readStatus svg {
-  width: 18px;
-  height: 18px;
-}
-
-.primaryButton:disabled,
-.secondaryButton:disabled,
-.readButton:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .stateCard,
 .emptyCard {
   min-height: 250px;
-  border: 1px solid var(--pc-border);
-  border-radius: 22px;
-  background: var(--pc-bg-card);
-  padding: 24px;
+  padding: var(--pc-space-6);
   display: grid;
   place-items: center;
   align-content: center;
-  gap: 10px;
+  gap: var(--pc-space-3);
   text-align: center;
 }
 
-.stateCard svg,
-.emptyCard svg {
+.stateCard > svg,
+.emptyCard > svg {
   width: 28px;
   height: 28px;
 }
@@ -155,21 +103,17 @@
 .stateCard h1,
 .emptyCard h2 {
   color: var(--pc-text-primary);
-  font-size: 22px;
+  font-size: var(--ds-font-title);
   line-height: 1.2;
-  font-weight: 950;
+  font-weight: 900;
 }
 
 .stateCard p,
 .emptyCard p {
   max-width: 46ch;
   color: var(--pc-text-muted);
-  font-size: 14px;
+  font-size: var(--ds-font-body);
   line-height: 1.5;
-}
-
-.errorIcon {
-  color: var(--pc-danger, #b42318);
 }
 
 .successIcon {
@@ -178,16 +122,13 @@
 
 .list {
   display: grid;
-  gap: 10px;
+  gap: var(--pc-space-3);
 }
 
 .item {
-  border: 1px solid var(--pc-border);
-  border-radius: 20px;
-  background: var(--pc-bg-card);
-  padding: 16px;
+  padding: var(--pc-space-4);
   display: grid;
-  gap: 12px;
+  gap: var(--pc-space-3);
 }
 
 .item[data-read='false'] {
@@ -199,43 +140,30 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-}
-
-.typeLabel {
-  min-height: 28px;
-  border: 1px solid var(--pc-border);
-  border-radius: 999px;
-  background: var(--pc-bg-elevated);
-  color: var(--pc-text-secondary);
-  padding: 0 9px;
-  display: inline-flex;
-  align-items: center;
-  font-size: 11px;
-  font-weight: 900;
+  gap: var(--pc-space-3);
 }
 
 .itemTop time {
   color: var(--pc-text-muted);
-  font-size: 11px;
-  font-weight: 750;
+  font-size: var(--ds-font-caption);
+  font-weight: 700;
 }
 
 .itemBody {
   display: grid;
-  gap: 6px;
+  gap: var(--pc-space-2);
 }
 
 .itemBody h2 {
   color: var(--pc-text-primary);
-  font-size: 16px;
+  font-size: var(--ds-font-body);
   line-height: 1.3;
-  font-weight: 950;
+  font-weight: 900;
 }
 
 .itemBody p {
   color: var(--pc-text-secondary);
-  font-size: 14px;
+  font-size: var(--ds-font-body);
   line-height: 1.5;
 }
 
@@ -243,26 +171,43 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--pc-space-2);
   flex-wrap: wrap;
 }
 
-.readStatus {
-  min-height: 40px;
+.primaryLink {
+  min-height: 44px;
+  border: 1px solid var(--pc-accent);
+  border-radius: var(--pc-radius-md);
+  background: var(--pc-accent);
+  color: var(--pc-accent-contrast);
+  padding: 0 var(--pc-space-4);
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  color: var(--pc-text-muted);
-  font-size: 12px;
-  font-weight: 850;
+  justify-content: center;
+  font-size: var(--ds-font-body);
+  font-weight: 800;
+  text-decoration: none;
 }
 
-.primaryButton:focus-visible,
-.secondaryButton:focus-visible,
-.readButton:focus-visible,
+.readStatus {
+  min-height: var(--ds-control-height-compact);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pc-space-2);
+  color: var(--pc-text-muted);
+  font-size: var(--ds-font-caption);
+  font-weight: 800;
+}
+
+.readStatus svg {
+  width: 18px;
+  height: 18px;
+}
+
 .primaryLink:focus-visible,
 .switchLabel input:focus-visible {
-  outline: 3px solid color-mix(in srgb, var(--pc-accent) 38%, transparent);
+  outline: 3px solid var(--ds-color-focus);
   outline-offset: 3px;
 }
 
@@ -278,38 +223,29 @@
   .hero {
     grid-template-columns: 44px minmax(0, 1fr);
     min-height: 84px;
-    padding: 14px;
-    border-radius: 18px;
+    padding: var(--pc-space-4);
   }
 
   .heroIcon {
     width: 44px;
     height: 44px;
-    border-radius: 14px;
   }
 
-  .controls {
-    align-items: stretch;
-    flex-direction: column;
+  .hero > :last-child {
+    grid-column: 1 / -1;
+    justify-self: start;
   }
 
-  .secondaryButton {
-    width: 100%;
-  }
-
-  .item {
-    padding: 14px;
-    border-radius: 18px;
-  }
-
+  .controls,
   .itemTop,
   .itemActions {
     align-items: stretch;
     flex-direction: column;
   }
 
+  .controls button,
   .primaryLink,
-  .readButton {
+  .itemActions button {
     width: 100%;
   }
 }
@@ -319,16 +255,9 @@
 }
 
 @media (forced-colors: active) {
-  .hero,
-  .controls,
-  .stateCard,
-  .emptyCard,
-  .item,
-  .typeLabel,
-  .primaryButton,
-  .secondaryButton,
-  .readButton,
-  .primaryLink {
+  .heroIcon,
+  .primaryLink,
+  .item[data-read='false'] {
     border: 1px solid CanvasText;
   }
 }

--- a/apps/web/app/platform-v7/notifications/page.tsx
+++ b/apps/web/app/platform-v7/notifications/page.tsx
@@ -2,9 +2,13 @@
 
 import * as React from 'react';
 import Link from 'next/link';
+import { useLocale } from 'next-intl';
 import { AlertTriangle, Bell, Check, CheckCheck, RefreshCw } from 'lucide-react';
-import { Surface } from '@pc/design-system-v8';
+import { Button, InlineNotice, StatusChip, Surface } from '@pc/design-system-v8';
 import styles from './notifications.module.css';
+
+type Locale = 'ru' | 'en' | 'zh';
+type NotificationTone = 'neutral' | 'information' | 'warning';
 
 type NotificationItem = {
   id: string;
@@ -21,6 +25,140 @@ type LoadState =
   | { kind: 'loading' }
   | { kind: 'ready'; items: NotificationItem[] }
   | { kind: 'error'; message: string };
+
+type Copy = Readonly<{
+  title: string;
+  loadingTitle: string;
+  loadingBody: string;
+  unavailableTitle: string;
+  sessionExpired: string;
+  loadFailed: string;
+  invalidPayload: string;
+  timeout: string;
+  retry: string;
+  unreadCount: (count: number) => string;
+  noNew: string;
+  controlsLabel: string;
+  unreadOnly: string;
+  markAll: string;
+  markAllBusy: string;
+  markRead: string;
+  markReadBusy: string;
+  read: string;
+  markReadFailed: string;
+  markAllFailed: string;
+  emptyUnreadTitle: string;
+  emptyTitle: string;
+  emptyBody: string;
+  listLabel: string;
+  openDeal: string;
+  timeUnknown: string;
+  types: Readonly<{
+    deal: string;
+    shipment: string;
+    document: string;
+    kyc: string;
+    financing: string;
+    support: string;
+    system: string;
+  }>;
+}>;
+
+const COPY: Record<Locale, Copy> = {
+  ru: {
+    title: 'Уведомления',
+    loadingTitle: 'Загружаем уведомления',
+    loadingBody: 'Покажем только события, полученные для твоего аккаунта и доступных сделок.',
+    unavailableTitle: 'Уведомления недоступны',
+    sessionExpired: 'Сессия не подтверждена. Войди в платформу заново.',
+    loadFailed: 'Не удалось получить уведомления.',
+    invalidPayload: 'Сервер вернул уведомления в неизвестном формате.',
+    timeout: 'Сервер не ответил вовремя. Повтори загрузку.',
+    retry: 'Повторить',
+    unreadCount: (count) => `Непрочитанных: ${count}`,
+    noNew: 'Новых уведомлений нет',
+    controlsLabel: 'Настройки списка уведомлений',
+    unreadOnly: 'Только непрочитанные',
+    markAll: 'Прочитать все',
+    markAllBusy: 'Сохраняем…',
+    markRead: 'Отметить прочитанным',
+    markReadBusy: 'Сохраняем…',
+    read: 'Прочитано',
+    markReadFailed: 'Не удалось сохранить отметку. Уведомление осталось непрочитанным.',
+    markAllFailed: 'Не удалось отметить все уведомления. Попробуй ещё раз.',
+    emptyUnreadTitle: 'Все уведомления прочитаны',
+    emptyTitle: 'Уведомлений пока нет',
+    emptyBody: 'Здесь появятся только фактические события твоего аккаунта и доступных сделок.',
+    listLabel: 'Список уведомлений',
+    openDeal: 'Открыть сделку',
+    timeUnknown: 'Время не указано',
+    types: { deal: 'Сделка', shipment: 'Перевозка', document: 'Документы', kyc: 'Проверка', financing: 'Финансирование', support: 'Поддержка', system: 'Система' },
+  },
+  en: {
+    title: 'Notifications',
+    loadingTitle: 'Loading notifications',
+    loadingBody: 'Only events issued for your account and accessible deals will be shown.',
+    unavailableTitle: 'Notifications are unavailable',
+    sessionExpired: 'The session is not confirmed. Sign in to the platform again.',
+    loadFailed: 'Notifications could not be loaded.',
+    invalidPayload: 'The server returned notifications in an unknown format.',
+    timeout: 'The server did not respond in time. Retry the request.',
+    retry: 'Retry',
+    unreadCount: (count) => `Unread: ${count}`,
+    noNew: 'No new notifications',
+    controlsLabel: 'Notification list settings',
+    unreadOnly: 'Unread only',
+    markAll: 'Mark all as read',
+    markAllBusy: 'Saving…',
+    markRead: 'Mark as read',
+    markReadBusy: 'Saving…',
+    read: 'Read',
+    markReadFailed: 'The read state could not be saved. The notification remains unread.',
+    markAllFailed: 'Notifications could not be marked as read. Try again.',
+    emptyUnreadTitle: 'All notifications are read',
+    emptyTitle: 'No notifications yet',
+    emptyBody: 'Only actual events from your account and accessible deals will appear here.',
+    listLabel: 'Notification list',
+    openDeal: 'Open deal',
+    timeUnknown: 'Time not provided',
+    types: { deal: 'Deal', shipment: 'Shipment', document: 'Documents', kyc: 'Verification', financing: 'Financing', support: 'Support', system: 'System' },
+  },
+  zh: {
+    title: '通知',
+    loadingTitle: '正在加载通知',
+    loadingBody: '这里只显示发送给你的账户以及你有权访问的交易事件。',
+    unavailableTitle: '通知暂不可用',
+    sessionExpired: '会话未确认。请重新登录平台。',
+    loadFailed: '无法加载通知。',
+    invalidPayload: '服务器返回了未知格式的通知。',
+    timeout: '服务器未及时响应。请重试。',
+    retry: '重试',
+    unreadCount: (count) => `未读：${count}`,
+    noNew: '没有新通知',
+    controlsLabel: '通知列表设置',
+    unreadOnly: '仅显示未读',
+    markAll: '全部标为已读',
+    markAllBusy: '正在保存…',
+    markRead: '标为已读',
+    markReadBusy: '正在保存…',
+    read: '已读',
+    markReadFailed: '无法保存已读状态。该通知仍为未读。',
+    markAllFailed: '无法将全部通知标为已读。请重试。',
+    emptyUnreadTitle: '所有通知均已读',
+    emptyTitle: '暂无通知',
+    emptyBody: '这里只会显示你的账户和可访问交易产生的真实事件。',
+    listLabel: '通知列表',
+    openDeal: '打开交易',
+    timeUnknown: '未提供时间',
+    types: { deal: '交易', shipment: '运输', document: '文件', kyc: '核验', financing: '融资', support: '支持', system: '系统' },
+  },
+};
+
+function localeOf(value: string): Locale {
+  if (value.startsWith('en')) return 'en';
+  if (value.startsWith('zh')) return 'zh';
+  return 'ru';
+}
 
 function validNotification(value: unknown): value is NotificationItem {
   if (!value || typeof value !== 'object') return false;
@@ -40,10 +178,11 @@ function parseItems(payload: unknown): NotificationItem[] | null {
   return items.every(validNotification) ? items : null;
 }
 
-function formatTime(value: string): string {
+function formatTime(value: string, locale: Locale, fallback: string): string {
   const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return 'Время не указано';
-  return new Intl.DateTimeFormat('ru-RU', {
+  if (Number.isNaN(date.getTime())) return fallback;
+  const localeTag = locale === 'en' ? 'en-GB' : locale === 'zh' ? 'zh-CN' : 'ru-RU';
+  return new Intl.DateTimeFormat(localeTag, {
     day: '2-digit',
     month: 'short',
     hour: '2-digit',
@@ -51,17 +190,19 @@ function formatTime(value: string): string {
   }).format(date);
 }
 
-function typeLabel(type: string): string {
-  if (type.startsWith('deal:')) return 'Сделка';
-  if (type.startsWith('shipment:') || type.startsWith('etn:')) return 'Перевозка';
-  if (type.startsWith('document:') || type.startsWith('edo:')) return 'Документы';
-  if (type.startsWith('kyc:')) return 'Проверка';
-  if (type.startsWith('factoring:')) return 'Финансирование';
-  if (type.startsWith('support:')) return 'Поддержка';
-  return 'Система';
+function notificationType(type: string, copy: Copy): { label: string; tone: NotificationTone } {
+  if (type.startsWith('deal:')) return { label: copy.types.deal, tone: 'information' };
+  if (type.startsWith('shipment:') || type.startsWith('etn:')) return { label: copy.types.shipment, tone: 'information' };
+  if (type.startsWith('document:') || type.startsWith('edo:')) return { label: copy.types.document, tone: 'neutral' };
+  if (type.startsWith('kyc:')) return { label: copy.types.kyc, tone: 'warning' };
+  if (type.startsWith('factoring:')) return { label: copy.types.financing, tone: 'information' };
+  if (type.startsWith('support:')) return { label: copy.types.support, tone: 'neutral' };
+  return { label: copy.types.system, tone: 'neutral' };
 }
 
 export default function NotificationsPage() {
+  const locale = localeOf(useLocale());
+  const copy = COPY[locale];
   const [state, setState] = React.useState<LoadState>({ kind: 'loading' });
   const [unreadOnly, setUnreadOnly] = React.useState(false);
   const [busyIds, setBusyIds] = React.useState<Set<string>>(new Set());
@@ -82,31 +223,24 @@ export default function NotificationsPage() {
       });
       const payload = await response.json().catch(() => null);
       if (!response.ok) {
-        setState({
-          kind: 'error',
-          message: response.status === 401 || response.status === 403
-            ? 'Сессия не подтверждена. Войди в платформу заново.'
-            : 'Не удалось получить уведомления.',
-        });
+        setState({ kind: 'error', message: response.status === 401 || response.status === 403 ? copy.sessionExpired : copy.loadFailed });
         return;
       }
       const items = parseItems(payload);
       if (!items) {
-        setState({ kind: 'error', message: 'Сервер вернул уведомления в неизвестном формате.' });
+        setState({ kind: 'error', message: copy.invalidPayload });
         return;
       }
       setState({ kind: 'ready', items });
     } catch (error) {
       setState({
         kind: 'error',
-        message: error instanceof DOMException && error.name === 'AbortError'
-          ? 'Сервер не ответил вовремя. Повтори загрузку.'
-          : 'Не удалось получить уведомления.',
+        message: error instanceof DOMException && error.name === 'AbortError' ? copy.timeout : copy.loadFailed,
       });
     } finally {
       window.clearTimeout(timeout);
     }
-  }, []);
+  }, [copy.invalidPayload, copy.loadFailed, copy.sessionExpired, copy.timeout]);
 
   React.useEffect(() => {
     void load();
@@ -123,15 +257,10 @@ export default function NotificationsPage() {
       });
       if (!response.ok) throw new Error('mark_read_failed');
       setState((current) => current.kind === 'ready'
-        ? {
-            kind: 'ready',
-            items: current.items.map((item) => item.id === id
-              ? { ...item, read: true, readAt: new Date().toISOString() }
-              : item),
-          }
+        ? { kind: 'ready', items: current.items.map((item) => item.id === id ? { ...item, read: true, readAt: new Date().toISOString() } : item) }
         : current);
     } catch {
-      setActionError('Не удалось сохранить отметку. Уведомление осталось непрочитанным.');
+      setActionError(copy.markReadFailed);
     } finally {
       setBusyIds((current) => {
         const next = new Set(current);
@@ -139,12 +268,10 @@ export default function NotificationsPage() {
         return next;
       });
     }
-  }, []);
+  }, [copy.markReadFailed]);
 
   const markAllRead = React.useCallback(async () => {
-    const unreadIds = state.kind === 'ready'
-      ? state.items.filter((item) => !item.read).map((item) => item.id)
-      : [];
+    const unreadIds = state.kind === 'ready' ? state.items.filter((item) => !item.read).map((item) => item.id) : [];
     if (!unreadIds.length) return;
     setActionError(null);
     setBusyIds(new Set(unreadIds));
@@ -156,29 +283,22 @@ export default function NotificationsPage() {
       });
       if (!response.ok) throw new Error('mark_all_failed');
       setState((current) => current.kind === 'ready'
-        ? {
-            kind: 'ready',
-            items: current.items.map((item) => ({
-              ...item,
-              read: true,
-              readAt: item.readAt ?? new Date().toISOString(),
-            })),
-          }
+        ? { kind: 'ready', items: current.items.map((item) => ({ ...item, read: true, readAt: item.readAt ?? new Date().toISOString() })) }
         : current);
     } catch {
-      setActionError('Не удалось отметить все уведомления. Попробуй ещё раз.');
+      setActionError(copy.markAllFailed);
     } finally {
       setBusyIds(new Set());
     }
-  }, [state]);
+  }, [copy.markAllFailed, state]);
 
   if (state.kind === 'loading') {
     return (
       <main className={styles.page}>
         <Surface className={styles.stateCard} aria-live='polite'>
           <RefreshCw className={styles.spin} aria-hidden='true' />
-          <h1>Загружаем уведомления</h1>
-          <p>Покажем только события, полученные для твоего аккаунта.</p>
+          <h1>{copy.loadingTitle}</h1>
+          <p>{copy.loadingBody}</p>
         </Surface>
       </main>
     );
@@ -187,13 +307,9 @@ export default function NotificationsPage() {
   if (state.kind === 'error') {
     return (
       <main className={styles.page}>
-        <Surface className={styles.stateCard} role='alert'>
-          <AlertTriangle className={styles.errorIcon} aria-hidden='true' />
-          <h1>Уведомления недоступны</h1>
-          <p>{state.message}</p>
-          <button className={styles.primaryButton} type='button' onClick={() => void load()}>
-            <RefreshCw aria-hidden='true' />Повторить
-          </button>
+        <Surface className={styles.stateCard}>
+          <InlineNotice tone='critical' icon={<AlertTriangle />} title={copy.unavailableTitle}>{state.message}</InlineNotice>
+          <Button onClick={() => void load()}><RefreshCw aria-hidden='true' />{copy.retry}</Button>
         </Surface>
       </main>
     );
@@ -204,46 +320,43 @@ export default function NotificationsPage() {
 
   return (
     <main className={styles.page}>
-      <header className={styles.hero}>
+      <Surface className={styles.hero}>
         <div className={styles.heroIcon}><Bell aria-hidden='true' /></div>
-        <div>
-          <h1>Уведомления</h1>
-          <p>{unreadCount ? `Непрочитанных: ${unreadCount}` : 'Новых уведомлений нет'}</p>
+        <div className={styles.heroCopy}>
+          <h1>{copy.title}</h1>
+          <p>{unreadCount ? copy.unreadCount(unreadCount) : copy.noNew}</p>
         </div>
-      </header>
-
-      <Surface variant='plain' padded={false} className={styles.controls} aria-label='Настройки списка уведомлений'>
-        <label className={styles.switchLabel}>
-          <input type='checkbox' checked={unreadOnly} onChange={(event) => setUnreadOnly(event.target.checked)} />
-          <span>Только непрочитанные</span>
-        </label>
-        <button className={styles.secondaryButton} type='button' disabled={!unreadCount || busyIds.size > 0} onClick={() => void markAllRead()}>
-          <CheckCheck aria-hidden='true' />Прочитать все
-        </button>
+        <StatusChip tone={unreadCount ? 'information' : 'success'}>{unreadCount ? copy.unreadCount(unreadCount) : copy.noNew}</StatusChip>
       </Surface>
 
-      {actionError ? (
-        <Surface variant='subtle' className={styles.controls} role='alert'>
-          <AlertTriangle className={styles.errorIcon} aria-hidden='true' />
-          <span>{actionError}</span>
-        </Surface>
-      ) : null}
+      <Surface className={styles.controls} variant='subtle' aria-label={copy.controlsLabel}>
+        <label className={styles.switchLabel}>
+          <input type='checkbox' checked={unreadOnly} onChange={(event) => setUnreadOnly(event.target.checked)} />
+          <span>{copy.unreadOnly}</span>
+        </label>
+        <Button variant='secondary' disabled={!unreadCount || busyIds.size > 0} onClick={() => void markAllRead()}>
+          <CheckCheck aria-hidden='true' />{busyIds.size > 0 ? copy.markAllBusy : copy.markAll}
+        </Button>
+      </Surface>
+
+      {actionError ? <InlineNotice tone='critical' icon={<AlertTriangle />} title={copy.unavailableTitle}>{actionError}</InlineNotice> : null}
 
       {visibleItems.length === 0 ? (
         <Surface className={styles.emptyCard}>
           <Check className={styles.successIcon} aria-hidden='true' />
-          <h2>{unreadOnly ? 'Все уведомления прочитаны' : 'Уведомлений пока нет'}</h2>
-          <p>Здесь появятся только фактические события твоего аккаунта и доступных сделок.</p>
+          <h2>{unreadOnly ? copy.emptyUnreadTitle : copy.emptyTitle}</h2>
+          <p>{copy.emptyBody}</p>
         </Surface>
       ) : (
-        <section className={styles.list} aria-label='Список уведомлений'>
+        <section className={styles.list} aria-label={copy.listLabel}>
           {visibleItems.map((item) => {
             const busy = busyIds.has(item.id);
+            const type = notificationType(item.type, copy);
             return (
-              <Surface className={styles.item} data-read={item.read ? 'true' : 'false'} key={item.id} role='article'>
+              <Surface className={styles.item} data-read={item.read ? 'true' : 'false'} key={item.id}>
                 <div className={styles.itemTop}>
-                  <span className={styles.typeLabel}>{typeLabel(item.type)}</span>
-                  <time dateTime={item.createdAt}>{formatTime(item.createdAt)}</time>
+                  <StatusChip tone={type.tone}>{type.label}</StatusChip>
+                  <time dateTime={item.createdAt}>{formatTime(item.createdAt, locale, copy.timeUnknown)}</time>
                 </div>
                 <div className={styles.itemBody}>
                   <h2>{item.title}</h2>
@@ -252,14 +365,14 @@ export default function NotificationsPage() {
                 <div className={styles.itemActions}>
                   {item.dealId ? (
                     <Link className={styles.primaryLink} href={`/platform-v7/deals/${encodeURIComponent(item.dealId)}/execution`}>
-                      Открыть сделку
+                      {copy.openDeal}
                     </Link>
                   ) : null}
                   {!item.read ? (
-                    <button className={styles.readButton} type='button' disabled={busy} onClick={() => void markRead(item.id)}>
-                      <Check aria-hidden='true' />{busy ? 'Сохраняем…' : 'Прочитано'}
-                    </button>
-                  ) : <span className={styles.readStatus}><Check aria-hidden='true' />Прочитано</span>}
+                    <Button variant='secondary' disabled={busy} onClick={() => void markRead(item.id)}>
+                      <Check aria-hidden='true' />{busy ? copy.markReadBusy : copy.markRead}
+                    </Button>
+                  ) : <span className={styles.readStatus}><Check aria-hidden='true' />{copy.read}</span>}
                 </div>
               </Surface>
             );

--- a/apps/web/tests/unit/platformV7NotificationsAuthority.test.ts
+++ b/apps/web/tests/unit/platformV7NotificationsAuthority.test.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(process.cwd(), '../..');
+const read = (relativePath: string) => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+const page = read('apps/web/app/platform-v7/notifications/page.tsx');
+const css = read('apps/web/app/platform-v7/notifications/notifications.module.css');
+const routePolicy = read('apps/web/lib/platform-v7/design-system-v8-route-policy.ts');
+const governance = JSON.parse(read('design-governance-v8.json'));
+const migrationScope = JSON.parse(read('scripts/design-system-v8-route-migration-scope.json')) as string[];
+const workflow = read('.github/workflows/design-system-v8.yml');
+
+const pagePath = 'apps/web/app/platform-v7/notifications/page.tsx';
+const cssPath = 'apps/web/app/platform-v7/notifications/notifications.module.css';
+const testPath = 'apps/web/tests/unit/platformV7NotificationsAuthority.test.ts';
+
+describe('platform-v7 notifications authority', () => {
+  it('uses the governed v8 components and complete RU, EN and ZH copy', () => {
+    expect(page).toContain("import { useLocale } from 'next-intl'");
+    expect(page).toContain("import { Button, InlineNotice, StatusChip, Surface } from '@pc/design-system-v8'");
+    expect(page).toContain("title: 'Уведомления'");
+    expect(page).toContain("title: 'Notifications'");
+    expect(page).toContain("title: '通知'");
+    expect(page).not.toContain('style={{');
+    expect(page).not.toContain('dangerouslySetInnerHTML');
+  });
+
+  it('keeps the account-scoped read and write API as the only notification authority', () => {
+    expect(page).toContain("fetch('/api/proxy/notifications'");
+    expect(page).toContain("fetch(`/api/proxy/notifications/${encodeURIComponent(id)}/read`");
+    expect(page).toContain("fetch('/api/proxy/notifications/read-all'");
+    expect(page).toContain("cache: 'no-store'");
+    expect(page.match(/credentials: 'same-origin'/g)?.length).toBe(3);
+    expect(page.match(/method: 'PATCH'/g)?.length).toBe(2);
+    expect(page).toContain('AbortController');
+    expect(page).toContain('12_000');
+    expect(page).toContain('validNotification');
+    expect(page).toContain('parseItems');
+    expect(page).not.toContain('localStorage');
+    expect(page).not.toContain('sessionStorage');
+  });
+
+  it('updates local read state only after a successful server response', () => {
+    const singlePatch = page.indexOf("fetch(`/api/proxy/notifications/${encodeURIComponent(id)}/read`");
+    const singleSuccessGuard = page.indexOf("if (!response.ok) throw new Error('mark_read_failed')", singlePatch);
+    const singleStateUpdate = page.indexOf('setState((current) => current.kind', singleSuccessGuard);
+    expect(singlePatch).toBeGreaterThan(-1);
+    expect(singleSuccessGuard).toBeGreaterThan(singlePatch);
+    expect(singleStateUpdate).toBeGreaterThan(singleSuccessGuard);
+
+    const allPatch = page.indexOf("fetch('/api/proxy/notifications/read-all'");
+    const allSuccessGuard = page.indexOf("if (!response.ok) throw new Error('mark_all_failed')", allPatch);
+    const allStateUpdate = page.indexOf('setState((current) => current.kind', allSuccessGuard);
+    expect(allPatch).toBeGreaterThan(-1);
+    expect(allSuccessGuard).toBeGreaterThan(allPatch);
+    expect(allStateUpdate).toBeGreaterThan(allSuccessGuard);
+  });
+
+  it('keeps fail-closed loading, error, empty and read states', () => {
+    expect(page).toContain("kind: 'loading'");
+    expect(page).toContain("kind: 'error'");
+    expect(page).toContain("kind: 'ready'");
+    expect(page).toContain('response.status === 401 || response.status === 403');
+    expect(page).toContain('visibleItems.length === 0');
+    expect(page).toContain('item.read');
+    expect(page).toContain('actionError');
+  });
+
+  it('uses token-only mobile and accessibility styles', () => {
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}\b/i);
+    expect(css).not.toMatch(/\brgba?\s*\(/i);
+    expect(css).not.toContain('!important');
+    expect(css).toContain('@media (max-width: 640px)');
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(css).toContain('@media (forced-colors: active)');
+    expect(css).toContain('var(--ds-color-focus)');
+    expect(css).toContain('var(--pc-space-4)');
+  });
+
+  it('registers the route, files and regression in exact governance', () => {
+    expect(routePolicy).toContain("'/platform-v7/notifications'");
+    expect(governance.migratedFiles).toContain(pagePath);
+    expect(governance.governedRoots).toContain(cssPath);
+    expect(migrationScope).toContain(pagePath);
+    expect(migrationScope).toContain(cssPath);
+    expect(migrationScope).toContain(testPath);
+    expect(workflow).toContain('tests/unit/platformV7NotificationsAuthority.test.ts');
+  });
+});

--- a/design-governance-v8.json
+++ b/design-governance-v8.json
@@ -1,5 +1,5 @@
 {
-  "version": 38,
+  "version": 39,
   "tokenSource": "packages/design-tokens/tokens.json",
   "tokenCss": "packages/design-tokens/tokens.css",
   "governedRoots": [
@@ -16,6 +16,7 @@
     "apps/web/app/platform-v7/bank/events/page.tsx",
     "apps/web/app/platform-v7/bank/events/[id]/page.tsx",
     "apps/web/app/platform-v7/bank/grain/page.tsx",
+    "apps/web/app/platform-v7/notifications/notifications.module.css",
     "apps/web/lib/audit-server.ts",
     "apps/web/lib/disputes-server.ts",
     "apps/web/lib/integrations-server.ts",

--- a/scripts/design-system-v8-route-migration-scope.json
+++ b/scripts/design-system-v8-route-migration-scope.json
@@ -11,6 +11,7 @@
   "apps/web/app/platform-v7/elevator/terminal/page.tsx",
   "apps/web/app/platform-v7/elevator/terminal/[operationId]/page.tsx",
   "apps/web/app/platform-v7/notifications/page.tsx",
+  "apps/web/app/platform-v7/notifications/notifications.module.css",
   "apps/web/app/platform-v7/pilot-runbook/page.tsx",
   "apps/web/app/platform-v7/readiness/page.tsx",
   "apps/web/app/platform-v7/support/page.tsx",


### PR DESCRIPTION
## Что изменено

После объединённого PR #2583 legacy-route inventory уже равен нулю. Этот PR не повторяет closure и не меняет route classification.

- `/platform-v7/notifications` сохраняет account-scoped GET/PATCH API и fail-closed модель;
- локальное read-state меняется только после успешного server PATCH;
- интерфейс полностью переведён на `Surface`, `Button`, `InlineNotice` и `StatusChip` Design System v8;
- добавлена полная RU/EN/ZH-копия, включая ошибки, пустые состояния, типы событий, кнопки и локализованное время;
- CSS переведён на токены, включён в governed roots и очищен от literal colors/local component styling;
- mobile-first, keyboard focus, reduced-motion и forced-colors сохранены;
- focused regression включён в governed Design System v8 CI и exact migration manifest.

## Архитектурная граница

- notification authority остаётся у account-scoped API и серверной сессии;
- браузер не создаёт уведомления, object access или факт прочтения без успешного PATCH;
- роль, tenant, Deal state, PostgreSQL schema, деньги и внешние интеграции не меняются;
- `zeroLegacy=true` должен сохраниться без изменения `pageFiles`, alias policy или catch-all boundary.

## Exact-head acceptance

- base: current main `9d9f6d9409298c08f32b55d06363bb6b19948774`;
- exact head: `0c83940c940a7161b957e83520c8f97791e36ebb`;
- один атомарный commit, 6 файлов;
- route inventory обязан сохранить `protected-legacy=0`, `legacyRouteFiles=0`, `zeroLegacy=true`;
- focused notifications authority regression;
- Design System v8, autopilot inventory, web-unit, Node CI, основной CI и security gates.

Продолжение #2516.