### PR TITLE
Audit SEO apply failure log tail

### DIFF
--- a/.github/workflows/seo-apply-log-snapshot.yml
+++ b/.github/workflows/seo-apply-log-snapshot.yml
@@ -1,0 +1,36 @@
+name: SEO apply log snapshot
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/seo-apply-log-snapshot.yml'
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download and print failed job log tail
+        env:
+          GH_TOKEN: ${{ github.token }}
+          JOB_ID: '87743835742'
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/seo-apply-log
+          curl --fail --location --silent --show-error \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/jobs/${JOB_ID}/logs" \
+            -o artifacts/seo-apply-log/job.log
+          tail -n 120 artifacts/seo-apply-log/job.log | tee artifacts/seo-apply-log/tail.log
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: seo-apply-log-tail-87743835742
+          path: artifacts/seo-apply-log
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
Diagnostics completed and superseded by clean implementation PR #2681. Closed without merge.

The exact-main SEO failure root cause was confirmed: public route indexability, sitemap and robots authority diverged.