### PR TITLE
Add unified fullscreen mode to public modal sheets

### DIFF
--- a/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
+++ b/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
@@ -6,10 +6,12 @@ import { AiAssistantPanel } from './AiAssistantPanel';
 import { ChatSupportWidget } from './ChatSupportWidget';
 import { PrivateAssistantShortcutLabel } from './PrivateAssistantShortcutLabel';
 import { PublicPlatformAssistant } from './PublicPlatformAssistant';
+import { UnifiedModalSheetFullscreenController } from './UnifiedModalSheetFullscreenController';
 import { installPublicAssistantFetchResilience } from '@/lib/platform-v7/install-public-assistant-fetch-resilience';
 import '@/styles/platform-v7-public-assistant.css';
 import '@/styles/platform-v7-public-assistant-shortcut.css';
 import '@/styles/platform-v7-public-assistant-mobile-fix.css';
+import '@/styles/platform-v7-unified-modal-fullscreen.css';
 
 const ASSISTANT_WORKSPACE = '/platform-v7/assistant';
 const PUBLIC_HOME = '/platform-v7';
@@ -105,6 +107,7 @@ export function ContextualSupportOrAssistant() {
   if (path === PUBLIC_HOME) {
     return (
       <>
+        <UnifiedModalSheetFullscreenController />
         <PublicPlatformAssistant />
         <ChatSupportWidget />
       </>
@@ -120,5 +123,10 @@ export function ContextualSupportOrAssistant() {
     );
   }
 
-  return <ChatSupportWidget />;
+  return (
+    <>
+      <UnifiedModalSheetFullscreenController />
+      <ChatSupportWidget />
+    </>
+  );
 }

--- a/apps/web/components/platform-v7/UnifiedModalSheetFullscreenController.tsx
+++ b/apps/web/components/platform-v7/UnifiedModalSheetFullscreenController.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import * as React from 'react';
+
+type Locale = 'ru' | 'en' | 'zh';
+
+type SheetConfig = {
+  panelSelector: string;
+  headerSelector: string;
+  closeSelector: string;
+  scrollSelector: string;
+  alignAnswers?: boolean;
+};
+
+const SHEETS: SheetConfig[] = [
+  {
+    panelSelector: '.pc-public-assistant-panel',
+    headerSelector: '.pc-public-assistant-header',
+    closeSelector: '.pc-public-assistant-icon-button',
+    scrollSelector: '.pc-public-assistant-messages',
+    alignAnswers: true,
+  },
+  {
+    panelSelector: '.p7-support-chat-panel',
+    headerSelector: '.p7-support-chat-head',
+    closeSelector: '.p7-support-chat-head button[aria-label]',
+    scrollSelector: '.p7-support-chat-form, .p7-support-chat-success',
+  },
+];
+
+const LABELS: Record<Locale, { expand: string; collapse: string }> = {
+  ru: { expand: 'На весь экран', collapse: 'Свернуть окно' },
+  en: { expand: 'Enter full screen', collapse: 'Exit full screen' },
+  zh: { expand: '全屏显示', collapse: '退出全屏' },
+};
+
+function resolveLocale(): Locale {
+  const query = new URLSearchParams(window.location.search).get('lang');
+  if (query === 'en' || query === 'zh') return query;
+  const lang = document.documentElement.lang.toLowerCase();
+  if (lang.startsWith('en')) return 'en';
+  if (lang.startsWith('zh')) return 'zh';
+  return 'ru';
+}
+
+function updateButton(button: HTMLButtonElement, expanded: boolean) {
+  const copy = LABELS[resolveLocale()];
+  const label = expanded ? copy.collapse : copy.expand;
+  button.dataset.expanded = String(expanded);
+  button.setAttribute('aria-pressed', String(expanded));
+  button.setAttribute('aria-label', label);
+  button.title = label;
+}
+
+function alignLatestAssistantAnswer(panel: HTMLElement) {
+  const scrollHost = panel.querySelector<HTMLElement>('.pc-public-assistant-messages');
+  if (!scrollHost) return () => undefined;
+
+  let timer = 0;
+  let latestAligned: HTMLElement | null = null;
+
+  const align = () => {
+    const answers = scrollHost.querySelectorAll<HTMLElement>(".pc-public-assistant-message[data-role='assistant']");
+    const latest = answers.item(answers.length - 1);
+    if (!latest || latest === latestAligned || !latest.querySelector('.pc-public-assistant-answer')) return;
+    latestAligned = latest;
+    window.clearTimeout(timer);
+    timer = window.setTimeout(() => {
+      const top = Math.max(0, latest.offsetTop - 8);
+      scrollHost.scrollTo({ top, behavior: 'smooth' });
+    }, 120);
+  };
+
+  const observer = new MutationObserver(align);
+  observer.observe(scrollHost, { childList: true, subtree: true });
+  align();
+
+  return () => {
+    window.clearTimeout(timer);
+    observer.disconnect();
+  };
+}
+
+function enhanceSheet(panel: HTMLElement, config: SheetConfig) {
+  if (panel.dataset.pcFullscreenEnhanced === 'true') return () => undefined;
+
+  const header = panel.querySelector<HTMLElement>(config.headerSelector);
+  const close = panel.querySelector<HTMLButtonElement>(config.closeSelector);
+  if (!header || !close) return () => undefined;
+
+  panel.dataset.pcFullscreenEnhanced = 'true';
+  panel.dataset.pcFullscreen = 'false';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'pc-modal-sheet-fullscreen-button';
+  updateButton(button, false);
+
+  const onToggle = () => {
+    const scrollHost = panel.querySelector<HTMLElement>(config.scrollSelector);
+    const scrollTop = scrollHost?.scrollTop ?? 0;
+    const expanded = panel.dataset.pcFullscreen !== 'true';
+    panel.dataset.pcFullscreen = String(expanded);
+    updateButton(button, expanded);
+
+    window.requestAnimationFrame(() => {
+      if (scrollHost) scrollHost.scrollTop = scrollTop;
+      button.focus({ preventScroll: true });
+    });
+  };
+
+  button.addEventListener('click', onToggle);
+  header.insertBefore(button, close);
+  const cleanupAnswerAlignment = config.alignAnswers ? alignLatestAssistantAnswer(panel) : () => undefined;
+
+  return () => {
+    cleanupAnswerAlignment();
+    button.removeEventListener('click', onToggle);
+    button.remove();
+    delete panel.dataset.pcFullscreen;
+    delete panel.dataset.pcFullscreenEnhanced;
+  };
+}
+
+export function UnifiedModalSheetFullscreenController() {
+  React.useEffect(() => {
+    const cleanups = new Map<HTMLElement, () => void>();
+
+    const scan = () => {
+      for (const config of SHEETS) {
+        for (const panel of document.querySelectorAll<HTMLElement>(config.panelSelector)) {
+          if (!cleanups.has(panel)) cleanups.set(panel, enhanceSheet(panel, config));
+        }
+      }
+
+      for (const [panel, cleanup] of cleanups) {
+        if (!panel.isConnected) {
+          cleanup();
+          cleanups.delete(panel);
+        }
+      }
+    };
+
+    const observer = new MutationObserver(scan);
+    observer.observe(document.body, { childList: true, subtree: true });
+    scan();
+
+    return () => {
+      observer.disconnect();
+      for (const cleanup of cleanups.values()) cleanup();
+      cleanups.clear();
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/styles/platform-v7-unified-modal-fullscreen.css
+++ b/apps/web/styles/platform-v7-unified-modal-fullscreen.css
@@ -1,0 +1,138 @@
+.pc-modal-sheet-fullscreen-button {
+  display: inline-flex;
+  flex: 0 0 48px;
+  width: 48px;
+  height: 48px;
+  min-width: 48px;
+  min-height: 48px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 15px;
+  background: rgba(255, 255, 255, 0.07);
+  color: #ffffff;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.pc-modal-sheet-fullscreen-button::before {
+  width: 22px;
+  height: 22px;
+  background: currentColor;
+  content: '';
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 3h6v6'/%3E%3Cpath d='M9 21H3v-6'/%3E%3Cpath d='M21 3l-7 7'/%3E%3Cpath d='M3 21l7-7'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 3h6v6'/%3E%3Cpath d='M9 21H3v-6'/%3E%3Cpath d='M21 3l-7 7'/%3E%3Cpath d='M3 21l7-7'/%3E%3C/svg%3E") center / contain no-repeat;
+}
+
+.pc-modal-sheet-fullscreen-button[data-expanded='true']::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 3v5H3'/%3E%3Cpath d='M16 21v-5h5'/%3E%3Cpath d='M3 8l5-5'/%3E%3Cpath d='M21 16l-5 5'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 3v5H3'/%3E%3Cpath d='M16 21v-5h5'/%3E%3Cpath d='M3 8l5-5'/%3E%3Cpath d='M21 16l-5 5'/%3E%3C/svg%3E");
+}
+
+.pc-modal-sheet-fullscreen-button:hover {
+  background: rgba(255, 255, 255, 0.13);
+}
+
+.pc-modal-sheet-fullscreen-button:focus-visible {
+  outline: 3px solid #7ef2c4;
+  outline-offset: 2px;
+}
+
+.pc-public-assistant-header {
+  justify-content: flex-start !important;
+}
+
+.pc-public-assistant-header .pc-public-assistant-identity {
+  flex: 1 1 auto;
+}
+
+.pc-public-assistant-header > .pc-modal-sheet-fullscreen-button {
+  margin-left: auto;
+}
+
+.p7-support-chat-head {
+  grid-template-columns: 44px minmax(0, 1fr) 48px 48px !important;
+}
+
+@media (min-width: 721px) {
+  .pc-public-assistant-panel[data-pc-fullscreen='true'],
+  .p7-support-chat-panel[data-pc-fullscreen='true'] {
+    position: fixed !important;
+    inset: 16px !important;
+    width: auto !important;
+    height: calc(100dvh - 32px) !important;
+    min-height: 0 !important;
+    max-width: none !important;
+    max-height: none !important;
+    border-radius: 24px !important;
+  }
+}
+
+@media (max-width: 720px) {
+  .pc-public-assistant-panel[data-pc-fullscreen='true'],
+  .p7-support-chat-panel[data-pc-fullscreen='true'] {
+    position: fixed !important;
+    top: var(--pc-visual-viewport-top) !important;
+    right: 0 !important;
+    bottom: var(--pc-visual-viewport-bottom) !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: var(--pc-visual-viewport-height) !important;
+    min-height: 0 !important;
+    max-width: none !important;
+    max-height: var(--pc-visual-viewport-height) !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+  }
+
+  .pc-public-assistant-panel[data-pc-fullscreen='true'] .pc-public-assistant-header,
+  .p7-support-chat-panel[data-pc-fullscreen='true'] .p7-support-chat-head {
+    border-radius: 0 !important;
+  }
+
+  .p7-support-chat-head {
+    grid-template-columns: 42px minmax(0, 1fr) 48px 48px !important;
+    gap: 8px !important;
+  }
+
+  .pc-public-assistant-header {
+    gap: 8px !important;
+  }
+}
+
+@media (max-width: 390px) {
+  .pc-public-assistant-mark,
+  .p7-support-chat-mark {
+    width: 40px !important;
+    height: 40px !important;
+  }
+
+  .pc-public-assistant-header,
+  .p7-support-chat-head {
+    padding-right: 8px !important;
+    padding-left: 10px !important;
+  }
+
+  .p7-support-chat-head {
+    grid-template-columns: 40px minmax(0, 1fr) 46px 46px !important;
+    gap: 6px !important;
+  }
+
+  .pc-modal-sheet-fullscreen-button,
+  .pc-public-assistant-icon-button,
+  .p7-support-chat-head > button {
+    width: 46px !important;
+    height: 46px !important;
+    min-width: 46px !important;
+    min-height: 46px !important;
+    flex-basis: 46px !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .pc-modal-sheet-fullscreen-button {
+    border: 2px solid ButtonText;
+  }
+}

--- a/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
+++ b/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
@@ -25,8 +25,8 @@ test.describe('unified public modal sheet fullscreen control', () => {
 
     const expanded = await dialog.boundingBox();
     expect(expanded).not.toBeNull();
-    expect(expanded!.top).toBeGreaterThanOrEqual(-1);
-    expect(expanded!.bottom).toBeLessThanOrEqual(861);
+    expect(expanded!.y).toBeGreaterThanOrEqual(-1);
+    expect(expanded!.y + expanded!.height).toBeLessThanOrEqual(861);
     expect(expanded!.height).toBeGreaterThan(compact!.height + 120);
     expect(expanded!.width).toBeGreaterThanOrEqual(389);
 
@@ -48,8 +48,8 @@ test.describe('unified public modal sheet fullscreen control', () => {
 
     const expanded = await dialog.boundingBox();
     expect(expanded).not.toBeNull();
-    expect(expanded!.top).toBeGreaterThanOrEqual(-1);
-    expect(expanded!.bottom).toBeLessThanOrEqual(861);
+    expect(expanded!.y).toBeGreaterThanOrEqual(-1);
+    expect(expanded!.y + expanded!.height).toBeLessThanOrEqual(861);
     expect(expanded!.width).toBeGreaterThanOrEqual(389);
   });
 });

--- a/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
+++ b/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('unified public modal sheet fullscreen control', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 860 });
+    await page.goto('/platform-v7?lang=ru', { waitUntil: 'load' });
+  });
+
+  test('platform assistant expands to the visual viewport and restores compact mode', async ({ page }) => {
+    await page.locator('.pc-public-assistant-shortcut').click();
+
+    const dialog = page.getByRole('dialog', { name: 'Помощник по платформе' });
+    const expand = dialog.getByRole('button', { name: 'На весь экран' });
+    await expect(dialog).toBeVisible();
+    await expect(expand).toBeVisible();
+    await expect(dialog).toHaveAttribute('data-pc-fullscreen', 'false');
+
+    const compact = await dialog.boundingBox();
+    expect(compact).not.toBeNull();
+
+    await expand.click();
+    await expect(dialog).toHaveAttribute('data-pc-fullscreen', 'true');
+    await expect(dialog.getByRole('button', { name: 'Свернуть окно' })).toBeFocused();
+    await expect(dialog.getByRole('button', { name: 'Закрыть помощника по платформе' })).toBeVisible();
+
+    const expanded = await dialog.boundingBox();
+    expect(expanded).not.toBeNull();
+    expect(expanded!.top).toBeGreaterThanOrEqual(-1);
+    expect(expanded!.bottom).toBeLessThanOrEqual(861);
+    expect(expanded!.height).toBeGreaterThan(compact!.height + 120);
+    expect(expanded!.width).toBeGreaterThanOrEqual(389);
+
+    await dialog.getByRole('button', { name: 'Свернуть окно' }).click();
+    await expect(dialog).toHaveAttribute('data-pc-fullscreen', 'false');
+  });
+
+  test('support uses the same fullscreen control without changing its short title', async ({ page }) => {
+    await page.locator('.p7-support-chat-button').click();
+
+    const dialog = page.getByRole('dialog', { name: 'Поддержка' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Поддержка', { exact: true })).toBeVisible();
+    await expect(dialog.getByText('Поддержка Прозрачной Цены', { exact: true })).toHaveCount(0);
+
+    await dialog.getByRole('button', { name: 'На весь экран' }).click();
+    await expect(dialog).toHaveAttribute('data-pc-fullscreen', 'true');
+    await expect(dialog.getByRole('button', { name: 'Закрыть поддержку' })).toBeVisible();
+
+    const expanded = await dialog.boundingBox();
+    expect(expanded).not.toBeNull();
+    expect(expanded!.top).toBeGreaterThanOrEqual(-1);
+    expect(expanded!.bottom).toBeLessThanOrEqual(861);
+    expect(expanded!.width).toBeGreaterThanOrEqual(389);
+  });
+});


### PR DESCRIPTION
## UX change
- add a 48×48 fullscreen toggle immediately before the single close control;
- support assistant and support with one shared controller and one shared visual contract;
- fill the actual `visualViewport` on iPhone/Safari rather than the obscured layout viewport;
- preserve internal scroll position when expanding or collapsing;
- align newly generated long assistant answers to their beginning instead of forcing the user to the answer footer;
- keep compact bottom-sheet mode as the default;
- keep `Escape`, focus behavior, close controls, support submission and assistant authority unchanged;
- localize fullscreen labels for RU/EN/ZH.

## Acceptance
Adds mobile Playwright coverage for both modal sheets, full-screen geometry, close-control visibility and the short `Поддержка` title.

## Scope
No authentication, RBAC, Deal, payment, API authority or external integration changes.