### PR TITLE
Fix mobile assistant bottom-sheet cascade

### DIFF
--- a/apps/web/styles/platform-v7-public-assistant-shortcut.css
+++ b/apps/web/styles/platform-v7-public-assistant-shortcut.css
@@ -80,13 +80,6 @@
     left: max(12px, env(safe-area-inset-left, 0px)) !important;
     bottom: max(12px, env(safe-area-inset-bottom, 0px)) !important;
   }
-
-  .pc-public-assistant .pc-public-assistant-panel {
-    left: max(10px, env(safe-area-inset-left, 0px)) !important;
-    right: max(10px, env(safe-area-inset-right, 0px)) !important;
-    width: auto !important;
-    max-width: calc(100vw - 20px) !important;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Removes the obsolete mobile panel geometry override from `platform-v7-public-assistant-shortcut.css`. That higher-specificity rule used `!important` and prevented the canonical full-width bottom-sheet geometry in `platform-v7-public-assistant-mobile-fix.css` from applying. No runtime, auth, role, Deal, payment, API authority, or data-access changes.