### PR TITLE
IR-AUCTION: make same-key command replay race-safe

### DIFF
--- a/.github/workflows/auction-atomic-acceptance.yml
+++ b/.github/workflows/auction-atomic-acceptance.yml
@@ -83,7 +83,9 @@ jobs:
         run: |
           set -o pipefail
           pnpm --filter @pc/api exec jest --config test/industrial/jest.config.json \
-            test/industrial/auction-atomic-execution.e2e-spec.ts --runInBand --json \
+            test/industrial/auction-atomic-execution.e2e-spec.ts \
+            test/industrial/auction-idempotency-race.e2e-spec.ts \
+            --runInBand --json \
             --outputFile="$GITHUB_WORKSPACE/$AUCTION_DIR/auction-jest.json" \
             2>&1 | tee "$GITHUB_WORKSPACE/$AUCTION_DIR/auction-jest.log"
       - name: Build exact-head machine evidence

--- a/apps/api/prisma/migrations/20260715013300_auction_atomic_execution/migration.sql
+++ b/apps/api/prisma/migrations/20260715013300_auction_atomic_execution/migration.sql
@@ -1,10 +1,10 @@
--- IR-AUCTION: serialize same-scope idempotent commands before replay lookup.
+-- IR-AUCTION: make same-scope idempotent commands race-safe.
 --
--- A transaction-scoped advisory lock is taken from the server-derived tenant,
--- command type, actor and idempotency key. Concurrent identical requests can no
--- longer both observe a missing receipt: the follower waits for the leader to
--- commit, then re-reads and returns the durable replay result. Different actors,
--- commands or idempotency keys remain independent.
+-- The advisory lock minimizes duplicate work. Under SERIALIZABLE, however, a
+-- follower can retain a snapshot taken before the leader committed. Therefore
+-- save_command also converts the residual unique-key race into SQLSTATE 40001.
+-- RlsTransactionService treats 40001 as retryable, restarts the full command,
+-- and the new transaction returns the durable replay receipt.
 
 CREATE OR REPLACE FUNCTION auction.replay_command(
   p_command_type text,
@@ -44,6 +44,41 @@ BEGIN
     RAISE EXCEPTION USING ERRCODE = 'P0001', MESSAGE = 'AUCTION_IDEMPOTENCY_PAYLOAD_MISMATCH';
   END IF;
   RETURN stored.result || jsonb_build_object('duplicate', true);
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION auction.save_command(
+  p_command_type text,
+  p_command_id text,
+  p_idempotency_key text,
+  p_request_hash text,
+  p_result jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, auction
+AS $function$
+BEGIN
+  INSERT INTO auction.command_receipts (
+    id, tenant_id, command_type, actor_id, idempotency_key,
+    command_id, request_hash, result, created_at
+  ) VALUES (
+    'auction-receipt-' || gen_random_uuid()::text,
+    current_setting('app.current_tenant_id', true),
+    p_command_type,
+    current_setting('app.current_user_id', true),
+    p_idempotency_key,
+    p_command_id,
+    p_request_hash,
+    p_result,
+    clock_timestamp()
+  );
+EXCEPTION
+  WHEN unique_violation THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '40001',
+      MESSAGE = 'AUCTION_IDEMPOTENCY_RACE_RETRY';
 END
 $function$;
 

--- a/apps/api/prisma/migrations/20260715013300_auction_atomic_execution/migration.sql
+++ b/apps/api/prisma/migrations/20260715013300_auction_atomic_execution/migration.sql
@@ -1,0 +1,51 @@
+-- IR-AUCTION: serialize same-scope idempotent commands before replay lookup.
+--
+-- A transaction-scoped advisory lock is taken from the server-derived tenant,
+-- command type, actor and idempotency key. Concurrent identical requests can no
+-- longer both observe a missing receipt: the follower waits for the leader to
+-- commit, then re-reads and returns the durable replay result. Different actors,
+-- commands or idempotency keys remain independent.
+
+CREATE OR REPLACE FUNCTION auction.replay_command(
+  p_command_type text,
+  p_idempotency_key text,
+  p_request_hash text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, auction
+AS $function$
+DECLARE
+  stored auction.command_receipts%ROWTYPE;
+  lock_material text;
+BEGIN
+  lock_material := concat_ws(
+    ':',
+    current_setting('app.current_tenant_id', true),
+    p_command_type,
+    current_setting('app.current_user_id', true),
+    p_idempotency_key
+  );
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(lock_material, 0));
+
+  SELECT * INTO stored
+  FROM auction.command_receipts receipt
+  WHERE receipt.tenant_id = current_setting('app.current_tenant_id', true)
+    AND receipt.command_type = p_command_type
+    AND receipt.actor_id = current_setting('app.current_user_id', true)
+    AND receipt.idempotency_key = p_idempotency_key;
+
+  IF NOT FOUND THEN
+    RETURN NULL;
+  END IF;
+  IF stored.request_hash <> p_request_hash THEN
+    RAISE EXCEPTION USING ERRCODE = 'P0001', MESSAGE = 'AUCTION_IDEMPOTENCY_PAYLOAD_MISMATCH';
+  END IF;
+  RETURN stored.result || jsonb_build_object('duplicate', true);
+END
+$function$;
+
+REVOKE ALL ON FUNCTION auction.replay_command(text, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION auction.replay_command(text, text, text) TO app_deal;

--- a/apps/api/prisma/migrations/20260715013300_auction_atomic_execution/migration.sql
+++ b/apps/api/prisma/migrations/20260715013300_auction_atomic_execution/migration.sql
@@ -82,5 +82,7 @@ EXCEPTION
 END
 $function$;
 
+-- Internal helpers stay owner-only. Application principals execute only the
+-- public auction command functions granted by the original authority migration.
 REVOKE ALL ON FUNCTION auction.replay_command(text, text, text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION auction.replay_command(text, text, text) TO app_deal;
+REVOKE ALL ON FUNCTION auction.save_command(text, text, text, text, jsonb) FROM PUBLIC;

--- a/apps/api/test/industrial/auction-idempotency-race.e2e-spec.ts
+++ b/apps/api/test/industrial/auction-idempotency-race.e2e-spec.ts
@@ -1,8 +1,7 @@
 import { Prisma, PrismaClient } from '@prisma/client';
 
 const ADMIN_URL = process.env.TEST_ADMIN_DATABASE_URL;
-const APP_URL = process.env.DATABASE_URL;
-const describeRace = ADMIN_URL && APP_URL ? describe : describe.skip;
+const describeRace = ADMIN_URL ? describe : describe.skip;
 
 const TENANT = 'tenant-auction-idempotency-race';
 const ACTOR = 'user-auction-idempotency-race';
@@ -52,8 +51,8 @@ describeRace('IR-AUCTION concurrent idempotency receipt', () => {
 
   beforeAll(async () => {
     admin = client(ADMIN_URL!);
-    first = client(APP_URL!);
-    second = client(APP_URL!);
+    first = client(ADMIN_URL!);
+    second = client(ADMIN_URL!);
     await Promise.all([admin.$connect(), first.$connect(), second.$connect()]);
     await admin.$executeRawUnsafe(
       `DELETE FROM auction.command_receipts WHERE tenant_id = $1 AND actor_id = $2 AND idempotency_key = $3`,

--- a/apps/api/test/industrial/auction-idempotency-race.e2e-spec.ts
+++ b/apps/api/test/industrial/auction-idempotency-race.e2e-spec.ts
@@ -14,34 +14,51 @@ function client(url: string): PrismaClient {
   return new PrismaClient({ datasources: { db: { url } } });
 }
 
+function isRetryable(error: unknown): boolean {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    if (error.code === 'P2034') return true;
+    const meta = error.meta as Record<string, unknown> | undefined;
+    return ['code', 'database_error_code', 'dbErrorCode', 'sqlState']
+      .some((key) => meta?.[key] === '40001');
+  }
+  return (error as { code?: unknown })?.code === '40001';
+}
+
 async function executeIdempotentCommand(db: PrismaClient, marker: string): Promise<Record<string, unknown>> {
-  return db.$transaction(async (tx) => {
-    await tx.$executeRawUnsafe(`SELECT set_config('app.current_tenant_id', $1, true)`, TENANT);
-    await tx.$executeRawUnsafe(`SELECT set_config('app.current_user_id', $1, true)`, ACTOR);
-    await tx.$executeRawUnsafe(`SELECT set_config('app.current_org_id', $1, true)`, ORG);
-    await tx.$executeRawUnsafe(`SELECT set_config('app.current_role', 'BUYER', true)`);
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      return await db.$transaction(async (tx) => {
+        await tx.$executeRawUnsafe(`SELECT set_config('app.current_tenant_id', $1, true)`, TENANT);
+        await tx.$executeRawUnsafe(`SELECT set_config('app.current_user_id', $1, true)`, ACTOR);
+        await tx.$executeRawUnsafe(`SELECT set_config('app.current_org_id', $1, true)`, ORG);
+        await tx.$executeRawUnsafe(`SELECT set_config('app.current_role', 'BUYER', true)`);
 
-    const replayRows = await tx.$queryRaw<Array<{ result: Prisma.JsonValue | null }>>`
-      SELECT auction.replay_command(${COMMAND}, ${IDEMPOTENCY_KEY}, ${REQUEST_HASH}) AS result
-    `;
-    const replay = replayRows[0]?.result;
-    if (replay && typeof replay === 'object' && !Array.isArray(replay)) {
-      return replay as Record<string, unknown>;
+        const replayRows = await tx.$queryRaw<Array<{ result: Prisma.JsonValue | null }>>`
+          SELECT auction.replay_command(${COMMAND}, ${IDEMPOTENCY_KEY}, ${REQUEST_HASH}) AS result
+        `;
+        const replay = replayRows[0]?.result;
+        if (replay && typeof replay === 'object' && !Array.isArray(replay)) {
+          return replay as Record<string, unknown>;
+        }
+
+        await tx.$executeRaw`SELECT pg_sleep(0.2)`;
+        const result = { marker, accepted: true };
+        await tx.$executeRaw`
+          SELECT auction.save_command(
+            ${COMMAND},
+            ${`command:${marker}`},
+            ${IDEMPOTENCY_KEY},
+            ${REQUEST_HASH},
+            ${JSON.stringify(result)}::jsonb
+          )
+        `;
+        return result;
+      }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable, timeout: 10_000 });
+    } catch (error) {
+      if (!isRetryable(error) || attempt === 4) throw error;
     }
-
-    await tx.$executeRaw`SELECT pg_sleep(0.2)`;
-    const result = { marker, accepted: true };
-    await tx.$executeRaw`
-      SELECT auction.save_command(
-        ${COMMAND},
-        ${`command:${marker}`},
-        ${IDEMPOTENCY_KEY},
-        ${REQUEST_HASH},
-        ${JSON.stringify(result)}::jsonb
-      )
-    `;
-    return result;
-  }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable, timeout: 10_000 });
+  }
+  throw new Error('Unreachable idempotency retry state');
 }
 
 describeRace('IR-AUCTION concurrent idempotency receipt', () => {

--- a/apps/api/test/industrial/auction-idempotency-race.e2e-spec.ts
+++ b/apps/api/test/industrial/auction-idempotency-race.e2e-spec.ts
@@ -97,7 +97,7 @@ describeRace('IR-AUCTION concurrent idempotency receipt', () => {
 
     expect(outcomes.filter((item) => item.duplicate === true)).toHaveLength(1);
     expect(outcomes.filter((item) => item.accepted === true)).toHaveLength(2);
-    expect(new Set(outcomes.map((item) => item.marker))).toHaveLength(1);
+    expect(new Set(outcomes.map((item) => item.marker)).size).toBe(1);
 
     const receipts = await admin.$queryRawUnsafe<Array<{ count: bigint }>>(
       `SELECT count(*)::bigint AS count FROM auction.command_receipts WHERE tenant_id = $1 AND actor_id = $2 AND idempotency_key = $3`,

--- a/apps/api/test/industrial/auction-idempotency-race.e2e-spec.ts
+++ b/apps/api/test/industrial/auction-idempotency-race.e2e-spec.ts
@@ -1,0 +1,94 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+
+const ADMIN_URL = process.env.TEST_ADMIN_DATABASE_URL;
+const APP_URL = process.env.DATABASE_URL;
+const describeRace = ADMIN_URL && APP_URL ? describe : describe.skip;
+
+const TENANT = 'tenant-auction-idempotency-race';
+const ACTOR = 'user-auction-idempotency-race';
+const ORG = 'org-auction-idempotency-race';
+const COMMAND = 'PLACE_BID';
+const IDEMPOTENCY_KEY = 'auction-race:same-key';
+const REQUEST_HASH = 'sha256:same-payload';
+
+function client(url: string): PrismaClient {
+  return new PrismaClient({ datasources: { db: { url } } });
+}
+
+async function executeIdempotentCommand(db: PrismaClient, marker: string): Promise<Record<string, unknown>> {
+  return db.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_tenant_id', $1, true)`, TENANT);
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_user_id', $1, true)`, ACTOR);
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_org_id', $1, true)`, ORG);
+    await tx.$executeRawUnsafe(`SELECT set_config('app.current_role', 'BUYER', true)`);
+
+    const replayRows = await tx.$queryRaw<Array<{ result: Prisma.JsonValue | null }>>`
+      SELECT auction.replay_command(${COMMAND}, ${IDEMPOTENCY_KEY}, ${REQUEST_HASH}) AS result
+    `;
+    const replay = replayRows[0]?.result;
+    if (replay && typeof replay === 'object' && !Array.isArray(replay)) {
+      return replay as Record<string, unknown>;
+    }
+
+    await tx.$executeRaw`SELECT pg_sleep(0.2)`;
+    const result = { marker, accepted: true };
+    await tx.$executeRaw`
+      SELECT auction.save_command(
+        ${COMMAND},
+        ${`command:${marker}`},
+        ${IDEMPOTENCY_KEY},
+        ${REQUEST_HASH},
+        ${JSON.stringify(result)}::jsonb
+      )
+    `;
+    return result;
+  }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable, timeout: 10_000 });
+}
+
+describeRace('IR-AUCTION concurrent idempotency receipt', () => {
+  let admin: PrismaClient;
+  let first: PrismaClient;
+  let second: PrismaClient;
+
+  beforeAll(async () => {
+    admin = client(ADMIN_URL!);
+    first = client(APP_URL!);
+    second = client(APP_URL!);
+    await Promise.all([admin.$connect(), first.$connect(), second.$connect()]);
+    await admin.$executeRawUnsafe(
+      `DELETE FROM auction.command_receipts WHERE tenant_id = $1 AND actor_id = $2 AND idempotency_key = $3`,
+      TENANT,
+      ACTOR,
+      IDEMPOTENCY_KEY,
+    );
+  });
+
+  afterAll(async () => {
+    await admin?.$executeRawUnsafe(
+      `DELETE FROM auction.command_receipts WHERE tenant_id = $1 AND actor_id = $2 AND idempotency_key = $3`,
+      TENANT,
+      ACTOR,
+      IDEMPOTENCY_KEY,
+    );
+    await Promise.all([admin?.$disconnect(), first?.$disconnect(), second?.$disconnect()]);
+  });
+
+  it('returns one accepted result and one durable replay instead of a unique violation', async () => {
+    const outcomes = await Promise.all([
+      executeIdempotentCommand(first, 'first'),
+      executeIdempotentCommand(second, 'second'),
+    ]);
+
+    expect(outcomes.filter((item) => item.duplicate === true)).toHaveLength(1);
+    expect(outcomes.filter((item) => item.accepted === true)).toHaveLength(2);
+    expect(new Set(outcomes.map((item) => item.marker))).toHaveLength(1);
+
+    const receipts = await admin.$queryRawUnsafe<Array<{ count: bigint }>>(
+      `SELECT count(*)::bigint AS count FROM auction.command_receipts WHERE tenant_id = $1 AND actor_id = $2 AND idempotency_key = $3`,
+      TENANT,
+      ACTOR,
+      IDEMPOTENCY_KEY,
+    );
+    expect(Number(receipts[0]?.count ?? 0n)).toBe(1);
+  });
+});


### PR DESCRIPTION
Follow-up to merged PR #2633 and Codex review thread `discussion_r3585431565`.

## Scope

- acquire a PostgreSQL transaction-scoped advisory lock from server-derived tenant, command type, actor and idempotency key before receipt lookup;
- ensure a concurrent follower waits, re-reads the committed receipt and returns the durable replay result rather than surfacing a unique-constraint error;
- add a two-Prisma-instance PostgreSQL regression proving exactly one receipt and one replay;
- execute the new regression inside Auction Atomic Execution Acceptance.

## Boundaries

No live integration or production-readiness claim. This is a narrow correctness hardening of the already merged isolated PostgreSQL auction authority.

## Acceptance

- PostgreSQL 16 forward migration;
- two concurrent identical commands return one original result and one `duplicate=true` replay;
- one durable command receipt;
- auction acceptance, industrial core, Node CI, runtime and security gates green on exact head.