### PR TITLE
Remove conflicting assistant viewport layer

### DIFF
--- a/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
+++ b/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
@@ -9,7 +9,6 @@ import { PublicPlatformAssistant } from './PublicPlatformAssistant';
 import { installPublicAssistantFetchResilience } from '@/lib/platform-v7/install-public-assistant-fetch-resilience';
 import '@/styles/platform-v7-public-assistant.css';
 import '@/styles/platform-v7-public-assistant-shortcut.css';
-import '@/styles/platform-v7-public-assistant-viewport.css';
 import '@/styles/platform-v7-public-assistant-mobile-fix.css';
 
 const ASSISTANT_WORKSPACE = '/platform-v7/assistant';

--- a/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
+++ b/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
@@ -4,7 +4,6 @@
   --pc-visual-viewport-bottom: 0px;
 }
 
-/* Keep the two public entry controls distinct: assistant on the left, support on the right. */
 .pc-public-assistant-shortcut {
   left: max(14px, env(safe-area-inset-left));
   right: auto;
@@ -23,17 +22,11 @@
   z-index: 129 !important;
 }
 
-/*
- * Use a flex column instead of positional grid rows. When optional rows are
- * hidden on short screens, CSS grid auto-placement previously assigned the
- * flexible row to the form and created the large empty gap seen on iPhone.
- */
+/* One authoritative dialog layout. Optional rows may never receive flexible space. */
 .pc-public-assistant-panel {
-  display: flex;
-  width: min(420px, calc(100vw - 28px));
-  max-height: min(680px, calc(var(--pc-visual-viewport-height) - 24px));
-  flex-direction: column;
-  overflow: hidden;
+  display: flex !important;
+  flex-direction: column !important;
+  overflow: hidden !important;
 }
 
 .pc-public-assistant-header,
@@ -42,7 +35,7 @@
 .pc-public-assistant-error,
 .pc-public-assistant-form,
 .pc-public-assistant-version {
-  flex: 0 0 auto;
+  flex: 0 0 auto !important;
 }
 
 .pc-public-assistant-header {
@@ -51,21 +44,17 @@
   z-index: 4;
 }
 
-.pc-public-assistant-icon-button {
-  flex: 0 0 44px;
-  background: rgba(255, 255, 255, 0.12);
-}
-
 .pc-public-assistant-messages {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-y: auto;
+  flex: 0 1 auto !important;
+  min-height: 0 !important;
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
   -webkit-overflow-scrolling: touch;
 }
 
 .pc-public-assistant-form {
-  grid-template-rows: auto auto;
-  align-content: start;
+  grid-template-rows: auto auto !important;
+  align-content: start !important;
 }
 
 .pc-public-assistant-backdrop {
@@ -101,44 +90,66 @@
   }
 
   .pc-public-assistant-backdrop {
-    top: var(--pc-visual-viewport-top);
-    bottom: var(--pc-visual-viewport-bottom);
+    inset: var(--pc-visual-viewport-top) 0 var(--pc-visual-viewport-bottom) 0 !important;
+    width: auto !important;
+    height: auto !important;
+    min-height: 0 !important;
   }
 
   .pc-public-assistant-panel {
-    top: auto;
-    right: 8px;
-    bottom: calc(var(--pc-visual-viewport-bottom) + 8px);
-    left: 8px;
-    width: auto;
-    height: min(560px, calc(var(--pc-visual-viewport-height) - 16px));
-    min-height: 0;
-    max-height: calc(var(--pc-visual-viewport-height) - 16px);
-    border-radius: 18px;
+    top: calc(var(--pc-visual-viewport-top) + 8px) !important;
+    right: 8px !important;
+    bottom: auto !important;
+    left: 8px !important;
+    width: auto !important;
+    height: auto !important;
+    min-height: 0 !important;
+    max-width: none !important;
+    max-height: min(440px, calc(var(--pc-visual-viewport-height) - 16px)) !important;
+    border-radius: 18px !important;
+  }
+
+  /* Emergency-independent close control: visible even if a browser clips the header. */
+  .pc-public-assistant-icon-button {
+    position: fixed !important;
+    top: calc(var(--pc-visual-viewport-top) + 14px) !important;
+    right: 14px !important;
+    z-index: 134 !important;
+    flex: 0 0 44px !important;
+    width: 44px !important;
+    height: 44px !important;
+    min-width: 44px !important;
+    min-height: 44px !important;
+    border-color: rgba(255, 255, 255, 0.34) !important;
+    background: #17382d !important;
+    color: #ffffff !important;
+    box-shadow: 0 8px 24px rgba(3, 18, 13, 0.28);
   }
 
   .pc-public-assistant-header {
     min-height: 58px;
-    padding: 8px 8px 8px 12px;
+    padding: 8px 60px 8px 12px;
   }
 
   .pc-public-assistant-identity span:not(.pc-public-assistant-mark) {
     display: none;
   }
 
-  .pc-public-assistant-boundary {
-    padding: 7px 10px;
-    gap: 5px;
-  }
-
-  .pc-public-assistant-boundary span {
-    min-height: 28px;
-    padding: 4px 7px;
-    font-size: 9px;
+  /* The mobile dialog starts with the conversation, not secondary status chips. */
+  .pc-public-assistant-boundary,
+  .pc-public-assistant-starters {
+    display: none !important;
   }
 
   .pc-public-assistant-messages {
-    padding: 10px;
+    flex: 0 1 190px !important;
+    min-height: 88px !important;
+    max-height: 240px !important;
+    padding: 10px !important;
+  }
+
+  .pc-public-assistant-message:last-child {
+    margin-bottom: 0;
   }
 
   .pc-public-assistant-form {
@@ -147,9 +158,11 @@
   }
 
   .pc-public-assistant-form textarea {
-    min-height: 46px;
-    max-height: 72px;
+    min-height: 48px !important;
+    max-height: 64px !important;
     padding: 8px 10px;
+    font-size: 16px;
+    line-height: 1.35;
   }
 
   .pc-public-assistant-form-actions {
@@ -159,7 +172,10 @@
   .pc-public-assistant-primary,
   .pc-public-assistant-secondary {
     min-height: 44px;
+    min-width: 0;
     padding-inline: 11px;
+    font-size: 14px;
+    white-space: nowrap;
   }
 
   .pc-public-assistant-version {
@@ -167,23 +183,36 @@
   }
 }
 
-@media (max-height: 620px), (max-width: 720px) and (max-height: 760px) {
+@media (max-width: 390px) {
   .pc-public-assistant-panel {
-    height: calc(var(--pc-visual-viewport-height) - 12px);
-    max-height: calc(var(--pc-visual-viewport-height) - 12px);
-    bottom: calc(var(--pc-visual-viewport-bottom) + 6px);
+    top: calc(var(--pc-visual-viewport-top) + 6px) !important;
+    right: 6px !important;
+    left: 6px !important;
+    max-height: min(430px, calc(var(--pc-visual-viewport-height) - 12px)) !important;
+    border-radius: 16px !important;
   }
 
-  .pc-public-assistant-boundary,
-  .pc-public-assistant-starters {
-    display: none;
+  .pc-public-assistant-icon-button {
+    top: calc(var(--pc-visual-viewport-top) + 12px) !important;
+    right: 12px !important;
   }
 
-  .pc-public-assistant-header {
-    min-height: 52px;
+  .pc-public-assistant-form-actions {
+    gap: 6px;
+  }
+}
+
+@media (max-height: 520px) and (max-width: 720px) {
+  .pc-public-assistant-panel {
+    max-height: calc(var(--pc-visual-viewport-height) - 12px) !important;
   }
 
-  .pc-public-assistant-form {
-    padding-top: 7px;
+  .pc-public-assistant-messages {
+    flex-basis: 96px !important;
+    min-height: 64px !important;
+  }
+
+  .pc-public-assistant-version {
+    display: none !important;
   }
 }


### PR DESCRIPTION
## Root cause
Production loaded both `platform-v7-public-assistant-viewport.css` and the newer mobile-fix stylesheet. Their competing `top`, `bottom`, `height` and `max-height` rules left the dialog oversized and could place its header outside the visible iPhone viewport.

## Fix
- remove the obsolete viewport stylesheet from the runtime import chain;
- keep one authoritative mobile layout;
- cap the dialog at 440px on mobile and size it to content;
- anchor it to the top of the actual visual viewport;
- make the existing close button fixed and independently visible;
- hide secondary status/starter rows on mobile;
- keep the conversation internally scrollable;
- preserve the separate support launcher.

No auth, role, Deal, payment, API authority or data-access changes.