### PR TITLE
Approve final public assistant viewport scope

### DIFF
--- a/docs/platform-v7/autopilot/scopes/fix-public-assistant-mobile-support.json
+++ b/docs/platform-v7/autopilot/scopes/fix-public-assistant-mobile-support.json
@@ -1,7 +1,7 @@
 {
-  "branch": "fix/public-assistant-mobile-support",
+  "branch": "fix/public-assistant-visual-viewport-final",
   "status": "active",
-  "purpose": "Restore independent support access and harden the public assistant mobile viewport without changing authentication, Deal authority or data scope.",
+  "purpose": "Finalize public assistant mobile geometry using visual viewport top and bottom offsets, flex-column containment and always-visible close controls without changing authentication, Deal authority or data scope.",
   "approvedBy": "independent-authority-pr",
   "allowedPaths": [
     "apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx",


### PR DESCRIPTION
Independent authority-only update for the final mobile assistant geometry correction. It authorizes exactly two existing UI files and explicitly excludes account access, cross-role access, Deal/payment mutation, autonomous commands and external model calls. No runtime behavior is changed in this PR.