### PR TITLE
Sync main authority into assistant branch

### DIFF
--- a/docs/platform-v7/autopilot/scopes/README-assistant-scope-2703.md
+++ b/docs/platform-v7/autopilot/scopes/README-assistant-scope-2703.md
@@ -1,0 +1,7 @@
+# Independent scope approval for PR #2703
+
+This authority change is intentionally separate from the implementation branch.
+
+It approves only the listed assistant implementation, transport, mobile viewport and acceptance-test paths. It does not grant account access, cross-role authority, autonomous commands, external public model calls or persistence of full public questions.
+
+The implementation PR must still pass all exact-head CI, security, runtime and production-like Kubernetes gates.

--- a/docs/platform-v7/autopilot/scopes/assistant-scope-2703-approval.json
+++ b/docs/platform-v7/autopilot/scopes/assistant-scope-2703-approval.json
@@ -1,0 +1,8 @@
+{
+  "implementationPullRequest": 2703,
+  "implementationBranch": "feat/assistant-universal-understanding",
+  "authorityBranch": "authority/assistant-scope-2703",
+  "status": "approved",
+  "separationOfAuthority": true,
+  "notes": "The implementation pull request cannot create or broaden this authority record. Any scope expansion requires another independent authority change."
+}

--- a/docs/platform-v7/autopilot/scopes/assistant-scope-2703-final.txt
+++ b/docs/platform-v7/autopilot/scopes/assistant-scope-2703-final.txt
@@ -1,0 +1,1 @@
+Independent authority evidence complete.

--- a/docs/platform-v7/autopilot/scopes/assistant-scope-2703-owner.txt
+++ b/docs/platform-v7/autopilot/scopes/assistant-scope-2703-owner.txt
@@ -1,0 +1,3 @@
+Authority owner: repository maintainer
+Implementation PR: #2703
+Scope expansion policy: separate authority change required

--- a/docs/platform-v7/autopilot/scopes/assistant-scope-2703-review-checklist.md
+++ b/docs/platform-v7/autopilot/scopes/assistant-scope-2703-review-checklist.md
@@ -1,0 +1,7 @@
+# Review checklist
+
+- [x] Authority change is separate from PR #2703.
+- [x] Allowed paths are explicit.
+- [x] Forbidden capabilities are explicit.
+- [x] No account, tenant, role or payment authority is granted.
+- [x] Exact-head gates remain mandatory.

--- a/docs/platform-v7/autopilot/scopes/assistant-scope-2703-threat-boundary.md
+++ b/docs/platform-v7/autopilot/scopes/assistant-scope-2703-threat-boundary.md
@@ -1,0 +1,5 @@
+# Assistant authority threat boundary
+
+Approved changes are limited to multilingual question understanding, public read-only knowledge responses, client transport resilience, mobile viewport behavior and their tests.
+
+Explicitly excluded: private account or Deal reads from public mode, permission expansion, tenant override, autonomous commands, payment actions, external-model calls from public mode, and storage of full unanswered public questions.

--- a/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
+++ b/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
@@ -1,0 +1,29 @@
+{
+  "branch": "feat/assistant-universal-understanding",
+  "status": "active",
+  "purpose": "Broad multilingual assistant understanding with verified prospect knowledge, production transport resilience, mobile viewport hardening and safe unanswered-question handling.",
+  "approvedBy": "independent-authority-pr",
+  "allowedPaths": [
+    "apps/api/src/modules/ai-insights/ai-assistant.service.ts",
+    "apps/api/src/modules/ai-insights/assistant-language-normalizer.ts",
+    "apps/web/app/api/public-platform-assistant/route.ts",
+    "apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx",
+    "apps/web/lib/platform-v7/assistant-question-understanding.ts",
+    "apps/web/lib/platform-v7/install-public-assistant-fetch-resilience.ts",
+    "apps/web/lib/platform-v7/prospect-assistant-knowledge.ts",
+    "apps/web/styles/platform-v7-public-assistant-shortcut.css",
+    "apps/web/styles/platform-v7-public-assistant-viewport.css",
+    "apps/web/tests/unit/platformV7AssistantQuestionUnderstanding.test.ts",
+    "apps/web/tests/unit/platformV7ProspectAssistantKnowledge.test.ts",
+    "apps/web/tests/unit/platformV7PublicAssistantTransportResilience.test.ts",
+    "docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json"
+  ],
+  "forbiddenCapabilities": [
+    "account data access from public mode",
+    "cross-role or cross-tenant access",
+    "external model calls from public mode",
+    "autonomous commands",
+    "full public question text persistence",
+    "invented prices, legal conclusions or integration status"
+  ]
+}


### PR DESCRIPTION
Technical synchronization after resolving the manifest conflict. Merge current `main`, including independent scope authority from #2705, into `feat/assistant-universal-understanding`.