### PR TITLE
DS-V8: disambiguate drawer and fixed cabinet navigation

### DIFF
--- a/apps/web/components/platform-v7/PlatformV7ShellUxController.tsx
+++ b/apps/web/components/platform-v7/PlatformV7ShellUxController.tsx
@@ -171,7 +171,7 @@ export function PlatformV7ShellUxController({ role }: { role: PlatformRole }) {
         <div className={styles.drawerNavigation}>
           <section className={styles.drawerSection} aria-labelledby='primary-role-navigation'>
             <h2 id='primary-role-navigation'>Основное</h2>
-            <nav className={styles.drawerLinks} aria-label='Основные действия кабинета'>
+            <nav className={styles.drawerLinks} aria-label='Основные действия меню кабинета'>
               {primary.map((item, index) => (
                 <NavigationLink
                   key={`${navKey(item)}:${item.label}`}

--- a/scripts/design-system-v8-route-migration-scope.json
+++ b/scripts/design-system-v8-route-migration-scope.json
@@ -13,6 +13,7 @@
   "apps/web/components/platform-v7/PlatformV7ProtectedRuntime.module.css",
   "apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx",
   "apps/web/components/platform-v7/PlatformV7ProtectedShell.module.css",
+  "apps/web/components/platform-v7/PlatformV7ShellUxController.tsx",
   "apps/web/components/platform-v7/UxFinalQuietLayer.tsx",
   "apps/web/components/platform-v7/WorkStepGuide.tsx",
   "apps/web/components/platform-v7/WorkStepGuide.module.css",


### PR DESCRIPTION
## Problem

PR #2660 exposed a deterministic Design System v8 browser-acceptance failure in all five browser profiles. The drawer navigation and fixed bottom dock shared the accessible name `Основные действия кабинета`; the acceptance selector therefore resolved the static drawer navigation before the fixed dock.

## Fix

- assign the drawer the distinct accessible name `Основные действия меню кабинета`;
- retain `Основные действия кабинета` exclusively for the fixed bottom dock;
- register `PlatformV7ShellUxController.tsx` in the source-controlled Design System v8 migration scope.

No CSS, runtime authority or acceptance threshold is weakened.

## Maturity boundary

This is a semantic accessibility/shell-contract correction only. It does not advance production maturity.

Refs #2660
Refs #2659