### PR TITLE
Fix Netlify deploy gate for runtime configuration changes

### DIFF
--- a/scripts/netlify-ignore.sh
+++ b/scripts/netlify-ignore.sh
@@ -2,15 +2,23 @@
 set -euo pipefail
 
 HEAD_REF="${COMMIT_REF:-HEAD}"
+DEPLOY_PATHS=(
+  apps/web
+  package.json
+  pnpm-lock.yaml
+  pnpm-workspace.yaml
+  netlify.toml
+  scripts/netlify-ignore.sh
+)
 
 if [ -n "${REVIEW_ID:-}" ]; then
   git fetch origin main >/dev/null 2>&1 || true
   if git rev-parse --verify origin/main >/dev/null 2>&1; then
-    if git diff --quiet origin/main..."$HEAD_REF" -- apps/web package.json pnpm-lock.yaml pnpm-workspace.yaml; then
-      echo "Netlify ignore: no web/runtime changes detected in PR."
+    if git diff --quiet origin/main..."$HEAD_REF" -- "${DEPLOY_PATHS[@]}"; then
+      echo "Netlify ignore: no web/runtime/deploy changes detected in PR."
       exit 0
     fi
-    echo "Netlify ignore: web/runtime changes detected in PR."
+    echo "Netlify ignore: web/runtime/deploy changes detected in PR."
     exit 1
   fi
 fi
@@ -20,10 +28,10 @@ if [ -z "$BASE_REF" ] || ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; t
   BASE_REF="$(git rev-parse HEAD^ 2>/dev/null || printf '%s' "$HEAD_REF")"
 fi
 
-if git diff --quiet "$BASE_REF" "$HEAD_REF" -- apps/web package.json pnpm-lock.yaml pnpm-workspace.yaml; then
-  echo "Netlify ignore: no web/runtime changes detected."
+if git diff --quiet "$BASE_REF" "$HEAD_REF" -- "${DEPLOY_PATHS[@]}"; then
+  echo "Netlify ignore: no web/runtime/deploy changes detected."
   exit 0
 fi
 
-echo "Netlify ignore: web/runtime changes detected."
+echo "Netlify ignore: web/runtime/deploy changes detected."
 exit 1


### PR DESCRIPTION
## Инцидент
Hotfix Netlify adapter был объединён, но production deploy не запустился.

## Причина
`scripts/netlify-ignore.sh` проверял только `apps/web`, package manifests и lockfile. Изменения `netlify.toml` и самого deploy-gate ошибочно считались нерелевантными и пропускали сборку.

## Исправление
- добавлены `netlify.toml` и `scripts/netlify-ignore.sh` в deployment paths;
- сообщения gate уточнены до web/runtime/deploy;
- текущий commit сам должен пройти ignore-gate и запустить Netlify build.

## Acceptance
- Netlify не пропускает изменения adapter/runtime configuration;
- новый production deploy собирается с OpenNext adapter;
- `/platform-v7` открывается без `snapshot is not a function`.
