### PR TITLE
DS-V8: disambiguate cabinet drawer and fixed dock navigation

### DIFF
--- a/apps/web/components/platform-v7/PlatformV7ShellUxController.tsx
+++ b/apps/web/components/platform-v7/PlatformV7ShellUxController.tsx
@@ -171,7 +171,7 @@ export function PlatformV7ShellUxController({ role }: { role: PlatformRole }) {
         <div className={styles.drawerNavigation}>
           <section className={styles.drawerSection} aria-labelledby='primary-role-navigation'>
             <h2 id='primary-role-navigation'>Основное</h2>
-            <nav className={styles.drawerLinks} aria-label='Основные действия кабинета'>
+            <nav className={styles.drawerLinks} aria-label='Основные действия меню кабинета'>
               {primary.map((item, index) => (
                 <NavigationLink
                   key={`${navKey(item)}:${item.label}`}


### PR DESCRIPTION
## Problem

Exact-head Design System v8 browser acceptance on PR #2660 failed in Chromium, Firefox, WebKit, Android Chromium and iPhone WebKit.

Both the drawer navigation and the fixed bottom dock used the same accessible name `Основные действия кабинета`. The acceptance query and `document.querySelector` therefore resolved the drawer navigation first, whose computed position is correctly `static`, instead of the fixed dock.

## Fix

Give the drawer navigation a distinct accessible name: `Основные действия меню кабинета`.

The fixed bottom dock retains `Основные действия кабинета` and its `position: fixed` contract. No CSS or acceptance threshold is weakened.

## Scope

One semantic accessibility correction in `PlatformV7ShellUxController.tsx`.

Refs #2660
Refs #2659