### PR TITLE
IR-FAULT: prove safe degradation and bounded recovery

### DIFF
--- a/.github/workflows/fault-injection-acceptance.yml
+++ b/.github/workflows/fault-injection-acceptance.yml
@@ -1,0 +1,120 @@
+name: Fault Injection and Recovery Acceptance
+
+on:
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'infra/docker/**'
+      - 'infra/helm/grainflow/**'
+      - 'infra/kind/production-like/**'
+      - 'infra/kind/fault-injection/**'
+      - 'scripts/release/**'
+      - '.github/workflows/fault-injection-acceptance.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/api/**'
+      - 'infra/docker/**'
+      - 'infra/helm/grainflow/**'
+      - 'infra/kind/production-like/**'
+      - 'infra/kind/fault-injection/**'
+      - 'scripts/release/**'
+      - '.github/workflows/fault-injection-acceptance.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fault-injection-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  EXACT_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+  EVIDENCE_DIR: artifacts/industrial-readiness
+
+jobs:
+  fault-injection:
+    name: Dependency faults · safe degradation · recovery · alerts
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    steps:
+      - name: Checkout exact head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.EXACT_HEAD }}
+          fetch-depth: 0
+
+      - name: Reclaim runner disk
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          docker system prune --all --force || true
+          df -h
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.18.4
+
+      - name: Install pinned kind and kubectl
+        run: |
+          set -euo pipefail
+          KIND_VERSION=v0.23.0
+          curl --fail --location --retry 5 \
+            "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64" \
+            -o /tmp/kind-linux-amd64
+          curl --fail --location --retry 5 \
+            "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64.sha256sum" \
+            -o /tmp/kind-linux-amd64.sha256sum
+          (cd /tmp && sha256sum --check kind-linux-amd64.sha256sum)
+          sudo install -m 0755 /tmp/kind-linux-amd64 /usr/local/bin/kind
+
+          KUBECTL_VERSION=v1.30.4
+          curl --fail --location --retry 5 \
+            "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+            -o /tmp/kubectl
+          curl --fail --location --retry 5 \
+            "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" \
+            -o /tmp/kubectl.sha256
+          echo "$(cat /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum --check
+          sudo install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+
+      - name: Execute accepted production-like deployment baseline
+        run: bash scripts/release/production-like-kubernetes-acceptance.sh
+
+      - name: Execute residual infrastructure fault acceptance
+        run: bash scripts/release/fault-injection-acceptance.sh
+
+      - name: Build and enforce machine-readable fault evidence
+        if: always()
+        run: |
+          node scripts/release/fault-injection-fallback-evidence.mjs
+          node scripts/release/enforce-fault-injection-evidence.mjs
+
+      - name: Upload fault-injection evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fault-injection-${{ env.EXACT_HEAD }}
+          path: ${{ env.EVIDENCE_DIR }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Cleanup disposable fault environment
+        if: always()
+        run: |
+          kind delete cluster --name grainflow-acceptance || true
+          docker rm -f kind-registry || true
+          docker system df || true
+
+  fault-injection-gate:
+    name: Fault Injection Gate · blocking
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [fault-injection]
+    steps:
+      - name: Enforce acceptance job
+        run: test "${{ needs.fault-injection.result }}" = success

--- a/infra/kind/fault-injection/scope.json
+++ b/infra/kind/fault-injection/scope.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 1,
+  "issue": 2695,
+  "parentIssue": 2597,
+  "baseline": "production-like-kubernetes-acceptance",
+  "evidenceClass": "FAULT_INJECTION_SAFE_DEGRADATION_RECOVERY",
+  "inheritedAcceptedScenarios": [
+    "api peer deletion",
+    "web peer deletion",
+    "PgBouncer peer deletion",
+    "outbox worker peer deletion",
+    "immutable rolling deployment",
+    "same-schema rollback",
+    "NetworkPolicy rejection"
+  ],
+  "residualScenarios": [
+    "total runtime database route outage with zero false command effect and exact-once recovery",
+    "API outage alert fire and clear",
+    "object-storage outage during evidence finalization with zero false VERIFIED state",
+    "Kafka outage with zero false SENT and bounded backlog recovery",
+    "bounded CPU, memory and ephemeral-storage pressure",
+    "platform workload evacuation from one cordoned node",
+    "failed transactional migration with zero schema residue and unchanged release authority",
+    "final Deal, document and outbox invariant reconciliation"
+  ],
+  "canonicalArtifact": "artifacts/industrial-readiness/fault/fault-injection-acceptance.json",
+  "maturityBoundary": "Reproducible production-like fault acceptance. This does not prove every future provider, live external integration, permanent production history or a completed 72-hour soak."
+}

--- a/scripts/release/enforce-fault-injection-evidence.mjs
+++ b/scripts/release/enforce-fault-injection-evidence.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+const root = process.env.EVIDENCE_DIR || 'artifacts/industrial-readiness';
+const file = `${root}/fault/fault-injection-acceptance.json`;
+if (!fs.existsSync(file)) throw new Error(`Missing fault evidence: ${file}`);
+const report = JSON.parse(fs.readFileSync(file, 'utf8'));
+const exact = process.env.EXACT_HEAD || process.env.GITHUB_SHA;
+const failures = [];
+if (report.schemaVersion !== 1) failures.push('schemaVersion');
+if (report.evidenceClass !== 'FAULT_INJECTION_SAFE_DEGRADATION_RECOVERY') failures.push('evidenceClass');
+if (!exact || report.exactCommit !== exact) failures.push(`exactCommit:${report.exactCommit}!=${exact}`);
+if (report.pass !== true || report.decision !== 'PASS') failures.push('decision');
+if (!Array.isArray(report.violations) || report.violations.length !== 0) failures.push('violations');
+for (const [name, value] of Object.entries(report.inheritedAcceptedScenarios || {})) {
+  if (value !== true) failures.push(`inherited:${name}`);
+}
+if (report.actualMeasurements?.databaseOutageFalseEffects !== 0) failures.push('databaseOutageFalseEffects');
+if (report.actualMeasurements?.databaseRecoveryCommandEvents !== 1) failures.push('databaseRecoveryCommandEvents');
+if (report.actualMeasurements?.apiAlertFired !== 1 || report.actualMeasurements?.apiAlertCleared !== 1) failures.push('alertContinuity');
+if (report.actualMeasurements?.objectOutageFalseVerified !== 0 || report.actualMeasurements?.objectRecoveryVerified !== 1) failures.push('objectStorageRecovery');
+if (report.actualMeasurements?.kafkaOutageFalseSent !== 0 || report.actualMeasurements?.kafkaRecoverySeconds > 90) failures.push('kafkaRecovery');
+if (report.actualMeasurements?.pressureApiFailures !== 0) failures.push('resourcePressure');
+if (report.actualMeasurements?.evacuationApiFailures !== 0 || report.actualMeasurements?.minimumWorkersDuringEvacuation < 1) failures.push('workloadEvacuation');
+if (report.actualMeasurements?.migrationResidue !== 0 || report.actualMeasurements?.releaseAuthorityMismatches !== 0) failures.push('migrationRollback');
+if (report.actualMeasurements?.duplicateLeaseTokens !== 0) failures.push('duplicateLeaseTokens');
+if (failures.length) {
+  console.error(JSON.stringify({ accepted: false, failures, report }, null, 2));
+  process.exit(1);
+}
+console.log(JSON.stringify({ accepted: true, exactCommit: exact, evidenceClass: report.evidenceClass }));

--- a/scripts/release/fault-injection-acceptance.d/00-bootstrap.part
+++ b/scripts/release/fault-injection-acceptance.d/00-bootstrap.part
@@ -1,0 +1,60 @@
+for command in base64 curl jq kubectl node sha256sum; do command -v "$command" >/dev/null; done
+
+POSTGRES_PASSWORD="$(kubectl get secret grainflow-postgresql-secrets -n "$NAMESPACE" -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)"
+export POSTGRES_PASSWORD
+printf '::add-mask::%s\n' "$POSTGRES_PASSWORD"
+
+admin_sql() {
+  kubectl exec -n "$NAMESPACE" statefulset/postgresql -- \
+    env PGPASSWORD="$POSTGRES_PASSWORD" psql -v ON_ERROR_STOP=1 -U postgres -d grainflow -Atc "$1"
+}
+
+curl_api() {
+  local method="$1" path="$2" token="${3:-}" body="${4:-}"
+  local args=(--silent --show-error --max-time 15 --resolve api.acceptance.grainflow.invalid:8080:127.0.0.1
+    -X "$method" -H 'Host: api.acceptance.grainflow.invalid' -H 'Accept: application/json')
+  [[ -n "$token" ]] && args+=(-H "Authorization: Bearer $token")
+  [[ -n "$body" ]] && args+=(-H 'Content-Type: application/json' --data "$body")
+  curl "${args[@]}" "http://api.acceptance.grainflow.invalid:8080${path}"
+}
+
+wait_deployment() {
+  kubectl rollout status -n "$NAMESPACE" "deployment/$1" --timeout="${2:-600s}"
+}
+
+wait_sql_count() {
+  local expected="$1" timeout="$2" sql="$3" deadline=$((SECONDS + timeout)) value=""
+  while (( SECONDS < deadline )); do
+    value="$(admin_sql "$sql" 2>/dev/null || true)"
+    [[ "$value" = "$expected" ]] && return 0
+    sleep 1
+  done
+  printf 'expected=%s actual=%s sql=%s\n' "$expected" "$value" "$sql" >&2
+  return 1
+}
+
+FAILURE_REASON="canonical persistent identity fixture could not be enabled"
+export FAILURE_REASON
+kubectl scale deployment/grainflow-api -n "$NAMESPACE" --replicas=1
+wait_deployment grainflow-api
+kubectl set env deployment/grainflow-api -n "$NAMESPACE" \
+  SEED_CANONICAL_TEST_DEAL=true ALLOW_CANONICAL_TEST_DEAL_IN_PRODUCTION=true
+wait_deployment grainflow-api 900s
+wait_sql_count 1 180 "SELECT count(*) FROM public.deals WHERE id='${DEAL_ID}';"
+kubectl scale deployment/grainflow-api -n "$NAMESPACE" --replicas=2
+wait_deployment grainflow-api 900s
+
+login_body='{"email":"compliance@demo.ru","password":"demo1234"}'
+login_response="$(curl_api POST /api/auth/login '' "$login_body")"
+printf '%s\n' "$login_response" > "$RAW_DIR/login.json"
+ACCESS_TOKEN="$(jq -r '.accessToken' <<<"$login_response")"
+[[ -n "$ACCESS_TOKEN" && "$ACCESS_TOKEN" != null ]]
+export ACCESS_TOKEN
+printf '::add-mask::%s\n' "$ACCESS_TOKEN"
+
+workspace="$(curl_api GET "/api/deals/${DEAL_ID}/workspace" "$ACCESS_TOKEN")"
+printf '%s\n' "$workspace" > "$RAW_DIR/workspace-before.json"
+expected_updated_at="$(jq -r '.deal.updatedAt' <<<"$workspace")"
+expected_version="$(jq -r '.deal.version' <<<"$workspace")"
+[[ -n "$expected_updated_at" && "$expected_updated_at" != null ]]
+export expected_updated_at expected_version

--- a/scripts/release/fault-injection-acceptance.d/01-database-alerts.part
+++ b/scripts/release/fault-injection-acceptance.d/01-database-alerts.part
@@ -1,0 +1,55 @@
+command_id="${RUN_ID}-approve"
+command_body="$(jq -nc --arg c "$command_id" --arg u "$expected_updated_at" --arg v "$expected_version" '{commandId:$c,idempotencyKey:($c+"-idem"),expectedUpdatedAt:$u,expectedVersion:$v,payload:{source:"fault-injection"}}')"
+export command_id
+
+FAILURE_REASON="PgBouncer total outage did not fail closed or recover exactly once"
+export FAILURE_REASON
+kubectl scale deployment/pgbouncer -n "$NAMESPACE" --replicas=0
+kubectl wait --for=delete pod -n "$NAMESPACE" -l app.kubernetes.io/name=pgbouncer --timeout=180s
+set +e
+db_outage_response="$(curl_api POST "/api/deals/${DEAL_ID}/commands/approve_admission" "$ACCESS_TOKEN" "$command_body" 2>"$RAW_DIR/db-outage-command.stderr")"
+db_outage_rc=$?
+set -e
+printf '%s\n' "$db_outage_response" > "$RAW_DIR/db-outage-command.json"
+false_db_effects="$(admin_sql "SELECT count(*) FROM public.deal_events WHERE \"dealId\"='${DEAL_ID}' AND payload->>'commandId'='${command_id}';")"
+printf '%s\n' "$false_db_effects" > "$RAW_DIR/db-outage-false-effects.txt"
+[[ "$db_outage_rc" != 0 || "$(jq -r '.statusCode // 500' <<<"${db_outage_response:-{}}" 2>/dev/null || echo 500)" -ge 400 ]]
+[[ "$false_db_effects" = 0 ]]
+
+kubectl scale deployment/pgbouncer -n "$NAMESPACE" --replicas=2
+wait_deployment pgbouncer
+wait_deployment grainflow-api
+recovered="$(curl_api POST "/api/deals/${DEAL_ID}/commands/approve_admission" "$ACCESS_TOKEN" "$command_body")"
+replayed="$(curl_api POST "/api/deals/${DEAL_ID}/commands/approve_admission" "$ACCESS_TOKEN" "$command_body")"
+printf '%s\n' "$recovered" > "$RAW_DIR/db-recovery-command.json"
+printf '%s\n' "$replayed" > "$RAW_DIR/db-replay-command.json"
+event_count="$(admin_sql "SELECT count(*) FROM public.deal_events WHERE \"dealId\"='${DEAL_ID}' AND payload->>'commandId'='${command_id}';")"
+printf '%s\n' "$event_count" > "$RAW_DIR/db-recovery-event-count.txt"
+[[ "$event_count" = 1 ]]
+
+FAILURE_REASON="API outage alert did not fire and clear"
+export FAILURE_REASON
+kubectl port-forward -n "$NAMESPACE" service/prometheus 39090:9090 > "$RAW_DIR/prometheus-port-forward.log" 2>&1 &
+prom_pid=$!
+for _ in $(seq 1 30); do curl -fsS http://127.0.0.1:39090/-/ready >/dev/null 2>&1 && break; sleep 1; done
+curl -fsS http://127.0.0.1:39090/-/ready >/dev/null
+kubectl scale deployment/grainflow-api -n "$NAMESPACE" --replicas=0
+kubectl wait --for=delete pod -n "$NAMESPACE" -l app.kubernetes.io/name=grainflow-api --timeout=180s
+alert_fired=0
+for _ in $(seq 1 18); do
+  if curl -fsS http://127.0.0.1:39090/api/v1/alerts | jq -e '.data.alerts[]? | select(.labels.alertname=="GrainflowApiUnavailable" and .state=="firing")' >/dev/null; then alert_fired=1; break; fi
+  sleep 5
+done
+printf '%s\n' "$alert_fired" > "$RAW_DIR/api-alert-fired.txt"
+[[ "$alert_fired" = 1 ]]
+kubectl scale deployment/grainflow-api -n "$NAMESPACE" --replicas=2
+wait_deployment grainflow-api 900s
+alert_cleared=0
+for _ in $(seq 1 18); do
+  if ! curl -fsS http://127.0.0.1:39090/api/v1/alerts | jq -e '.data.alerts[]? | select(.labels.alertname=="GrainflowApiUnavailable" and .state=="firing")' >/dev/null; then alert_cleared=1; break; fi
+  sleep 5
+done
+printf '%s\n' "$alert_cleared" > "$RAW_DIR/api-alert-cleared.txt"
+[[ "$alert_cleared" = 1 ]]
+kill "$prom_pid" >/dev/null 2>&1 || true
+wait "$prom_pid" 2>/dev/null || true

--- a/scripts/release/fault-injection-acceptance.d/02-storage-kafka.part
+++ b/scripts/release/fault-injection-acceptance.d/02-storage-kafka.part
@@ -1,0 +1,66 @@
+FAILURE_REASON="object-storage outage produced false verification or did not recover"
+export FAILURE_REASON
+object_content="industrial-fault-proof"
+object_hash="$(printf '%s' "$object_content" | sha256sum | awk '{print $1}')"
+upload_request="$(jq -nc --arg deal "$DEAL_ID" --argjson size "${#object_content}" '{filename:"fault-proof.txt",mimeType:"text/plain",sizeBytes:$size,dealId:$deal}')"
+upload="$(curl_api POST /api/storage/request-upload "$ACCESS_TOKEN" "$upload_request")"
+printf '%s\n' "$upload" > "$RAW_DIR/object-upload-request.json"
+file_id="$(jq -r '.fileId' <<<"$upload")"
+upload_url="$(jq -r '.uploadUrl' <<<"$upload")"
+[[ -n "$file_id" && "$file_id" != null && -n "$upload_url" && "$upload_url" != null ]]
+export file_id
+
+kubectl run fault-object-client -n "$NAMESPACE" --restart=Never \
+  --image=curlimages/curl:8.8.0 \
+  --labels=app.kubernetes.io/name=grainflow-api,app.kubernetes.io/component=acceptance-probe \
+  --overrides='{"spec":{"automountServiceAccountToken":false,"securityContext":{"runAsNonRoot":true,"runAsUser":100,"runAsGroup":101,"seccompProfile":{"type":"RuntimeDefault"}}}}' \
+  --command -- sh -ec 'sleep 1200'
+kubectl wait --for=condition=Ready pod/fault-object-client -n "$NAMESPACE" --timeout=180s
+printf '%s' "$object_content" | kubectl exec -i -n "$NAMESPACE" pod/fault-object-client -- \
+  curl -kfsS -X PUT -H 'content-type: text/plain' --data-binary @- "$upload_url"
+
+kubectl scale deployment/minio -n "$NAMESPACE" --replicas=0
+kubectl wait --for=delete pod -n "$NAMESPACE" -l app.kubernetes.io/name=minio --timeout=180s
+set +e
+object_outage="$(curl_api POST "/api/storage/confirm-upload/${file_id}" "$ACCESS_TOKEN" "{\"sha256\":\"${object_hash}\"}" 2>"$RAW_DIR/object-outage.stderr")"
+object_outage_rc=$?
+set -e
+printf '%s\n' "$object_outage" > "$RAW_DIR/object-outage-response.json"
+false_verified="$(admin_sql "SELECT count(*) FROM public.deal_documents WHERE id='${file_id}' AND status='VERIFIED' AND \"isImmutable\"=true;")"
+printf '%s\n' "$false_verified" > "$RAW_DIR/object-outage-false-verified.txt"
+[[ "$object_outage_rc" != 0 || "$(jq -r '.statusCode // 500' <<<"${object_outage:-{}}" 2>/dev/null || echo 500)" -ge 400 ]]
+[[ "$false_verified" = 0 ]]
+
+kubectl scale deployment/minio -n "$NAMESPACE" --replicas=1
+wait_deployment minio
+object_recovered="$(curl_api POST "/api/storage/confirm-upload/${file_id}" "$ACCESS_TOKEN" "{\"sha256\":\"${object_hash}\"}")"
+printf '%s\n' "$object_recovered" > "$RAW_DIR/object-recovery-response.json"
+verified="$(admin_sql "SELECT count(*) FROM public.deal_documents WHERE id='${file_id}' AND status='VERIFIED' AND \"isImmutable\"=true AND hash='${object_hash}';")"
+printf '%s\n' "$verified" > "$RAW_DIR/object-recovery-verified.txt"
+[[ "$verified" = 1 ]]
+
+FAILURE_REASON="Kafka outage was falsely acknowledged or backlog did not recover"
+export FAILURE_REASON
+kubectl scale deployment/kafka -n "$NAMESPACE" --replicas=0
+kubectl wait --for=delete pod -n "$NAMESPACE" -l app.kubernetes.io/name=kafka --timeout=180s
+admin_sql "
+INSERT INTO public.outbox_entries
+  (id,type,payload,status,\"idempotencyKey\",\"maxRetries\",\"retryCount\",\"nextRetryAt\",\"correlationId\")
+SELECT '${RUN_ID}-outbox-'||i, '${RUN_ID}.kafka', jsonb_build_object('runId','${RUN_ID}','i',i),
+       'PENDING','${RUN_ID}-outbox-idem-'||i,20,0,now()-interval '1 second','${RUN_ID}.kafka'
+FROM generate_series(1,25) g(i)
+ON CONFLICT (id) DO NOTHING;
+" >/dev/null
+sleep 10
+false_sent="$(admin_sql "SELECT count(*) FROM public.outbox_entries WHERE \"correlationId\"='${RUN_ID}.kafka' AND status='SENT';")"
+printf '%s\n' "$false_sent" > "$RAW_DIR/kafka-outage-false-sent.txt"
+[[ "$false_sent" = 0 ]]
+
+kubectl scale deployment/kafka -n "$NAMESPACE" --replicas=1
+wait_deployment kafka
+admin_sql "UPDATE public.outbox_entries SET \"nextRetryAt\"=now()-interval '1 second' WHERE \"correlationId\"='${RUN_ID}.kafka' AND status='PENDING';" >/dev/null
+kafka_recovery_start="$(date +%s)"
+wait_sql_count 25 90 "SELECT count(*) FROM public.outbox_entries WHERE \"correlationId\"='${RUN_ID}.kafka' AND status='SENT';"
+kafka_recovery_seconds=$(( $(date +%s) - kafka_recovery_start ))
+printf '%s\n' "$kafka_recovery_seconds" > "$RAW_DIR/kafka-recovery-seconds.txt"
+[[ "$kafka_recovery_seconds" -le 90 ]]

--- a/scripts/release/fault-injection-acceptance.d/02-storage-kafka.part
+++ b/scripts/release/fault-injection-acceptance.d/02-storage-kafka.part
@@ -3,7 +3,7 @@ export FAILURE_REASON
 object_content="industrial-fault-proof"
 object_hash="$(printf '%s' "$object_content" | sha256sum | awk '{print $1}')"
 upload_request="$(jq -nc --arg deal "$DEAL_ID" --argjson size "${#object_content}" '{filename:"fault-proof.txt",mimeType:"text/plain",sizeBytes:$size,dealId:$deal}')"
-upload="$(curl_api POST /api/storage/request-upload "$ACCESS_TOKEN" "$upload_request")"
+upload="$(curl_api POST /api/api/storage/request-upload "$ACCESS_TOKEN" "$upload_request")"
 printf '%s\n' "$upload" > "$RAW_DIR/object-upload-request.json"
 file_id="$(jq -r '.fileId' <<<"$upload")"
 upload_url="$(jq -r '.uploadUrl' <<<"$upload")"
@@ -22,7 +22,7 @@ printf '%s' "$object_content" | kubectl exec -i -n "$NAMESPACE" pod/fault-object
 kubectl scale deployment/minio -n "$NAMESPACE" --replicas=0
 kubectl wait --for=delete pod -n "$NAMESPACE" -l app.kubernetes.io/name=minio --timeout=180s
 set +e
-object_outage="$(curl_api POST "/api/storage/confirm-upload/${file_id}" "$ACCESS_TOKEN" "{\"sha256\":\"${object_hash}\"}" 2>"$RAW_DIR/object-outage.stderr")"
+object_outage="$(curl_api POST "/api/api/storage/confirm-upload/${file_id}" "$ACCESS_TOKEN" "{\"sha256\":\"${object_hash}\"}" 2>"$RAW_DIR/object-outage.stderr")"
 object_outage_rc=$?
 set -e
 printf '%s\n' "$object_outage" > "$RAW_DIR/object-outage-response.json"
@@ -33,7 +33,7 @@ printf '%s\n' "$false_verified" > "$RAW_DIR/object-outage-false-verified.txt"
 
 kubectl scale deployment/minio -n "$NAMESPACE" --replicas=1
 wait_deployment minio
-object_recovered="$(curl_api POST "/api/storage/confirm-upload/${file_id}" "$ACCESS_TOKEN" "{\"sha256\":\"${object_hash}\"}")"
+object_recovered="$(curl_api POST "/api/api/storage/confirm-upload/${file_id}" "$ACCESS_TOKEN" "{\"sha256\":\"${object_hash}\"}")"
 printf '%s\n' "$object_recovered" > "$RAW_DIR/object-recovery-response.json"
 verified="$(admin_sql "SELECT count(*) FROM public.deal_documents WHERE id='${file_id}' AND status='VERIFIED' AND \"isImmutable\"=true AND hash='${object_hash}';")"
 printf '%s\n' "$verified" > "$RAW_DIR/object-recovery-verified.txt"

--- a/scripts/release/fault-injection-acceptance.d/03-pressure-drain-migration.part
+++ b/scripts/release/fault-injection-acceptance.d/03-pressure-drain-migration.part
@@ -1,0 +1,127 @@
+FAILURE_REASON="bounded resource pressure broke API availability"
+export FAILURE_REASON
+pressure_node="$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name=grainflow-api -o jsonpath='{.items[0].spec.nodeName}')"
+cat > "$RAW_DIR/pressure-pod.yaml" <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fault-pressure
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: fault-pressure
+    app.kubernetes.io/component: acceptance-probe
+spec:
+  automountServiceAccountToken: false
+  nodeName: ${pressure_node}
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: pressure
+      image: alpine:3.20.2
+      command: ["/bin/sh","-ec"]
+      args:
+        - >-
+          head -c 100663296 /dev/zero > /memory/blob;
+          head -c 134217728 /dev/zero > /disk/blob;
+          end=$((SECONDS+45)); while [ $SECONDS -lt $end ]; do :; done
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+          ephemeral-storage: 160Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+          ephemeral-storage: 256Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+      volumeMounts:
+        - name: memory
+          mountPath: /memory
+        - name: disk
+          mountPath: /disk
+  volumes:
+    - name: memory
+      emptyDir:
+        medium: Memory
+        sizeLimit: 128Mi
+    - name: disk
+      emptyDir:
+        sizeLimit: 192Mi
+YAML
+kubectl apply -f "$RAW_DIR/pressure-pod.yaml"
+pressure_failures=0
+for _ in $(seq 1 75); do
+  curl -fsS --max-time 5 --resolve api.acceptance.grainflow.invalid:8080:127.0.0.1 \
+    http://api.acceptance.grainflow.invalid:8080/health >/dev/null || pressure_failures=$((pressure_failures+1))
+  phase="$(kubectl get pod fault-pressure -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+  [[ "$phase" = Succeeded ]] && break
+  [[ "$phase" = Failed ]] && { kubectl logs -n "$NAMESPACE" fault-pressure; false; }
+  sleep 1
+done
+printf '%s\n' "$pressure_failures" > "$RAW_DIR/pressure-api-failures.txt"
+[[ "$pressure_failures" = 0 ]]
+[[ "$(kubectl get pod fault-pressure -n "$NAMESPACE" -o jsonpath='{.status.phase}')" = Succeeded ]]
+
+FAILURE_REASON="platform workload evacuation violated availability or worker quorum"
+export FAILURE_REASON
+postgres_node="$(kubectl get pod postgresql-0 -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}')"
+drain_node="$(kubectl get pods -n "$NAMESPACE" -l app.kubernetes.io/name=grainflow-api -o json | jq -r --arg pg "$postgres_node" '[.items[].spec.nodeName | select(. != $pg)][0] // .items[0].spec.nodeName')"
+printf '%s\n' "$drain_node" > "$RAW_DIR/drained-node.txt"
+kubectl cordon "$drain_node"
+mapfile -t evicted_pods < <(kubectl get pods -n "$NAMESPACE" --field-selector "spec.nodeName=${drain_node}" -o json | jq -r '.items[] | select(.metadata.labels["app.kubernetes.io/name"] | IN("grainflow-api","grainflow-web","grainflow-outbox-worker","pgbouncer")) | .metadata.name')
+(
+  failures=0
+  min_workers=2
+  for _ in $(seq 1 160); do
+    curl -fsS --max-time 5 --resolve api.acceptance.grainflow.invalid:8080:127.0.0.1 \
+      http://api.acceptance.grainflow.invalid:8080/health >/dev/null || failures=$((failures+1))
+    ready="$(kubectl get deployment grainflow-outbox-worker -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo 0)"
+    ready="${ready:-0}"
+    (( ready < min_workers )) && min_workers="$ready"
+    printf '%s\n' "$failures" > "$RAW_DIR/node-evacuation-api-failures.txt"
+    printf '%s\n' "$min_workers" > "$RAW_DIR/node-evacuation-min-workers.txt"
+    sleep 0.5
+  done
+) &
+probe_pid=$!
+for pod in "${evicted_pods[@]}"; do
+  kubectl delete pod "$pod" -n "$NAMESPACE" --grace-period=30 --wait=false
+done
+wait "$probe_pid"
+wait_deployment grainflow-api
+wait_deployment grainflow-web
+wait_deployment grainflow-outbox-worker
+wait_deployment pgbouncer
+[[ "$(cat "$RAW_DIR/node-evacuation-api-failures.txt")" = 0 ]]
+[[ "$(cat "$RAW_DIR/node-evacuation-min-workers.txt")" -ge 1 ]]
+kubectl uncordon "$drain_node"
+
+FAILURE_REASON="transactional migration failure left schema residue or changed release authority"
+export FAILURE_REASON
+release_before="$(kubectl get configmap grainflow-release-authority -n "$NAMESPACE" -o json | jq -S '.data')"
+set +e
+kubectl exec -i -n "$NAMESPACE" statefulset/postgresql -- \
+  env PGPASSWORD="$POSTGRES_PASSWORD" psql -v ON_ERROR_STOP=1 -U postgres -d grainflow \
+  > "$RAW_DIR/migration-failure.log" 2>&1 <<'SQL'
+BEGIN;
+CREATE TABLE public.fault_migration_residue(id integer primary key);
+SELECT 1/0;
+COMMIT;
+SQL
+migration_rc=$?
+set -e
+[[ "$migration_rc" != 0 ]]
+migration_residue="$(admin_sql "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='public' AND c.relname='fault_migration_residue';")"
+printf '%s\n' "$migration_residue" > "$RAW_DIR/migration-residue-count.txt"
+[[ "$migration_residue" = 0 ]]
+release_after="$(kubectl get configmap grainflow-release-authority -n "$NAMESPACE" -o json | jq -S '.data')"
+[[ "$release_before" = "$release_after" ]]
+printf '0\n' > "$RAW_DIR/release-authority-mismatches.txt"

--- a/scripts/release/fault-injection-acceptance.d/03-pressure-drain-migration.part
+++ b/scripts/release/fault-injection-acceptance.d/03-pressure-drain-migration.part
@@ -28,7 +28,7 @@ spec:
         - >-
           head -c 100663296 /dev/zero > /memory/blob;
           head -c 134217728 /dev/zero > /disk/blob;
-          end=$((SECONDS+45)); while [ $SECONDS -lt $end ]; do :; done
+          end=\$((\$(date +%s)+45)); while [ "\$(date +%s)" -lt "\$end" ]; do :; done
       resources:
         requests:
           cpu: 100m

--- a/scripts/release/fault-injection-acceptance.d/04-final.part
+++ b/scripts/release/fault-injection-acceptance.d/04-final.part
@@ -1,0 +1,20 @@
+FAILURE_REASON="final invariant reconciliation failed"
+export FAILURE_REASON
+admin_sql "
+SELECT jsonb_pretty(jsonb_build_object(
+  'dealId','${DEAL_ID}',
+  'dealVersion',(SELECT version FROM public.deals WHERE id='${DEAL_ID}'),
+  'faultCommandEvents',(SELECT count(*) FROM public.deal_events WHERE \"dealId\"='${DEAL_ID}' AND payload->>'commandId'='${command_id}'),
+  'verifiedObject',(SELECT count(*) FROM public.deal_documents WHERE id='${file_id}' AND status='VERIFIED' AND \"isImmutable\"=true),
+  'kafkaSent',(SELECT count(*) FROM public.outbox_entries WHERE \"correlationId\"='${RUN_ID}.kafka' AND status='SENT'),
+  'kafkaDead',(SELECT count(*) FROM public.outbox_entries WHERE \"correlationId\"='${RUN_ID}.kafka' AND status='DEAD_LETTER'),
+  'duplicateLeaseTokens',(SELECT count(*) FROM (SELECT \"leaseToken\" FROM public.outbox_entries WHERE \"leaseToken\" IS NOT NULL GROUP BY \"leaseToken\" HAVING count(*)>1) q)
+));
+" > "$RAW_DIR/final-invariants.json"
+jq -e '.faultCommandEvents==1 and .verifiedObject==1 and .kafkaSent==25 and .kafkaDead==0 and .duplicateLeaseTokens==0' "$RAW_DIR/final-invariants.json" >/dev/null
+
+touch "$FAULT_DIR/acceptance-complete"
+printf '1\n' > "$FAULT_DIR/success.txt"
+FAILURE_REASON=""
+export FAILURE_REASON
+printf 'Residual fault injection acceptance PASS for %s\n' "$EXACT_HEAD"

--- a/scripts/release/fault-injection-acceptance.sh
+++ b/scripts/release/fault-injection-acceptance.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+export EXACT_HEAD="${EXACT_HEAD:?EXACT_HEAD is required}"
+export EVIDENCE_ROOT="${EVIDENCE_DIR:-artifacts/industrial-readiness}"
+export FAULT_DIR="$EVIDENCE_ROOT/fault"
+export RAW_DIR="$FAULT_DIR/raw"
+export NAMESPACE="grainflow-acceptance"
+export DEAL_ID="DEAL-INDUSTRIAL-001"
+export RUN_ID="fault-${EXACT_HEAD:0:12}"
+export FAILURE_REASON="fault acceptance did not start"
+
+mkdir -p "$RAW_DIR"
+rm -f "$FAULT_DIR/acceptance-complete" "$FAULT_DIR/failure-reason.txt"
+printf '%s\n' "$EXACT_HEAD" > "$FAULT_DIR/exact-head.txt"
+date -u +%Y-%m-%dT%H:%M:%SZ > "$FAULT_DIR/started-at.txt"
+date +%s > "$FAULT_DIR/started-epoch.txt"
+
+on_exit() {
+  local rc=$?
+  set +e
+  date -u +%Y-%m-%dT%H:%M:%SZ > "$FAULT_DIR/completed-at.txt"
+  date +%s > "$FAULT_DIR/completed-epoch.txt"
+  if (( rc != 0 )); then printf '%s\n' "$FAILURE_REASON" > "$FAULT_DIR/failure-reason.txt"; fi
+  kubectl scale deployment/grainflow-api -n "$NAMESPACE" --replicas=2 >/dev/null 2>&1 || true
+  kubectl scale deployment/pgbouncer -n "$NAMESPACE" --replicas=2 >/dev/null 2>&1 || true
+  kubectl scale deployment/minio -n "$NAMESPACE" --replicas=1 >/dev/null 2>&1 || true
+  kubectl scale deployment/kafka -n "$NAMESPACE" --replicas=1 >/dev/null 2>&1 || true
+  kubectl delete pod fault-object-client -n "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl get nodes -o wide > "$RAW_DIR/nodes.txt" 2>&1 || true
+  kubectl get deployments,statefulsets,pods,services,pdb -n "$NAMESPACE" -o wide > "$RAW_DIR/kubernetes-inventory.txt" 2>&1 || true
+  kubectl get events -n "$NAMESPACE" --sort-by=.lastTimestamp > "$RAW_DIR/events.txt" 2>&1 || true
+  exit "$rc"
+}
+trap on_exit EXIT
+
+for part in scripts/release/fault-injection-acceptance.d/*.part; do
+  source "$part"
+done

--- a/scripts/release/fault-injection-fallback-evidence.mjs
+++ b/scripts/release/fault-injection-fallback-evidence.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.env.EVIDENCE_DIR || 'artifacts/industrial-readiness';
+const dir = path.join(root, 'fault');
+const raw = path.join(dir, 'raw');
+const output = path.join(dir, 'fault-injection-acceptance.json');
+const exactHead = process.env.EXACT_HEAD || process.env.GITHUB_SHA || 'unknown';
+
+const read = (file, fallback = null) => {
+  const target = path.join(dir, file);
+  if (!fs.existsSync(target)) return fallback;
+  const value = fs.readFileSync(target, 'utf8').trim();
+  return value === '' ? fallback : value;
+};
+const readRaw = (file, fallback = null) => {
+  const target = path.join(raw, file);
+  if (!fs.existsSync(target)) return fallback;
+  const value = fs.readFileSync(target, 'utf8').trim();
+  return value === '' ? fallback : value;
+};
+const num = (file, fallback = 999) => {
+  const value = Number(readRaw(file, fallback));
+  return Number.isFinite(value) ? value : fallback;
+};
+const json = (target) => {
+  try { return JSON.parse(fs.readFileSync(target, 'utf8')); } catch { return null; }
+};
+
+const baseline = json(path.join(root, 'production-like-kubernetes-evidence.json'));
+const invariants = json(path.join(raw, 'final-invariants.json')) || {};
+const started = Number(read('started-epoch.txt', 0));
+const ended = Number(read('completed-epoch.txt', Math.floor(Date.now() / 1000)));
+const complete = fs.existsSync(path.join(dir, 'acceptance-complete'));
+
+const thresholds = {
+  baselineAccepted: true,
+  databaseOutageFalseEffects: 0,
+  databaseRecoveryCommandEvents: 1,
+  apiAlertFired: 1,
+  apiAlertCleared: 1,
+  objectOutageFalseVerified: 0,
+  objectRecoveryVerified: 1,
+  kafkaOutageFalseSent: 0,
+  kafkaRecoverySeconds: 90,
+  pressureApiFailures: 0,
+  evacuationApiFailures: 0,
+  minimumWorkersDuringEvacuation: 1,
+  migrationResidue: 0,
+  releaseAuthorityMismatches: 0,
+  duplicateLeaseTokens: 0,
+};
+
+const actual = {
+  baselineAccepted: baseline?.pass === true,
+  databaseOutageFalseEffects: num('db-outage-false-effects.txt'),
+  databaseRecoveryCommandEvents: num('db-recovery-event-count.txt'),
+  apiAlertFired: num('api-alert-fired.txt', 0),
+  apiAlertCleared: num('api-alert-cleared.txt', 0),
+  objectOutageFalseVerified: num('object-outage-false-verified.txt'),
+  objectRecoveryVerified: num('object-recovery-verified.txt', 0),
+  kafkaOutageFalseSent: num('kafka-outage-false-sent.txt'),
+  kafkaRecoverySeconds: num('kafka-recovery-seconds.txt'),
+  pressureApiFailures: num('pressure-api-failures.txt'),
+  evacuationApiFailures: num('node-evacuation-api-failures.txt'),
+  minimumWorkersDuringEvacuation: num('node-evacuation-min-workers.txt', 0),
+  migrationResidue: num('migration-residue-count.txt'),
+  releaseAuthorityMismatches: num('release-authority-mismatches.txt'),
+  duplicateLeaseTokens: Number(invariants.duplicateLeaseTokens ?? 999),
+};
+
+const violations = [];
+if (!actual.baselineAccepted) violations.push('baselineAccepted:false');
+for (const key of [
+  'databaseOutageFalseEffects',
+  'objectOutageFalseVerified',
+  'kafkaOutageFalseSent',
+  'pressureApiFailures',
+  'evacuationApiFailures',
+  'migrationResidue',
+  'releaseAuthorityMismatches',
+  'duplicateLeaseTokens',
+]) {
+  if (actual[key] !== thresholds[key]) violations.push(`${key}:${actual[key]}!=${thresholds[key]}`);
+}
+for (const key of ['databaseRecoveryCommandEvents', 'apiAlertFired', 'apiAlertCleared', 'objectRecoveryVerified']) {
+  if (actual[key] !== thresholds[key]) violations.push(`${key}:${actual[key]}!=${thresholds[key]}`);
+}
+if (actual.kafkaRecoverySeconds > thresholds.kafkaRecoverySeconds) {
+  violations.push(`kafkaRecoverySeconds:${actual.kafkaRecoverySeconds}>${thresholds.kafkaRecoverySeconds}`);
+}
+if (actual.minimumWorkersDuringEvacuation < thresholds.minimumWorkersDuringEvacuation) {
+  violations.push(`minimumWorkersDuringEvacuation:${actual.minimumWorkersDuringEvacuation}<${thresholds.minimumWorkersDuringEvacuation}`);
+}
+
+const pass = complete && violations.length === 0 && read('exact-head.txt') === exactHead;
+const report = {
+  schemaVersion: 1,
+  evidenceClass: 'FAULT_INJECTION_SAFE_DEGRADATION_RECOVERY',
+  repository: process.env.GITHUB_REPOSITORY || 'pachaninm-lab/pachanin-demo',
+  exactCommit: exactHead,
+  environment: 'github-actions-multi-node-kind-production-like',
+  generatedAt: new Date().toISOString(),
+  durationSeconds: Math.max(0, ended - started),
+  pass,
+  decision: pass ? 'PASS' : 'FAIL',
+  failureReason: pass ? null : read('failure-reason.txt', 'fault acceptance incomplete'),
+  thresholds,
+  actualMeasurements: actual,
+  violations,
+  inheritedAcceptedScenarios: {
+    apiPeerDeletion: baseline?.actualMeasurements?.apiAvailabilityProbeFailures === 0,
+    webPeerDeletion: baseline?.actualMeasurements?.webAvailabilityProbeFailures === 0,
+    pgbouncerPeerDeletion: baseline?.actualMeasurements?.pgbouncerAvailabilityProbeFailures === 0,
+    workerPeerDeletion: Number(baseline?.actualMeasurements?.minimumReadyWorkersDuringPeerDeletion ?? 0) >= 1,
+    immutableRollingDeployment: baseline?.assertions?.rollingUpdateDigestSetApplied === true,
+    sameSchemaRollback: baseline?.assertions?.sameSchemaRollbackDigestSetRestored === true,
+    networkPolicy: baseline?.assertions?.unauthorizedNetworkConnectionBlocked === true,
+  },
+  residualScenarios: {
+    databaseTotalRouteOutage: { falseBusinessEffects: actual.databaseOutageFalseEffects, recoveredCommandEvents: actual.databaseRecoveryCommandEvents },
+    alertContinuity: { fired: actual.apiAlertFired === 1, cleared: actual.apiAlertCleared === 1 },
+    objectStorageOutage: { falseVerified: actual.objectOutageFalseVerified, recoveredVerified: actual.objectRecoveryVerified },
+    kafkaOutage: { falseSent: actual.kafkaOutageFalseSent, recoverySeconds: actual.kafkaRecoverySeconds },
+    boundedResourcePressure: { apiFailures: actual.pressureApiFailures },
+    platformWorkloadEvacuation: { apiFailures: actual.evacuationApiFailures, minimumReadyWorkers: actual.minimumWorkersDuringEvacuation },
+    failedMigrationRollback: { schemaResidue: actual.migrationResidue, releaseAuthorityMismatches: actual.releaseAuthorityMismatches },
+    finalInvariantReconciliation: invariants,
+  },
+  evidence: [
+    'production-like-kubernetes-evidence.json',
+    'fault/raw/db-outage-command.json',
+    'fault/raw/db-recovery-command.json',
+    'fault/raw/api-alert-fired.txt',
+    'fault/raw/api-alert-cleared.txt',
+    'fault/raw/object-outage-response.json',
+    'fault/raw/object-recovery-response.json',
+    'fault/raw/kafka-recovery-seconds.txt',
+    'fault/raw/pressure-pod.yaml',
+    'fault/raw/node-evacuation-api-failures.txt',
+    'fault/raw/migration-failure.log',
+    'fault/raw/final-invariants.json',
+  ],
+  maturity: {
+    acceptedLevel: pass ? 'PRODUCTION_LIKE_ACCEPTED' : 'IMPLEMENTED_NOT_OPERATIONALLY_PROVEN',
+    permittedClaim: pass ? 'Residual infrastructure fault handling, safe degradation and bounded recovery are accepted on reproducible production-like infrastructure.' : null,
+    prohibitedClaims: ['fully operational production', 'real provider resilience', 'live user traffic', 'permanent production history'],
+  },
+};
+
+fs.mkdirSync(dir, { recursive: true });
+fs.writeFileSync(output, `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ output, pass, violations }));


### PR DESCRIPTION
## Scope

Implements the residual production-like fault acceptance from #2695 under master #2597 without duplicating already accepted #2659 scenarios.

The workflow reuses the accepted multi-node Kubernetes baseline and adds machine evidence for:

- total PgBouncer route outage with zero false Deal-command effect and exact-once recovery;
- API-unavailable alert firing and clearing;
- S3-compatible object-storage outage during evidence finalization with zero false `VERIFIED` state;
- Kafka outage with zero false `SENT` and bounded backlog recovery;
- bounded CPU, memory and ephemeral-storage pressure;
- platform workload evacuation from one cordoned worker node while API and worker quorum remain available;
- failed transactional migration with zero schema residue and unchanged immutable release authority;
- final Deal, document, outbox and lease-token reconciliation.

Already accepted peer-deletion, NetworkPolicy, immutable rollout and same-schema rollback measurements are imported from the exact-head production-like baseline rather than rerun through a second authority.

## Canonical artifact

`artifacts/industrial-readiness/fault/fault-injection-acceptance.json`

## Boundary

This proves reproducible internal resilience in disposable production-like infrastructure. It does not prove every future provider, live integrations, permanent production history or the required 72-hour soak.

`PRODUCTION_OPERATIONALLY_ACCEPTED = NO_GO` until #2649, #2693, #2694, #2696 and #2697 also pass on exact main.

Closes #2695 only after exact-main evidence passes.