### PR TITLE
IR-IMAGE: prove executable API and worker images

### DIFF
--- a/docs/platform-v7/autopilot/scopes/ir-runtime-images-2664.json
+++ b/docs/platform-v7/autopilot/scopes/ir-runtime-images-2664.json
@@ -1,0 +1,42 @@
+{
+  "id": "IR-IMAGE-2664",
+  "parentProgramIssue": 2597,
+  "issue": 2664,
+  "branch": "ir/runtime-images-2664",
+  "status": "active",
+  "maturityBoundary": "executable-release-artifacts-only",
+  "globalProgramStateUnchanged": "This isolated release-artifact repair does not change production maturity or the serialized primary autopilot task.",
+  "allowedPaths": [
+    "docs/platform-v7/autopilot/scopes/ir-runtime-images-2664.json",
+    "infra/docker/Dockerfile.api",
+    "infra/docker/Dockerfile.outbox-worker",
+    "infra/helm/grainflow/templates/web-deployment.yaml",
+    "scripts/p7-autopilot-guard.sh",
+    "scripts/release/build-exact-head-images.sh",
+    "scripts/release/materialize-prisma-client.mjs"
+  ],
+  "forbiddenPaths": [
+    "apps/**",
+    "packages/**",
+    "prisma/**",
+    "package.json",
+    "pnpm-lock.yaml",
+    "package-lock.json"
+  ],
+  "forbiddenClaims": [
+    "production deployment accepted",
+    "production capacity proven",
+    "live external integration",
+    "production RTO or RPO established",
+    "Industrial Integration-Ready"
+  ],
+  "requiredEvidence": [
+    "API final-image entrypoint smoke",
+    "API final-image Prisma Client resolution",
+    "outbox-worker final-image entrypoint smoke",
+    "outbox-worker final-image Prisma Client resolution",
+    "web probes reference built unauthenticated routes",
+    "exact-head immutable release authority",
+    "exact-head security gates"
+  ]
+}

--- a/infra/docker/Dockerfile.api
+++ b/infra/docker/Dockerfile.api
@@ -16,6 +16,16 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 RUN pnpm --filter @pc/api build
 RUN pnpm --filter @pc/api --prod deploy --legacy /prod/api
 
+# pnpm deploy creates the production dependency graph but does not guarantee that
+# workspace build output or Prisma's generated client side effects are copied.
+# Materialize both explicitly and prove the final runtime tree before distroless.
+RUN rm -rf /prod/api/src /prod/api/test /prod/api/prisma /prod/api/dist \
+  && cp -R /workspace/apps/api/dist /prod/api/dist \
+  && node scripts/release/materialize-prisma-client.mjs /workspace/apps/api /prod/api \
+  && test -f /prod/api/dist/src/main.js \
+  && cd /prod/api \
+  && node -e "const {PrismaClient}=require('@prisma/client'); if(typeof PrismaClient!=='function') process.exit(1)"
+
 FROM gcr.io/distroless/nodejs24-debian13:nonroot AS runtime
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown

--- a/infra/docker/Dockerfile.api
+++ b/infra/docker/Dockerfile.api
@@ -14,16 +14,15 @@ COPY . .
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
   pnpm install --frozen-lockfile
 RUN pnpm --filter @pc/api build
-RUN test -f /workspace/apps/api/dist/src/main.js \
-  || { echo 'API build did not emit dist/src/main.js' >&2; find /workspace/apps/api/dist -maxdepth 4 -type f -print >&2; exit 1; }
+RUN test -f /workspace/apps/api/dist/apps/api/src/main.js
 RUN pnpm --filter @pc/api --prod deploy --legacy /prod/api
 
-# pnpm deploy creates the production dependency graph but does not guarantee that
-# workspace build output or Prisma's generated client side effects are copied.
-# Materialize both explicitly and prove each final runtime invariant separately.
+# TypeScript emits the API below the workspace-relative path because the API
+# imports shared workspace packages. pnpm deploy carries dependencies only, so
+# copy that exact output and materialize Prisma's generated side effects.
 RUN rm -rf /prod/api/src /prod/api/test /prod/api/prisma /prod/api/dist \
   && cp -R /workspace/apps/api/dist /prod/api/dist
-RUN test -f /prod/api/dist/src/main.js
+RUN test -f /prod/api/dist/apps/api/src/main.js
 RUN node scripts/release/materialize-prisma-client.mjs /workspace/apps/api /prod/api
 RUN cd /prod/api \
   && node -e "const {PrismaClient}=require('@prisma/client'); if(typeof PrismaClient!=='function') throw new Error('PrismaClient export is unavailable')"
@@ -43,4 +42,4 @@ COPY --from=build --chown=nonroot:nonroot /prod/api/ ./
 
 EXPOSE 3001
 USER nonroot
-CMD ["dist/src/main.js"]
+CMD ["dist/apps/api/src/main.js"]

--- a/infra/docker/Dockerfile.api
+++ b/infra/docker/Dockerfile.api
@@ -14,17 +14,19 @@ COPY . .
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
   pnpm install --frozen-lockfile
 RUN pnpm --filter @pc/api build
+RUN test -f /workspace/apps/api/dist/src/main.js \
+  || { echo 'API build did not emit dist/src/main.js' >&2; find /workspace/apps/api/dist -maxdepth 4 -type f -print >&2; exit 1; }
 RUN pnpm --filter @pc/api --prod deploy --legacy /prod/api
 
 # pnpm deploy creates the production dependency graph but does not guarantee that
 # workspace build output or Prisma's generated client side effects are copied.
-# Materialize both explicitly and prove the final runtime tree before distroless.
+# Materialize both explicitly and prove each final runtime invariant separately.
 RUN rm -rf /prod/api/src /prod/api/test /prod/api/prisma /prod/api/dist \
-  && cp -R /workspace/apps/api/dist /prod/api/dist \
-  && node scripts/release/materialize-prisma-client.mjs /workspace/apps/api /prod/api \
-  && test -f /prod/api/dist/src/main.js \
-  && cd /prod/api \
-  && node -e "const {PrismaClient}=require('@prisma/client'); if(typeof PrismaClient!=='function') process.exit(1)"
+  && cp -R /workspace/apps/api/dist /prod/api/dist
+RUN test -f /prod/api/dist/src/main.js
+RUN node scripts/release/materialize-prisma-client.mjs /workspace/apps/api /prod/api
+RUN cd /prod/api \
+  && node -e "const {PrismaClient}=require('@prisma/client'); if(typeof PrismaClient!=='function') throw new Error('PrismaClient export is unavailable')"
 
 FROM gcr.io/distroless/nodejs24-debian13:nonroot AS runtime
 ARG GIT_COMMIT=unknown

--- a/infra/docker/Dockerfile.outbox-worker
+++ b/infra/docker/Dockerfile.outbox-worker
@@ -16,7 +16,11 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 RUN pnpm --filter @pc/api build:outbox-worker
 RUN pnpm --filter @pc/api --prod deploy --legacy /prod/outbox-worker
 RUN rm -rf /prod/outbox-worker/src /prod/outbox-worker/test /prod/outbox-worker/prisma /prod/outbox-worker/dist-outbox-worker \
-  && cp -R /workspace/apps/api/dist-outbox-worker /prod/outbox-worker/dist-outbox-worker
+  && cp -R /workspace/apps/api/dist-outbox-worker /prod/outbox-worker/dist-outbox-worker \
+  && node scripts/release/materialize-prisma-client.mjs /workspace/apps/api /prod/outbox-worker \
+  && test -f /prod/outbox-worker/dist-outbox-worker/outbox-worker.js \
+  && cd /prod/outbox-worker \
+  && node -e "const {PrismaClient}=require('@prisma/client'); if(typeof PrismaClient!=='function') process.exit(1)"
 
 FROM gcr.io/distroless/nodejs24-debian13:nonroot AS runtime
 ARG GIT_COMMIT=unknown

--- a/infra/helm/grainflow/templates/web-deployment.yaml
+++ b/infra/helm/grainflow/templates/web-deployment.yaml
@@ -59,18 +59,25 @@ spec:
             - name: http
               containerPort: {{ .Values.web.service.port }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /robots.txt
+              port: {{ .Values.web.service.port }}
+            periodSeconds: 5
+            failureThreshold: 36
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
-              path: /api/health
+              path: /robots.txt
               port: {{ .Values.web.service.port }}
-            initialDelaySeconds: 20
             periodSeconds: 15
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
-              path: /api/health
+              path: /sitemap.xml
               port: {{ .Values.web.service.port }}
-            initialDelaySeconds: 10
             periodSeconds: 5
+            timeoutSeconds: 3
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/scripts/p7-autopilot-guard.sh
+++ b/scripts/p7-autopilot-guard.sh
@@ -209,6 +209,13 @@ scripts/release/**
 scripts/security/build-runtime-security-manifest.mjs
 scripts/p7-autopilot-guard.sh'
 
+IR_RUNTIME_IMAGE_SCOPE='infra/docker/Dockerfile.api
+infra/docker/Dockerfile.outbox-worker
+infra/helm/grainflow/templates/web-deployment.yaml
+scripts/release/build-exact-head-images.sh
+scripts/release/materialize-prisma-client.mjs
+scripts/p7-autopilot-guard.sh'
+
 if [ "${GITHUB_HEAD_REF:-}" = "agent/harden-platform-v7-public-entry" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/public-entry-human-copy" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/landing-hero-support" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/login-human-grade-ui" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/exact-approved-header-logo" ]; then
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$PUBLIC_ENTRY_SCOPE")
 fi
@@ -263,6 +270,10 @@ fi
 
 if [ "${GITHUB_HEAD_REF:-}" = "ir/immutable-release-authority-2652" ]; then
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$IMMUTABLE_RELEASE_AUTHORITY_SCOPE")
+fi
+
+if [ "${GITHUB_HEAD_REF:-}" = "ir/runtime-images-2664" ]; then
+  ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$IR_RUNTIME_IMAGE_SCOPE")
 fi
 
 APPROVED_BRANCH_SCOPE=$(GITHUB_HEAD_REF="${GITHUB_HEAD_REF:-}" node - <<'JS'

--- a/scripts/release/build-exact-head-images.sh
+++ b/scripts/release/build-exact-head-images.sh
@@ -18,7 +18,7 @@ runtime_smoke() {
   local image="$2"
   local entrypoint=""
   case "$component" in
-    api) entrypoint=/app/dist/src/main.js ;;
+    api) entrypoint=/app/dist/apps/api/src/main.js ;;
     outbox-worker) entrypoint=/app/dist-outbox-worker/outbox-worker.js ;;
     *) return 0 ;;
   esac

--- a/scripts/release/build-exact-head-images.sh
+++ b/scripts/release/build-exact-head-images.sh
@@ -13,6 +13,33 @@ mkdir -p "$evidence_dir"
 build_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 docker buildx version | tee "$evidence_dir/docker-buildx-version.txt"
 
+runtime_smoke() {
+  local component="$1"
+  local image="$2"
+  local entrypoint=""
+  case "$component" in
+    api) entrypoint=/app/dist/src/main.js ;;
+    outbox-worker) entrypoint=/app/dist-outbox-worker/outbox-worker.js ;;
+    *) return 0 ;;
+  esac
+
+  docker run --rm "$image" -e '
+    const fs = require("node:fs");
+    const entrypoint = process.argv[1];
+    if (!fs.existsSync(entrypoint)) throw new Error(`missing runtime entrypoint: ${entrypoint}`);
+    const evidencePath = "/app/prisma-client-materialization.json";
+    if (!fs.existsSync(evidencePath)) throw new Error(`missing Prisma materialization evidence: ${evidencePath}`);
+    const evidence = JSON.parse(fs.readFileSync(evidencePath, "utf8"));
+    const client = require("/app/node_modules/@prisma/client");
+    if (typeof client.PrismaClient !== "function") throw new Error("PrismaClient export is unavailable");
+    const manifest = JSON.parse(fs.readFileSync("/app/node_modules/@prisma/client/package.json", "utf8"));
+    if (manifest.version !== evidence.prismaClientVersion) {
+      throw new Error(`Prisma Client evidence mismatch: package=${manifest.version}, evidence=${evidence.prismaClientVersion}`);
+    }
+    process.stdout.write(`${JSON.stringify({entrypoint, prismaClientVersion: manifest.version, engines: evidence.engines})}\n`);
+  ' "$entrypoint" | tee "$evidence_dir/${component}-runtime-smoke.json"
+}
+
 while read -r component dockerfile; do
   image="prozrachnaya-cena-${component}:release-${exact_head}"
   metadata="$evidence_dir/${component}-build-metadata.json"
@@ -46,6 +73,7 @@ NODE
   test "$(cat "$evidence_dir/${component}-revision.txt")" = "$exact_head"
   grep -Eq '^sha256:[0-9a-f]{64}$' "$evidence_dir/${component}-digest.txt"
   grep -Eq '^sha256:[0-9a-f]{64}$' "$evidence_dir/${component}-config-id.txt"
+  runtime_smoke "$component" "$image"
 done <<'COMPONENTS'
 api infra/docker/Dockerfile.api
 web infra/docker/Dockerfile.web

--- a/scripts/release/materialize-prisma-client.mjs
+++ b/scripts/release/materialize-prisma-client.mjs
@@ -1,0 +1,67 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const [sourceProjectRoot, runtimeRoot] = process.argv.slice(2).map((value) => path.resolve(value ?? ''));
+if (!sourceProjectRoot || !runtimeRoot) {
+  throw new Error('usage: node materialize-prisma-client.mjs <source-project-root> <runtime-root>');
+}
+
+function resolveClient(root) {
+  const requireFromRoot = createRequire(path.join(root, 'package.json'));
+  const packageJsonPath = fs.realpathSync(requireFromRoot.resolve('@prisma/client/package.json'));
+  const packageDir = path.dirname(packageJsonPath);
+  const packageNodeModules = path.resolve(packageDir, '..', '..');
+  const manifest = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  return {
+    requireFromRoot,
+    version: manifest.version,
+    generatedDir: path.join(packageNodeModules, '.prisma', 'client'),
+  };
+}
+
+function sha256(file) {
+  return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+const source = resolveClient(sourceProjectRoot);
+const target = resolveClient(runtimeRoot);
+if (source.version !== target.version) {
+  throw new Error(`Prisma Client version mismatch: source=${source.version}, target=${target.version}`);
+}
+
+const sourceDefault = path.join(source.generatedDir, 'default.js');
+if (!fs.existsSync(sourceDefault)) {
+  throw new Error(`Generated Prisma Client is absent at ${source.generatedDir}`);
+}
+
+fs.rmSync(target.generatedDir, { recursive: true, force: true });
+fs.mkdirSync(path.dirname(target.generatedDir), { recursive: true });
+fs.cpSync(source.generatedDir, target.generatedDir, { recursive: true, preserveTimestamps: true });
+
+const targetDefault = path.join(target.generatedDir, 'default.js');
+if (!fs.existsSync(targetDefault)) {
+  throw new Error(`Prisma Client copy is incomplete at ${target.generatedDir}`);
+}
+if (sha256(sourceDefault) !== sha256(targetDefault)) {
+  throw new Error('Prisma Client default.js digest changed during materialization');
+}
+
+const runtimeClient = target.requireFromRoot('@prisma/client');
+if (typeof runtimeClient.PrismaClient !== 'function') {
+  throw new Error('Deployed @prisma/client does not export PrismaClient');
+}
+
+const engines = fs.readdirSync(target.generatedDir)
+  .filter((name) => /query_engine|libquery_engine/.test(name))
+  .sort();
+if (engines.length === 0) {
+  throw new Error('Deployed Prisma Client contains no query engine');
+}
+
+fs.writeFileSync(path.join(runtimeRoot, 'prisma-client-materialization.json'), `${JSON.stringify({
+  prismaClientVersion: target.version,
+  defaultJsSha256: sha256(targetDefault),
+  engines,
+}, null, 2)}\n`);


### PR DESCRIPTION
## Scope

Repairs release-artifact defects found by production-like Kubernetes acceptance #2659 / PR #2660.

- explicitly copies API TypeScript output into the production runtime tree;
- uses the actual workspace-relative API entrypoint `dist/apps/api/src/main.js` exposed by the compiler output;
- deterministically materializes generated Prisma Client files into API and outbox-worker pnpm deployment trees;
- validates Prisma version, generated engine presence and copied digest;
- executes entrypoint and Prisma module smoke checks inside the final distroless images;
- replaces the nonexistent authenticated `/api/health` web probe with built unauthenticated routes: `/robots.txt` for startup/liveness and `/sitemap.xml` for readiness.

Application source, Prisma schema, dependencies and lockfiles are unchanged.

## Acceptance

- exact-head API final image contains `/app/dist/apps/api/src/main.js`;
- exact-head worker final image contains `/app/dist-outbox-worker/outbox-worker.js`;
- both final images resolve `@prisma/client` and retain generated query engines;
- immutable image smoke evidence is retained;
- Helm web probes reference routes present in the Next.js build and remain valid under private mode;
- exact-head release and security gates are green.

## Maturity boundary

This proves executable release artifacts only. It does not establish production operational acceptance, production capacity, provider HA/PITR, live integrations or operational soak.

Closes #2664
Refs #2659
Refs #2660
Refs #2597