### PR TITLE
Keep mobile assistant header height invariant

### DIFF
--- a/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
+++ b/apps/web/styles/platform-v7-public-assistant-mobile-fix.css
@@ -209,7 +209,6 @@
   }
 
   .pc-public-assistant-header {
-    min-height: 60px !important;
     border-radius: 20px 20px 0 0;
   }
 
@@ -232,7 +231,6 @@
   }
 
   .pc-public-assistant-header {
-    min-height: 56px !important;
     padding-top: 6px !important;
     padding-bottom: 6px !important;
     border-radius: 18px 18px 0 0;


### PR DESCRIPTION
Removes the narrow/short-viewport reductions from 64px to 60px/56px. The assistant header now remains at least 64px on all supported mobile widths and keyboard-open/short viewport modes, while retaining the 48px close control and contained bottom-sheet geometry. No runtime, auth, role, Deal, payment, API authority, or data-access changes.