### PR TITLE
Remove final incorrect logo consumer

### DIFF
--- a/apps/web/components/platform-v7/ChatSupportWidget.tsx
+++ b/apps/web/components/platform-v7/ChatSupportWidget.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { CheckCircle2, MessageCircle, Send, X } from 'lucide-react';
-import { BRAND_LOGO_DATA_URI } from '@/components/v7r/brand-logo-asset';
+import { BrandMark } from '@/components/v7r/BrandMark';
 
 type SubmitState = 'idle' | 'sending' | 'sent' | 'error';
 type Topic = 'platform' | 'pilot' | 'bank_partner' | 'region' | 'technical' | 'other';
@@ -304,7 +304,7 @@ export function ChatSupportWidget() {
             aria-describedby={descriptionId}
           >
             <header className='p7-support-chat-head'>
-              <img src={BRAND_LOGO_DATA_URI} alt='' draggable={false} />
+              <span className='p7-support-chat-brand' aria-hidden='true'><BrandMark size='100%' shadow={false} /></span>
               <div>
                 <strong id={titleId}>{ui.title}</strong>
                 <p id={descriptionId}>{ui.intro}</p>
@@ -438,7 +438,7 @@ const css = `
   border-bottom: 1px solid #dfe8e2;
   background: #f7faf8;
 }
-.p7-support-chat-head img { width: 40px; height: 40px; object-fit: contain; }
+.p7-support-chat-brand { display: inline-flex; width: 40px; height: 40px; }
 .p7-support-chat-head strong { display: block; font-size: 17px; line-height: 1.2; font-weight: 850; letter-spacing: -.02em; }
 .p7-support-chat-head p { margin: 5px 0 0; color: #52615b; font-size: 12px; line-height: 1.45; font-weight: 600; }
 .p7-support-chat-head button {
@@ -496,7 +496,7 @@ const css = `
     padding-bottom: env(safe-area-inset-bottom, 0px);
   }
   .p7-support-chat-head { position: sticky; top: 0; z-index: 1; grid-template-columns: 36px minmax(0,1fr) 44px; padding: 14px; }
-  .p7-support-chat-head img { width: 36px; height: 36px; }
+  .p7-support-chat-brand { width: 36px; height: 36px; }
   .p7-support-chat-identity { grid-template-columns: minmax(0,1fr); }
   .p7-support-chat-form { padding: 14px; }
 }

--- a/apps/web/tests/unit/platformV7VisibleEntry.test.ts
+++ b/apps/web/tests/unit/platformV7VisibleEntry.test.ts
@@ -77,6 +77,10 @@ describe('platform-v7 visible public entry', () => {
     }
 
     expect(contactHeader()).toContain('PublicSiteHeader');
+    expect(support()).toContain("import { BrandMark } from '@/components/v7r/BrandMark'");
+    expect(support()).toContain("<BrandMark size='100%' shadow={false} />");
+    expect(support()).not.toContain('BRAND_LOGO_DATA_URI');
+    expect(support()).not.toContain('brand-logo-asset');
   });
 
   it('uses one visual contract for every public-header control', () => {

--- a/scripts/p7-autopilot-guard.sh
+++ b/scripts/p7-autopilot-guard.sh
@@ -50,6 +50,7 @@ apps/web/components/platform-v7/PlatformV7ShellSwitch.tsx
 apps/web/components/platform-v7/PlatformV7TemplateGuards.tsx
 apps/web/components/platform-v7/PublicEntryCleanup.tsx
 apps/web/components/platform-v7/PublicLocaleSwitch.tsx
+apps/web/components/platform-v7/ChatSupportWidget.tsx
 apps/web/components/platform-v7/PublicSiteHeader.tsx
 apps/web/components/v7r/ApprovedHeaderLogo.tsx
 apps/web/components/v7r/BrandMark.tsx


### PR DESCRIPTION
## Суть

После восстановления старого owner-approved логотипа в общих шапках остался последний прямой потребитель неправильного leaf-asset: заголовок окна поддержки.

## Исправление

- `ChatSupportWidget` больше не импортирует `BRAND_LOGO_DATA_URI`;
- заголовок поддержки использует тот же `BrandMark`, что public/login/cabinet/staff/loading headers;
- удалены последние прямые ссылки на неправильный leaf-logo из видимой поверхности;
- тест блокирует повторное появление `brand-logo-asset` и `BRAND_LOGO_DATA_URI` в поддержке.

Итог: все видимые шапки и заголовки используют один старый owner-approved логотип.