### PR TITLE
Hotfix production Netlify runtime for Next.js 15

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,3 @@
   NEXT_TELEMETRY_DISABLED = "1"
   PNPM_CONFIG_NODE_LINKER = "hoisted"
   NPM_FLAGS = "--config.node-linker=hoisted"
-
-[[plugins]]
-  package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Инцидент
Production-деплой на процент-агро.рф падает при первом SSR-запросе с `snapshot is not a function`.

## Причина
После перехода на Next.js 15.5.18 Netlify продолжил использовать legacy `@netlify/plugin-nextjs` / `@netlify/next-runtime@4.41.6`, хотя актуальная платформа Netlify для Next.js 13.5+ использует OpenNext adapter автоматически.

## Исправление
Удалён явный legacy-plugin из `netlify.toml`, чтобы Netlify выбрал текущий OpenNext adapter автоматически.

## Acceptance
- production build должен использовать OpenNext v5, а не next-runtime v4.41.6;
- `/platform-v7` должен вернуть HTML без runtime exception;
- мобильный Safari должен открыть главную без `snapshot is not a function`.
