### PR TITLE
fix(brand): cover v9 and landing header surfaces

### DIFF
--- a/apps/landing/app/components/HeaderLogo.tsx
+++ b/apps/landing/app/components/HeaderLogo.tsx
@@ -1,17 +1,17 @@
-const logoSrc =
-  'data:image/webp;base64,UklGRgQHAABXRUJQVlA4WAoAAAAQAAAAPwAAPwAAQUxQSHMBAAABkGttu2k735xzx1ZnVbbTWa2NS7BRJVWuQZVtu1Rr21hznjXxBYfrj9NExASgXAP0WX/u0ec8t865zNnMZc5aV37mMuucs845Z+3H+0cWdgEMKqkU+u1yLPT7zV2hVQVKYV0kQ0xFSTGSdhGUKkfpWtuZAoudPLnZaAVAGexknlj4lHMbDACDVSyjyJxLYGDQN/okI4W8mzIapxgoNPAQDPozUmxMPYFN9HI8N0BfZZQTeAWt3zPJSXzZaihlh16jmURxyChpg8UNETf4/7/R4kb98RsrbtRfnzHixokbLW1gr0DBiZ87NX7CJCfydl0cTEGOT7uBBfRyAucALd7EKCWl181QwnJ6KZ5rUVK6zg0GGYE3G2oFjR6fGCTE6AdCAzAYn9MXL5DTYPB9CSOeM4RiRc+Pk1BC+Qbt95AMMRUjxUDyfHeUULEBJh4rY4HT5RmAQWW1BvqsOfngk3OZq6p131vrvrcu+/Ts0sbhADTKBQBWUDggagUAALAXAJ0BKkAAQAA+MRiIQ6IhioWaLhABglFnAhom2CUjincuYmVtn0kbcTzAeb3ps28yeUBgO7TbVv9L+VvJnaS/peIlsZfTP8H8oHpAcUB+WPq7+Rf9U8pf+X9SH/R+1X3bfT/+1/Kr+gfYL/H/5l/qf7XwpH6yDOgR6MsccfitTmRMDBWfZB4NYyRfp5Q4MGmO2g1cRRl6XbnzoWX+v0prvu7+g3pbNrggpCCSluhz0wY1gZkp0H7GSs88FBxldCnsvlNRKAD+/z/AlfXoWw1/T25S6EFS9qpJa/qDxfp1SXh6YI4qx58XaHpj2FfhNdjzMat/N56lSGW9QT16i9tGRBYG5SIDrlSrVtAvIM6d7lVO/6QtbUSfLD4/RjTAf+gTv+NEVVz/EtZrjTupTioyI+j//vZaSqDGH/3adePa/4HTPY68vfz0BNQ1Oxjk3aRXy3ELUmejbVFJ4F2MjSOZGpP+nxmeHMVhfZ9NbMZ6f82VcLn3lyUKYTE5OAVMuqJJQUytmcZr+BHf0gTu/C2Fp/9pWPxYjcRE/QNRmEnBG6CLNJGoP62uH6kfjkLjTdzZRlBbYMwoW4c+/N2oW5Et90NLTr7k6yvFLVJ4DvATxMBBd8Hav2/AH3QF0KuBSifdGuRuheOdKevgf2YfA+XBvE5Hvb+DB8rqxQ801bZ/q2gw0RYiK573vWUfreaFoJU+w8G4Bgei2jfIH6X3a7fiYXMNs5D+rbLrTqucfwNM253b/6L5to7JXALkrWsGrXMUwFOyxTFOdtmCL33b4QDvzymJj+aB5cVgemAe2kwa27AK1z8xXpNIqKjZKd+fn/d//W7PjgUyKiHdlt3NEbmIL48eDuVU8GQfib5o87wjsKSkNgbj+TQLVdBs9Es2gLL9B2L1Y8hyuOx4qFdA3VpxPU0JZEv1R7mysrhAK4P+mNn31yp3f/P1iYWKSyp58uajqFlOsj/HdxYGb/SDjH+qM4NSCg2eGneFMOfyr+zfQsJyofMQrEQFVIZ9jdrL/ideFyfsOHnE1wwmzl0aM30RgUvbB2Hm5KJYphCNzxsOHJPn++DTz3SnvAcnOGtGa/WgK/Dqoc90LFk79rVrrS+8BLL9Rm5MD0NUr0t4P8XnF3u68qoNVNBUhWndbYBn7TNn0+TKP2vL6F0M2dprvnfbYpZruMXLXsFTzHTIQVIPnS2R/oSl3XvueklPXymyktYhXTuGsj7gJy/S4vslAJfl1DTM0ssgFaIiwRfY+lTLQHv3HHa78W2QVG4hphB02hsxR98xOqGfo8prHiM1ePP66+Vm+qyTsXJKn/gzr5r+r7EAoMmAepQTDIiz/ha3WcWvI4dA0rbbg/JHS8SdJ0TU64bcm9ewob6M2+ahViqeFdb+jR4HSLAWz+lXJQzLiGWAbZL13oc6weXIeCNhYUWlJ/33/oRsV/T4MWdpjtNlXoFHbBTc7B0UUPmxpYXRdfVdYwReqw7+DgdOzw5LfM9u7pwHS7HFhDCAsQKmmT1SZN10gFAXwkqHcqdin8oHC+vdXPXGFy/JNEcJXONwHY93PofC/IiYMCelaaC86hijXO3IeSdbq5TO9RDwrEji4vhCRRAzyIplVnOBRxoik18VK2u8FQY/ySgJV4AaVzm9QDNAf+dHNHbd5EmMMkxpuMlPsZ2cCODAuLN8kuB6Bn2p/SfMMFC4wKa2XCLDV2hT8mvpO0rxoTWPlV4cTXVidS2kkRdjBCKeVoe8MCkMJwthqu8r+zFiRDcPdDQ375pRXAjVp8V+F0gBioLEV3dE8jJBRBJm8vVQsnZQ8InH0kJDO2yN/DrsNwyr2GJJojOmIL7YM+j5zoAAAA==';
+import { BRAND_LOGO_DATA_URI } from '../../../web/components/v7r/brand-logo-asset';
 
 export default function HeaderLogo() {
   return (
     <span className="brand-logo-mark shrink-0" aria-hidden="true">
       <img
-        src={logoSrc}
+        src={BRAND_LOGO_DATA_URI}
         alt=""
         width={48}
         height={48}
         className="header-logo-image"
         loading="eager"
         decoding="sync"
+        draggable={false}
       />
     </span>
   );

--- a/apps/web/components/v9/layout/Header.tsx
+++ b/apps/web/components/v9/layout/Header.tsx
@@ -7,6 +7,7 @@ import { useSessionStore } from '@/stores/useSessionStore';
 import { RoleSwitcher } from './RoleSwitcher';
 import { SandboxBadge } from '../bank/SandboxBadge';
 import { cn } from '@/lib/v9/utils';
+import { BrandMark } from '@/components/v7r/BrandMark';
 
 function buildBreadcrumbs(pathname: string) {
   const labels: Record<string, string> = {
@@ -49,6 +50,8 @@ export function Header({ onOpenCmd, onToggleAi, aiOpen }: HeaderProps) {
       >
         <Menu size={18} />
       </button>
+
+      <BrandMark size={32} shadow={false} />
 
       {/* Breadcrumbs */}
       <nav aria-label="Хлебные крошки" className="flex items-center gap-1 flex-1 min-w-0">

--- a/apps/web/components/v9/layout/Sidebar.tsx
+++ b/apps/web/components/v9/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
 import { useSessionStore } from '@/stores/useSessionStore';
 import { getNavItems, roleLabels } from '@/lib/v9/roles';
 import { cn } from '@/lib/v9/utils';
+import { BrandMark } from '@/components/v7r/BrandMark';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const iconMap: Record<string, React.ComponentType<any>> = {
@@ -34,9 +35,7 @@ export function Sidebar({ aiOpen, onToggleAi }: SidebarProps) {
     >
       {/* Logo */}
       <div className="flex items-center gap-2.5 px-4 py-4 border-b border-border">
-        <div aria-hidden style={{ width: 32, height: 32, background: '#0A7A5F', borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-          <Layers size={18} color="#fff" />
-        </div>
+        <BrandMark size={32} shadow={false} />
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontWeight: 800, fontSize: 14, color: '#0F1419', lineHeight: 1.2 }}>Прозрачная Цена</div>
           <div style={{ fontSize: 10, fontWeight: 700, color: '#6B778C', letterSpacing: '0.06em' }}>v9 · PLATFORM</div>


### PR DESCRIPTION
## Срез 2 — оставшиеся header surfaces

- отдельное landing-приложение использует тот же канонический asset;
- v9 sidebar placeholder заменён на общий `BrandMark`;
- v9 page header теперь также отображает общий `BrandMark`;
- существующие шапки, где правильный общий компонент уже стоял, не переписывались.

Канонический asset уже объединён в `main` через PR #2667. Этот PR закрывает оставшиеся независимые header surfaces.