### PR TITLE
Fix public assistant mobile viewport and restore support

### DIFF
--- a/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
+++ b/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
 import { AiAssistantPanel } from './AiAssistantPanel';
 import { ChatSupportWidget } from './ChatSupportWidget';
@@ -9,6 +10,7 @@ import { installPublicAssistantFetchResilience } from '@/lib/platform-v7/install
 import '@/styles/platform-v7-public-assistant.css';
 import '@/styles/platform-v7-public-assistant-shortcut.css';
 import '@/styles/platform-v7-public-assistant-viewport.css';
+import '@/styles/platform-v7-public-assistant-mobile-fix.css';
 
 const ASSISTANT_WORKSPACE = '/platform-v7/assistant';
 const PUBLIC_HOME = '/platform-v7';
@@ -53,17 +55,44 @@ function isPrivateWorkspace(pathname: string): boolean {
   return true;
 }
 
+function useVisualViewportHeight() {
+  useEffect(() => {
+    const root = document.documentElement;
+    const viewport = window.visualViewport;
+
+    const sync = () => {
+      const height = Math.round(viewport?.height ?? window.innerHeight);
+      root.style.setProperty('--pc-visual-viewport-height', `${height}px`);
+    };
+
+    sync();
+    viewport?.addEventListener('resize', sync);
+    viewport?.addEventListener('scroll', sync);
+    window.addEventListener('resize', sync);
+
+    return () => {
+      viewport?.removeEventListener('resize', sync);
+      viewport?.removeEventListener('scroll', sync);
+      window.removeEventListener('resize', sync);
+      root.style.removeProperty('--pc-visual-viewport-height');
+    };
+  }, []);
+}
+
 export function ContextualSupportOrAssistant() {
   installPublicAssistantFetchResilience();
+  useVisualViewportHeight();
   const pathname = usePathname() || PUBLIC_HOME;
   const path = normalize(pathname);
   if (path === ASSISTANT_WORKSPACE) return null;
 
   if (path === PUBLIC_HOME) {
-    // The public assistant is the only floating control on the public home page.
-    // Rendering the generic support widget here creates an overlapping fixed layer
-    // on mobile and can cover the send/close controls when the keyboard is open.
-    return <PublicPlatformAssistant />;
+    return (
+      <>
+        <PublicPlatformAssistant />
+        <ChatSupportWidget />
+      </>
+    );
   }
 
   if (isPrivateWorkspace(path)) {

--- a/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
+++ b/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
@@ -52,7 +52,15 @@
   }
 
   .pc-public-assistant-shortcut-copy {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .pc-public-assistant-panel {

--- a/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
+++ b/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
@@ -1,0 +1,124 @@
+:root {
+  --pc-visual-viewport-height: 100dvh;
+}
+
+/* Keep the two public entry controls distinct: assistant on the left, support on the right. */
+.pc-public-assistant-shortcut {
+  left: max(14px, env(safe-area-inset-left));
+  right: auto;
+}
+
+.p7-support-chat-button {
+  left: auto !important;
+  right: max(14px, env(safe-area-inset-right)) !important;
+  bottom: max(14px, calc(env(safe-area-inset-bottom) + 10px)) !important;
+  z-index: 129 !important;
+}
+
+/* The dialog must fit the currently visible viewport, not the layout viewport hidden by iOS keyboard chrome. */
+.pc-public-assistant-panel {
+  width: min(420px, calc(100vw - 28px));
+  max-height: min(680px, calc(var(--pc-visual-viewport-height) - max(28px, env(safe-area-inset-top)) - max(20px, env(safe-area-inset-bottom))));
+  grid-template-rows: auto auto minmax(96px, 1fr) auto auto auto;
+}
+
+.pc-public-assistant-header {
+  position: relative;
+  z-index: 2;
+}
+
+.pc-public-assistant-icon-button {
+  flex: 0 0 44px;
+}
+
+.pc-public-assistant-messages {
+  min-height: 0;
+}
+
+@media (max-width: 720px) {
+  .pc-public-assistant-shortcut {
+    width: 56px;
+    min-width: 56px;
+    max-width: 56px;
+    min-height: 56px;
+    padding: 8px;
+    justify-content: center;
+    border-radius: 18px;
+  }
+
+  .pc-public-assistant-shortcut-icon {
+    width: 40px;
+    height: 40px;
+  }
+
+  .pc-public-assistant-shortcut-copy {
+    display: none;
+  }
+
+  .pc-public-assistant-panel {
+    inset: auto 10px max(10px, env(safe-area-inset-bottom)) 10px;
+    width: auto;
+    height: min(620px, calc(var(--pc-visual-viewport-height) - max(24px, env(safe-area-inset-top)) - max(16px, env(safe-area-inset-bottom))));
+    max-height: calc(var(--pc-visual-viewport-height) - max(24px, env(safe-area-inset-top)) - max(16px, env(safe-area-inset-bottom)));
+    border-radius: 20px;
+  }
+
+  .pc-public-assistant-header {
+    padding: 10px 10px 9px 12px;
+  }
+
+  .pc-public-assistant-identity span:not(.pc-public-assistant-mark) {
+    display: none;
+  }
+
+  .pc-public-assistant-boundary {
+    padding: 7px 10px;
+    gap: 5px;
+  }
+
+  .pc-public-assistant-boundary span {
+    min-height: 28px;
+    padding: 4px 7px;
+    font-size: 9px;
+  }
+
+  .pc-public-assistant-messages {
+    padding: 10px;
+  }
+
+  .pc-public-assistant-form {
+    gap: 7px;
+    padding: 9px 10px 10px;
+  }
+
+  .pc-public-assistant-form textarea {
+    min-height: 48px;
+    max-height: 84px;
+    padding: 9px 10px;
+  }
+
+  .pc-public-assistant-primary,
+  .pc-public-assistant-secondary {
+    min-height: 44px;
+    padding-inline: 12px;
+  }
+
+  .pc-public-assistant-version {
+    padding: 0 10px 8px;
+  }
+}
+
+@media (max-height: 620px), (max-width: 720px) and (max-height: 760px) {
+  .pc-public-assistant-panel {
+    height: calc(var(--pc-visual-viewport-height) - max(16px, env(safe-area-inset-top)) - max(10px, env(safe-area-inset-bottom)));
+    max-height: calc(var(--pc-visual-viewport-height) - max(16px, env(safe-area-inset-top)) - max(10px, env(safe-area-inset-bottom)));
+  }
+
+  .pc-public-assistant-boundary {
+    display: none;
+  }
+
+  .pc-public-assistant-starters {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Scope

- restore the real `ChatSupportWidget` on `/platform-v7` alongside the public platform assistant;
- keep assistant and support as separate left/right floating controls;
- bind assistant height to `window.visualViewport` so iOS keyboard/browser chrome cannot push the close control off-screen;
- reduce mobile assistant density and make the assistant launcher icon-only;
- preserve Escape, backdrop close, focus return, safe-area offsets and 44px controls.

## Acceptance

- assistant header and close button remain visible with the mobile keyboard open;
- assistant panel fits the visible viewport at 320/375/390/430 CSS px;
- messages scroll inside the panel instead of expanding the page;
- support launcher is visible independently on the public home page;
- no role, auth, Deal, API authority or data-access changes.