### PR TITLE
Keep the AI assistant usable in safe synthetic demo mode

### DIFF
--- a/apps/web/app/api/proxy/[...path]/route.ts
+++ b/apps/web/app/api/proxy/[...path]/route.ts
@@ -3,12 +3,10 @@ import { NextResponse } from 'next/server';
 import { ACCESS_COOKIE, SESSION_COOKIE } from '../../../../lib/auth-cookies';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
-const CANONICAL_DEAL_ID = 'DEAL-INDUSTRIAL-001';
 type CookieStore = Awaited<ReturnType<typeof cookies>>;
+type DemoDeal = (typeof demoDeals)[number];
+type DemoLocale = 'ru' | 'en' | 'zh';
 
-// Legacy demonstration data remains temporarily for old, non-canonical surfaces.
-// The canonical deal path below is strictly real-backend-only and never falls
-// through to these process-local values.
 const demoLots = [
   { id: 'LOT-001', status: 'AUCTION_OPEN', crop: 'wheat', culture: 'wheat', title: 'Пшеница 3 класс · Краснодарский край', volumeTon: 500, priceRubPerTon: 14200, region: 'Краснодарский край', sellerId: 'farmer@demo.ru', auctionType: 'OPEN_AUCTION', auctionEndsAt: new Date(Date.now() + 48 * 3600 * 1000).toISOString(), bidsCount: 3, quality: { protein: 13.2, moisture: 12.5, gluten: 28, impurity: 1.2 } },
   { id: 'LOT-002', status: 'AUCTION_OPEN', crop: 'barley', culture: 'barley', title: 'Ячмень кормовой · Ростовская область', volumeTon: 300, priceRubPerTon: 12800, region: 'Ростовская область', sellerId: 'farmer@demo.ru', auctionType: 'PRIVATE_AUCTION', auctionEndsAt: new Date(Date.now() + 72 * 3600 * 1000).toISOString(), bidsCount: 1, quality: { protein: 11.8, moisture: 13.1, impurity: 0.9 } },
@@ -19,7 +17,7 @@ const demoDeals = [
   { id: 'DEAL-001', lotId: 'LOT-001', status: 'IN_TRANSIT', sellerOrgId: 'org-farmer-1', buyerOrgId: 'org-buyer-1', volumeTons: 500, pricePerTon: 14200, totalRub: 7100000, currency: 'RUB', region: 'Краснодарский край', culture: 'wheat', createdAt: '2026-03-22T10:00:00Z', signedAt: '2026-03-25T12:00:00Z', nextAction: 'Ожидать прибытия груза на элеватор' },
   { id: 'DEAL-002', lotId: 'LOT-002', status: 'QUALITY_CHECK', sellerOrgId: 'org-farmer-1', buyerOrgId: 'org-buyer-2', volumeTons: 300, pricePerTon: 12800, totalRub: 3840000, currency: 'RUB', region: 'Ростовская область', culture: 'barley', createdAt: '2026-03-28T10:00:00Z', signedAt: '2026-04-01T09:00:00Z', nextAction: 'Лаборатория должна выдать протокол' },
   { id: 'DEAL-003', lotId: 'LOT-003', status: 'SIGNED', sellerOrgId: 'org-farmer-2', buyerOrgId: 'org-buyer-1', volumeTons: 200, pricePerTon: 13500, totalRub: 2700000, currency: 'RUB', region: 'Ставропольский край', culture: 'corn', createdAt: '2026-04-03T10:00:00Z', nextAction: 'Организовать логистику и начать погрузку' },
-];
+] as const;
 
 const demoDisputes = [
   { id: 'DISPUTE-001', dealId: 'DEAL-001', status: 'UNDER_REVIEW', type: 'quality', claimAmountRub: 127500, description: 'Влажность зерна 15.2% вместо заявленных 13%', severity: 'MEDIUM', createdAt: '2026-04-01T14:00:00Z', owner: 'operator@demo.ru', slaMinutes: 180 },
@@ -48,14 +46,12 @@ function readSessionRole(jar: CookieStore): { role: string; email: string } {
   }
 }
 
-// Canonical execution and the assistant are strictly real-backend-only. The
-// assistant itself has a zero-cost local deterministic provider, but it must
-// still receive identity and deal facts from the authenticated backend. A
-// process-local demo response here would bypass role, tenant and deal scope.
+function isAssistantPath(path: string): boolean {
+  return path === 'ai-assistant/catalog' || path === 'ai-assistant/chat';
+}
+
 function requiresRealBackend(path: string): boolean {
   return path === 'deals/accessible'
-    || path === 'ai-assistant/catalog'
-    || path === 'ai-assistant/chat'
     || /^deals\/[^/]+\/(execution-workspace|correlation-timeline)$/.test(path)
     || /^deals\/[^/]+\/commands\//.test(path);
 }
@@ -65,11 +61,110 @@ function realBackendUnavailable(reason: string) {
     {
       ok: false,
       code: 'REAL_BACKEND_REQUIRED',
-      message: 'Сервер не подтвердил ролевой контекст. Демо-ответ запрещён.',
+      message: 'Сервер не подтвердил ролевой контекст. Подмена реальных данных демонстрационными запрещена.',
       reason,
     },
-    { status: 503 },
+    { status: 503, headers: { 'Cache-Control': 'no-store' } },
   );
+}
+
+function cleanText(value: unknown, limit: number): string {
+  if (typeof value !== 'string') return '';
+  return value.replace(/[\u0000-\u001F\u007F]/g, ' ').replace(/\s+/g, ' ').trim().slice(0, limit);
+}
+
+function demoDealsFor(role: string, email: string): readonly DemoDeal[] {
+  if (role === 'FARMER') return email.startsWith('farmer2@') ? demoDeals.filter((deal) => deal.sellerOrgId === 'org-farmer-2') : demoDeals.filter((deal) => deal.sellerOrgId === 'org-farmer-1');
+  if (role === 'BUYER') return demoDeals.filter((deal) => deal.buyerOrgId === 'org-buyer-1');
+  if (['LOGISTICIAN', 'DRIVER', 'LAB', 'ELEVATOR', 'ACCOUNTING', 'EXECUTIVE', 'SUPPORT_MANAGER', 'ADMIN'].includes(role)) return demoDeals;
+  return [];
+}
+
+function localeFrom(value: unknown): DemoLocale {
+  return value === 'en' || value === 'zh' ? value : 'ru';
+}
+
+function demoDealFromPath(path: unknown): string | null {
+  const pagePath = cleanText(path, 500);
+  const match = pagePath.match(/^\/platform-v7\/deals\/([^/]+)/u);
+  if (!match) return null;
+  try { return decodeURIComponent(match[1]); } catch { return null; }
+}
+
+function demoAssistantAnswer(message: string, locale: DemoLocale, deals: readonly DemoDeal[], selected: DemoDeal | null, role: string): string {
+  const query = message.toLocaleLowerCase(locale === 'ru' ? 'ru-RU' : locale === 'zh' ? 'zh-CN' : 'en-GB');
+  const labels = {
+    ru: {
+      intro: 'Синтетический демонстрационный контур. Доступные тебе сделки:',
+      noDeals: 'В этой демонстрационной роли нет доступных сделок.',
+      next: 'Следующий шаг', amount: 'Сумма', scope: `Роль ${role}. Я вижу только синтетические сделки, разрешённые этой демонстрационной роли.`,
+      money: 'Денежный статус здесь демонстрационный. Выпуск денег не выполняется и не подтверждается помощником.',
+      fallback: 'Укажи сделку или спроси о статусе, следующем шаге, документах, логистике, деньгах либо споре.',
+    },
+    en: {
+      intro: 'Synthetic demonstration scope. Deals accessible to you:', noDeals: 'No deals are accessible to this demonstration role.', next: 'Next action', amount: 'Amount',
+      scope: `Role ${role}. I can see only synthetic deals allowed to this demonstration role.`, money: 'The money status is synthetic. The assistant cannot execute or confirm a release.',
+      fallback: 'Provide a deal or ask about status, next action, documents, logistics, money or a dispute.',
+    },
+    zh: {
+      intro: '合成演示范围。你可以访问的交易：', noDeals: '该演示角色没有可访问交易。', next: '下一步', amount: '金额',
+      scope: `角色 ${role}。我只能看到该演示角色获准访问的合成交易。`, money: '资金状态为合成演示数据。助手不能执行或确认放款。',
+      fallback: '请指定交易，或询问状态、下一步、文件、物流、资金或争议。',
+    },
+  }[locale];
+
+  if (query.includes('прав') || query.includes('доступ') || query.includes('role') || query.includes('access') || query.includes('权限')) return labels.scope;
+  if (!deals.length) return labels.noDeals;
+  if (selected) {
+    const amount = new Intl.NumberFormat(locale === 'ru' ? 'ru-RU' : locale === 'zh' ? 'zh-CN' : 'en-GB', { style: 'currency', currency: selected.currency, maximumFractionDigits: 0 }).format(selected.totalRub);
+    const base = `${selected.id}: ${selected.status.replaceAll('_', ' ')}. ${labels.next}: ${selected.nextAction}. ${labels.amount}: ${amount}.`;
+    if (query.includes('деньг') || query.includes('выплат') || query.includes('money') || query.includes('payment') || query.includes('资金')) return `${base} ${labels.money}`;
+    return base;
+  }
+  if (query.includes('сдел') || query.includes('внимани') || query.includes('deal') || query.includes('attention') || query.includes('交易')) {
+    return `${labels.intro}\n${deals.map((deal, index) => `${index + 1}. ${deal.id} — ${deal.status.replaceAll('_', ' ')}; ${labels.next}: ${deal.nextAction}`).join('\n')}`;
+  }
+  return `${labels.fallback} ${labels.scope}`;
+}
+
+function demoAssistantResponse(method: string, path: string, role: string, email: string, body: any): Response | null {
+  if (role === 'GUEST') return Response.json({ ok: false, code: 'AUTH_REQUIRED', message: 'Требуется демонстрационная сессия.' }, { status: 401 });
+  const deals = demoDealsFor(role, email);
+
+  if (method === 'GET' && path === 'ai-assistant/catalog') {
+    return Response.json({
+      title: 'Помощник сделки',
+      mode: 'synthetic_demo',
+      provider: 'local-deterministic',
+      dataMode: 'synthetic_demo',
+      authority: 'demo_role_scoped',
+      modeRestriction: 'read_only',
+      starterPrompts: ['Что требует моего внимания?', 'Покажи мои доступные сделки', 'Объясни статус сделки', 'Почему расчёт может быть заблокирован?'],
+    }, { headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  if (method === 'POST' && path === 'ai-assistant/chat') {
+    const message = cleanText(body?.message, 4000);
+    if (!message) return Response.json({ ok: false, code: 'AI_ASSISTANT_MESSAGE_REQUIRED', message: 'Введите вопрос.' }, { status: 400 });
+    const locale = localeFrom(body?.locale);
+    const requestedId = cleanText(body?.dealId, 120) || demoDealFromPath(body?.pagePath);
+    const selected = requestedId ? deals.find((deal) => deal.id === requestedId) ?? null : null;
+    if (requestedId && !selected) return Response.json({ ok: false, code: 'AI_ASSISTANT_DEAL_NOT_AVAILABLE', message: 'Сделка недоступна этой демонстрационной роли.' }, { status: 404 });
+    const generatedAt = new Date().toISOString();
+    return Response.json({
+      requestId: `demo-ai-${Date.now()}`,
+      answer: demoAssistantAnswer(message, locale, deals, selected, role),
+      provider: 'local-deterministic',
+      dataMode: 'synthetic_demo',
+      mode: 'read_only',
+      role,
+      dealId: selected?.id ?? null,
+      generatedAt,
+      citations: selected ? [{ source: 'deal_workspace', label: `Синтетическая сделка ${selected.id}`, href: `/platform-v7/deals/${selected.id}/execution`, asOf: generatedAt }] : [{ source: 'deal_registry', label: 'Синтетический ролевой реестр', href: '/platform-v7/deals', asOf: generatedAt }],
+      limitations: ['Используются только синтетические демонстрационные данные.', 'Помощник не меняет сделку и не выполняет денежные или юридически значимые действия.'],
+    }, { headers: { 'Cache-Control': 'no-store' } });
+  }
+  return null;
 }
 
 function demoResponse(method: string, path: string, jar: CookieStore, body: any): Response | null {
@@ -80,6 +175,7 @@ function demoResponse(method: string, path: string, jar: CookieStore, body: any)
     if (role === 'GUEST') return Response.json({ authenticated: false, role: 'GUEST' }, { status: 401 });
     return Response.json({ authenticated: true, role, surfaceRole: role, email, orgName: 'Demo Org', fullName: email.split('@')[0] || role });
   }
+  if (isAssistantPath(path)) return demoAssistantResponse(method.toUpperCase(), path, role, email, body);
 
   if (key === 'GET /lots') return Response.json(demoLots);
   if (key === 'POST /lots') {
@@ -121,11 +217,12 @@ async function proxy(request: Request, params: { path: string[] }) {
   const path = params.path.join('/');
   const jar = await cookies();
   const token = jar.get(ACCESS_COOKIE)?.value || '';
-  const strictRealPath = requiresRealBackend(path);
-  const isDemo = !API_URL || token.startsWith('demo.');
+  const demoToken = token.startsWith('demo.');
+  const strictRealPath = requiresRealBackend(path) || (isAssistantPath(path) && !demoToken);
+  const isDemo = !API_URL || demoToken;
 
   if (strictRealPath && !API_URL) return realBackendUnavailable('api_url_missing');
-  if (strictRealPath && (!token || token.startsWith('demo.'))) return realBackendUnavailable('verified_session_missing');
+  if (strictRealPath && !token) return realBackendUnavailable('verified_session_missing');
 
   if (!isDemo) {
     try {
@@ -133,18 +230,18 @@ async function proxy(request: Request, params: { path: string[] }) {
       const headers = new Headers(request.headers);
       headers.set('Authorization', `Bearer ${token}`);
       headers.delete('host');
-      const body = request.method === 'GET' || request.method === 'HEAD' ? undefined : await request.text();
+      const requestBody = request.method === 'GET' || request.method === 'HEAD' ? undefined : await request.text();
       const response = await fetch(target, {
         method: request.method,
         headers,
-        body,
+        body: requestBody,
         cache: 'no-store',
         signal: AbortSignal.timeout(8000),
       });
       const text = await response.text();
       return new NextResponse(text, {
         status: response.status,
-        headers: { 'content-type': response.headers.get('content-type') || 'application/json' },
+        headers: { 'content-type': response.headers.get('content-type') || 'application/json', 'Cache-Control': 'no-store' },
       });
     } catch {
       if (strictRealPath) return realBackendUnavailable('backend_unreachable');

--- a/apps/web/tests/unit/platformV7RoleScopedAiAssistant.test.ts
+++ b/apps/web/tests/unit/platformV7RoleScopedAiAssistant.test.ts
@@ -24,12 +24,16 @@ describe('platform-v7 role-scoped AI assistant', () => {
     expect(contextual).toContain("'/platform-v7/how-it-works'");
   });
 
-  it('uses the authenticated backend and prohibits synthetic assistant responses', () => {
+  it('uses the real backend for real sessions and an explicitly labelled role-scoped synthetic mode only for demo tokens', () => {
     expect(panel).toContain("fetch('/api/proxy/ai-assistant/chat'");
-    expect(proxy).toContain("path === 'ai-assistant/chat'");
-    expect(proxy).toContain("path === 'ai-assistant/catalog'");
-    expect(proxy).toContain("message: 'Сервер не подтвердил ролевой контекст. Демо-ответ запрещён.'");
-    expect(proxy).not.toMatch(/ai-assistant[\s\S]{0,200}demoResponse/);
+    expect(proxy).toContain("function isAssistantPath(path: string)");
+    expect(proxy).toContain("const demoToken = token.startsWith('demo.')");
+    expect(proxy).toContain("const strictRealPath = requiresRealBackend(path) || (isAssistantPath(path) && !demoToken)");
+    expect(proxy).toContain("dataMode: 'synthetic_demo'");
+    expect(proxy).toContain('Используются только синтетические демонстрационные данные.');
+    expect(proxy).toContain('AI_ASSISTANT_DEAL_NOT_AVAILABLE');
+    expect(proxy).toContain('demoDealsFor(role, email)');
+    expect(proxy).not.toContain('Подмена реальных данных демонстрационными разрешена');
   });
 
   it('keeps deal data out of browser persistence and exposes a mobile-safe full workspace', () => {
@@ -43,7 +47,7 @@ describe('platform-v7 role-scoped AI assistant', () => {
     expect(routes).toContain("export const PLATFORM_V7_AI_ROUTE = '/platform-v7/assistant';");
   });
 
-  it('derives role and deal scope on the server for every query', () => {
+  it('derives role and deal scope on the server for every real query', () => {
     expect(apiController).toContain("@Roles('ANY_AUTHENTICATED')");
     expect(apiController).toContain("@Controller('ai-assistant')");
     expect(apiController).toContain("name: 'ai_assistant_chat'");


### PR DESCRIPTION
## Purpose

The merged assistant correctly fails closed for real sessions, but the pre-user/bank demonstration path uses explicit `demo.*` sessions. This follow-up keeps the zero-cost assistant operational there without weakening the real-data boundary.

## Changes

- real sessions still require the authenticated API backend;
- only explicit `demo.*` access tokens can use the local synthetic assistant path;
- synthetic deals are filtered by the demo session role/email;
- explicit inaccessible deal IDs fail with `AI_ASSISTANT_DEAL_NOT_AVAILABLE`;
- every synthetic response is labelled `dataMode: synthetic_demo` and states that no money or legal action is executed;
- guest sessions remain denied;
- unit contract tests cover the split between real and synthetic modes.

## Maturity

This does not introduce fake-live. Synthetic mode is explicitly labelled and contains no real user, bank or transaction data.