### PR TITLE
Fix exact-main production SEO and security evidence orchestration

### DIFF
--- a/.github/workflows/indexnow-submit.yml
+++ b/.github/workflows/indexnow-submit.yml
@@ -10,6 +10,10 @@ on:
       - 'apps/web/middleware.ts'
       - 'apps/web/app/layout.tsx'
       - 'apps/web/app/platform-v7/**'
+      - 'apps/web/lib/platform-v7/public-seo-routes.json'
+      - 'apps/web/public/*.txt'
+      - 'netlify.toml'
+      - 'scripts/write-deploy-evidence.mjs'
       - 'scripts/indexnow-submit.mjs'
       - '.github/workflows/indexnow-submit.yml'
   workflow_dispatch:
@@ -21,13 +25,31 @@ jobs:
   submit:
     name: Submit public URLs to IndexNow
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 25
     steps:
-      - name: Checkout
+      - name: Checkout exact head
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
 
-      - name: Submit sitemap URLs
+      - name: Submit exact deployed public URLs
         run: node scripts/indexnow-submit.mjs
         env:
           SITE_URL: https://xn----8sbjf4befbjgs9b.xn--p1ai
-          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
+          EXPECTED_DEPLOY_SHA: ${{ github.sha }}
+          INDEXNOW_EVIDENCE: artifacts/indexnow/indexnow-evidence.json
+
+      - name: Enforce machine-readable IndexNow evidence
+        if: always()
+        run: |
+          test -f artifacts/indexnow/indexnow-evidence.json
+          node -e 'const r=require("./artifacts/indexnow/indexnow-evidence.json"); if(r.commitSha!==process.env.GITHUB_SHA||r.pass!==true||r.result!=="PASS"||r.violatedThresholds.length!==0) { console.error(JSON.stringify(r,null,2)); process.exit(1); }'
+
+      - name: Upload IndexNow evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: indexnow-${{ github.sha }}
+          path: artifacts/indexnow
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/security-abuse-evidence.yml
+++ b/.github/workflows/security-abuse-evidence.yml
@@ -105,45 +105,33 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-      - name: Wait for matching blocking security workflow
+      - name: Capture matching Security Quality Gate authority
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/security/capture-base-security-jobs.mjs
+
+      - name: Download exact-head security artifacts
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          deadline=$((SECONDS + 3000))
-          while (( SECONDS < deadline )); do
-            runs="$(gh run list \
-              --workflow security-quality-gate.yml \
-              --commit "$EXACT_HEAD" \
-              --limit 20 \
-              --json databaseId,status,conclusion,headSha,createdAt)"
-            run_id="$(jq -r --arg sha "$EXACT_HEAD" '[.[] | select(.headSha == $sha)] | sort_by(.createdAt) | last | .databaseId // empty' <<< "$runs")"
-            if [[ -n "$run_id" ]]; then
-              status="$(jq -r --argjson id "$run_id" '.[] | select(.databaseId == $id) | .status' <<< "$runs")"
-              conclusion="$(jq -r --argjson id "$run_id" '.[] | select(.databaseId == $id) | .conclusion // ""' <<< "$runs")"
-              if [[ "$status" == "completed" ]]; then
-                if [[ "$conclusion" != "success" ]]; then
-                  echo "Blocking Security Quality Gate run $run_id concluded $conclusion" >&2
-                  exit 1
-                fi
-                echo "BASE_SECURITY_RUN_ID=$run_id" >> "$GITHUB_ENV"
-                exit 0
-              fi
-            fi
-            sleep 15
-          done
-          echo "Timed out waiting for Security Quality Gate on exact head $EXACT_HEAD" >&2
-          exit 1
-
-      - name: Download exact-head security artifacts
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
           mkdir -p "$SECURITY_INPUT_DIR"
-          gh run download "$BASE_SECURITY_RUN_ID" --dir "$SECURITY_INPUT_DIR"
+          downloaded=false
+          for attempt in {1..8}; do
+            if gh run download "$BASE_SECURITY_RUN_ID" --dir "$SECURITY_INPUT_DIR"; then
+              downloaded=true
+              break
+            fi
+            if [[ "$attempt" == 8 ]]; then
+              echo "Unable to download exact-head Security Quality artifacts after bounded retries." >&2
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
+          [[ "$downloaded" == true ]]
           cp -R "$SECURITY_ABUSE_DIR" "$SECURITY_INPUT_DIR/security-abuse-${EXACT_HEAD}"
-          gh run view "$BASE_SECURITY_RUN_ID" --json jobs > "$SECURITY_INPUT_DIR/base-security-jobs.json"
+          test -s "$SECURITY_INPUT_DIR/base-security-jobs.json"
 
       - name: Derive exact-head job evidence
         env:

--- a/.github/workflows/seo-live-smoke.yml
+++ b/.github/workflows/seo-live-smoke.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'apps/web/**'
       - 'netlify.toml'
+      - 'scripts/write-deploy-evidence.mjs'
       - '.github/workflows/seo-live-smoke.yml'
   workflow_dispatch:
 
@@ -17,52 +18,131 @@ jobs:
   live-smoke:
     name: Verify production SEO headers
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
     steps:
-      - name: Wait for production deploy and check SEO headers
+      - name: Wait for exact production deploy
         shell: bash
         run: |
           set -euo pipefail
-
           SITE="https://xn----8sbjf4befbjgs9b.xn--p1ai"
-          HEALTH="$SITE/platform-v7/role-preview/seo-health"
-          PUBLIC_URLS=(
-            "$SITE/platform-v7"
-            "$SITE/platform-v7/secure-grain-deal"
-            "$SITE/platform-v7/fgis-zerno"
-          )
-          PRIVATE_URLS=(
-            "$SITE/platform-v7/buyer"
-            "$SITE/platform-v7/bank"
-          )
+          DEPLOY_EVIDENCE="$SITE/.well-known/pc-deploy.json"
+          mkdir -p artifacts/seo-live
 
-          echo "Checking deploy marker: $HEALTH"
-          for attempt in {1..8}; do
-            if curl -fsSL "$HEALTH" | grep -q "seo-live-smoke-2026-07-01"; then
-              echo "Deploy marker found on attempt $attempt"
+          for attempt in {1..60}; do
+            body="$(curl --fail --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              "$DEPLOY_EVIDENCE?expected=$GITHUB_SHA&attempt=$attempt" 2>/dev/null || true)"
+            live_sha="$(jq -r '.commitSha // empty' <<< "$body" 2>/dev/null || true)"
+            printf '%s\n' "$body" > artifacts/seo-live/deploy-evidence-latest.json
+            echo "Deploy attempt $attempt: expected=$GITHUB_SHA live=${live_sha:-missing}"
+            if [[ "$live_sha" == "$GITHUB_SHA" ]]; then
+              echo "Exact production deploy confirmed."
               break
             fi
-            if [ "$attempt" = "8" ]; then
-              echo "Deploy marker was not found after waiting. Production may not have picked up the latest main commit."
+            if [[ "$attempt" == 60 ]]; then
+              echo "Production did not expose exact commit $GITHUB_SHA within the acceptance window." >&2
               exit 1
             fi
-            sleep 45
+            sleep 20
           done
 
-          for url in "${PUBLIC_URLS[@]}"; do
-            echo "Checking public indexable header: $url"
-            headers="$(curl -fsSI "$url" | tr -d '\r')"
-            echo "$headers"
-            echo "$headers" | grep -qi "x-robots-tag: index, follow"
+      - name: Verify live SEO authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          SITE="https://xn----8sbjf4befbjgs9b.xn--p1ai"
+          EVIDENCE="artifacts/seo-live"
+          PUBLIC_PATHS=(
+            "/platform-v7"
+            "/platform-v7/secure-grain-deal"
+            "/platform-v7/fgis-zerno"
+            "/platform-v7/deal-flow"
+          )
+          PRIVATE_PATHS=(
+            "/platform-v7/buyer"
+            "/platform-v7/bank"
+            "/platform-v7/deals/DL-9102/clean"
+          )
+
+          public_json='[]'
+          private_json='[]'
+
+          for path in "${PUBLIC_PATHS[@]}"; do
+            safe="$(tr '/-' '__' <<< "${path#/}")"
+            headers_file="$EVIDENCE/public-${safe}.headers.txt"
+            curl --fail --silent --show-error --head --location \
+              --retry 5 --retry-all-errors \
+              "$SITE$path?acceptance_sha=$GITHUB_SHA" | tr -d '\r' | tee "$headers_file"
+            status="$(awk 'toupper($1) ~ /^HTTP\// { code=$2 } END { print code }' "$headers_file")"
+            robots="$(awk -F': ' 'tolower($1)=="x-robots-tag" { value=$2 } END { print value }' "$headers_file")"
+            [[ "$status" =~ ^(2|3)[0-9][0-9]$ ]]
+            grep -Eqi '^x-robots-tag: index, follow([,]|$)' "$headers_file"
+            public_json="$(jq --arg path "$path" --arg status "$status" --arg robots "$robots" '. + [{path:$path,status:($status|tonumber),xRobotsTag:$robots}]' <<< "$public_json")"
           done
 
-          for url in "${PRIVATE_URLS[@]}"; do
-            echo "Checking private noindex header: $url"
-            headers="$(curl -fsSI "$url" | tr -d '\r')"
-            echo "$headers"
-            echo "$headers" | grep -qi "x-robots-tag: noindex, nofollow"
+          for path in "${PRIVATE_PATHS[@]}"; do
+            safe="$(tr '/-' '__' <<< "${path#/}")"
+            headers_file="$EVIDENCE/private-${safe}.headers.txt"
+            curl --fail --silent --show-error --head --location \
+              --retry 5 --retry-all-errors \
+              "$SITE$path?acceptance_sha=$GITHUB_SHA" | tr -d '\r' | tee "$headers_file"
+            status="$(awk 'toupper($1) ~ /^HTTP\// { code=$2 } END { print code }' "$headers_file")"
+            robots="$(awk -F': ' 'tolower($1)=="x-robots-tag" { value=$2 } END { print value }' "$headers_file")"
+            [[ "$status" =~ ^(2|3)[0-9][0-9]$ ]]
+            grep -Eqi '^x-robots-tag: noindex, nofollow([,]|$)' "$headers_file"
+            private_json="$(jq --arg path "$path" --arg status "$status" --arg robots "$robots" '. + [{path:$path,status:($status|tonumber),xRobotsTag:$robots}]' <<< "$private_json")"
           done
 
-          echo "Checking sitemap and robots content"
-          curl -fsSL "$SITE/sitemap.xml" | grep -q "/platform-v7/secure-grain-deal"
-          curl -fsSL "$SITE/robots.txt" | grep -q "/platform-v7/secure-grain-deal"
+          curl --fail --silent --show-error --location --retry 5 --retry-all-errors \
+            "$SITE/sitemap.xml?acceptance_sha=$GITHUB_SHA" -o "$EVIDENCE/sitemap.xml"
+          curl --fail --silent --show-error --location --retry 5 --retry-all-errors \
+            "$SITE/robots.txt?acceptance_sha=$GITHUB_SHA" -o "$EVIDENCE/robots.txt"
+
+          for required in \
+            "/platform-v7" \
+            "/platform-v7/secure-grain-deal" \
+            "/platform-v7/fgis-zerno" \
+            "/platform-v7/deal-flow"; do
+            grep -Fq "$required" "$EVIDENCE/sitemap.xml"
+            grep -Fq "$required" "$EVIDENCE/robots.txt"
+          done
+
+          for forbidden in \
+            "/platform-v7/buyer" \
+            "/platform-v7/bank" \
+            "/platform-v7/deals/" \
+            "/platform-v7/lots/" \
+            "/platform-v7/counterparty/" \
+            "/platform-v7/demo"; do
+            ! grep -Fq "$forbidden" "$EVIDENCE/sitemap.xml"
+          done
+
+          grep -Fq '/platform-v7/buyer' "$EVIDENCE/robots.txt"
+          grep -Fq '/platform-v7/bank' "$EVIDENCE/robots.txt"
+
+          sitemap_sha="sha256:$(sha256sum "$EVIDENCE/sitemap.xml" | awk '{print $1}')"
+          robots_sha="sha256:$(sha256sum "$EVIDENCE/robots.txt" | awk '{print $1}')"
+          jq -n \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg branch "$GITHUB_REF_NAME" \
+            --arg commitSha "$GITHUB_SHA" \
+            --arg runId "$GITHUB_RUN_ID" \
+            --arg checkedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg sitemapSha256 "$sitemap_sha" \
+            --arg robotsSha256 "$robots_sha" \
+            --argjson public "$public_json" \
+            --argjson private "$private_json" \
+            '{schemaVersion:1,repository:$repository,branch:$branch,commitSha:$commitSha,runId:$runId,checkedAt:$checkedAt,public:$public,private:$private,sitemap:{sha256:$sitemapSha256},robots:{sha256:$robotsSha256},violatedThresholds:[],pass:true,result:"PASS"}' \
+            > "$EVIDENCE/seo-live-evidence.json"
+
+      - name: Enforce machine-readable SEO evidence
+        run: |
+          node -e 'const r=require("./artifacts/seo-live/seo-live-evidence.json"); if(r.commitSha!==process.env.GITHUB_SHA||r.pass!==true||r.result!=="PASS"||r.violatedThresholds.length!==0) process.exit(1)'
+
+      - name: Upload production SEO evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: seo-live-${{ github.sha }}
+          path: artifacts/seo-live
+          if-no-files-found: error
+          retention-days: 90

--- a/apps/web/tests/unit/exactMainLiveEvidenceContract.test.ts
+++ b/apps/web/tests/unit/exactMainLiveEvidenceContract.test.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const currentFile = fileURLToPath(import.meta.url);
+const root = path.resolve(path.dirname(currentFile), '../../../..');
+const read = (relativePath: string) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+const netlifyConfig = read('netlify.toml');
+const deployEvidence = read('scripts/write-deploy-evidence.mjs');
+const seoWorkflow = read('.github/workflows/seo-live-smoke.yml');
+const indexNowWorkflow = read('.github/workflows/indexnow-submit.yml');
+const indexNowScript = read('scripts/indexnow-submit.mjs');
+const securityWorkflow = read('.github/workflows/security-abuse-evidence.yml');
+const securityCapture = read('scripts/security/capture-base-security-jobs.mjs');
+
+describe('exact-main live evidence authority', () => {
+  it('binds Netlify production evidence to the immutable build commit', () => {
+    expect(netlifyConfig).toContain('node scripts/write-deploy-evidence.mjs');
+    expect(deployEvidence).toContain('process.env.COMMIT_REF');
+    expect(deployEvidence).toContain("'apps/web/public'");
+    expect(deployEvidence).toContain("'.well-known'");
+    expect(deployEvidence).toContain("'pc-deploy.json'");
+    expect(deployEvidence).toContain('commitSha');
+  });
+
+  it('waits for the exact production SHA before asserting SEO headers', () => {
+    expect(seoWorkflow).toContain('/.well-known/pc-deploy.json');
+    expect(seoWorkflow).toContain('live_sha" == "$GITHUB_SHA');
+    expect(seoWorkflow).toContain('/platform-v7/secure-grain-deal');
+    expect(seoWorkflow).toContain('/platform-v7/fgis-zerno');
+    expect(seoWorkflow).toContain('/platform-v7/deal-flow');
+    expect(seoWorkflow).toContain('seo-live-evidence.json');
+    expect(seoWorkflow).toContain('seo-live-${{ github.sha }}');
+    expect(seoWorkflow).not.toContain('seo-live-smoke-2026-07-01');
+  });
+
+  it('generates the protocol root key file and submits only exact deployed public routes', () => {
+    expect(deployEvidence).toContain('const indexNowKey = process.env.INDEXNOW_KEY ||');
+    expect(deployEvidence).toContain('`${indexNowKey}.txt`');
+    expect(deployEvidence).toContain('fs.writeFileSync(indexNowKeyFile, indexNowKey)');
+    expect(indexNowScript).toContain('`${origin}/${indexNowKey}.txt`');
+    expect(indexNowScript).toContain('/.well-known/pc-deploy.json');
+    expect(indexNowScript).toContain('publicSeoAuthority.routes.map');
+    expect(indexNowScript).toContain('indexnow-evidence.json');
+    expect(indexNowWorkflow).toContain('EXPECTED_DEPLOY_SHA: ${{ github.sha }}');
+    expect(indexNowWorkflow).toContain('indexnow-${{ github.sha }}');
+  });
+
+  it('derives Security Quality job authority from exact-head GraphQL checks', () => {
+    expect(securityWorkflow).toContain('node scripts/security/capture-base-security-jobs.mjs');
+    expect(securityWorkflow).not.toContain('gh run list');
+    expect(securityWorkflow).not.toContain('gh run view');
+    expect(securityCapture).toContain('statusCheckRollup');
+    expect(securityCapture).toContain("'Security Quality Gate'");
+    expect(securityCapture).toContain("'Secrets · Gitleaks blocking'");
+    expect(securityCapture).toContain("'TypeScript · strict blocking'");
+    expect(securityCapture).toContain('BASE_SECURITY_RUN_ID=');
+  });
+});

--- a/docs/platform-v7/autopilot/exact-main-live-evidence-2659.md
+++ b/docs/platform-v7/autopilot/exact-main-live-evidence-2659.md
@@ -1,0 +1,25 @@
+# Exact-main live evidence correction for #2659
+
+Target baseline: `2cf9613f6d89b0d1057b8cdb22df97a816f054e8`.
+
+Confirmed exact-main failures:
+
+- SEO Live Smoke tested production before the matching Netlify deployment was published because its marker was not commit-bound.
+- IndexNow submitted before exact deployment/key verification and used a non-canonical key location.
+- Security Abuse completed its abuse cases but failed while deriving job metadata from `gh run view --json jobs`.
+
+Correction:
+
+- generate `/.well-known/pc-deploy.json` during the Netlify build with the exact commit SHA;
+- wait for that exact SHA before SEO and IndexNow production checks;
+- retain machine-readable SEO and IndexNow evidence artifacts;
+- generate the IndexNow root key file during the production build rather than storing it in source control;
+- derive Security Quality job authority from exact-head GraphQL check runs, preserving all fail-closed abuse/security gates;
+- constrain the correction to the source-controlled `fix/exact-main-live-evidence-2659` autopilot branch scope.
+
+Maturity boundary:
+
+- this corrects exact-main evidence orchestration only;
+- it does not prove provider-level HA/PITR, target production load, operational soak, external penetration testing or live external integrations;
+- issue #2649 remains open;
+- `PRODUCTION_OPERATIONALLY_ACCEPTED = NO_GO`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "pnpm install --frozen-lockfile --config.node-linker=hoisted && pnpm --filter @pc/web build"
+  command = "pnpm install --frozen-lockfile --config.node-linker=hoisted && node scripts/write-deploy-evidence.mjs && pnpm --filter @pc/web build"
   publish = "apps/web/.next"
   ignore = "bash scripts/netlify-ignore.sh"
 

--- a/scripts/indexnow-submit.mjs
+++ b/scripts/indexnow-submit.mjs
@@ -1,8 +1,11 @@
 import fs from 'node:fs';
+import path from 'node:path';
 
 const siteUrl = process.env.SITE_URL || 'https://xn----8sbjf4befbjgs9b.xn--p1ai';
-const indexNowKey = process.env.INDEXNOW_KEY || 'a7a2b84a1d594be0b7648166c4c4cf26';
+const indexNowKey = process.env.INDEXNOW_KEY || 'transparent-price-indexnow';
 const endpoint = process.env.INDEXNOW_ENDPOINT || 'https://api.indexnow.org/indexnow';
+const expectedDeploySha = process.env.EXPECTED_DEPLOY_SHA || '';
+const evidenceFile = process.env.INDEXNOW_EVIDENCE || 'artifacts/indexnow/indexnow-evidence.json';
 const publicSeoAuthority = JSON.parse(
   fs.readFileSync(new URL('../apps/web/lib/platform-v7/public-seo-routes.json', import.meta.url), 'utf8'),
 );
@@ -10,29 +13,133 @@ const defaultPaths = [
   ...publicSeoAuthority.routes.map((route) => route.path),
   '/sitemap.xml',
   '/robots.txt',
-  '/indexnow.txt',
 ];
 const paths = (process.env.INDEXNOW_URLS ? process.env.INDEXNOW_URLS.split(',') : defaultPaths)
-  .map((path) => path.trim())
+  .map((value) => value.trim())
   .filter(Boolean);
 
+if (!/^[A-Za-z0-9-]{8,128}$/.test(indexNowKey)) {
+  throw new Error('INDEXNOW_KEY must contain 8-128 letters, digits or dashes.');
+}
+
 const origin = new URL(siteUrl).origin;
+const keyLocation = `${origin}/${indexNowKey}.txt`;
 const payload = {
   host: new URL(origin).host,
   key: indexNowKey,
-  keyLocation: `${origin}/indexnow.txt`,
-  urlList: paths.map((path) => new URL(path, origin).toString()),
+  keyLocation,
+  urlList: paths.map((value) => new URL(value, origin).toString()),
 };
 
-const response = await fetch(endpoint, {
-  method: 'POST',
-  headers: { 'content-type': 'application/json; charset=utf-8' },
-  body: JSON.stringify(payload),
-});
-
-if (!response.ok) {
-  const responseText = await response.text().catch(() => '');
-  throw new Error(`IndexNow submit failed: ${response.status} ${responseText}`);
+for (const url of payload.urlList) {
+  if (new URL(url).host !== payload.host) {
+    throw new Error(`IndexNow URL does not belong to payload host: ${url}`);
+  }
 }
 
-console.log(`IndexNow submit accepted for ${payload.urlList.length} URLs`);
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+const evidence = {
+  schemaVersion: 1,
+  repository: process.env.GITHUB_REPOSITORY || 'pachaninm-lab/pachanin-demo',
+  branch: process.env.GITHUB_REF_NAME || null,
+  commitSha: process.env.GITHUB_SHA || expectedDeploySha || null,
+  endpoint,
+  host: payload.host,
+  keyLocation,
+  urlCount: payload.urlList.length,
+  checkedAt: new Date().toISOString(),
+  deployAttempts: [],
+  keyVerificationAttempts: [],
+  submissionAttempts: [],
+  violatedThresholds: [],
+  pass: false,
+  result: 'FAIL',
+};
+
+function persistEvidence() {
+  fs.mkdirSync(path.dirname(evidenceFile), { recursive: true });
+  evidence.checkedAt = new Date().toISOString();
+  fs.writeFileSync(evidenceFile, `${JSON.stringify(evidence, null, 2)}\n`);
+}
+
+async function fetchWithRetry(url, options, attempts, classify) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetch(url, options);
+      const body = await response.text();
+      const record = { attempt, status: response.status, bodyPrefix: body.slice(0, 500) };
+      classify(record);
+      if (response.ok) return { response, body };
+      lastError = new Error(`HTTP ${response.status} for ${url}: ${body.slice(0, 500)}`);
+      if (!(response.status === 403 || response.status === 429 || response.status >= 500)) throw lastError;
+    } catch (error) {
+      lastError = error;
+      classify({ attempt, error: String(error) });
+    }
+    if (attempt === attempts) throw lastError;
+    await sleep(Math.min(60_000, 2_000 * 2 ** (attempt - 1)));
+  }
+  throw lastError;
+}
+
+try {
+  if (expectedDeploySha) {
+    const deployEvidenceUrl = `${origin}/.well-known/pc-deploy.json`;
+    let matched = false;
+    for (let attempt = 1; attempt <= 60; attempt += 1) {
+      try {
+        const response = await fetch(`${deployEvidenceUrl}?expected=${expectedDeploySha}&attempt=${attempt}`, { cache: 'no-store' });
+        const body = await response.text();
+        let liveSha = null;
+        try {
+          liveSha = JSON.parse(body).commitSha || null;
+        } catch {
+          liveSha = null;
+        }
+        evidence.deployAttempts.push({ attempt, status: response.status, liveSha });
+        if (response.ok && liveSha === expectedDeploySha) {
+          matched = true;
+          break;
+        }
+      } catch (error) {
+        evidence.deployAttempts.push({ attempt, error: String(error) });
+      }
+      if (attempt < 60) await sleep(20_000);
+    }
+    if (!matched) {
+      throw new Error(`Production did not expose exact deployment ${expectedDeploySha}.`);
+    }
+  }
+
+  const keyVerification = await fetchWithRetry(
+    `${keyLocation}?verification=${encodeURIComponent(expectedDeploySha || Date.now())}`,
+    { cache: 'no-store' },
+    8,
+    (record) => evidence.keyVerificationAttempts.push(record),
+  );
+  if (keyVerification.body.trim() !== indexNowKey) {
+    throw new Error(`IndexNow key file content mismatch at ${keyLocation}.`);
+  }
+
+  const submission = await fetchWithRetry(
+    endpoint,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+      body: JSON.stringify(payload),
+    },
+    8,
+    (record) => evidence.submissionAttempts.push(record),
+  );
+
+  evidence.acceptedStatus = submission.response.status;
+  evidence.pass = true;
+  evidence.result = 'PASS';
+  persistEvidence();
+  console.log(`IndexNow submit accepted for ${payload.urlList.length} URLs with HTTP ${submission.response.status}.`);
+} catch (error) {
+  evidence.violatedThresholds.push(error.message || String(error));
+  persistEvidence();
+  throw error;
+}

--- a/scripts/p7-autopilot-guard.sh
+++ b/scripts/p7-autopilot-guard.sh
@@ -216,6 +216,17 @@ scripts/release/build-exact-head-images.sh
 scripts/release/materialize-prisma-client.mjs
 scripts/p7-autopilot-guard.sh'
 
+EXACT_MAIN_LIVE_EVIDENCE_SCOPE='.github/workflows/indexnow-submit.yml
+.github/workflows/security-abuse-evidence.yml
+.github/workflows/seo-live-smoke.yml
+apps/web/tests/unit/exactMainLiveEvidenceContract.test.ts
+docs/platform-v7/autopilot/exact-main-live-evidence-2659.md
+netlify.toml
+scripts/indexnow-submit.mjs
+scripts/security/capture-base-security-jobs.mjs
+scripts/write-deploy-evidence.mjs
+scripts/p7-autopilot-guard.sh'
+
 if [ "${GITHUB_HEAD_REF:-}" = "agent/harden-platform-v7-public-entry" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/public-entry-human-copy" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/landing-hero-support" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/login-human-grade-ui" ] || [ "${GITHUB_HEAD_REF:-}" = "fix/exact-approved-header-logo" ]; then
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$PUBLIC_ENTRY_SCOPE")
 fi
@@ -274,6 +285,10 @@ fi
 
 if [ "${GITHUB_HEAD_REF:-}" = "ir/runtime-images-2664" ]; then
   ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$IR_RUNTIME_IMAGE_SCOPE")
+fi
+
+if [ "${GITHUB_HEAD_REF:-}" = "fix/exact-main-live-evidence-2659" ]; then
+  ALLOWED_CURRENT=$(printf '%s\n%s\n' "$ALLOWED_CURRENT" "$EXACT_MAIN_LIVE_EVIDENCE_SCOPE")
 fi
 
 APPROVED_BRANCH_SCOPE=$(GITHUB_HEAD_REF="${GITHUB_HEAD_REF:-}" node - <<'JS'

--- a/scripts/security/capture-base-security-jobs.mjs
+++ b/scripts/security/capture-base-security-jobs.mjs
@@ -1,0 +1,170 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repository = process.env.GITHUB_REPOSITORY;
+const [owner, name] = repository.split('/');
+const exactHead = process.env.EXACT_HEAD;
+const inputDir = process.env.SECURITY_INPUT_DIR;
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+const githubEnv = process.env.GITHUB_ENV;
+const requiredJobs = [
+  'Secrets · Gitleaks blocking',
+  'TypeScript · strict blocking',
+  'Security Gate · all blocking checks',
+];
+
+if (!repository || !exactHead || !inputDir || !token || !githubEnv) {
+  throw new Error('Missing required security evidence environment.');
+}
+
+fs.mkdirSync(inputDir, { recursive: true });
+
+const query = `
+  query SecurityQualityChecks($owner: String!, $name: String!, $oid: GitObjectID!) {
+    repository(owner: $owner, name: $name) {
+      object(oid: $oid) {
+        ... on Commit {
+          oid
+          statusCheckRollup {
+            contexts(first: 100) {
+              nodes {
+                __typename
+                ... on CheckRun {
+                  databaseId
+                  name
+                  status
+                  conclusion
+                  detailsUrl
+                  checkSuite {
+                    databaseId
+                    status
+                    conclusion
+                    app { slug }
+                    workflowRun {
+                      databaseId
+                      event
+                      runAttempt
+                      runNumber
+                      url
+                      workflow { name }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function graphql() {
+  let lastError;
+  for (let attempt = 1; attempt <= 8; attempt += 1) {
+    try {
+      const response = await fetch('https://api.github.com/graphql', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'User-Agent': 'pachanin-demo-security-evidence-capture',
+        },
+        body: JSON.stringify({ query, variables: { owner, name, oid: exactHead } }),
+      });
+      const text = await response.text();
+      if (!response.ok) {
+        lastError = new Error(`GraphQL HTTP ${response.status}: ${text.slice(0, 1200)}`);
+        if (!(response.status === 429 || response.status >= 500)) throw lastError;
+      } else {
+        const payload = JSON.parse(text);
+        if (payload.errors?.length) throw new Error(`GraphQL errors: ${JSON.stringify(payload.errors)}`);
+        return payload.data;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    if (attempt === 8) throw lastError;
+    await sleep(Math.min(30_000, 2_000 * 2 ** (attempt - 1)));
+  }
+  throw lastError;
+}
+
+function normalize(value) {
+  return typeof value === 'string' ? value.toLowerCase() : null;
+}
+
+const deadline = Date.now() + 50 * 60 * 1000;
+while (Date.now() < deadline) {
+  const data = await graphql();
+  const commit = data?.repository?.object;
+  if (!commit || commit.oid !== exactHead) {
+    throw new Error(`Security evidence commit mismatch: expected ${exactHead}, actual ${commit?.oid || 'missing'}.`);
+  }
+
+  const checks = (commit.statusCheckRollup?.contexts?.nodes || [])
+    .filter((node) => node?.__typename === 'CheckRun')
+    .filter((node) => node.checkSuite?.app?.slug === 'github-actions')
+    .filter((node) => node.checkSuite?.workflowRun?.workflow?.name === 'Security Quality Gate')
+    .map((node) => ({
+      name: node.name,
+      databaseId: node.databaseId,
+      status: normalize(node.status),
+      conclusion: normalize(node.conclusion),
+      detailsUrl: node.detailsUrl,
+      workflowRunId: node.checkSuite.workflowRun.databaseId,
+      workflowRunNumber: node.checkSuite.workflowRun.runNumber,
+      workflowRunAttempt: node.checkSuite.workflowRun.runAttempt,
+      workflowRunEvent: node.checkSuite.workflowRun.event,
+      workflowRunUrl: node.checkSuite.workflowRun.url,
+      suiteId: node.checkSuite.databaseId,
+      suiteStatus: normalize(node.checkSuite.status),
+      suiteConclusion: normalize(node.checkSuite.conclusion),
+    }));
+
+  const required = requiredJobs.map((jobName) => checks.find((check) => check.name === jobName) || null);
+  const active = required.filter((check) => check && check.status !== 'completed');
+  const missing = requiredJobs.filter((_, index) => !required[index]);
+
+  console.log(JSON.stringify({
+    observedAt: new Date().toISOString(),
+    exactHead,
+    missing,
+    active: active.map((check) => `${check.name}:${check.status}`),
+    required: required.map((check, index) => check ? `${requiredJobs[index]}:${check.status}/${check.conclusion}` : `${requiredJobs[index]}:missing`),
+  }));
+
+  if (missing.length === 0 && active.length === 0) {
+    for (const check of required) {
+      if (check.conclusion !== 'success') {
+        throw new Error(`Required base security job ${check.name} concluded ${check.conclusion}.`);
+      }
+    }
+    const runIds = new Set(required.map((check) => check.workflowRunId));
+    if (runIds.size !== 1) {
+      throw new Error(`Security Quality jobs resolve to multiple workflow runs: ${[...runIds].join(',')}.`);
+    }
+    const baseSecurityRunId = String([...runIds][0]);
+    const payload = {
+      schemaVersion: 1,
+      repository,
+      commitSha: exactHead,
+      workflow: 'Security Quality Gate',
+      workflowRunId: baseSecurityRunId,
+      capturedAt: new Date().toISOString(),
+      jobs: checks,
+    };
+    fs.writeFileSync(path.join(inputDir, 'base-security-jobs.json'), `${JSON.stringify(payload, null, 2)}\n`);
+    fs.appendFileSync(githubEnv, `BASE_SECURITY_RUN_ID=${baseSecurityRunId}\n`);
+    console.log(`Captured Security Quality Gate run ${baseSecurityRunId} for ${exactHead}.`);
+    process.exit(0);
+  }
+
+  await sleep(15_000);
+}
+
+throw new Error(`Timed out waiting for Security Quality Gate on exact head ${exactHead}.`);

--- a/scripts/write-deploy-evidence.mjs
+++ b/scripts/write-deploy-evidence.mjs
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const repository = process.env.REPOSITORY || 'pachaninm-lab/pachanin-demo';
+const branch = process.env.BRANCH || process.env.HEAD || 'main';
+const commitSha = process.env.COMMIT_REF || process.env.GITHUB_SHA || execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+const indexNowKey = process.env.INDEXNOW_KEY || 'transparent-price-indexnow';
+
+if (!/^[0-9a-f]{40}$/.test(commitSha)) {
+  throw new Error(`Invalid deployment commit SHA: ${commitSha}`);
+}
+if (!/^[A-Za-z0-9-]{8,128}$/.test(indexNowKey)) {
+  throw new Error('INDEXNOW_KEY must contain 8-128 letters, digits or dashes.');
+}
+
+const publicDir = path.resolve('apps/web/public');
+const wellKnownDir = path.join(publicDir, '.well-known');
+const deployEvidenceFile = path.join(wellKnownDir, 'pc-deploy.json');
+const indexNowKeyFile = path.join(publicDir, `${indexNowKey}.txt`);
+
+fs.mkdirSync(wellKnownDir, { recursive: true });
+fs.writeFileSync(deployEvidenceFile, `${JSON.stringify({
+  schemaVersion: 1,
+  repository,
+  branch,
+  commitSha,
+  generatedAt: new Date().toISOString(),
+}, null, 2)}\n`);
+fs.writeFileSync(indexNowKeyFile, indexNowKey);
+
+console.log(`Deployment evidence written for ${repository}@${commitSha}`);
+console.log(`IndexNow ownership file written to /${indexNowKey}.txt`);


### PR DESCRIPTION
## Objective

Correct the three confirmed exact-main failures on `0a45a565f134921cd8bbe3361863e62660b128df` without weakening any product, security or release gate.

## Confirmed root causes

1. **SEO Live Smoke race** — the workflow accepted a static July marker and tested production at 21:54 UTC, while the exact-main Netlify deploy was not published until 21:56 UTC. `/platform-v7/secure-grain-deal` therefore still returned the previous `noindex` header.
2. **IndexNow ownership timing/contract** — submission ran before exact production deployment and ownership verification, then returned HTTP 403. The key was exposed at `/indexnow.txt` instead of the protocol-recommended root `/{key}.txt` path.
3. **Security evidence metadata** — all abuse cases and the Security Quality jobs passed, but `gh run view --json jobs` produced incomplete job metadata, causing the evidence derivation to report the successful Gitleaks job as missing.

## Fix

- generate `/.well-known/pc-deploy.json` during the Netlify build with the exact commit SHA;
- make SEO Live Smoke wait for that exact SHA before testing headers, sitemap and robots;
- retain exact-SHA machine-readable SEO evidence;
- host the IndexNow key at `/{key}.txt`, verify it from production and wait for the exact deployed SHA before submission;
- retain exact-SHA IndexNow evidence;
- derive Security Quality job authority through exact-head GraphQL check runs instead of `gh run list/view` metadata;
- retain the original fail-closed security evaluator, mandatory abuse cases and unified evidence manifest;
- add regression tests for all evidence contracts.

## Scope boundary

This PR changes deployment/evidence orchestration only. It does not modify Deal state authority, RBAC, money, auction, outbox or integration runtime behavior.

`PRODUCTION_OPERATIONALLY_ACCEPTED = NO_GO` remains unchanged. Issue #2649 remains open. Refs #2659 and #2600.