### PR TITLE
Sync assistant mobile scope authority into feature branch

### DIFF
--- a/docs/platform-v7/autopilot/scopes/fix-public-assistant-mobile-support.json
+++ b/docs/platform-v7/autopilot/scopes/fix-public-assistant-mobile-support.json
@@ -1,0 +1,17 @@
+{
+  "branch": "fix/public-assistant-mobile-support",
+  "status": "active",
+  "purpose": "Restore independent support access and harden the public assistant mobile viewport without changing authentication, Deal authority or data scope.",
+  "approvedBy": "independent-authority-pr",
+  "allowedPaths": [
+    "apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx",
+    "apps/web/styles/platform-v7-public-assistant-mobile-fix.css"
+  ],
+  "forbiddenCapabilities": [
+    "account data access from public mode",
+    "cross-role or cross-tenant access",
+    "autonomous commands",
+    "payment or Deal state mutation",
+    "external model calls from public mode"
+  ]
+}


### PR DESCRIPTION
Sync the independently recorded scope manifest from main into fix/public-assistant-mobile-support so PR #2709 can pass the active autopilot scope gate. No runtime changes.