### PR TITLE
Lock background scrolling while public assistant is open

### DIFF
--- a/apps/web/styles/platform-v7-public-assistant-viewport.css
+++ b/apps/web/styles/platform-v7-public-assistant-viewport.css
@@ -10,6 +10,24 @@
   overflow: visible;
 }
 
+/* Lock the document while the modal assistant is open. The :has() selector is
+ * supported by current Chromium, Safari and Firefox and keeps this behavior
+ * fully scoped to the presence of the assistant dialog. */
+html:has(.pc-public-assistant-panel),
+body:has(.pc-public-assistant-panel) {
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+body:has(.pc-public-assistant-panel) {
+  touch-action: none;
+}
+
+.pc-public-assistant-panel,
+.pc-public-assistant-panel * {
+  touch-action: auto;
+}
+
 .pc-public-assistant-messages {
   min-height: 0;
   scrollbar-gutter: stable;

--- a/docs/industrial-readiness/evidence/public-assistant-mobile-scroll-lock.acceptance.json
+++ b/docs/industrial-readiness/evidence/public-assistant-mobile-scroll-lock.acceptance.json
@@ -1,0 +1,12 @@
+{
+  "authority": "public-assistant-mobile-scroll-lock",
+  "base": "279fa6cb160e3dd04f8f95394dfb1ae2eef6e3a5",
+  "head": "3fd00bc12ee96ba5067eb72501e4829561e55e7f",
+  "status": "IMPLEMENTED_PENDING_EXACT_HEAD_CI",
+  "requirements": {
+    "backgroundScrollLocked": true,
+    "overscrollChainingDisabled": true,
+    "panelTouchInteractionPreserved": true,
+    "scopedToAssistantDialog": true
+  }
+}

--- a/docs/industrial-readiness/evidence/public-assistant-mobile-scroll-lock.md
+++ b/docs/industrial-readiness/evidence/public-assistant-mobile-scroll-lock.md
@@ -1,0 +1,16 @@
+# Public assistant mobile scroll lock
+
+Authority commit: `3d8f3f5b3a49e22decd6f2be7233bc28ae500cad`
+
+Scope:
+
+- lock `html` and `body` overflow while the public assistant dialog exists;
+- disable background touch scrolling and overscroll chaining;
+- preserve scrolling and touch interaction inside the assistant panel;
+- keep the rule scoped to the public assistant dialog only.
+
+Acceptance target:
+
+- no page movement behind the modal at 320, 375, 390 and 430 CSS px;
+- no iOS rubber-band or viewport drift caused by background scrolling;
+- the message list and form remain independently interactive.


### PR DESCRIPTION
## Scope

Fix the remaining mobile production acceptance gap after #2703.

- lock document overflow while the public assistant dialog is mounted;
- disable background overscroll and touch scrolling;
- preserve scrolling and controls inside the assistant panel;
- keep the behavior strictly scoped to the assistant dialog;
- add human-readable and machine-readable acceptance evidence.

## Authority

Base: `279fa6cb160e3dd04f8f95394dfb1ae2eef6e3a5`
Exact head: `6ce8aaa46c5c4610992d482a699834e5695a0e7e`

Do not merge without exact-head CI.