### PR TITLE
Fix production routing for exact-main evidence

### DIFF
--- a/.github/workflows/seo-live-smoke.yml
+++ b/.github/workflows/seo-live-smoke.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           set -euo pipefail
           SITE="https://xn----8sbjf4befbjgs9b.xn--p1ai"
-          DEPLOY_EVIDENCE="$SITE/.well-known/pc-deploy.json"
+          DEPLOY_EVIDENCE="$SITE/manifest-pc-deploy.json"
           mkdir -p artifacts/seo-live
 
           for attempt in {1..60}; do

--- a/apps/web/tests/unit/exactMainLiveEvidenceContract.test.ts
+++ b/apps/web/tests/unit/exactMainLiveEvidenceContract.test.ts
@@ -16,17 +16,17 @@ const securityWorkflow = read('.github/workflows/security-abuse-evidence.yml');
 const securityCapture = read('scripts/security/capture-base-security-jobs.mjs');
 
 describe('exact-main live evidence authority', () => {
-  it('binds Netlify production evidence to the immutable build commit', () => {
+  it('binds Netlify production evidence to the immutable build commit on a public middleware-safe path', () => {
     expect(netlifyConfig).toContain('node scripts/write-deploy-evidence.mjs');
     expect(deployEvidence).toContain('process.env.COMMIT_REF');
     expect(deployEvidence).toContain("'apps/web/public'");
-    expect(deployEvidence).toContain("'.well-known'");
-    expect(deployEvidence).toContain("'pc-deploy.json'");
+    expect(deployEvidence).toContain("'manifest-pc-deploy.json'");
     expect(deployEvidence).toContain('commitSha');
+    expect(deployEvidence).not.toContain("'.well-known'");
   });
 
   it('waits for the exact production SHA before asserting SEO headers', () => {
-    expect(seoWorkflow).toContain('/.well-known/pc-deploy.json');
+    expect(seoWorkflow).toContain('/manifest-pc-deploy.json');
     expect(seoWorkflow).toContain('live_sha" == "$GITHUB_SHA');
     expect(seoWorkflow).toContain('/platform-v7/secure-grain-deal');
     expect(seoWorkflow).toContain('/platform-v7/fgis-zerno');
@@ -36,12 +36,12 @@ describe('exact-main live evidence authority', () => {
     expect(seoWorkflow).not.toContain('seo-live-smoke-2026-07-01');
   });
 
-  it('generates the protocol root key file and submits only exact deployed public routes', () => {
+  it('generates a public ownership file and submits only exact deployed public routes', () => {
     expect(deployEvidence).toContain('const indexNowKey = process.env.INDEXNOW_KEY ||');
-    expect(deployEvidence).toContain('`${indexNowKey}.txt`');
+    expect(deployEvidence).toContain('`manifest-indexnow-${indexNowKey}.txt`');
     expect(deployEvidence).toContain('fs.writeFileSync(indexNowKeyFile, indexNowKey)');
-    expect(indexNowScript).toContain('`${origin}/${indexNowKey}.txt`');
-    expect(indexNowScript).toContain('/.well-known/pc-deploy.json');
+    expect(indexNowScript).toContain('`${origin}/manifest-indexnow-${indexNowKey}.txt`');
+    expect(indexNowScript).toContain('/manifest-pc-deploy.json');
     expect(indexNowScript).toContain('publicSeoAuthority.routes.map');
     expect(indexNowScript).toContain('indexnow-evidence.json');
     expect(indexNowWorkflow).toContain('EXPECTED_DEPLOY_SHA: ${{ github.sha }}');

--- a/docs/platform-v7/autopilot/exact-main-live-evidence-2659.md
+++ b/docs/platform-v7/autopilot/exact-main-live-evidence-2659.md
@@ -1,19 +1,20 @@
 # Exact-main live evidence correction for #2659
 
-Target baseline: `2cf9613f6d89b0d1057b8cdb22df97a816f054e8`.
+Target baseline: `452da9fdeca729d91a2bef9b9b2b4891bd515c73`.
 
 Confirmed exact-main failures:
 
-- SEO Live Smoke tested production before the matching Netlify deployment was published because its marker was not commit-bound.
-- IndexNow submitted before exact deployment/key verification and used a non-canonical key location.
-- Security Abuse completed its abuse cases but failed while deriving job metadata from `gh run view --json jobs`.
+- SEO Live Smoke originally tested production before the matching Netlify deployment was published because its marker was not commit-bound.
+- The first commit-bound marker used `/.well-known/pc-deploy.json`, but the production middleware treated that unregistered path as protected and returned the public entry HTML instead of JSON.
+- The same middleware boundary prevented a root `/{key}.txt` IndexNow ownership file from being served as plain text.
+- Security Abuse previously completed its abuse cases but failed while deriving job metadata from `gh run view --json jobs`.
 
 Correction:
 
-- generate `/.well-known/pc-deploy.json` during the Netlify build with the exact commit SHA;
-- wait for that exact SHA before SEO and IndexNow production checks;
-- retain machine-readable SEO and IndexNow evidence artifacts;
-- generate the IndexNow root key file during the production build rather than storing it in source control;
+- generate `/manifest-pc-deploy.json` during the Netlify build with the exact commit SHA; the existing `/manifest` public prefix makes this endpoint reachable without widening middleware or RBAC;
+- generate `/manifest-indexnow-{key}.txt` during the production build and pass that same-host URL explicitly as `keyLocation`;
+- wait for the exact deployed SHA before SEO and IndexNow production checks;
+- retain exact-SHA machine-readable SEO and IndexNow evidence artifacts;
 - derive Security Quality job authority from exact-head GraphQL check runs, preserving all fail-closed abuse/security gates;
 - constrain the correction to the source-controlled `fix/exact-main-live-evidence-2659` autopilot branch scope.
 

--- a/scripts/indexnow-submit.mjs
+++ b/scripts/indexnow-submit.mjs
@@ -23,7 +23,7 @@ if (!/^[A-Za-z0-9-]{8,128}$/.test(indexNowKey)) {
 }
 
 const origin = new URL(siteUrl).origin;
-const keyLocation = `${origin}/${indexNowKey}.txt`;
+const keyLocation = `${origin}/manifest-indexnow-${indexNowKey}.txt`;
 const payload = {
   host: new URL(origin).host,
   key: indexNowKey,
@@ -85,7 +85,7 @@ async function fetchWithRetry(url, options, attempts, classify) {
 
 try {
   if (expectedDeploySha) {
-    const deployEvidenceUrl = `${origin}/.well-known/pc-deploy.json`;
+    const deployEvidenceUrl = `${origin}/manifest-pc-deploy.json`;
     let matched = false;
     for (let attempt = 1; attempt <= 60; attempt += 1) {
       try {

--- a/scripts/write-deploy-evidence.mjs
+++ b/scripts/write-deploy-evidence.mjs
@@ -15,11 +15,10 @@ if (!/^[A-Za-z0-9-]{8,128}$/.test(indexNowKey)) {
 }
 
 const publicDir = path.resolve('apps/web/public');
-const wellKnownDir = path.join(publicDir, '.well-known');
-const deployEvidenceFile = path.join(wellKnownDir, 'pc-deploy.json');
-const indexNowKeyFile = path.join(publicDir, `${indexNowKey}.txt`);
+const deployEvidenceFile = path.join(publicDir, 'manifest-pc-deploy.json');
+const indexNowKeyFile = path.join(publicDir, `manifest-indexnow-${indexNowKey}.txt`);
 
-fs.mkdirSync(wellKnownDir, { recursive: true });
+fs.mkdirSync(publicDir, { recursive: true });
 fs.writeFileSync(deployEvidenceFile, `${JSON.stringify({
   schemaVersion: 1,
   repository,
@@ -29,5 +28,5 @@ fs.writeFileSync(deployEvidenceFile, `${JSON.stringify({
 }, null, 2)}\n`);
 fs.writeFileSync(indexNowKeyFile, indexNowKey);
 
-console.log(`Deployment evidence written for ${repository}@${commitSha}`);
-console.log(`IndexNow ownership file written to /${indexNowKey}.txt`);
+console.log(`Deployment evidence written for ${repository}@${commitSha} at /manifest-pc-deploy.json`);
+console.log(`IndexNow ownership file written to /manifest-indexnow-${indexNowKey}.txt`);


### PR DESCRIPTION
Production middleware currently returns the public entry page for the deploy marker and IndexNow ownership endpoints. This change moves both build-generated files under the existing public manifest prefix while preserving exact-SHA verification, machine-readable evidence and fail-closed checks.

No transaction, authorization, money, auction, outbox or integration runtime is changed.

PRODUCTION_OPERATIONALLY_ACCEPTED remains NO_GO. Issue #2649 remains open. Refs #2659.