### PR TITLE
chore: verify external publisher cleanup

### DIFF
--- a/docs/platform-v7/autopilot/external-publisher-control-2026-07-17.md
+++ b/docs/platform-v7/autopilot/external-publisher-control-2026-07-17.md
@@ -1,0 +1,7 @@
+# External publisher cleanup control
+
+Date: 2026-07-17
+Base commit: `0a45a565f134921cd8bbe3361863e62660b128df`
+Purpose: create a fresh GitHub commit and pull request to prove that obsolete Vercel and Deno commit-status publishers have been disconnected.
+
+This file is control evidence only. Do not merge unless it is intentionally retained.


### PR DESCRIPTION
## Purpose

Create a fresh exact-head commit to verify that obsolete Vercel and Deno commit-status publishers have been disconnected.

## Acceptance

- no `Vercel – *` contexts;
- no `deploy/pachaninm-lab/pachanin-demo` Deno context;
- canonical GitHub Actions and Netlify remain healthy.

Control only. Do not merge until evidence is reviewed.

Refs #2600 #2659