### PR TITLE
Authorize public assistant modal sheet stylesheet

### DIFF
--- a/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
+++ b/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
@@ -11,6 +11,7 @@
     "apps/web/lib/platform-v7/assistant-question-understanding.ts",
     "apps/web/lib/platform-v7/install-public-assistant-fetch-resilience.ts",
     "apps/web/lib/platform-v7/prospect-assistant-knowledge.ts",
+    "apps/web/styles/platform-v7-public-assistant-mobile-fix.css",
     "apps/web/styles/platform-v7-public-assistant-shortcut.css",
     "apps/web/styles/platform-v7-public-assistant-viewport.css",
     "apps/web/tests/unit/platformV7AssistantQuestionUnderstanding.test.ts",


### PR DESCRIPTION
Independent authority-only change. Adds exactly `apps/web/styles/platform-v7-public-assistant-mobile-fix.css` to the already source-controlled `feat/assistant-universal-understanding` scope. No runtime behavior, auth, role, Deal, payment, API authority or data-access changes.