### PR TITLE
Fix mobile homepage card density and support overlap

### DIFF
--- a/apps/web/styles/platform-v7-public-typography.css
+++ b/apps/web/styles/platform-v7-public-typography.css
@@ -347,13 +347,128 @@ html:is([lang='zh-CN'], [data-p7-language='zh']) .pc-v7-public-entry :where(h1, 
     line-height: 1.25;
   }
 
+  .pc-v7-public-entry .entry-section {
+    padding-top: 36px !important;
+    padding-bottom: 36px !important;
+  }
+
+  .pc-v7-public-entry .entry-section-head {
+    gap: 8px !important;
+    margin-bottom: 18px !important;
+  }
+
   .pc-v7-public-entry .entry-section-head h2 {
-    font-size: clamp(30px, 8.2vw, 40px);
-    line-height: 1.1;
+    font-size: 30px !important;
+    font-weight: 700 !important;
+    line-height: 1.1 !important;
+    letter-spacing: -0.03em !important;
   }
 
   .pc-v7-public-entry .entry-section-head p {
-    font-size: 15px;
+    max-width: 36rem;
+    font-size: 15px !important;
+    font-weight: 400 !important;
+    line-height: 1.5 !important;
+  }
+
+  html body .pc-v7-public-entry .entry-control-grid,
+  html body .pc-v7-public-entry .entry-role-grid {
+    grid-template-columns: minmax(0, 1fr) !important;
+    gap: 12px !important;
+  }
+
+  html body .pc-v7-public-entry .entry-control-tile,
+  html body .pc-v7-public-entry .entry-role-tile {
+    min-width: 0 !important;
+    min-height: 0 !important;
+    display: grid !important;
+    grid-template-columns: 44px minmax(0, 1fr) !important;
+    align-items: start !important;
+    align-content: start !important;
+    gap: 5px 14px !important;
+    padding: 16px !important;
+    border-radius: 20px !important;
+  }
+
+  html body .pc-v7-public-entry .entry-control-tile > b,
+  html body .pc-v7-public-entry .entry-role-tile > b {
+    grid-column: 1 !important;
+    grid-row: 1 / span 3 !important;
+    width: 44px !important;
+    height: 44px !important;
+    border-radius: 14px !important;
+    font-family: Arial, "Helvetica Neue", sans-serif !important;
+    font-variant-emoji: text;
+  }
+
+  html body .pc-v7-public-entry .entry-control-tile > strong,
+  html body .pc-v7-public-entry .entry-role-tile > strong {
+    grid-column: 2 !important;
+    font-size: 20px !important;
+    font-weight: 700 !important;
+    line-height: 1.2 !important;
+    letter-spacing: -0.02em !important;
+  }
+
+  html body .pc-v7-public-entry .entry-control-tile > span,
+  html body .pc-v7-public-entry .entry-role-tile > span {
+    grid-column: 2 !important;
+    font-size: 14px !important;
+    font-weight: 400 !important;
+    line-height: 1.45 !important;
+    letter-spacing: 0 !important;
+  }
+
+  html body .pc-v7-public-entry .entry-role-tile > em {
+    grid-column: 2 !important;
+    justify-self: start !important;
+    min-height: 0 !important;
+    margin-top: 3px !important;
+    padding: 0 !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    font-size: 11.5px !important;
+    font-weight: 650 !important;
+    line-height: 1.3 !important;
+    letter-spacing: 0.01em !important;
+    white-space: normal !important;
+  }
+
+  html body .pc-v7-public-entry .entry-process-tile strong {
+    font-size: 18px !important;
+    font-weight: 700 !important;
+    line-height: 1.18 !important;
+    letter-spacing: -0.02em !important;
+  }
+
+  html body .pc-v7-public-entry .entry-process-tile small {
+    font-size: 13px !important;
+    font-weight: 400 !important;
+    line-height: 1.42 !important;
+    letter-spacing: 0 !important;
+  }
+
+  html body .pc-v7-public-entry .entry-process-index {
+    font-size: 13px !important;
+    font-weight: 700 !important;
+  }
+
+  html body .pc-v7-public-entry .entry-process-icon b {
+    font-family: Arial, "Helvetica Neue", sans-serif !important;
+    font-variant-emoji: text;
+  }
+
+  html body .pc-v7-public-entry .p7-support-chat-button {
+    right: max(12px, env(safe-area-inset-right, 0px)) !important;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 14px) !important;
+    width: 48px !important;
+    height: 48px !important;
+    border-radius: 16px !important;
+    box-shadow: 0 12px 28px rgba(0, 122, 47, 0.22) !important;
+  }
+
+  .pc-v7-public-entry .entry-footer {
+    padding-bottom: max(86px, env(safe-area-inset-bottom)) !important;
   }
 }
 
@@ -365,5 +480,18 @@ html:is([lang='zh-CN'], [data-p7-language='zh']) .pc-v7-public-entry :where(h1, 
   .pc-v7-public-entry .entry-kicker {
     font-size: 9px;
     letter-spacing: 0.035em;
+  }
+
+  html body .pc-v7-public-entry .entry-control-tile,
+  html body .pc-v7-public-entry .entry-role-tile {
+    grid-template-columns: 40px minmax(0, 1fr) !important;
+    gap: 5px 12px !important;
+    padding: 14px !important;
+  }
+
+  html body .pc-v7-public-entry .entry-control-tile > b,
+  html body .pc-v7-public-entry .entry-role-tile > b {
+    width: 40px !important;
+    height: 40px !important;
   }
 }

--- a/apps/web/tests/unit/platformV7PublicTypography.test.ts
+++ b/apps/web/tests/unit/platformV7PublicTypography.test.ts
@@ -50,4 +50,20 @@ describe('platform-v7 public homepage typography', () => {
     expect(typography).toContain('font-weight: 700;');
     expect(typography).toContain('font-size: 16px;');
   });
+
+  it('keeps mobile control and role content readable instead of forcing dense two-column cards', () => {
+    expect(typography).toContain('html body .pc-v7-public-entry .entry-control-grid');
+    expect(typography).toContain('html body .pc-v7-public-entry .entry-role-grid');
+    expect(typography).toContain('grid-template-columns: minmax(0, 1fr) !important;');
+    expect(typography).toContain('grid-template-columns: 44px minmax(0, 1fr) !important;');
+    expect(typography).toContain('font-size: 14px !important;');
+    expect(typography).toContain('background: transparent !important;');
+  });
+
+  it('reduces fixed support overlap and preserves text glyph rendering on iOS', () => {
+    expect(typography).toContain('html body .pc-v7-public-entry .p7-support-chat-button');
+    expect(typography).toContain('width: 48px !important;');
+    expect(typography).toContain('height: 48px !important;');
+    expect(typography).toContain('font-variant-emoji: text;');
+  });
 });


### PR DESCRIPTION
## Проверено по мобильным скриншотам
- hero после PR #2603 стал приемлемым;
- fixed-header имеет штатную высоту 64 px, обрезанный заголовок на отдельных кадрах вызван промежуточной позицией прокрутки, а не заходом стартового контента под шапку;
- реальные дефекты оставались ниже: двухколоночные карточки с длинными текстами, слишком тяжёлая вторичная типографика, ложный вид CTA у подписи роли, emoji-рендер стрелки на iOS и перекрытие контента виджетом поддержки.

## Исправление
- control и role cards на телефоне переведены в компактные одноколоночные горизонтальные карточки;
- заголовки секций ограничены 30 px, основной текст — 15 px;
- карточки: заголовок 20 px, описание 14 px, нормальный вес 400;
- «Обязанности участника» больше не выглядит кнопкой;
- process carousel облегчен до 18/13 px без веса 950;
- символьные glyph принудительно рендерятся как текст, а не цветные emoji iOS;
- support FAB уменьшен до 48 px, снижена тень, footer получил безопасный нижний резерв;
- desktop, header architecture, auth, RBAC и transaction contour не изменены.

## Проверка
Добавлены статические guards на одноколоночную mobile-сетку, компактную карточку, размер support FAB и text glyph rendering.