### PR TITLE
Finalize public assistant mobile containment

### DIFF
--- a/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
+++ b/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
@@ -55,33 +55,50 @@ function isPrivateWorkspace(pathname: string): boolean {
   return true;
 }
 
-function useVisualViewportHeight() {
+function useVisualViewportMetrics() {
   useEffect(() => {
     const root = document.documentElement;
     const viewport = window.visualViewport;
+    let frame = 0;
 
     const sync = () => {
-      const height = Math.round(viewport?.height ?? window.innerHeight);
+      frame = 0;
+      const height = Math.max(1, Math.round(viewport?.height ?? window.innerHeight));
+      const offsetTop = Math.max(0, Math.round(viewport?.offsetTop ?? 0));
+      const hiddenBottom = Math.max(0, Math.round(window.innerHeight - offsetTop - height));
+
       root.style.setProperty('--pc-visual-viewport-height', `${height}px`);
+      root.style.setProperty('--pc-visual-viewport-top', `${offsetTop}px`);
+      root.style.setProperty('--pc-visual-viewport-bottom', `${hiddenBottom}px`);
+    };
+
+    const scheduleSync = () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(sync);
     };
 
     sync();
-    viewport?.addEventListener('resize', sync);
-    viewport?.addEventListener('scroll', sync);
-    window.addEventListener('resize', sync);
+    viewport?.addEventListener('resize', scheduleSync);
+    viewport?.addEventListener('scroll', scheduleSync);
+    window.addEventListener('resize', scheduleSync);
+    window.addEventListener('orientationchange', scheduleSync);
 
     return () => {
-      viewport?.removeEventListener('resize', sync);
-      viewport?.removeEventListener('scroll', sync);
-      window.removeEventListener('resize', sync);
+      if (frame) window.cancelAnimationFrame(frame);
+      viewport?.removeEventListener('resize', scheduleSync);
+      viewport?.removeEventListener('scroll', scheduleSync);
+      window.removeEventListener('resize', scheduleSync);
+      window.removeEventListener('orientationchange', scheduleSync);
       root.style.removeProperty('--pc-visual-viewport-height');
+      root.style.removeProperty('--pc-visual-viewport-top');
+      root.style.removeProperty('--pc-visual-viewport-bottom');
     };
   }, []);
 }
 
 export function ContextualSupportOrAssistant() {
   installPublicAssistantFetchResilience();
-  useVisualViewportHeight();
+  useVisualViewportMetrics();
   const pathname = usePathname() || PUBLIC_HOME;
   const path = normalize(pathname);
   if (path === ASSISTANT_WORKSPACE) return null;

--- a/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
+++ b/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
@@ -1,11 +1,19 @@
 :root {
   --pc-visual-viewport-height: 100dvh;
+  --pc-visual-viewport-top: 0px;
+  --pc-visual-viewport-bottom: 0px;
 }
 
 /* Keep the two public entry controls distinct: assistant on the left, support on the right. */
 .pc-public-assistant-shortcut {
   left: max(14px, env(safe-area-inset-left));
   right: auto;
+}
+
+.pc-public-assistant-shortcut[aria-expanded='true'] {
+  visibility: hidden;
+  pointer-events: none;
+  opacity: 0;
 }
 
 .p7-support-chat-button {
@@ -15,24 +23,53 @@
   z-index: 129 !important;
 }
 
-/* The dialog must fit the currently visible viewport, not the layout viewport hidden by iOS keyboard chrome. */
+/*
+ * Use a flex column instead of positional grid rows. When optional rows are
+ * hidden on short screens, CSS grid auto-placement previously assigned the
+ * flexible row to the form and created the large empty gap seen on iPhone.
+ */
 .pc-public-assistant-panel {
+  display: flex;
   width: min(420px, calc(100vw - 28px));
-  max-height: min(680px, calc(var(--pc-visual-viewport-height) - max(28px, env(safe-area-inset-top)) - max(20px, env(safe-area-inset-bottom))));
-  grid-template-rows: auto auto minmax(96px, 1fr) auto auto auto;
+  max-height: min(680px, calc(var(--pc-visual-viewport-height) - 24px));
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.pc-public-assistant-header,
+.pc-public-assistant-boundary,
+.pc-public-assistant-starters,
+.pc-public-assistant-error,
+.pc-public-assistant-form,
+.pc-public-assistant-version {
+  flex: 0 0 auto;
 }
 
 .pc-public-assistant-header {
-  position: relative;
-  z-index: 2;
+  position: sticky;
+  top: 0;
+  z-index: 4;
 }
 
 .pc-public-assistant-icon-button {
   flex: 0 0 44px;
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .pc-public-assistant-messages {
+  flex: 1 1 auto;
   min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.pc-public-assistant-form {
+  grid-template-rows: auto auto;
+  align-content: start;
+}
+
+.pc-public-assistant-backdrop {
+  touch-action: none;
 }
 
 @media (max-width: 720px) {
@@ -63,16 +100,26 @@
     border: 0;
   }
 
+  .pc-public-assistant-backdrop {
+    top: var(--pc-visual-viewport-top);
+    bottom: var(--pc-visual-viewport-bottom);
+  }
+
   .pc-public-assistant-panel {
-    inset: auto 10px max(10px, env(safe-area-inset-bottom)) 10px;
+    top: auto;
+    right: 8px;
+    bottom: calc(var(--pc-visual-viewport-bottom) + 8px);
+    left: 8px;
     width: auto;
-    height: min(620px, calc(var(--pc-visual-viewport-height) - max(24px, env(safe-area-inset-top)) - max(16px, env(safe-area-inset-bottom))));
-    max-height: calc(var(--pc-visual-viewport-height) - max(24px, env(safe-area-inset-top)) - max(16px, env(safe-area-inset-bottom)));
-    border-radius: 20px;
+    height: min(560px, calc(var(--pc-visual-viewport-height) - 16px));
+    min-height: 0;
+    max-height: calc(var(--pc-visual-viewport-height) - 16px);
+    border-radius: 18px;
   }
 
   .pc-public-assistant-header {
-    padding: 10px 10px 9px 12px;
+    min-height: 58px;
+    padding: 8px 8px 8px 12px;
   }
 
   .pc-public-assistant-identity span:not(.pc-public-assistant-mark) {
@@ -96,37 +143,47 @@
 
   .pc-public-assistant-form {
     gap: 7px;
-    padding: 9px 10px 10px;
+    padding: 8px 10px 9px;
   }
 
   .pc-public-assistant-form textarea {
-    min-height: 48px;
-    max-height: 84px;
-    padding: 9px 10px;
+    min-height: 46px;
+    max-height: 72px;
+    padding: 8px 10px;
+  }
+
+  .pc-public-assistant-form-actions {
+    align-items: stretch;
   }
 
   .pc-public-assistant-primary,
   .pc-public-assistant-secondary {
     min-height: 44px;
-    padding-inline: 12px;
+    padding-inline: 11px;
   }
 
   .pc-public-assistant-version {
-    padding: 0 10px 8px;
+    padding: 0 10px 7px;
   }
 }
 
 @media (max-height: 620px), (max-width: 720px) and (max-height: 760px) {
   .pc-public-assistant-panel {
-    height: calc(var(--pc-visual-viewport-height) - max(16px, env(safe-area-inset-top)) - max(10px, env(safe-area-inset-bottom)));
-    max-height: calc(var(--pc-visual-viewport-height) - max(16px, env(safe-area-inset-top)) - max(10px, env(safe-area-inset-bottom)));
+    height: calc(var(--pc-visual-viewport-height) - 12px);
+    max-height: calc(var(--pc-visual-viewport-height) - 12px);
+    bottom: calc(var(--pc-visual-viewport-bottom) + 6px);
   }
 
-  .pc-public-assistant-boundary {
-    display: none;
-  }
-
+  .pc-public-assistant-boundary,
   .pc-public-assistant-starters {
     display: none;
+  }
+
+  .pc-public-assistant-header {
+    min-height: 52px;
+  }
+
+  .pc-public-assistant-form {
+    padding-top: 7px;
   }
 }


### PR DESCRIPTION
## Fix
- track `visualViewport.height`, `offsetTop` and hidden bottom chrome separately;
- anchor the assistant above the actual iPhone browser chrome and keyboard;
- replace fragile optional CSS-grid row placement with a flex-column dialog;
- keep the header and close button permanently visible;
- keep messages as the only flexible, internally scrollable region;
- cap the normal mobile sheet at 560px and use the full visible viewport only on short/keyboard-open screens;
- remove the launcher from the foreground while the dialog is open;
- preserve the separate support launcher.

## Root cause
When optional boundary/starter rows were hidden, grid auto-placement assigned the flexible row to the form, producing the large empty area. Bottom positioning also ignored `visualViewport.offsetTop` and the browser's hidden lower portion, so the dialog could move beyond the visible iPhone viewport.

No auth, role, Deal, payment, API authority or data-access changes.