### PR TITLE
Remove empty-space waste from compact modal sheets

### DIFF
--- a/apps/web/styles/platform-v7-unified-modal-fullscreen.css
+++ b/apps/web/styles/platform-v7-unified-modal-fullscreen.css
@@ -70,6 +70,14 @@
 }
 
 @media (max-width: 720px) {
+  /* Compact sheets use only the space their content needs, up to the shared cap. */
+  .pc-public-assistant-panel:not([data-pc-fullscreen='true']),
+  .p7-support-chat-panel:not([data-pc-fullscreen='true']) {
+    height: auto !important;
+    min-height: min(380px, calc(var(--pc-visual-viewport-height) - 8px)) !important;
+    max-height: min(68dvh, 560px, calc(var(--pc-visual-viewport-height) - 8px)) !important;
+  }
+
   .pc-public-assistant-panel[data-pc-fullscreen='true'],
   .p7-support-chat-panel[data-pc-fullscreen='true'] {
     position: fixed !important;

--- a/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
+++ b/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
@@ -17,6 +17,8 @@ test.describe('unified public modal sheet fullscreen control', () => {
 
     const compact = await dialog.boundingBox();
     expect(compact).not.toBeNull();
+    expect(compact!.height).toBeGreaterThanOrEqual(360);
+    expect(compact!.height).toBeLessThanOrEqual(480);
 
     await expand.click();
     await expect(dialog).toHaveAttribute('data-pc-fullscreen', 'true');


### PR DESCRIPTION
## UX correction
- compact assistant/support sheets size to content rather than reserving the full 68dvh envelope;
- retain a 380px minimum usable workspace;
- retain the shared 68dvh/560px maximum and internal scrolling for long content;
- leave fullscreen mode and visualViewport behavior unchanged.

## Acceptance
The mobile assistant greeting state must remain between 360px and 480px high at a 390×860 viewport, while fullscreen still expands substantially.

## Scope
Only the already independently approved shared modal CSS and its focused E2E acceptance change.