### PR TITLE
TAI AP-05: deterministic governed retrieval core

### DIFF
--- a/apps/tai/tai/knowledge_chunking.py
+++ b/apps/tai/tai/knowledge_chunking.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Final
+
+_WHITESPACE: Final[re.Pattern[str]] = re.compile(r"\s+")
+_PARAGRAPH_BREAK: Final[re.Pattern[str]] = re.compile(r"\n\s*\n+")
+
+
+@dataclass(frozen=True, slots=True)
+class KnowledgeChunk:
+    chunk_id: str
+    source_id: str
+    document_checksum_sha256: str
+    ordinal: int
+    text: str
+    token_estimate: int
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkingPolicy:
+    max_chars: int = 1600
+    overlap_chars: int = 160
+    min_chars: int = 80
+
+    def __post_init__(self) -> None:
+        if self.max_chars < 256:
+            raise ValueError("max_chars must be at least 256")
+        if self.overlap_chars < 0:
+            raise ValueError("overlap_chars must not be negative")
+        if self.overlap_chars >= self.max_chars:
+            raise ValueError("overlap_chars must be smaller than max_chars")
+        if self.min_chars < 1 or self.min_chars > self.max_chars:
+            raise ValueError("min_chars must be between 1 and max_chars")
+
+
+class DeterministicKnowledgeChunker:
+    """Split normalized knowledge into stable, reproducible retrieval units."""
+
+    def __init__(self, policy: ChunkingPolicy | None = None) -> None:
+        self._policy = policy or ChunkingPolicy()
+
+    def chunk(
+        self,
+        *,
+        source_id: str,
+        document_checksum_sha256: str,
+        text: str,
+    ) -> tuple[KnowledgeChunk, ...]:
+        normalized_source_id = source_id.strip()
+        normalized_checksum = document_checksum_sha256.strip().lower()
+        normalized_text = self._normalize_text(text)
+
+        if not normalized_source_id:
+            raise ValueError("source_id must not be blank")
+        if len(normalized_checksum) != 64 or any(
+            character not in "0123456789abcdef" for character in normalized_checksum
+        ):
+            raise ValueError("document_checksum_sha256 must be a lowercase SHA-256 hex digest")
+        if not normalized_text:
+            return ()
+
+        segments = self._segments(normalized_text)
+        chunks: list[KnowledgeChunk] = []
+        buffer = ""
+
+        for segment in segments:
+            if not buffer:
+                buffer = segment
+                continue
+            candidate = f"{buffer}\n\n{segment}"
+            if len(candidate) <= self._policy.max_chars:
+                buffer = candidate
+                continue
+            chunks.extend(
+                self._emit_with_hard_limit(
+                    source_id=normalized_source_id,
+                    checksum=normalized_checksum,
+                    text=buffer,
+                    start_ordinal=len(chunks),
+                )
+            )
+            overlap = self._tail(buffer)
+            buffer = f"{overlap}\n\n{segment}" if overlap else segment
+
+        if buffer:
+            chunks.extend(
+                self._emit_with_hard_limit(
+                    source_id=normalized_source_id,
+                    checksum=normalized_checksum,
+                    text=buffer,
+                    start_ordinal=len(chunks),
+                )
+            )
+
+        return tuple(chunks)
+
+    def _emit_with_hard_limit(
+        self,
+        *,
+        source_id: str,
+        checksum: str,
+        text: str,
+        start_ordinal: int,
+    ) -> list[KnowledgeChunk]:
+        emitted: list[KnowledgeChunk] = []
+        cursor = 0
+        ordinal = start_ordinal
+        while cursor < len(text):
+            end = min(len(text), cursor + self._policy.max_chars)
+            candidate = text[cursor:end].strip()
+            if candidate and (
+                len(candidate) >= self._policy.min_chars or end == len(text)
+            ):
+                emitted.append(
+                    self._build_chunk(
+                        source_id=source_id,
+                        checksum=checksum,
+                        ordinal=ordinal,
+                        text=candidate,
+                    )
+                )
+                ordinal += 1
+            if end == len(text):
+                break
+            cursor = max(cursor + 1, end - self._policy.overlap_chars)
+        return emitted
+
+    @staticmethod
+    def _normalize_text(text: str) -> str:
+        paragraphs = []
+        for paragraph in _PARAGRAPH_BREAK.split(text.replace("\r\n", "\n")):
+            normalized = _WHITESPACE.sub(" ", paragraph).strip()
+            if normalized:
+                paragraphs.append(normalized)
+        return "\n\n".join(paragraphs)
+
+    @staticmethod
+    def _segments(text: str) -> tuple[str, ...]:
+        return tuple(segment for segment in text.split("\n\n") if segment)
+
+    def _tail(self, text: str) -> str:
+        if self._policy.overlap_chars == 0:
+            return ""
+        return text[-self._policy.overlap_chars :].strip()
+
+    @staticmethod
+    def _build_chunk(
+        *,
+        source_id: str,
+        checksum: str,
+        ordinal: int,
+        text: str,
+    ) -> KnowledgeChunk:
+        digest = hashlib.sha256(
+            f"{source_id}\n{checksum}\n{ordinal}\n{text}".encode()
+        ).hexdigest()
+        return KnowledgeChunk(
+            chunk_id=digest,
+            source_id=source_id,
+            document_checksum_sha256=checksum,
+            ordinal=ordinal,
+            text=text,
+            token_estimate=max(1, (len(text) + 3) // 4),
+        )

--- a/apps/tai/tai/migrations/0005_retrieval_index.sql
+++ b/apps/tai/tai/migrations/0005_retrieval_index.sql
@@ -1,0 +1,75 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS tai_retrieval_generations (
+    generation BIGSERIAL PRIMARY KEY,
+    status TEXT NOT NULL CHECK (status IN ('BUILDING', 'ACTIVE', 'RETIRED', 'FAILED')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    activated_at TIMESTAMPTZ,
+    retired_at TIMESTAMPTZ,
+    version BIGINT NOT NULL DEFAULT 1 CHECK (version > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS tai_retrieval_one_active_generation
+    ON tai_retrieval_generations ((status))
+    WHERE status = 'ACTIVE';
+
+CREATE TABLE IF NOT EXISTS tai_retrieval_chunks (
+    generation BIGINT NOT NULL REFERENCES tai_retrieval_generations(generation) ON DELETE RESTRICT,
+    chunk_id TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    document_checksum_sha256 TEXT NOT NULL,
+    ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+    tenant_id TEXT,
+    trust_score DOUBLE PRECISION NOT NULL CHECK (trust_score >= 0 AND trust_score <= 1),
+    valid_until TIMESTAMPTZ,
+    revoked BOOLEAN NOT NULL DEFAULT FALSE,
+    chunk_text TEXT NOT NULL,
+    search_vector TSVECTOR GENERATED ALWAYS AS (
+        to_tsvector('simple', coalesce(chunk_text, ''))
+    ) STORED,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (generation, chunk_id),
+    UNIQUE (generation, source_id, document_checksum_sha256, ordinal)
+);
+
+CREATE INDEX IF NOT EXISTS tai_retrieval_chunks_search_idx
+    ON tai_retrieval_chunks USING GIN (search_vector);
+
+CREATE INDEX IF NOT EXISTS tai_retrieval_chunks_authority_idx
+    ON tai_retrieval_chunks (generation, tenant_id, revoked, valid_until, trust_score);
+
+CREATE OR REPLACE FUNCTION tai_activate_retrieval_generation(target_generation BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM tai_retrieval_generations
+        WHERE generation = target_generation
+          AND status = 'BUILDING'
+        FOR UPDATE
+    ) THEN
+        RAISE EXCEPTION 'retrieval generation is not BUILDING';
+    END IF;
+
+    UPDATE tai_retrieval_generations
+    SET status = 'RETIRED',
+        retired_at = clock_timestamp(),
+        version = version + 1
+    WHERE status = 'ACTIVE';
+
+    UPDATE tai_retrieval_generations
+    SET status = 'ACTIVE',
+        activated_at = clock_timestamp(),
+        version = version + 1
+    WHERE generation = target_generation
+      AND status = 'BUILDING';
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'retrieval generation activation lost compare-and-swap';
+    END IF;
+END;
+$$;
+
+COMMIT;

--- a/apps/tai/tai/postgres_retrieval_index.py
+++ b/apps/tai/tai/postgres_retrieval_index.py
@@ -189,9 +189,14 @@ class PostgreSQLRetrievalIndexRepository:
             try:
                 with connection.cursor() as cursor:
                     cursor.execute(query, parameters)
-                    rows = tuple(cursor.fetchall())
+                    rows: list[Mapping[str, Any]] = []
+                    while True:
+                        row = cursor.fetchone()
+                        if row is None:
+                            break
+                        rows.append(row)
                 connection.commit()
-                return rows
+                return tuple(rows)
             except Exception:
                 connection.rollback()
                 raise

--- a/apps/tai/tai/postgres_retrieval_index.py
+++ b/apps/tai/tai/postgres_retrieval_index.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+from tai.postgres_loader_state import ConnectionFactory
+from tai.retrieval_index import IndexedChunk, RetrievalDocument
+from tai.knowledge_chunking import KnowledgeChunk
+
+
+class PostgreSQLRetrievalIndexRepository:
+    """Durable retrieval authority with transactional generation activation."""
+
+    def __init__(self, connection_factory: ConnectionFactory) -> None:
+        self._connection_factory = connection_factory
+
+    def begin_generation(self) -> int:
+        query = """
+            INSERT INTO tai_retrieval_generations (status)
+            VALUES ('BUILDING')
+            RETURNING generation
+        """
+        row = self._execute_returning(query, ())
+        if row is None:
+            raise RuntimeError("retrieval generation insert returned no row")
+        return int(row["generation"])
+
+    def add(self, generation: int, documents: tuple[RetrievalDocument, ...]) -> None:
+        if generation < 1:
+            raise ValueError("generation must be positive")
+        if not documents:
+            return
+        status_query = """
+            SELECT status
+            FROM tai_retrieval_generations
+            WHERE generation = %s
+            FOR UPDATE
+        """
+        insert_query = """
+            INSERT INTO tai_retrieval_chunks (
+                generation,
+                chunk_id,
+                source_id,
+                document_checksum_sha256,
+                ordinal,
+                tenant_id,
+                trust_score,
+                valid_until,
+                revoked,
+                chunk_text
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (generation, chunk_id) DO UPDATE
+            SET tenant_id = EXCLUDED.tenant_id,
+                trust_score = EXCLUDED.trust_score,
+                valid_until = EXCLUDED.valid_until,
+                revoked = EXCLUDED.revoked,
+                chunk_text = EXCLUDED.chunk_text
+            WHERE tai_retrieval_chunks.source_id = EXCLUDED.source_id
+              AND tai_retrieval_chunks.document_checksum_sha256 = EXCLUDED.document_checksum_sha256
+              AND tai_retrieval_chunks.ordinal = EXCLUDED.ordinal
+        """
+        with self._connection_factory() as connection:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(status_query, (generation,))
+                    row = cursor.fetchone()
+                    if row is None or str(row["status"]) != "BUILDING":
+                        raise RuntimeError(
+                            "documents can only be added to a building generation"
+                        )
+                    for document in documents:
+                        chunk = document.chunk
+                        cursor.execute(
+                            insert_query,
+                            (
+                                generation,
+                                chunk.chunk_id,
+                                chunk.source_id,
+                                chunk.document_checksum_sha256,
+                                chunk.ordinal,
+                                document.tenant_id,
+                                document.trust_score,
+                                document.valid_until,
+                                document.revoked,
+                                chunk.text,
+                            ),
+                        )
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+
+    def activate(self, generation: int) -> None:
+        if generation < 1:
+            raise ValueError("generation must be positive")
+        self._execute("SELECT tai_activate_retrieval_generation(%s)", (generation,))
+
+    def active_documents(self) -> tuple[IndexedChunk, ...]:
+        query = """
+            SELECT
+                c.generation,
+                c.chunk_id,
+                c.source_id,
+                c.document_checksum_sha256,
+                c.ordinal,
+                c.tenant_id,
+                c.trust_score,
+                c.valid_until,
+                c.revoked,
+                c.chunk_text,
+                regexp_split_to_array(
+                    trim(regexp_replace(lower(c.chunk_text), '[^0-9a-zа-яё]+', ' ', 'g')),
+                    '\\s+'
+                ) AS terms
+            FROM tai_retrieval_chunks c
+            JOIN tai_retrieval_generations g
+              ON g.generation = c.generation
+             AND g.status = 'ACTIVE'
+            ORDER BY c.chunk_id
+        """
+        rows = self._execute_all(query, ())
+        results: list[IndexedChunk] = []
+        for row in rows:
+            raw_terms = row.get("terms") or []
+            frequencies: dict[str, int] = {}
+            for raw_term in raw_terms:
+                term = str(raw_term).strip()
+                if term:
+                    frequencies[term] = frequencies.get(term, 0) + 1
+            chunk = KnowledgeChunk(
+                chunk_id=str(row["chunk_id"]),
+                source_id=str(row["source_id"]),
+                document_checksum_sha256=str(row["document_checksum_sha256"]),
+                ordinal=int(row["ordinal"]),
+                text=str(row["chunk_text"]),
+                token_estimate=max(1, (len(str(row["chunk_text"])) + 3) // 4),
+            )
+            results.append(
+                IndexedChunk(
+                    generation=int(row["generation"]),
+                    document=RetrievalDocument(
+                        chunk=chunk,
+                        tenant_id=(
+                            None if row["tenant_id"] is None else str(row["tenant_id"])
+                        ),
+                        trust_score=float(row["trust_score"]),
+                        valid_until=row["valid_until"],
+                        revoked=bool(row["revoked"]),
+                    ),
+                    term_frequencies=tuple(sorted(frequencies.items())),
+                    document_length=sum(frequencies.values()),
+                )
+            )
+        return tuple(results)
+
+    def _execute(self, query: str, parameters: Sequence[Any]) -> None:
+        with self._connection_factory() as connection:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(query, parameters)
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+
+    def _execute_returning(
+        self,
+        query: str,
+        parameters: Sequence[Any],
+    ) -> Mapping[str, Any] | None:
+        with self._connection_factory() as connection:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(query, parameters)
+                    row = cursor.fetchone()
+                connection.commit()
+                return row
+            except Exception:
+                connection.rollback()
+                raise
+
+    def _execute_all(
+        self,
+        query: str,
+        parameters: Sequence[Any],
+    ) -> tuple[Mapping[str, Any], ...]:
+        with self._connection_factory() as connection:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(query, parameters)
+                    rows = tuple(cursor.fetchall())
+                connection.commit()
+                return rows
+            except Exception:
+                connection.rollback()
+                raise

--- a/apps/tai/tai/postgres_retrieval_index.py
+++ b/apps/tai/tai/postgres_retrieval_index.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from datetime import datetime
 from typing import Any
 
+from tai.knowledge_chunking import KnowledgeChunk
 from tai.postgres_loader_state import ConnectionFactory
 from tai.retrieval_index import IndexedChunk, RetrievalDocument
-from tai.knowledge_chunking import KnowledgeChunk
 
 
 class PostgreSQLRetrievalIndexRepository:

--- a/apps/tai/tai/retrieval_index.py
+++ b/apps/tai/tai/retrieval_index.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Protocol
+
+from tai.knowledge_chunking import KnowledgeChunk
+
+_TOKEN = re.compile(r"[0-9A-Za-zА-Яа-яЁё]+", re.UNICODE)
+
+
+class IndexGenerationStatus(StrEnum):
+    BUILDING = "BUILDING"
+    ACTIVE = "ACTIVE"
+    RETIRED = "RETIRED"
+    FAILED = "FAILED"
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalDocument:
+    chunk: KnowledgeChunk
+    tenant_id: str | None
+    trust_score: float
+    valid_until: datetime | None
+    revoked: bool = False
+
+    def __post_init__(self) -> None:
+        if self.tenant_id is not None and not self.tenant_id.strip():
+            raise ValueError("tenant_id must be null or non-blank")
+        if not 0.0 <= self.trust_score <= 1.0:
+            raise ValueError("trust_score must be between 0 and 1")
+
+
+@dataclass(frozen=True, slots=True)
+class IndexedChunk:
+    generation: int
+    document: RetrievalDocument
+    term_frequencies: tuple[tuple[str, int], ...]
+    document_length: int
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalQuery:
+    text: str
+    tenant_id: str | None
+    now: datetime
+    minimum_trust_score: float = 0.5
+    limit: int = 10
+
+    def __post_init__(self) -> None:
+        if not self.text.strip():
+            raise ValueError("query text must not be blank")
+        if self.tenant_id is not None and not self.tenant_id.strip():
+            raise ValueError("tenant_id must be null or non-blank")
+        if not 0.0 <= self.minimum_trust_score <= 1.0:
+            raise ValueError("minimum_trust_score must be between 0 and 1")
+        if self.limit < 1 or self.limit > 100:
+            raise ValueError("limit must be between 1 and 100")
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalHit:
+    chunk_id: str
+    source_id: str
+    generation: int
+    score: float
+    text: str
+    trust_score: float
+
+
+class RetrievalIndexRepository(Protocol):
+    def begin_generation(self) -> int: ...
+
+    def add(self, generation: int, documents: tuple[RetrievalDocument, ...]) -> None: ...
+
+    def activate(self, generation: int) -> None: ...
+
+    def active_documents(self) -> tuple[IndexedChunk, ...]: ...
+
+
+class InMemoryRetrievalIndexRepository:
+    """Deterministic test/local authority. Production must use PostgreSQL."""
+
+    def __init__(self) -> None:
+        self._next_generation = 1
+        self._statuses: dict[int, IndexGenerationStatus] = {}
+        self._documents: dict[int, dict[str, IndexedChunk]] = {}
+
+    def begin_generation(self) -> int:
+        generation = self._next_generation
+        self._next_generation += 1
+        self._statuses[generation] = IndexGenerationStatus.BUILDING
+        self._documents[generation] = {}
+        return generation
+
+    def add(self, generation: int, documents: tuple[RetrievalDocument, ...]) -> None:
+        if self._statuses.get(generation) is not IndexGenerationStatus.BUILDING:
+            raise RuntimeError("documents can only be added to a building generation")
+        target = self._documents[generation]
+        for document in documents:
+            terms = Counter(_tokens(document.chunk.text))
+            target[document.chunk.chunk_id] = IndexedChunk(
+                generation=generation,
+                document=document,
+                term_frequencies=tuple(sorted(terms.items())),
+                document_length=sum(terms.values()),
+            )
+
+    def activate(self, generation: int) -> None:
+        if self._statuses.get(generation) is not IndexGenerationStatus.BUILDING:
+            raise RuntimeError("only a building generation can be activated")
+        for current, status in tuple(self._statuses.items()):
+            if status is IndexGenerationStatus.ACTIVE:
+                self._statuses[current] = IndexGenerationStatus.RETIRED
+        self._statuses[generation] = IndexGenerationStatus.ACTIVE
+
+    def active_documents(self) -> tuple[IndexedChunk, ...]:
+        active = [
+            generation
+            for generation, status in self._statuses.items()
+            if status is IndexGenerationStatus.ACTIVE
+        ]
+        if len(active) != 1:
+            return ()
+        return tuple(self._documents[active[0]].values())
+
+
+class LexicalRetriever:
+    """BM25-style deterministic retrieval with pre-ranking authority filters."""
+
+    def __init__(self, repository: RetrievalIndexRepository) -> None:
+        self._repository = repository
+
+    def search(self, query: RetrievalQuery) -> tuple[RetrievalHit, ...]:
+        query_terms = _tokens(query.text)
+        if not query_terms:
+            return ()
+        eligible = tuple(
+            item
+            for item in self._repository.active_documents()
+            if _eligible(item.document, query)
+        )
+        if not eligible:
+            return ()
+
+        average_length = max(
+            1.0,
+            sum(item.document_length for item in eligible) / len(eligible),
+        )
+        document_frequency = Counter(
+            term
+            for item in eligible
+            for term, _ in item.term_frequencies
+            if term in query_terms
+        )
+        hits: list[RetrievalHit] = []
+        for item in eligible:
+            frequencies = dict(item.term_frequencies)
+            score = 0.0
+            for term in query_terms:
+                frequency = frequencies.get(term, 0)
+                if frequency == 0:
+                    continue
+                containing = document_frequency[term]
+                inverse_frequency = math.log(
+                    1.0 + (len(eligible) - containing + 0.5) / (containing + 0.5)
+                )
+                denominator = frequency + 1.2 * (
+                    0.25 + 0.75 * item.document_length / average_length
+                )
+                score += inverse_frequency * frequency * 2.2 / denominator
+            score *= 0.5 + 0.5 * item.document.trust_score
+            if score > 0:
+                chunk = item.document.chunk
+                hits.append(
+                    RetrievalHit(
+                        chunk_id=chunk.chunk_id,
+                        source_id=chunk.source_id,
+                        generation=item.generation,
+                        score=score,
+                        text=chunk.text,
+                        trust_score=item.document.trust_score,
+                    )
+                )
+        hits.sort(key=lambda hit: (-hit.score, hit.chunk_id))
+        return tuple(hits[: query.limit])
+
+
+def _tokens(text: str) -> tuple[str, ...]:
+    return tuple(match.group(0).casefold() for match in _TOKEN.finditer(text))
+
+
+def _eligible(document: RetrievalDocument, query: RetrievalQuery) -> bool:
+    if document.revoked or document.trust_score < query.minimum_trust_score:
+        return False
+    if document.valid_until is not None and document.valid_until <= query.now:
+        return False
+    if document.tenant_id is None:
+        return True
+    return query.tenant_id is not None and document.tenant_id == query.tenant_id

--- a/apps/tai/tai/retrieval_service.py
+++ b/apps/tai/tai/retrieval_service.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from tai.retrieval_index import LexicalRetriever, RetrievalHit, RetrievalQuery
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalBudget:
+    max_results: int = 10
+    max_total_chars: int = 12_000
+
+    def __post_init__(self) -> None:
+        if self.max_results < 1 or self.max_results > 100:
+            raise ValueError("max_results must be between 1 and 100")
+        if self.max_total_chars < 256 or self.max_total_chars > 100_000:
+            raise ValueError("max_total_chars must be between 256 and 100000")
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalEvidence:
+    request_id: str
+    query_sha256: str
+    tenant_id: str | None
+    generation: int | None
+    retrieved_at: datetime
+    minimum_trust_score: float
+    result_count: int
+    total_chars: int
+    chunk_ids: tuple[str, ...]
+    source_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalResponse:
+    hits: tuple[RetrievalHit, ...]
+    evidence: RetrievalEvidence
+
+
+class RetrievalAuditSink(Protocol):
+    def record(self, evidence: RetrievalEvidence) -> None: ...
+
+
+class NullRetrievalAuditSink:
+    def record(self, evidence: RetrievalEvidence) -> None:
+        del evidence
+
+
+class RetrievalService:
+    """Bounded retrieval facade producing immutable provenance evidence."""
+
+    def __init__(
+        self,
+        retriever: LexicalRetriever,
+        audit_sink: RetrievalAuditSink | None = None,
+        budget: RetrievalBudget | None = None,
+    ) -> None:
+        self._retriever = retriever
+        self._audit_sink = audit_sink or NullRetrievalAuditSink()
+        self._budget = budget or RetrievalBudget()
+
+    def retrieve(
+        self,
+        *,
+        request_id: str,
+        text: str,
+        tenant_id: str | None,
+        now: datetime,
+        minimum_trust_score: float = 0.5,
+    ) -> RetrievalResponse:
+        normalized_request_id = request_id.strip()
+        if not normalized_request_id:
+            raise ValueError("request_id must not be blank")
+
+        query = RetrievalQuery(
+            text=text,
+            tenant_id=tenant_id,
+            now=now,
+            minimum_trust_score=minimum_trust_score,
+            limit=self._budget.max_results,
+        )
+        candidates = self._retriever.search(query)
+        selected: list[RetrievalHit] = []
+        total_chars = 0
+        for hit in candidates:
+            projected = total_chars + len(hit.text)
+            if projected > self._budget.max_total_chars:
+                continue
+            selected.append(hit)
+            total_chars = projected
+
+        hits = tuple(selected)
+        generations = {hit.generation for hit in hits}
+        generation = next(iter(generations)) if len(generations) == 1 else None
+        evidence = RetrievalEvidence(
+            request_id=normalized_request_id,
+            query_sha256=hashlib.sha256(text.strip().encode()).hexdigest(),
+            tenant_id=None if tenant_id is None else tenant_id.strip(),
+            generation=generation,
+            retrieved_at=now,
+            minimum_trust_score=minimum_trust_score,
+            result_count=len(hits),
+            total_chars=total_chars,
+            chunk_ids=tuple(hit.chunk_id for hit in hits),
+            source_ids=tuple(hit.source_id for hit in hits),
+        )
+        self._audit_sink.record(evidence)
+        return RetrievalResponse(hits=hits, evidence=evidence)

--- a/apps/tai/tests/test_knowledge_chunking.py
+++ b/apps/tai/tests/test_knowledge_chunking.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+from tai.knowledge_chunking import ChunkingPolicy, DeterministicKnowledgeChunker
+
+CHECKSUM = "a" * 64
+
+
+def test_chunking_is_deterministic_and_normalizes_whitespace() -> None:
+    chunker = DeterministicKnowledgeChunker(ChunkingPolicy(max_chars=256, overlap_chars=32))
+    text = "  Урожай   пшеницы.\r\n\r\n  Цена зависит от качества.  "
+
+    first = chunker.chunk(source_id="rosstat", document_checksum_sha256=CHECKSUM, text=text)
+    second = chunker.chunk(source_id="rosstat", document_checksum_sha256=CHECKSUM, text=text)
+
+    assert first == second
+    assert len(first) == 1
+    assert first[0].text == "Урожай пшеницы.\n\nЦена зависит от качества."
+    assert first[0].chunk_id
+    assert first[0].token_estimate > 0
+
+
+def test_chunk_ids_change_when_authoritative_document_changes() -> None:
+    chunker = DeterministicKnowledgeChunker()
+
+    first = chunker.chunk(
+        source_id="minselhoz",
+        document_checksum_sha256="a" * 64,
+        text="Официальный документ о зерновом рынке.",
+    )
+    second = chunker.chunk(
+        source_id="minselhoz",
+        document_checksum_sha256="b" * 64,
+        text="Официальный документ о зерновом рынке.",
+    )
+
+    assert first[0].chunk_id != second[0].chunk_id
+
+
+def test_long_text_is_bounded_and_has_stable_ordinals() -> None:
+    chunker = DeterministicKnowledgeChunker(
+        ChunkingPolicy(max_chars=256, overlap_chars=40, min_chars=20)
+    )
+    text = "\n\n".join(f"Раздел {index}: " + ("данные " * 30) for index in range(5))
+
+    chunks = chunker.chunk(
+        source_id="federal-source",
+        document_checksum_sha256=CHECKSUM,
+        text=text,
+    )
+
+    assert len(chunks) > 1
+    assert [chunk.ordinal for chunk in chunks] == list(range(len(chunks)))
+    assert all(len(chunk.text) <= 256 for chunk in chunks)
+    assert all(chunk.source_id == "federal-source" for chunk in chunks)
+
+
+def test_blank_document_produces_no_chunks() -> None:
+    chunker = DeterministicKnowledgeChunker()
+
+    assert (
+        chunker.chunk(
+            source_id="source",
+            document_checksum_sha256=CHECKSUM,
+            text=" \n\n ",
+        )
+        == ()
+    )
+
+
+@pytest.mark.parametrize(
+    ("policy", "message"),
+    [
+        (ChunkingPolicy(max_chars=256, overlap_chars=0, min_chars=1), None),
+    ],
+)
+def test_valid_policy(policy: ChunkingPolicy, message: str | None) -> None:
+    assert policy.max_chars == 256
+    assert message is None
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_chars": 255},
+        {"overlap_chars": -1},
+        {"max_chars": 256, "overlap_chars": 256},
+        {"max_chars": 256, "min_chars": 257},
+    ],
+)
+def test_invalid_policy_is_rejected(kwargs: dict[str, int]) -> None:
+    with pytest.raises(ValueError):
+        ChunkingPolicy(**kwargs)
+
+
+def test_invalid_authority_identity_is_rejected() -> None:
+    chunker = DeterministicKnowledgeChunker()
+
+    with pytest.raises(ValueError, match="source_id"):
+        chunker.chunk(source_id=" ", document_checksum_sha256=CHECKSUM, text="data")
+    with pytest.raises(ValueError, match="SHA-256"):
+        chunker.chunk(source_id="source", document_checksum_sha256="bad", text="data")

--- a/apps/tai/tests/test_retrieval_index.py
+++ b/apps/tai/tests/test_retrieval_index.py
@@ -1,0 +1,142 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tai.knowledge_chunking import DeterministicKnowledgeChunker
+from tai.retrieval_index import (
+    InMemoryRetrievalIndexRepository,
+    LexicalRetriever,
+    RetrievalDocument,
+    RetrievalQuery,
+)
+
+NOW = datetime(2026, 7, 18, tzinfo=UTC)
+
+
+def _document(
+    text: str,
+    *,
+    source_id: str = "source-1",
+    tenant_id: str | None = None,
+    trust_score: float = 0.9,
+    valid_until: datetime | None = None,
+    revoked: bool = False,
+) -> RetrievalDocument:
+    chunk = DeterministicKnowledgeChunker().chunk(
+        source_id=source_id,
+        document_checksum_sha256="a" * 64,
+        text=text,
+    )[0]
+    return RetrievalDocument(
+        chunk=chunk,
+        tenant_id=tenant_id,
+        trust_score=trust_score,
+        valid_until=valid_until,
+        revoked=revoked,
+    )
+
+
+def _query(text: str, *, tenant_id: str | None = None) -> RetrievalQuery:
+    return RetrievalQuery(text=text, tenant_id=tenant_id, now=NOW)
+
+
+def test_building_generation_is_not_searchable() -> None:
+    repository = InMemoryRetrievalIndexRepository()
+    generation = repository.begin_generation()
+    repository.add(generation, (_document("Пшеница урожай качество"),))
+
+    assert LexicalRetriever(repository).search(_query("пшеница")) == ()
+
+
+def test_activation_atomically_replaces_previous_generation() -> None:
+    repository = InMemoryRetrievalIndexRepository()
+    first = repository.begin_generation()
+    repository.add(first, (_document("старые данные пшеница"),))
+    repository.activate(first)
+    second = repository.begin_generation()
+    repository.add(second, (_document("новые данные кукуруза", source_id="source-2"),))
+    repository.activate(second)
+
+    retriever = LexicalRetriever(repository)
+    assert retriever.search(_query("пшеница")) == ()
+    hits = retriever.search(_query("кукуруза"))
+    assert len(hits) == 1
+    assert hits[0].generation == second
+
+
+def test_tenant_document_is_only_visible_to_same_tenant() -> None:
+    repository = InMemoryRetrievalIndexRepository()
+    generation = repository.begin_generation()
+    repository.add(
+        generation,
+        (
+            _document("общая рыночная цена", source_id="public"),
+            _document("частный контракт цена", source_id="private", tenant_id="tenant-a"),
+        ),
+    )
+    repository.activate(generation)
+    retriever = LexicalRetriever(repository)
+
+    anonymous = retriever.search(_query("цена"))
+    tenant_a = retriever.search(_query("цена", tenant_id="tenant-a"))
+    tenant_b = retriever.search(_query("цена", tenant_id="tenant-b"))
+
+    assert {hit.source_id for hit in anonymous} == {"public"}
+    assert {hit.source_id for hit in tenant_a} == {"public", "private"}
+    assert {hit.source_id for hit in tenant_b} == {"public"}
+
+
+def test_revoked_expired_and_low_trust_documents_are_filtered_before_ranking() -> None:
+    repository = InMemoryRetrievalIndexRepository()
+    generation = repository.begin_generation()
+    repository.add(
+        generation,
+        (
+            _document("зерно разрешённый источник", source_id="allowed"),
+            _document("зерно отозванный источник", source_id="revoked", revoked=True),
+            _document(
+                "зерно просроченный источник",
+                source_id="expired",
+                valid_until=NOW - timedelta(seconds=1),
+            ),
+            _document("зерно слабый источник", source_id="weak", trust_score=0.49),
+        ),
+    )
+    repository.activate(generation)
+
+    hits = LexicalRetriever(repository).search(_query("зерно"))
+    assert [hit.source_id for hit in hits] == ["allowed"]
+
+
+def test_trust_score_affects_ranking_but_not_authority_identity() -> None:
+    repository = InMemoryRetrievalIndexRepository()
+    generation = repository.begin_generation()
+    repository.add(
+        generation,
+        (
+            _document("пшеница цена", source_id="trusted", trust_score=1.0),
+            _document("пшеница цена", source_id="less-trusted", trust_score=0.6),
+        ),
+    )
+    repository.activate(generation)
+
+    hits = LexicalRetriever(repository).search(_query("пшеница цена"))
+    assert [hit.source_id for hit in hits] == ["trusted", "less-trusted"]
+
+
+def test_invalid_queries_and_documents_fail_closed() -> None:
+    with pytest.raises(ValueError):
+        RetrievalQuery(text=" ", tenant_id=None, now=NOW)
+    with pytest.raises(ValueError):
+        RetrievalQuery(text="зерно", tenant_id=None, now=NOW, limit=0)
+    with pytest.raises(ValueError):
+        _document("зерно", trust_score=1.1)
+
+
+def test_non_token_query_returns_no_results() -> None:
+    repository = InMemoryRetrievalIndexRepository()
+    generation = repository.begin_generation()
+    repository.add(generation, (_document("зерно"),))
+    repository.activate(generation)
+
+    assert LexicalRetriever(repository).search(_query("---")) == ()

--- a/apps/tai/tests/test_retrieval_service.py
+++ b/apps/tai/tests/test_retrieval_service.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from tai.knowledge_chunking import KnowledgeChunk
+from tai.retrieval_index import (
+    InMemoryRetrievalIndexRepository,
+    LexicalRetriever,
+    RetrievalDocument,
+)
+from tai.retrieval_service import RetrievalBudget, RetrievalEvidence, RetrievalService
+
+
+def _document(chunk_id: str, text: str, *, source_id: str = "source") -> RetrievalDocument:
+    return RetrievalDocument(
+        chunk=KnowledgeChunk(
+            chunk_id=chunk_id,
+            source_id=source_id,
+            document_checksum_sha256="a" * 64,
+            ordinal=0,
+            text=text,
+            token_estimate=1,
+        ),
+        tenant_id=None,
+        trust_score=1.0,
+        valid_until=None,
+    )
+
+
+class _AuditSink:
+    def __init__(self) -> None:
+        self.records: list[RetrievalEvidence] = []
+
+    def record(self, evidence: RetrievalEvidence) -> None:
+        self.records.append(evidence)
+
+
+def _service(*documents: RetrievalDocument, budget: RetrievalBudget | None = None):
+    repository = InMemoryRetrievalIndexRepository()
+    generation = repository.begin_generation()
+    repository.add(generation, tuple(documents))
+    repository.activate(generation)
+    sink = _AuditSink()
+    service = RetrievalService(
+        LexicalRetriever(repository),
+        audit_sink=sink,
+        budget=budget,
+    )
+    return service, sink, generation
+
+
+def test_retrieval_emits_generation_and_provenance_evidence() -> None:
+    service, sink, generation = _service(
+        _document("chunk-a", "пшеница экспорт качество", source_id="authority-a")
+    )
+    now = datetime(2026, 7, 18, tzinfo=UTC)
+
+    response = service.retrieve(
+        request_id="request-1",
+        text="пшеница качество",
+        tenant_id=None,
+        now=now,
+    )
+
+    assert response.evidence.generation == generation
+    assert response.evidence.chunk_ids == ("chunk-a",)
+    assert response.evidence.source_ids == ("authority-a",)
+    assert response.evidence.result_count == 1
+    assert response.evidence.total_chars == len(response.hits[0].text)
+    assert sink.records == [response.evidence]
+
+
+def test_retrieval_applies_total_character_budget_without_partial_chunks() -> None:
+    service, _, _ = _service(
+        _document("chunk-a", "зерно " * 50),
+        _document("chunk-b", "зерно коротко"),
+        budget=RetrievalBudget(max_results=10, max_total_chars=256),
+    )
+
+    response = service.retrieve(
+        request_id="request-2",
+        text="зерно",
+        tenant_id=None,
+        now=datetime(2026, 7, 18, tzinfo=UTC),
+    )
+
+    assert all(len(hit.text) <= 256 for hit in response.hits)
+    assert response.evidence.total_chars <= 256
+    assert "chunk-a" not in response.evidence.chunk_ids
+
+
+def test_empty_result_is_still_audited_without_generation_claim() -> None:
+    service, sink, _ = _service(_document("chunk-a", "кукуруза"))
+
+    response = service.retrieve(
+        request_id="request-3",
+        text="подсолнечник",
+        tenant_id=None,
+        now=datetime(2026, 7, 18, tzinfo=UTC),
+    )
+
+    assert response.hits == ()
+    assert response.evidence.generation is None
+    assert response.evidence.result_count == 0
+    assert sink.records == [response.evidence]
+
+
+def test_request_id_is_fail_closed() -> None:
+    service, sink, _ = _service(_document("chunk-a", "пшеница"))
+
+    with pytest.raises(ValueError, match="request_id"):
+        service.retrieve(
+            request_id=" ",
+            text="пшеница",
+            tenant_id=None,
+            now=datetime(2026, 7, 18, tzinfo=UTC),
+        )
+
+    assert sink.records == []
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"max_results": 0}, "max_results"),
+        ({"max_results": 101}, "max_results"),
+        ({"max_total_chars": 255}, "max_total_chars"),
+        ({"max_total_chars": 100_001}, "max_total_chars"),
+    ],
+)
+def test_budget_validation(kwargs: dict[str, int], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        RetrievalBudget(**kwargs)


### PR DESCRIPTION
## Цель

Завершить AP-05: создать бесплатный, воспроизводимый, tenant-safe и fail-closed контур промышленного поиска по управляемым знаниям TAI.

## Реализовано

- детерминированная нормализация текста;
- стабильное chunking-разбиение с ограниченным overlap;
- content-addressed `chunk_id`, привязанный к source authority и checksum документа;
- неизменяемые ordinal и provenance-поля;
- PostgreSQL authority для retrieval generations и chunks;
- статусы поколений `BUILDING / ACTIVE / RETIRED / FAILED`;
- транзакционная активация единственного ACTIVE generation;
- generation fencing: поиск только по ACTIVE generation;
- детерминированное lexical/BM25-like ranking;
- фильтрация tenant, trust score, TTL и revoked;
- bounded RetrievalService без обрезания chunk посередине;
- evidence envelope с request ID, query digest, generation, chunk/source IDs и бюджетом контекста;
- аудит успешных и пустых retrieval-запросов;
- fail-closed поведение при отсутствии ACTIVE generation;
- unit-тесты chunking, retrieval authority, ranking, isolation, TTL, revoked, evidence, audit и budget;
- отсутствие внешних embedding API, платных моделей и монетизационных примитивов.

## Exact-head acceptance

Exact-head: `1a1c03487699267c710b91903cd229c6729e6144`

Успешно завершены:

- TAI Foundation;
- CI;
- Node CI;
- Security Quality Gate;
- Security Abuse and Evidence Acceptance;
- Runtime Context Security Gate;
- Security Scan;
- Dependency Review;
- Auction Atomic Execution Acceptance;
- Outbox PostgreSQL Authority Acceptance;
- Disputes PostgreSQL Authority Acceptance;
- Optional Runtime Retirement Gate.

Review threads: отсутствуют.

Base main: `d43eef6310cc608bce200c3f0d237bb7930ae8e5`