### PR TITLE
Replace assistant popup with canonical mobile bottom sheet

### DIFF
--- a/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
+++ b/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
@@ -4,6 +4,18 @@
   --pc-visual-viewport-bottom: 0px;
 }
 
+/*
+ * Mobile assistant authority.
+ * The assistant root must not create a low stacking context: otherwise even a
+ * very large child z-index remains underneath the public site header.
+ */
+.pc-public-assistant {
+  position: static !important;
+  z-index: auto !important;
+  isolation: auto !important;
+  transform: none !important;
+}
+
 .pc-public-assistant-shortcut {
   left: max(14px, env(safe-area-inset-left));
   right: auto;
@@ -22,11 +34,22 @@
   z-index: 129 !important;
 }
 
-/* One authoritative dialog layout. Optional rows may never receive flexible space. */
+.pc-public-assistant-backdrop {
+  position: fixed !important;
+  z-index: 2147483600 !important;
+  border: 0 !important;
+  background: rgba(5, 17, 13, 0.58) !important;
+  backdrop-filter: blur(5px) !important;
+  touch-action: none;
+}
+
 .pc-public-assistant-panel {
+  position: fixed !important;
+  z-index: 2147483601 !important;
   display: flex !important;
   flex-direction: column !important;
   overflow: hidden !important;
+  transform: none !important;
 }
 
 .pc-public-assistant-header,
@@ -39,26 +62,33 @@
 }
 
 .pc-public-assistant-header {
-  position: sticky;
-  top: 0;
-  z-index: 4;
+  position: sticky !important;
+  top: 0 !important;
+  z-index: 3 !important;
+}
+
+.pc-public-assistant-icon-button {
+  flex: 0 0 48px !important;
+  width: 48px !important;
+  height: 48px !important;
+  min-width: 48px !important;
+  min-height: 48px !important;
 }
 
 .pc-public-assistant-messages {
-  flex: 0 1 auto !important;
+  flex: 1 1 auto !important;
   min-height: 0 !important;
   overflow-x: hidden !important;
   overflow-y: auto !important;
+  overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
 }
 
 .pc-public-assistant-form {
+  position: relative !important;
+  z-index: 2 !important;
   grid-template-rows: auto auto !important;
   align-content: start !important;
-}
-
-.pc-public-assistant-backdrop {
-  touch-action: none;
 }
 
 @media (max-width: 720px) {
@@ -96,56 +126,47 @@
     min-height: 0 !important;
   }
 
+  /*
+   * Canonical modal bottom sheet: anchored to the bottom, never taller than
+   * roughly two thirds of the visible viewport, with the header always inside
+   * the sheet and the message list as the only flexible region.
+   */
   .pc-public-assistant-panel {
-    top: calc(var(--pc-visual-viewport-top) + 8px) !important;
-    right: 8px !important;
-    bottom: auto !important;
-    left: 8px !important;
-    width: auto !important;
-    height: auto !important;
-    min-height: 0 !important;
+    top: auto !important;
+    right: 0 !important;
+    bottom: var(--pc-visual-viewport-bottom) !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: min(68dvh, 560px, calc(var(--pc-visual-viewport-height) - 8px)) !important;
+    min-height: min(360px, calc(var(--pc-visual-viewport-height) - 8px)) !important;
     max-width: none !important;
-    max-height: min(440px, calc(var(--pc-visual-viewport-height) - 16px)) !important;
-    border-radius: 18px !important;
-  }
-
-  /* Emergency-independent close control: visible even if a browser clips the header. */
-  .pc-public-assistant-icon-button {
-    position: fixed !important;
-    top: calc(var(--pc-visual-viewport-top) + 14px) !important;
-    right: 14px !important;
-    z-index: 134 !important;
-    flex: 0 0 44px !important;
-    width: 44px !important;
-    height: 44px !important;
-    min-width: 44px !important;
-    min-height: 44px !important;
-    border-color: rgba(255, 255, 255, 0.34) !important;
-    background: #17382d !important;
-    color: #ffffff !important;
-    box-shadow: 0 8px 24px rgba(3, 18, 13, 0.28);
+    max-height: calc(var(--pc-visual-viewport-height) - 8px) !important;
+    border-right: 0 !important;
+    border-bottom: 0 !important;
+    border-left: 0 !important;
+    border-radius: 24px 24px 0 0 !important;
+    box-shadow: 0 -18px 60px rgba(2, 18, 12, 0.34) !important;
   }
 
   .pc-public-assistant-header {
-    min-height: 58px;
-    padding: 8px 60px 8px 12px;
+    min-height: 64px !important;
+    padding: 8px 10px 8px 14px !important;
+    border-radius: 24px 24px 0 0;
   }
 
   .pc-public-assistant-identity span:not(.pc-public-assistant-mark) {
-    display: none;
+    display: block !important;
+    max-width: min(62vw, 310px);
   }
 
-  /* The mobile dialog starts with the conversation, not secondary status chips. */
   .pc-public-assistant-boundary,
-  .pc-public-assistant-starters {
+  .pc-public-assistant-starters,
+  .pc-public-assistant-version {
     display: none !important;
   }
 
   .pc-public-assistant-messages {
-    flex: 0 1 190px !important;
-    min-height: 88px !important;
-    max-height: 240px !important;
-    padding: 10px !important;
+    padding: 12px !important;
   }
 
   .pc-public-assistant-message:last-child {
@@ -153,66 +174,71 @@
   }
 
   .pc-public-assistant-form {
-    gap: 7px;
-    padding: 8px 10px 9px;
+    gap: 8px !important;
+    padding: 10px 12px calc(10px + env(safe-area-inset-bottom)) !important;
+    border-top: 1px solid #dce9e2 !important;
+    background: #ffffff !important;
   }
 
   .pc-public-assistant-form textarea {
     min-height: 48px !important;
-    max-height: 64px !important;
-    padding: 8px 10px;
-    font-size: 16px;
-    line-height: 1.35;
+    max-height: 72px !important;
+    padding: 9px 11px !important;
+    font-size: 16px !important;
+    line-height: 1.35 !important;
   }
 
   .pc-public-assistant-form-actions {
-    align-items: stretch;
+    align-items: stretch !important;
+    gap: 8px !important;
   }
 
   .pc-public-assistant-primary,
   .pc-public-assistant-secondary {
-    min-height: 44px;
-    min-width: 0;
-    padding-inline: 11px;
-    font-size: 14px;
+    min-width: 0 !important;
+    min-height: 46px !important;
+    padding-inline: 12px !important;
+    font-size: 14px !important;
     white-space: nowrap;
-  }
-
-  .pc-public-assistant-version {
-    padding: 0 10px 7px;
   }
 }
 
 @media (max-width: 390px) {
   .pc-public-assistant-panel {
-    top: calc(var(--pc-visual-viewport-top) + 6px) !important;
-    right: 6px !important;
-    left: 6px !important;
-    max-height: min(430px, calc(var(--pc-visual-viewport-height) - 12px)) !important;
-    border-radius: 16px !important;
+    border-radius: 20px 20px 0 0 !important;
   }
 
-  .pc-public-assistant-icon-button {
-    top: calc(var(--pc-visual-viewport-top) + 12px) !important;
-    right: 12px !important;
+  .pc-public-assistant-header {
+    min-height: 60px !important;
+    border-radius: 20px 20px 0 0;
+  }
+
+  .pc-public-assistant-identity span:not(.pc-public-assistant-mark) {
+    display: none !important;
   }
 
   .pc-public-assistant-form-actions {
-    gap: 6px;
+    gap: 6px !important;
   }
 }
 
-@media (max-height: 520px) and (max-width: 720px) {
+/* Keyboard-open and short landscape viewports become a contained full-height sheet. */
+@media (max-height: 600px) and (max-width: 720px) {
   .pc-public-assistant-panel {
-    max-height: calc(var(--pc-visual-viewport-height) - 12px) !important;
+    height: calc(var(--pc-visual-viewport-height) - 4px) !important;
+    min-height: 0 !important;
+    max-height: calc(var(--pc-visual-viewport-height) - 4px) !important;
+    border-radius: 18px 18px 0 0 !important;
   }
 
-  .pc-public-assistant-messages {
-    flex-basis: 96px !important;
-    min-height: 64px !important;
+  .pc-public-assistant-header {
+    min-height: 56px !important;
+    padding-top: 6px !important;
+    padding-bottom: 6px !important;
+    border-radius: 18px 18px 0 0;
   }
 
-  .pc-public-assistant-version {
-    display: none !important;
+  .pc-public-assistant-form {
+    padding-top: 8px !important;
   }
 }


### PR DESCRIPTION
## Basis
Reworks the mobile assistant using the platform modal-sheet pattern recommended by Apple HIG, Material 3 and WAI-ARIA dialog guidance.

## Root cause
The assistant root itself created a low stacking context (`z-index: 132`). Child dialog layers could not escape it, so the public header could remain above the assistant and the dialog header/close control could be clipped or hidden.

## Fix
- remove the assistant root stacking context;
- promote backdrop and sheet to the top document layer;
- use a canonical modal bottom sheet capped at 68dvh / 560px;
- keep a 64px sheet header and 48px close control permanently visible;
- make messages the only flexible scroll region;
- keep the composer at the bottom with safe-area padding;
- switch to contained full-height only for short or keyboard-open viewports;
- preserve the independent support launcher.

No auth, role, Deal, payment, API authority or data-access changes.