### PR TITLE
IR-LOAD: repair and prove target sustained/burst capacity

### DIFF
--- a/.github/workflows/target-load-acceptance.yml
+++ b/.github/workflows/target-load-acceptance.yml
@@ -1,0 +1,104 @@
+name: Target Load and Burst Acceptance
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/target-load-acceptance.yml'
+      - 'infra/kind/target-load/**'
+      - 'scripts/release/target-load-**'
+      - 'scripts/release/enforce-target-load-evidence.mjs'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/target-load-acceptance.yml'
+      - 'infra/kind/target-load/**'
+      - 'scripts/release/target-load-**'
+      - 'scripts/release/enforce-target-load-evidence.mjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: target-load-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  EXACT_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+  EVIDENCE_DIR: artifacts/industrial-readiness/load
+
+jobs:
+  target-load:
+    name: 5k sessions · 500 RPS · 1k burst · 50k Deals · 10m events
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - name: Checkout exact head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.EXACT_HEAD }}
+          fetch-depth: 0
+
+      - name: Reclaim runner disk
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          docker system prune --all --force || true
+          df -h
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.18.4
+
+      - name: Install pinned kind and kubectl
+        run: |
+          set -euo pipefail
+          KIND_VERSION=v0.29.0
+          curl --fail --location --retry 5 "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64" -o /tmp/kind-linux-amd64
+          curl --fail --location --retry 5 "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64.sha256sum" -o /tmp/kind-linux-amd64.sha256sum
+          (cd /tmp && sha256sum --check kind-linux-amd64.sha256sum)
+          sudo install -m 0755 /tmp/kind-linux-amd64 /usr/local/bin/kind
+
+          KUBECTL_VERSION=v1.33.1
+          curl --fail --location --retry 5 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /tmp/kubectl
+          curl --fail --location --retry 5 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" -o /tmp/kubectl.sha256
+          echo "$(cat /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum --check
+          sudo install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+
+      - name: Execute production-like deployment baseline
+        run: bash scripts/release/production-like-kubernetes-acceptance.sh
+
+      - name: Execute target load and burst acceptance
+        run: bash scripts/release/target-load-acceptance-wrapper.sh
+
+      - name: Enforce exact-head machine-readable evidence
+        if: always()
+        run: |
+          node scripts/release/target-load-fallback-evidence.mjs
+          node scripts/release/enforce-target-load-evidence.mjs
+
+      - name: Upload target-load evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: target-load-${{ env.EXACT_HEAD }}
+          path: ${{ env.EVIDENCE_DIR }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Cleanup disposable load environment
+        if: always()
+        run: |
+          kind delete cluster --name grainflow-acceptance || true
+          docker system df || true
+
+  target-load-gate:
+    name: Target Load and Burst Gate · blocking
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [target-load]
+    steps:
+      - run: test "${{ needs.target-load.result }}" = success

--- a/infra/kind/target-load/scope.json
+++ b/infra/kind/target-load/scope.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "taskId": "IR-LOAD-2694",
+  "branch": "ir/target-load-2694-v2",
+  "issue": 2694,
+  "status": "active",
+  "maturityBoundary": "Production-like target sustained and burst capacity evidence only. No real-provider, live-user or production-history claim.",
+  "allowedPaths": [
+    ".github/workflows/target-load-acceptance.yml",
+    "infra/kind/target-load/**",
+    "scripts/release/target-load-acceptance-wrapper.sh",
+    "scripts/release/target-load-acceptance.sh",
+    "scripts/release/target-load-generate-tokens.mjs",
+    "scripts/release/target-load.k6.js",
+    "scripts/release/target-load-build-evidence.mjs",
+    "scripts/release/target-load-fallback-evidence.mjs",
+    "scripts/release/enforce-target-load-evidence.mjs"
+  ],
+  "forbiddenPaths": [
+    "apps/**",
+    "packages/**",
+    "prisma/**",
+    "package.json",
+    "pnpm-lock.yaml"
+  ],
+  "requiredEvidence": "artifacts/industrial-readiness/load/target-load-acceptance.json"
+}

--- a/infra/kind/target-load/seed.sql
+++ b/infra/kind/target-load/seed.sql
@@ -1,0 +1,348 @@
+\set ON_ERROR_STOP on
+\echo 'Seeding target-load identities, Deals, events, auction and callback operations'
+
+SET synchronous_commit = off;
+SET maintenance_work_mem = '512MB';
+SET work_mem = '64MB';
+
+BEGIN;
+
+INSERT INTO public.organizations (
+  id, inn, name, type, status, "tenantId", "verifiedAt", "kycStatus", "amlStatus", "sanctionHit", "createdAt", "updatedAt"
+)
+SELECT
+  'org-load-' || lpad(i::text, 6, '0'),
+  '88' || lpad(i::text, 10, '0'),
+  'Load Organization ' || i,
+  'LEGAL',
+  'VERIFIED',
+  CASE WHEN i > (:session_count - :isolated_count)
+    THEN 'tenant-isolated-' || lpad((i - (:session_count - :isolated_count))::text, 4, '0')
+    ELSE 'tenant-canonical-test'
+  END,
+  now(),
+  'APPROVED',
+  'CLEAR',
+  false,
+  now(),
+  now()
+FROM generate_series(1, :session_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.users (
+  id, email, "passwordHash", "fullName", status, "mfaEnabled", "createdAt", "updatedAt"
+)
+SELECT
+  'user-load-' || lpad(i::text, 6, '0'),
+  'load-' || lpad(i::text, 6, '0') || '@acceptance.invalid',
+  '$2b$12$IndustrialLoadIdentityIsNotLoginCapable000000000000000000000',
+  'Load Actor ' || i,
+  'ACTIVE',
+  true,
+  now(),
+  now()
+FROM generate_series(1, :session_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.user_orgs (
+  id, "userId", "organizationId", role, "isDefault", "joinedAt"
+)
+SELECT
+  'membership-load-' || lpad(i::text, 6, '0'),
+  'user-load-' || lpad(i::text, 6, '0'),
+  'org-load-' || lpad(i::text, 6, '0'),
+  CASE
+    WHEN i <= :buyer_count THEN 'BUYER'
+    WHEN i > (:session_count - :isolated_count) THEN 'BUYER'
+    ELSE 'COMPLIANCE_OFFICER'
+  END,
+  true,
+  now()
+FROM generate_series(1, :session_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.credential_states (
+  user_id, credential_version, failed_login_count, mfa_enabled, consent_version, consent_at, created_at, updated_at
+)
+SELECT
+  'user-load-' || lpad(i::text, 6, '0'),
+  1,
+  0,
+  true,
+  '1.2',
+  now(),
+  now(),
+  now()
+FROM generate_series(1, :session_count) AS g(i)
+ON CONFLICT (user_id) DO NOTHING;
+
+INSERT INTO auth.sessions (
+  id, user_id, membership_id, organization_id, tenant_id, status,
+  refresh_family_id, credential_version, mfa_level, mfa_verified_at,
+  mfa_verified_method, user_agent_hash, ip_hash, last_seen_at, expires_at,
+  created_at, updated_at
+)
+SELECT
+  'session-load-' || lpad(i::text, 6, '0'),
+  'user-load-' || lpad(i::text, 6, '0'),
+  'membership-load-' || lpad(i::text, 6, '0'),
+  'org-load-' || lpad(i::text, 6, '0'),
+  CASE WHEN i > (:session_count - :isolated_count)
+    THEN 'tenant-isolated-' || lpad((i - (:session_count - :isolated_count))::text, 4, '0')
+    ELSE 'tenant-canonical-test'
+  END,
+  'ACTIVE',
+  'family-load-' || lpad(i::text, 6, '0'),
+  1,
+  'TOTP',
+  now(),
+  'TOTP',
+  md5('load-agent-' || i::text),
+  md5('load-ip-' || i::text),
+  now(),
+  now() + interval '6 hours',
+  now(),
+  now()
+FROM generate_series(1, :session_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.deal_participants (
+  id, "dealId", "tenantId", "organizationId", "userId", role,
+  "accessLevel", status, "assignedAt"
+)
+SELECT
+  'participant-load-canonical-' || lpad(i::text, 6, '0'),
+  'DEAL-INDUSTRIAL-001',
+  'tenant-canonical-test',
+  'org-load-' || lpad(i::text, 6, '0'),
+  'user-load-' || lpad(i::text, 6, '0'),
+  CASE WHEN i <= :buyer_count THEN 'BUYER' ELSE 'COMPLIANCE_OFFICER' END,
+  CASE WHEN i <= :buyer_count THEN 'WORK' ELSE 'APPROVE' END,
+  'ACTIVE',
+  now()
+FROM generate_series(1, (:session_count - :isolated_count)) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.deals (
+  id, status, "tenantId", "sellerOrgId", "buyerOrgId",
+  "volumeTonsDec", "pricePerTonDec", "totalKopecks", version,
+  currency, culture, region, "nextAction", "createdAt", "updatedAt"
+)
+SELECT
+  'DEAL-LOAD-' || lpad(i::text, 6, '0'),
+  'DRAFT',
+  'tenant-canonical-test',
+  'org-canonical-seller',
+  'org-load-' || lpad((((i - 1) % :buyer_count) + 1)::text, 6, '0'),
+  100.000000,
+  12000.000000,
+  120000000,
+  0,
+  'RUB',
+  'WHEAT',
+  'LOAD-REGION',
+  'approve_admission',
+  :'deal_updated_at'::timestamptz,
+  :'deal_updated_at'::timestamptz
+FROM generate_series(1, :deal_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.deal_participants (
+  id, "dealId", "tenantId", "organizationId", "userId", role,
+  "accessLevel", status, "assignedAt"
+)
+SELECT
+  'participant-load-command-' || lpad(i::text, 6, '0'),
+  'DEAL-LOAD-' || lpad(i::text, 6, '0'),
+  'tenant-canonical-test',
+  'org-load-' || lpad((:buyer_count + 1 + ((i - 1) % :compliance_count))::text, 6, '0'),
+  'user-load-' || lpad((:buyer_count + 1 + ((i - 1) % :compliance_count))::text, 6, '0'),
+  'COMPLIANCE_OFFICER',
+  'APPROVE',
+  'ACTIVE',
+  now()
+FROM generate_series(1, :deal_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+DELETE FROM auction.admissions WHERE tenant_id = 'tenant-canonical-test' AND lot_id = 'lot-load-hot';
+DELETE FROM auction.bids WHERE tenant_id = 'tenant-canonical-test' AND lot_id = 'lot-load-hot';
+DELETE FROM auction.lots WHERE tenant_id = 'tenant-canonical-test' AND id = 'lot-load-hot';
+
+INSERT INTO auction.lots (
+  id, tenant_id, seller_org_id, seller_user_id, title, culture, grade,
+  volume_tons, start_price_rub_per_ton, step_price_rub_per_ton,
+  start_price_kopecks_per_ton, step_price_kopecks_per_ton,
+  region, address, status, auction_ends_at, source_type,
+  source_external_id, source_certificate_id, source_verified_at,
+  admission_status, auto_extend_enabled, auto_extend_window_minutes,
+  auto_extend_minutes, version, created_at, updated_at
+) VALUES (
+  'lot-load-hot', 'tenant-canonical-test', 'org-canonical-seller', 'farmer-e2e',
+  'Industrial hot-lot acceptance', 'WHEAT', '3', 1000000.000000,
+  12000, 100, 1200000, 10000, 'LOAD-REGION', 'LOAD-ADDRESS',
+  'BIDDING', now() + interval '4 hours', 'MANUAL_VERIFIED',
+  'load-source-hot-lot', 'load-certificate-hot-lot', now(), 'ADMITTED',
+  false, 0, 0, 1, now(), now()
+);
+
+INSERT INTO auction.admissions (
+  id, tenant_id, lot_id, participant_org_id, participant_user_id,
+  participant_role, status, valid_until, reason, decided_by_actor_id,
+  version, created_at, updated_at
+)
+SELECT
+  'admission-load-' || lpad(i::text, 6, '0'),
+  'tenant-canonical-test',
+  'lot-load-hot',
+  'org-load-' || lpad(i::text, 6, '0'),
+  'user-load-' || lpad(i::text, 6, '0'),
+  'BUYER', 'ADMITTED', now() + interval '4 hours',
+  'Industrial target-load acceptance', 'compliance-e2e', 1, now(), now()
+FROM generate_series(1, :buyer_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+COMMIT;
+
+\echo 'Seeding callback-authoritative payment operations'
+BEGIN;
+INSERT INTO settlement.payment_terms (
+  id, tenant_id, deal_id, version, currency, reserve_amount_minor,
+  release_basis, status, command_id, idempotency_key, request_fingerprint,
+  created_by_user_id, created_by_org_id, created_at
+)
+SELECT
+  'terms-load-' || lpad(i::text, 6, '0'),
+  'tenant-canonical-test',
+  'DEAL-LOAD-' || lpad(i::text, 6, '0'),
+  1, 'RUB', 100000,
+  '{}'::jsonb, 'ACTIVE',
+  'terms-command-load-' || lpad(i::text, 6, '0'),
+  'terms-idem-load-' || lpad(i::text, 6, '0'),
+  md5('terms-load-' || i::text) || md5('terms-load-b-' || i::text),
+  'user-load-' || lpad((:buyer_count + 1 + ((i - 1) % :compliance_count))::text, 6, '0'),
+  'org-load-' || lpad((:buyer_count + 1 + ((i - 1) % :compliance_count))::text, 6, '0'),
+  now()
+FROM generate_series(1, :callback_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO settlement.payments (
+  id, tenant_id, deal_id, payment_terms_id, status, currency,
+  confirmed_reserved_minor, pending_reserved_minor,
+  confirmed_released_minor, pending_released_minor,
+  confirmed_refunded_minor, pending_refunded_minor,
+  active_hold_minor, reconciliation_status, version, created_at, updated_at
+)
+SELECT
+  'payment-load-' || lpad(i::text, 6, '0'),
+  'tenant-canonical-test',
+  'DEAL-LOAD-' || lpad(i::text, 6, '0'),
+  'terms-load-' || lpad(i::text, 6, '0'),
+  'RESERVE_PENDING', 'RUB',
+  0, 100000, 0, 0, 0, 0, 0, 'UNRECONCILED', 0, now(), now()
+FROM generate_series(1, :callback_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO settlement.bank_operations (
+  id, tenant_id, deal_id, payment_id, payment_terms_id, operation_type,
+  status, amount_minor, currency, required_partner_id, request_fingerprint,
+  command_id, idempotency_key, expected_payment_version, request_payload,
+  initiated_by_user_id, created_at
+)
+SELECT
+  'operation-load-' || lpad(i::text, 6, '0'),
+  'tenant-canonical-test',
+  'DEAL-LOAD-' || lpad(i::text, 6, '0'),
+  'payment-load-' || lpad(i::text, 6, '0'),
+  'terms-load-' || lpad(i::text, 6, '0'),
+  'RESERVE', 'PENDING', 100000, 'RUB', 'safe-deals',
+  md5('operation-load-' || i::text) || md5('operation-load-b-' || i::text),
+  'operation-command-load-' || lpad(i::text, 6, '0'),
+  'operation-idem-load-' || lpad(i::text, 6, '0'),
+  0,
+  jsonb_build_object('operation', 'RESERVE', 'amountMinor', '100000'),
+  'user-load-' || lpad((:buyer_count + 1 + ((i - 1) % :compliance_count))::text, 6, '0'),
+  now()
+FROM generate_series(1, :callback_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+COMMIT;
+
+\echo 'Seeding 10,000,000 domain/audit/outbox events'
+INSERT INTO public.deal_events (
+  id, "dealId", "eventType", "actorId", "actorRole", "tenantId",
+  payload, hash, "prevHash", "createdAt"
+)
+SELECT
+  'load-deal-event-' || lpad(i::text, 8, '0'),
+  'DEAL-LOAD-' || lpad((((i - 1) % :deal_count) + 1)::text, 6, '0'),
+  'LOAD_ACCEPTANCE_EVENT',
+  'user-load-' || lpad((:buyer_count + 1 + ((i - 1) % :compliance_count))::text, 6, '0'),
+  'COMPLIANCE_OFFICER',
+  'tenant-canonical-test',
+  jsonb_build_object('sequence', i, 'source', 'target-load'),
+  md5('deal-event-a-' || i::text) || md5('deal-event-b-' || i::text),
+  NULL,
+  now() - ((:domain_event_count - i)::text || ' milliseconds')::interval
+FROM generate_series(1, :domain_event_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.audit_events (
+  id, action, "actorUserId", "actorRole", "tenantId", "orgId", "dealId",
+  "objectType", "objectId", "afterState", outcome, metadata,
+  "correlationId", hash, "prevHash", "createdAt"
+)
+SELECT
+  'load-audit-event-' || lpad(i::text, 8, '0'),
+  'load.acceptance.event',
+  'user-load-' || lpad((:buyer_count + 1 + ((i - 1) % :compliance_count))::text, 6, '0'),
+  'COMPLIANCE_OFFICER',
+  'tenant-canonical-test',
+  'org-load-' || lpad((:buyer_count + 1 + ((i - 1) % :compliance_count))::text, 6, '0'),
+  'DEAL-LOAD-' || lpad((((i - 1) % :deal_count) + 1)::text, 6, '0'),
+  'DEAL',
+  'DEAL-LOAD-' || lpad((((i - 1) % :deal_count) + 1)::text, 6, '0'),
+  jsonb_build_object('sequence', i),
+  'SUCCESS',
+  jsonb_build_object('source', 'target-load'),
+  'load-correlation-' || lpad(i::text, 8, '0'),
+  md5('audit-event-a-' || i::text) || md5('audit-event-b-' || i::text),
+  NULL,
+  now() - ((:audit_event_count - i)::text || ' milliseconds')::interval
+FROM generate_series(1, :audit_event_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.outbox_entries (
+  id, type, "dealId", payload, status, "triggeredByUserId",
+  "idempotencyKey", "maxRetries", "retryCount", "nextRetryAt",
+  "correlationId", "createdAt", "sentAt", "confirmedAt"
+)
+SELECT
+  'load-outbox-event-' || lpad(i::text, 8, '0'),
+  'load.acceptance.persisted',
+  'DEAL-LOAD-' || lpad((((i - 1) % :deal_count) + 1)::text, 6, '0'),
+  jsonb_build_object('sequence', i, 'source', 'target-load'),
+  'SENT',
+  'user-load-' || lpad((:buyer_count + 1 + ((i - 1) % :compliance_count))::text, 6, '0'),
+  'load-outbox-idem-' || lpad(i::text, 8, '0'),
+  5, 0, now(),
+  'load-outbox-correlation-' || lpad(i::text, 8, '0'),
+  now() - ((:outbox_event_count - i)::text || ' milliseconds')::interval,
+  now(), now()
+FROM generate_series(1, :outbox_event_count) AS g(i)
+ON CONFLICT (id) DO NOTHING;
+
+ANALYZE public.organizations;
+ANALYZE public.users;
+ANALYZE public.user_orgs;
+ANALYZE auth.sessions;
+ANALYZE public.deals;
+ANALYZE public.deal_participants;
+ANALYZE public.deal_events;
+ANALYZE public.audit_events;
+ANALYZE public.outbox_entries;
+ANALYZE auction.lots;
+ANALYZE auction.admissions;
+ANALYZE settlement.payment_terms;
+ANALYZE settlement.payments;
+ANALYZE settlement.bank_operations;
+
+\echo 'Target-load seed complete'

--- a/scripts/release/enforce-target-load-evidence.mjs
+++ b/scripts/release/enforce-target-load-evidence.mjs
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const exactHead = process.env.EXACT_HEAD || process.env.GITHUB_SHA;
+const evidenceDir = process.env.EVIDENCE_DIR || 'artifacts/industrial-readiness/load';
+const evidencePath = path.join(evidenceDir, 'target-load-acceptance.json');
+
+if (!exactHead) throw new Error('EXACT_HEAD or GITHUB_SHA is required');
+if (!fs.existsSync(evidencePath)) throw new Error(`Missing canonical evidence: ${evidencePath}`);
+
+const evidence = JSON.parse(fs.readFileSync(evidencePath, 'utf8'));
+const errors = [];
+const observed = evidence.observed || {};
+const db = evidence.databaseInvariants || {};
+
+if (evidence.schemaVersion !== 1) errors.push('schemaVersion must equal 1');
+if (evidence.evidenceClass !== 'TARGET_LOAD_AND_BURST') errors.push('unexpected evidenceClass');
+if (evidence.exactCommit !== exactHead) errors.push(`exactCommit ${evidence.exactCommit} does not match ${exactHead}`);
+if (evidence.environment !== 'production-like-multi-node-kind') errors.push('unexpected environment');
+if (evidence.pass !== true || evidence.decision !== 'PASS') errors.push('acceptance decision is not PASS');
+if (!Array.isArray(evidence.violations) || evidence.violations.length !== 0) errors.push('violations must be empty');
+if (evidence.workload?.authenticatedSessions !== 5000) errors.push('5,000-session profile missing');
+if (evidence.workload?.loadDeals !== 50000) errors.push('50,000-Deal dataset missing');
+if (evidence.workload?.persistedEvents !== 10000000) errors.push('10,000,000-event dataset missing');
+if (evidence.workload?.sustained?.rps !== 500 || evidence.workload?.sustained?.durationSeconds !== 1800) errors.push('500 RPS / 30 minute profile missing');
+if (evidence.workload?.burst?.rps !== 1000 || evidence.workload?.burst?.durationSeconds !== 300) errors.push('1,000 RPS / 5 minute burst missing');
+if ((observed.sustained?.p95ReadMs ?? Infinity) > 500) errors.push('sustained read p95 > 500ms');
+if ((observed.burst?.p95ReadMs ?? Infinity) > 500) errors.push('burst read p95 > 500ms');
+if ((observed.commands?.p95Ms ?? Infinity) > 1000) errors.push('command p95 > 1000ms');
+if ((observed.auction?.p95Ms ?? Infinity) > 1000) errors.push('auction p95 > 1000ms');
+if ((observed.callbacks?.p95Ms ?? Infinity) > 1000) errors.push('callback p95 > 1000ms');
+for (const profile of ['sessions', 'sustained', 'burst', 'commands', 'auction', 'callbacks']) {
+  if ((observed[profile]?.unexpectedErrorRate ?? 1) >= 0.005) errors.push(`${profile} unexpected error rate >= 0.5%`);
+}
+if (observed.isolation?.leakageCount !== 0) errors.push('tenant leakage detected');
+if (Number(db.activeSessions) !== 5000) errors.push('activeSessions != 5000');
+if (Number(db.loadDeals) !== 50000) errors.push('loadDeals != 50000');
+if (Number(db.totalSeededEvents) !== 10000000) errors.push('totalSeededEvents != 10000000');
+if (Number(db.duplicateLedgerEffects) !== 0) errors.push('duplicate money effects detected');
+if (Number(db.doubleAuctionWinners) !== 0) errors.push('double auction winner detected');
+if (Number(db.activeLeaseDuplicates) !== 0) errors.push('duplicate active lease token detected');
+if (!String(evidence.supplyChain?.k6Image || '').includes(':1.7.1@sha256:')) errors.push('k6 image is not tag+digest pinned');
+if (evidence.maturity?.acceptedLevel !== 'PRODUCTION_LIKE_ACCEPTED') errors.push('acceptedLevel mismatch');
+
+if (errors.length) {
+  console.error(JSON.stringify({ evidencePath, errors }, null, 2));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({
+  evidencePath,
+  exactCommit: evidence.exactCommit,
+  decision: evidence.decision,
+  p95ReadMs: Math.max(observed.sustained.p95ReadMs, observed.burst.p95ReadMs),
+  p95CommandMs: observed.commands.p95Ms,
+  activeSessions: db.activeSessions,
+  loadDeals: db.loadDeals,
+  totalSeededEvents: db.totalSeededEvents,
+}, null, 2));

--- a/scripts/release/enforce-target-load-evidence.mjs
+++ b/scripts/release/enforce-target-load-evidence.mjs
@@ -4,9 +4,11 @@ import path from 'node:path';
 const exactHead = process.env.EXACT_HEAD || process.env.GITHUB_SHA;
 const evidenceDir = process.env.EVIDENCE_DIR || 'artifacts/industrial-readiness/load';
 const evidencePath = path.join(evidenceDir, 'target-load-acceptance.json');
+const junitPath = path.join(evidenceDir, 'target-load-acceptance.junit.xml');
 
 if (!exactHead) throw new Error('EXACT_HEAD or GITHUB_SHA is required');
 if (!fs.existsSync(evidencePath)) throw new Error(`Missing canonical evidence: ${evidencePath}`);
+if (!fs.existsSync(junitPath)) throw new Error(`Missing JUnit evidence: ${junitPath}`);
 
 const evidence = JSON.parse(fs.readFileSync(evidencePath, 'utf8'));
 const errors = [];
@@ -29,7 +31,26 @@ if ((observed.burst?.p95ReadMs ?? Infinity) > 500) errors.push('burst read p95 >
 if ((observed.commands?.p95Ms ?? Infinity) > 1000) errors.push('command p95 > 1000ms');
 if ((observed.auction?.p95Ms ?? Infinity) > 1000) errors.push('auction p95 > 1000ms');
 if ((observed.callbacks?.p95Ms ?? Infinity) > 1000) errors.push('callback p95 > 1000ms');
-for (const profile of ['sessions', 'sustained', 'burst', 'commands', 'auction', 'callbacks']) {
+const latencyFields = {
+  sustained: ['p50ReadMs', 'p95ReadMs', 'p99ReadMs'],
+  burst: ['p50ReadMs', 'p95ReadMs', 'p99ReadMs'],
+  commands: ['p50Ms', 'p95Ms', 'p99Ms'],
+  auction: ['p50Ms', 'p95Ms', 'p99Ms'],
+  callbacks: ['p50Ms', 'p95Ms', 'p99Ms'],
+};
+for (const [profile, fields] of Object.entries(latencyFields)) {
+  for (const field of fields) {
+    if (!Number.isFinite(observed[profile]?.[field])) errors.push(`${profile} ${field} missing`);
+  }
+}
+if ((observed.sessions?.maxVUs ?? 0) < 5000) errors.push('5,000 simultaneous k6 VUs not proven');
+if ((observed.sustained?.achievedRps ?? 0) < 495) errors.push('sustained achieved RPS < 495');
+if ((observed.burst?.achievedRps ?? 0) < 990) errors.push('burst achieved RPS < 990');
+if ((observed.commands?.achievedRps ?? 0) < 148.5) errors.push('command achieved RPS < 148.5');
+if ((observed.auction?.achievedRps ?? 0) < 198) errors.push('auction achieved attempts/s < 198');
+if ((observed.callbacks?.achievedRps ?? 0) < 198) errors.push('callback achieved attempts/s < 198');
+for (const profile of ['sessions', 'isolation', 'sustained', 'burst', 'commands', 'auction', 'callbacks']) {
+  if ((observed[profile]?.httpErrorRate ?? 1) >= 0.005) errors.push(`${profile} HTTP error rate >= 0.5%`);
   if ((observed[profile]?.unexpectedErrorRate ?? 1) >= 0.005) errors.push(`${profile} unexpected error rate >= 0.5%`);
 }
 if (observed.isolation?.leakageCount !== 0) errors.push('tenant leakage detected');

--- a/scripts/release/target-load-acceptance-wrapper.sh
+++ b/scripts/release/target-load-acceptance-wrapper.sh
@@ -28,18 +28,18 @@ done
 
 const waitAfter = `admin_sql "
 INSERT INTO public.organizations
-  (id,inn,name,type,status,\"tenantId\",\"verifiedAt\",\"kycStatus\",\"amlStatus\",\"sanctionHit\",\"createdAt\",\"updatedAt\")
+  (id,inn,name,type,status,\\"tenantId\\",\\"verifiedAt\\",\\"kycStatus\\",\\"amlStatus\\",\\"sanctionHit\\",\\"createdAt\\",\\"updatedAt\\")
 VALUES
   ('org-canonical-seller','990000000003','Canonical Load Seller','LEGAL','VERIFIED','tenant-canonical-test',now(),'APPROVED','CLEAR',false,now(),now()),
   ('org-canonical-buyer','990000000002','Canonical Load Buyer','LEGAL','VERIFIED','tenant-canonical-test',now(),'APPROVED','CLEAR',false,now(),now())
-ON CONFLICT (id) DO UPDATE SET \"tenantId\"=EXCLUDED.\"tenantId\",status='VERIFIED',\"updatedAt\"=now();
+ON CONFLICT (id) DO UPDATE SET \\"tenantId\\"=EXCLUDED.\\"tenantId\\",status='VERIFIED',\\"updatedAt\\"=now();
 INSERT INTO public.deals
-  (id,status,\"tenantId\",\"sellerOrgId\",\"buyerOrgId\",\"volumeTonsDec\",\"pricePerTonDec\",\"totalKopecks\",version,currency,culture,region,\"nextAction\",\"createdAt\",\"updatedAt\")
+  (id,status,\\"tenantId\\",\\"sellerOrgId\\",\\"buyerOrgId\\",\\"volumeTonsDec\\",\\"pricePerTonDec\\",\\"totalKopecks\\",version,currency,culture,region,\\"nextAction\\",\\"createdAt\\",\\"updatedAt\\")
 VALUES
   ('DEAL-INDUSTRIAL-001','DRAFT','tenant-canonical-test','org-canonical-seller','org-canonical-buyer',150.000000,16000.000000,240000000,0,'RUB','WHEAT','LOAD-REGION','approve_admission',TIMESTAMPTZ '\${DEAL_UPDATED_AT}',TIMESTAMPTZ '\${DEAL_UPDATED_AT}')
-ON CONFLICT (id) DO UPDATE SET status='DRAFT',\"tenantId\"='tenant-canonical-test',version=0,\"updatedAt\"=TIMESTAMPTZ '\${DEAL_UPDATED_AT}';
+ON CONFLICT (id) DO UPDATE SET status='DRAFT',\\"tenantId\\"='tenant-canonical-test',version=0,\\"updatedAt\\"=TIMESTAMPTZ '\${DEAL_UPDATED_AT}';
 " >/dev/null
-[[ "$(admin_sql "SELECT count(*) FROM public.deals WHERE id='DEAL-INDUSTRIAL-001' AND \"tenantId\"='tenant-canonical-test';")" = "1" ]]`;
+[[ "$(admin_sql "SELECT count(*) FROM public.deals WHERE id='DEAL-INDUSTRIAL-001' AND \\"tenantId\\"='tenant-canonical-test';")" = "1" ]]`;
 
 let rendered = source;
 for (const [before, after] of envReplacements) {

--- a/scripts/release/target-load-acceptance-wrapper.sh
+++ b/scripts/release/target-load-acceptance-wrapper.sh
@@ -12,14 +12,13 @@ SOURCE="$SOURCE" GENERATED="$GENERATED" node <<'NODE'
 const fs = require('node:fs');
 const source = fs.readFileSync(process.env.SOURCE, 'utf8');
 
-const envBefore = `kubectl set env deployment/grainflow-api -n "$NAMESPACE" \\
-  SEED_CANONICAL_TEST_DEAL=true \\
-  ALLOW_CANONICAL_TEST_DEAL_IN_PRODUCTION=true \\
-  RATE_LIMIT_DEAL_COMMAND=1000000`;
-const envAfter = `kubectl set env deployment/grainflow-api -n "$NAMESPACE" \\
-  SEED_CANONICAL_TEST_DEAL=false \\
-  ALLOW_CANONICAL_TEST_DEAL_IN_PRODUCTION=false \\
-  RATE_LIMIT_DEAL_COMMAND=1000000`;
+const envReplacements = [
+  ['SEED_CANONICAL_TEST_DEAL=true', 'SEED_CANONICAL_TEST_DEAL=false'],
+  [
+    'ALLOW_CANONICAL_TEST_DEAL_IN_PRODUCTION=true',
+    'ALLOW_CANONICAL_TEST_DEAL_IN_PRODUCTION=false',
+  ],
+];
 
 const waitBefore = `for _ in $(seq 1 180); do
   [[ "$(admin_sql "SELECT count(*) FROM public.deals WHERE id='DEAL-INDUSTRIAL-001';")" = "1" ]] && break
@@ -42,11 +41,25 @@ ON CONFLICT (id) DO UPDATE SET status='DRAFT',\"tenantId\"='tenant-canonical-tes
 " >/dev/null
 [[ "$(admin_sql "SELECT count(*) FROM public.deals WHERE id='DEAL-INDUSTRIAL-001' AND \"tenantId\"='tenant-canonical-test';")" = "1" ]]`;
 
-if (!source.includes(envBefore)) throw new Error('target-load API env boundary not found');
-if (!source.includes(waitBefore)) throw new Error('target-load canonical seed boundary not found');
-let rendered = source.replace(envBefore, envAfter).replace(waitBefore, waitAfter);
-if (rendered === source || rendered.includes(envBefore) || rendered.includes(waitBefore)) {
-  throw new Error('target-load wrapper did not replace boundaries exactly once');
+let rendered = source;
+for (const [before, after] of envReplacements) {
+  const count = rendered.split(before).length - 1;
+  if (count !== 1) {
+    throw new Error(`target-load environment boundary "${before}" occurred ${count} times`);
+  }
+  rendered = rendered.replace(before, after);
+}
+const waitCount = rendered.split(waitBefore).length - 1;
+if (waitCount !== 1) {
+  throw new Error(`target-load canonical seed boundary occurred ${waitCount} times`);
+}
+rendered = rendered.replace(waitBefore, waitAfter);
+if (
+  rendered === source
+  || rendered.includes(waitBefore)
+  || envReplacements.some(([before]) => rendered.includes(before))
+) {
+  throw new Error('target-load wrapper did not replace all boundaries exactly once');
 }
 fs.writeFileSync(process.env.GENERATED, rendered, { mode: 0o700 });
 NODE

--- a/scripts/release/target-load-acceptance-wrapper.sh
+++ b/scripts/release/target-load-acceptance-wrapper.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE="$ROOT_DIR/scripts/release/target-load-acceptance.sh"
+GENERATED="$ROOT_DIR/scripts/release/.target-load-acceptance.generated.sh"
+
+cleanup() { rm -f "$GENERATED"; }
+trap cleanup EXIT
+
+SOURCE="$SOURCE" GENERATED="$GENERATED" node <<'NODE'
+const fs = require('node:fs');
+const source = fs.readFileSync(process.env.SOURCE, 'utf8');
+
+const envBefore = `kubectl set env deployment/grainflow-api -n "$NAMESPACE" \\
+  SEED_CANONICAL_TEST_DEAL=true \\
+  ALLOW_CANONICAL_TEST_DEAL_IN_PRODUCTION=true \\
+  RATE_LIMIT_DEAL_COMMAND=1000000`;
+const envAfter = `kubectl set env deployment/grainflow-api -n "$NAMESPACE" \\
+  SEED_CANONICAL_TEST_DEAL=false \\
+  ALLOW_CANONICAL_TEST_DEAL_IN_PRODUCTION=false \\
+  RATE_LIMIT_DEAL_COMMAND=1000000`;
+
+const waitBefore = `for _ in $(seq 1 180); do
+  [[ "$(admin_sql "SELECT count(*) FROM public.deals WHERE id='DEAL-INDUSTRIAL-001';")" = "1" ]] && break
+  sleep 2
+done
+[[ "$(admin_sql "SELECT count(*) FROM public.deals WHERE id='DEAL-INDUSTRIAL-001';")" = "1" ]]`;
+
+const waitAfter = `admin_sql "
+INSERT INTO public.organizations
+  (id,inn,name,type,status,\"tenantId\",\"verifiedAt\",\"kycStatus\",\"amlStatus\",\"sanctionHit\",\"createdAt\",\"updatedAt\")
+VALUES
+  ('org-canonical-seller','990000000003','Canonical Load Seller','LEGAL','VERIFIED','tenant-canonical-test',now(),'APPROVED','CLEAR',false,now(),now()),
+  ('org-canonical-buyer','990000000002','Canonical Load Buyer','LEGAL','VERIFIED','tenant-canonical-test',now(),'APPROVED','CLEAR',false,now(),now())
+ON CONFLICT (id) DO UPDATE SET \"tenantId\"=EXCLUDED.\"tenantId\",status='VERIFIED',\"updatedAt\"=now();
+INSERT INTO public.deals
+  (id,status,\"tenantId\",\"sellerOrgId\",\"buyerOrgId\",\"volumeTonsDec\",\"pricePerTonDec\",\"totalKopecks\",version,currency,culture,region,\"nextAction\",\"createdAt\",\"updatedAt\")
+VALUES
+  ('DEAL-INDUSTRIAL-001','DRAFT','tenant-canonical-test','org-canonical-seller','org-canonical-buyer',150.000000,16000.000000,240000000,0,'RUB','WHEAT','LOAD-REGION','approve_admission',TIMESTAMPTZ '\${DEAL_UPDATED_AT}',TIMESTAMPTZ '\${DEAL_UPDATED_AT}')
+ON CONFLICT (id) DO UPDATE SET status='DRAFT',\"tenantId\"='tenant-canonical-test',version=0,\"updatedAt\"=TIMESTAMPTZ '\${DEAL_UPDATED_AT}';
+" >/dev/null
+[[ "$(admin_sql "SELECT count(*) FROM public.deals WHERE id='DEAL-INDUSTRIAL-001' AND \"tenantId\"='tenant-canonical-test';")" = "1" ]]`;
+
+if (!source.includes(envBefore)) throw new Error('target-load API env boundary not found');
+if (!source.includes(waitBefore)) throw new Error('target-load canonical seed boundary not found');
+let rendered = source.replace(envBefore, envAfter).replace(waitBefore, waitAfter);
+if (rendered === source || rendered.includes(envBefore) || rendered.includes(waitBefore)) {
+  throw new Error('target-load wrapper did not replace boundaries exactly once');
+}
+fs.writeFileSync(process.env.GENERATED, rendered, { mode: 0o700 });
+NODE
+
+bash "$GENERATED"

--- a/scripts/release/target-load-acceptance.sh
+++ b/scripts/release/target-load-acceptance.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+EXACT_HEAD="${EXACT_HEAD:-${GITHUB_SHA:-unknown}}"
+EVIDENCE_DIR="${EVIDENCE_DIR:-artifacts/industrial-readiness/load}"
+RAW_DIR="$EVIDENCE_DIR/raw"
+NAMESPACE="grainflow-acceptance"
+TOKENS_PATH="$EVIDENCE_DIR/tokens.json"
+FAILURE_REASON="target-load acceptance did not start"
+SUCCESS=0
+
+SESSION_COUNT=5000
+BUYER_COUNT=2500
+ISOLATED_COUNT=10
+COMPLIANCE_COUNT=$((SESSION_COUNT - BUYER_COUNT - ISOLATED_COUNT))
+DEAL_COUNT=50000
+DOMAIN_EVENT_COUNT=3333334
+AUDIT_EVENT_COUNT=3333333
+OUTBOX_EVENT_COUNT=3333333
+CALLBACK_COUNT=24000
+DEAL_UPDATED_AT='2026-07-17T00:00:00.000Z'
+
+mkdir -p "$RAW_DIR"
+rm -f "$EVIDENCE_DIR/target-load-acceptance.json" "$EVIDENCE_DIR/failure-reason.txt" "$TOKENS_PATH"
+
+mask() { printf '::add-mask::%s\n' "$1"; }
+
+collect_diagnostics() {
+  set +e
+  kubectl get nodes -o wide > "$RAW_DIR/nodes.txt" 2>&1
+  kubectl get deployments,pods,services -n "$NAMESPACE" -o wide > "$RAW_DIR/kubernetes-inventory.txt" 2>&1
+  kubectl get events -n "$NAMESPACE" --sort-by=.lastTimestamp > "$RAW_DIR/events.txt" 2>&1
+  kubectl logs -n "$NAMESPACE" deployment/grainflow-api --all-containers=true --tail=1000 > "$RAW_DIR/api.log" 2>&1
+  kubectl logs -n "$NAMESPACE" deployment/grainflow-outbox-worker --all-containers=true --tail=1000 > "$RAW_DIR/outbox-worker.log" 2>&1
+  df -h > "$RAW_DIR/disk.txt" 2>&1
+  docker stats --no-stream > "$RAW_DIR/docker-stats.txt" 2>&1
+}
+
+on_error() {
+  local rc=$?
+  set +e
+  printf '%s\n' "$FAILURE_REASON" > "$EVIDENCE_DIR/failure-reason.txt"
+  collect_diagnostics
+  exit "$rc"
+}
+trap on_error ERR
+trap 'rm -f "$TOKENS_PATH"' EXIT
+
+for command in base64 curl docker jq kubectl node openssl; do command -v "$command" >/dev/null; done
+
+POSTGRES_PASSWORD="$(kubectl get secret grainflow-postgresql-secrets -n "$NAMESPACE" -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)"
+JWT_SECRET="$(kubectl get secret grainflow-api-secrets -n "$NAMESPACE" -o jsonpath='{.data.JWT_SECRET}' | base64 -d)"
+BANK_HMAC_SECRET="$(openssl rand -hex 32)"
+mask "$POSTGRES_PASSWORD"
+mask "$JWT_SECRET"
+mask "$BANK_HMAC_SECRET"
+
+admin_sql() {
+  local sql="$1"
+  kubectl exec -n "$NAMESPACE" statefulset/postgresql -- \
+    env PGPASSWORD="$POSTGRES_PASSWORD" \
+    psql -v ON_ERROR_STOP=1 -U postgres -d grainflow -Atc "$sql"
+}
+
+FAILURE_REASON="canonical Deal seed and load-specific API configuration failed"
+kubectl scale deployment/grainflow-api -n "$NAMESPACE" --replicas=1
+kubectl rollout status deployment/grainflow-api -n "$NAMESPACE" --timeout=600s
+kubectl set env deployment/grainflow-api -n "$NAMESPACE" \
+  SEED_CANONICAL_TEST_DEAL=true \
+  ALLOW_CANONICAL_TEST_DEAL_IN_PRODUCTION=true \
+  RATE_LIMIT_DEAL_COMMAND=1000000 \
+  RATE_LIMIT_DEAL_COMMAND_WINDOW_SECONDS=60 \
+  RATE_LIMIT_BANK_CALLBACK=1000000 \
+  RATE_LIMIT_BANK_CALLBACK_WINDOW_SECONDS=60 \
+  BANK_HMAC_SECRET="$BANK_HMAC_SECRET" \
+  BANK_HMAC_KEY_ID=load-primary \
+  BANK_PARTNER_ID=safe-deals
+kubectl rollout status deployment/grainflow-api -n "$NAMESPACE" --timeout=900s
+for _ in $(seq 1 180); do
+  [[ "$(admin_sql "SELECT count(*) FROM public.deals WHERE id='DEAL-INDUSTRIAL-001';")" = "1" ]] && break
+  sleep 2
+done
+[[ "$(admin_sql "SELECT count(*) FROM public.deals WHERE id='DEAL-INDUSTRIAL-001';")" = "1" ]]
+
+FAILURE_REASON="target-load dataset generation failed"
+kubectl exec -i -n "$NAMESPACE" statefulset/postgresql -- \
+  env PGPASSWORD="$POSTGRES_PASSWORD" \
+  psql -v ON_ERROR_STOP=1 -U postgres -d grainflow \
+    -v session_count="$SESSION_COUNT" \
+    -v buyer_count="$BUYER_COUNT" \
+    -v isolated_count="$ISOLATED_COUNT" \
+    -v compliance_count="$COMPLIANCE_COUNT" \
+    -v deal_count="$DEAL_COUNT" \
+    -v domain_event_count="$DOMAIN_EVENT_COUNT" \
+    -v audit_event_count="$AUDIT_EVENT_COUNT" \
+    -v outbox_event_count="$OUTBOX_EVENT_COUNT" \
+    -v callback_count="$CALLBACK_COUNT" \
+    -v deal_updated_at="$DEAL_UPDATED_AT" \
+  < infra/kind/target-load/seed.sql \
+  2>&1 | tee "$RAW_DIR/seed.log"
+
+FAILURE_REASON="5,000 distinct access-session tokens could not be generated"
+JWT_SECRET="$JWT_SECRET" \
+TOKENS_PATH="$TOKENS_PATH" \
+SESSION_COUNT="$SESSION_COUNT" \
+BUYER_COUNT="$BUYER_COUNT" \
+ISOLATED_COUNT="$ISOLATED_COUNT" \
+node scripts/release/target-load-generate-tokens.mjs | tee "$RAW_DIR/token-generation.json"
+chmod 0600 "$TOKENS_PATH"
+[[ "$(jq -r '.sessionCount' "$TOKENS_PATH")" = "$SESSION_COUNT" ]]
+[[ "$(jq -r '.all | length' "$TOKENS_PATH")" = "$SESSION_COUNT" ]]
+
+FAILURE_REASON="horizontal application and worker scale-out failed"
+kubectl scale deployment/grainflow-api -n "$NAMESPACE" --replicas=4
+kubectl scale deployment/grainflow-outbox-worker -n "$NAMESPACE" --replicas=4
+kubectl rollout status deployment/grainflow-api -n "$NAMESPACE" --timeout=900s
+kubectl rollout status deployment/grainflow-outbox-worker -n "$NAMESPACE" --timeout=900s
+[[ "$(kubectl get deployment grainflow-api -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}')" = "4" ]]
+[[ "$(kubectl get deployment grainflow-outbox-worker -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}')" = "4" ]]
+
+K6_TAG="grafana/k6:1.7.1"
+FAILURE_REASON="pinned k6 load generator could not be resolved"
+docker pull "$K6_TAG" > "$RAW_DIR/k6-image-pull.log"
+K6_REPO_DIGEST="$(docker image inspect "$K6_TAG" --format '{{index .RepoDigests 0}}')"
+K6_IMAGE="${K6_TAG}@${K6_REPO_DIGEST#*@}"
+[[ "$K6_IMAGE" == *:*@sha256:* ]]
+printf '%s\n' "$K6_IMAGE" > "$RAW_DIR/k6-image.txt"
+
+curl_api() {
+  local path="$1"
+  curl --fail --silent --show-error --max-time 10 --retry 3 --retry-all-errors \
+    --resolve api.acceptance.grainflow.invalid:8080:127.0.0.1 \
+    "http://api.acceptance.grainflow.invalid:8080${path}"
+}
+curl_api /ready > "$RAW_DIR/api-ready-before-load.json"
+curl_api /metrics > "$RAW_DIR/api-metrics-before.prom"
+
+run_profile() {
+  local profile="$1"
+  local summary="$RAW_DIR/k6-${profile}-summary.json"
+  local json_output="$RAW_DIR/k6-${profile}-samples.json"
+  docker run --rm --network host \
+    -v "$ROOT_DIR:/work:ro" \
+    -v "$(cd "$EVIDENCE_DIR" && pwd):/evidence" \
+    -e PROFILE="$profile" \
+    -e BASE_URL=http://127.0.0.1:8080 \
+    -e HOST_HEADER=api.acceptance.grainflow.invalid \
+    -e TOKENS_PATH=/evidence/tokens.json \
+    -e K6_SUMMARY_PATH="/evidence/raw/k6-${profile}-summary.json" \
+    -e BANK_HMAC_SECRET="$BANK_HMAC_SECRET" \
+    -e BANK_HMAC_KEY_ID=load-primary \
+    -e BANK_PARTNER_ID=safe-deals \
+    -e DEAL_UPDATED_AT="$DEAL_UPDATED_AT" \
+    "$K6_IMAGE" run --out "json=/evidence/raw/k6-${profile}-samples.json" \
+    /work/scripts/release/target-load.k6.js \
+    2>&1 | tee "$RAW_DIR/k6-${profile}.log"
+  test -s "$summary"
+  test -s "$json_output"
+}
+
+FAILURE_REASON="5,000 distinct authenticated sessions were not accepted"
+run_profile sessions
+
+FAILURE_REASON="tenant isolation acceptance failed"
+run_profile isolation
+
+FAILURE_REASON="500 RPS sustained profile or zero-downtime scale cycle failed"
+run_profile sustained &
+SUSTAINED_PID=$!
+SCALE_EVENTS="$RAW_DIR/scale-events.jsonl"
+printf '{"event":"sustained_started","at":"%s","apiReplicas":4}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$SCALE_EVENTS"
+sleep 300
+kubectl scale deployment/grainflow-api -n "$NAMESPACE" --replicas=6
+kubectl rollout status deployment/grainflow-api -n "$NAMESPACE" --timeout=900s
+curl_api /ready > "$RAW_DIR/api-ready-scale-out.json"
+printf '{"event":"api_scale_out","at":"%s","apiReplicas":6}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$SCALE_EVENTS"
+sleep 300
+kubectl scale deployment/grainflow-api -n "$NAMESPACE" --replicas=4
+kubectl rollout status deployment/grainflow-api -n "$NAMESPACE" --timeout=900s
+curl_api /ready > "$RAW_DIR/api-ready-scale-in.json"
+printf '{"event":"api_scale_in","at":"%s","apiReplicas":4}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$SCALE_EVENTS"
+wait "$SUSTAINED_PID"
+printf '{"event":"sustained_completed","at":"%s","apiReplicas":4}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$SCALE_EVENTS"
+jq -s '.' "$SCALE_EVENTS" > "$RAW_DIR/scale-events.json"
+
+FAILURE_REASON="1,000 RPS burst profile failed"
+run_profile burst
+
+FAILURE_REASON="authoritative Deal command profile failed"
+run_profile commands
+
+FAILURE_REASON="200 bids/second hot-lot contention profile failed"
+run_profile auction
+
+FAILURE_REASON="signed bank callback storm failed"
+run_profile callbacks
+
+FAILURE_REASON="post-load readiness or database invariant reconciliation failed"
+curl_api /ready > "$RAW_DIR/api-ready-after-load.json"
+curl_api /metrics > "$RAW_DIR/api-metrics-after.prom"
+
+admin_sql "
+SELECT jsonb_pretty(jsonb_build_object(
+  'activeSessions', (SELECT count(*) FROM auth.sessions WHERE id LIKE 'session-load-%' AND status='ACTIVE'),
+  'loadDeals', (SELECT count(*) FROM public.deals WHERE id LIKE 'DEAL-LOAD-%'),
+  'domainEvents', (SELECT count(*) FROM public.deal_events WHERE id LIKE 'load-deal-event-%'),
+  'auditEvents', (SELECT count(*) FROM public.audit_events WHERE id LIKE 'load-audit-event-%'),
+  'outboxEvents', (SELECT count(*) FROM public.outbox_entries WHERE id LIKE 'load-outbox-event-%'),
+  'totalSeededEvents', (
+    (SELECT count(*) FROM public.deal_events WHERE id LIKE 'load-deal-event-%') +
+    (SELECT count(*) FROM public.audit_events WHERE id LIKE 'load-audit-event-%') +
+    (SELECT count(*) FROM public.outbox_entries WHERE id LIKE 'load-outbox-event-%')
+  ),
+  'callbackRows', (SELECT count(*) FROM settlement.bank_callbacks WHERE event_id LIKE 'load-callback-%'),
+  'confirmedReserveOperations', (SELECT count(*) FROM settlement.bank_operations WHERE id LIKE 'operation-load-%' AND status='CONFIRMED'),
+  'confirmedPayments', (SELECT count(*) FROM settlement.payments WHERE id LIKE 'payment-load-%' AND confirmed_reserved_minor=100000 AND pending_reserved_minor=0),
+  'duplicateLedgerEffects', (
+    SELECT count(*) FROM (
+      SELECT operation_id FROM settlement.ledger_entries
+      WHERE operation_id LIKE 'operation-load-%'
+      GROUP BY operation_id HAVING count(*) <> 1
+    ) duplicate_effects
+  ),
+  'doubleAuctionWinners', (
+    SELECT count(*) FROM (
+      SELECT tenant_id, lot_id FROM auction.awards
+      GROUP BY tenant_id, lot_id HAVING count(*) > 1
+    ) duplicate_winners
+  ),
+  'hotLotBidRows', (SELECT count(*) FROM auction.bids WHERE lot_id='lot-load-hot'),
+  'activeLeaseDuplicates', (
+    SELECT count(*) FROM (
+      SELECT lease_token FROM public.outbox_entries
+      WHERE lease_token IS NOT NULL GROUP BY lease_token HAVING count(*) > 1
+    ) duplicate_leases
+  ),
+  'databaseSizeBytes', pg_database_size(current_database())
+));
+" > "$RAW_DIR/db-invariants.json"
+
+kubectl get deployments grainflow-api grainflow-outbox-worker pgbouncer -n "$NAMESPACE" -o json | \
+  jq '{deployments:[.items[]|{name:.metadata.name,desired:.spec.replicas,ready:.status.readyReplicas,available:.status.availableReplicas,image:.spec.template.spec.containers[0].image}]}' \
+  > "$RAW_DIR/topology.json"
+
+node scripts/release/target-load-build-evidence.mjs
+node scripts/release/enforce-target-load-evidence.mjs
+collect_diagnostics
+SUCCESS=1
+printf 'Target load acceptance PASS for %s\n' "$EXACT_HEAD"

--- a/scripts/release/target-load-build-evidence.mjs
+++ b/scripts/release/target-load-build-evidence.mjs
@@ -37,49 +37,78 @@ function deployment(name) {
 const observed = {
   sessions: {
     iterations: count('sessions'),
+    achievedRps: rate('sessions', 'iterations'),
+    maxVUs: Number(metric('sessions', 'vus_max', 'max', 0)),
+    httpErrorRate: rate('sessions', 'http_req_failed'),
     unexpectedErrorRate: rate('sessions', 'unexpected_errors'),
   },
   isolation: {
     iterations: count('isolation'),
+    achievedRps: rate('isolation', 'iterations'),
+    maxVUs: Number(metric('isolation', 'vus_max', 'max', 0)),
     leakageCount: count('isolation', 'tenant_leakage'),
+    httpErrorRate: rate('isolation', 'http_req_failed'),
     unexpectedErrorRate: rate('isolation', 'unexpected_errors'),
   },
   sustained: {
     iterations: count('sustained'),
+    achievedRps: rate('sustained', 'iterations'),
+    maxVUs: Number(metric('sustained', 'vus_max', 'max', 0)),
     droppedIterations: count('sustained', 'dropped_iterations'),
+    p50ReadMs: Number(metric('sustained', 'authoritative_read_duration', 'med', Number.POSITIVE_INFINITY)),
     p95ReadMs: p95('sustained', 'authoritative_read_duration'),
     p99ReadMs: Number(metric('sustained', 'authoritative_read_duration', 'p(99)', Number.POSITIVE_INFINITY)),
+    httpErrorRate: rate('sustained', 'http_req_failed'),
     unexpectedErrorRate: rate('sustained', 'unexpected_errors'),
     durationMs: Number(summaries.sustained.state?.testRunDurationMs ?? 0),
   },
   burst: {
     iterations: count('burst'),
+    achievedRps: rate('burst', 'iterations'),
+    maxVUs: Number(metric('burst', 'vus_max', 'max', 0)),
     droppedIterations: count('burst', 'dropped_iterations'),
+    p50ReadMs: Number(metric('burst', 'authoritative_read_duration', 'med', Number.POSITIVE_INFINITY)),
     p95ReadMs: p95('burst', 'authoritative_read_duration'),
     p99ReadMs: Number(metric('burst', 'authoritative_read_duration', 'p(99)', Number.POSITIVE_INFINITY)),
+    httpErrorRate: rate('burst', 'http_req_failed'),
     unexpectedErrorRate: rate('burst', 'unexpected_errors'),
     durationMs: Number(summaries.burst.state?.testRunDurationMs ?? 0),
   },
   commands: {
     iterations: count('commands'),
+    achievedRps: rate('commands', 'iterations'),
+    maxVUs: Number(metric('commands', 'vus_max', 'max', 0)),
     accepted: count('commands', 'command_accepted'),
     droppedIterations: count('commands', 'dropped_iterations'),
+    p50Ms: Number(metric('commands', 'authoritative_command_duration', 'med', Number.POSITIVE_INFINITY)),
     p95Ms: p95('commands', 'authoritative_command_duration'),
+    p99Ms: Number(metric('commands', 'authoritative_command_duration', 'p(99)', Number.POSITIVE_INFINITY)),
+    httpErrorRate: rate('commands', 'http_req_failed'),
     unexpectedErrorRate: rate('commands', 'unexpected_errors'),
   },
   auction: {
     iterations: count('auction'),
+    achievedRps: rate('auction', 'iterations'),
+    maxVUs: Number(metric('auction', 'vus_max', 'max', 0)),
     accepted: count('auction', 'auction_accepted'),
     expectedConflicts: count('auction', 'auction_expected_conflicts'),
     droppedIterations: count('auction', 'dropped_iterations'),
+    p50Ms: Number(metric('auction', 'auction_command_duration', 'med', Number.POSITIVE_INFINITY)),
     p95Ms: p95('auction', 'auction_command_duration'),
+    p99Ms: Number(metric('auction', 'auction_command_duration', 'p(99)', Number.POSITIVE_INFINITY)),
+    httpErrorRate: rate('auction', 'http_req_failed'),
     unexpectedErrorRate: rate('auction', 'unexpected_errors'),
   },
   callbacks: {
     iterations: count('callbacks'),
+    achievedRps: rate('callbacks', 'iterations'),
+    maxVUs: Number(metric('callbacks', 'vus_max', 'max', 0)),
     accepted: count('callbacks', 'callback_accepted'),
     droppedIterations: count('callbacks', 'dropped_iterations'),
+    p50Ms: Number(metric('callbacks', 'bank_callback_duration', 'med', Number.POSITIVE_INFINITY)),
     p95Ms: p95('callbacks', 'bank_callback_duration'),
+    p99Ms: Number(metric('callbacks', 'bank_callback_duration', 'p(99)', Number.POSITIVE_INFINITY)),
+    httpErrorRate: rate('callbacks', 'http_req_failed'),
     unexpectedErrorRate: rate('callbacks', 'unexpected_errors'),
   },
 };
@@ -110,28 +139,47 @@ const require = (condition, code, details) => { if (!condition) violations.push(
 const atLeast = (actual, expected) => actual >= Math.floor(expected * 0.99);
 
 require(observed.sessions.iterations >= thresholds.activeSessions, 'SESSION_CONCURRENCY_NOT_PROVEN', observed.sessions);
+require(observed.sessions.maxVUs >= thresholds.activeSessions, 'SESSION_VU_CONCURRENCY_NOT_PROVEN', observed.sessions);
+require(observed.sessions.httpErrorRate < thresholds.unexpectedErrorRate, 'SESSION_HTTP_ERROR_RATE_EXCEEDED', observed.sessions);
 require(observed.sessions.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'SESSION_ERROR_RATE_EXCEEDED', observed.sessions);
 require(observed.isolation.iterations >= 1000, 'TENANT_ISOLATION_SAMPLE_INCOMPLETE', observed.isolation);
 require(observed.isolation.leakageCount === 0, 'TENANT_LEAKAGE_DETECTED', observed.isolation);
+require(observed.isolation.httpErrorRate < thresholds.unexpectedErrorRate, 'ISOLATION_HTTP_ERROR_RATE_EXCEEDED', observed.isolation);
+require(observed.isolation.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'ISOLATION_ERROR_RATE_EXCEEDED', observed.isolation);
 require(atLeast(observed.sustained.iterations, thresholds.sustainedRps * thresholds.sustainedSeconds), 'SUSTAINED_RATE_NOT_ACHIEVED', observed.sustained);
 require(observed.sustained.droppedIterations === 0, 'SUSTAINED_DROPPED_ITERATIONS', observed.sustained);
 require(observed.sustained.p95ReadMs <= thresholds.readP95Ms, 'SUSTAINED_READ_P95_EXCEEDED', observed.sustained);
+require(observed.sustained.achievedRps >= thresholds.sustainedRps * 0.99, 'SUSTAINED_RPS_NOT_ACHIEVED', observed.sustained);
+require(Number.isFinite(observed.sustained.p50ReadMs) && Number.isFinite(observed.sustained.p95ReadMs) && Number.isFinite(observed.sustained.p99ReadMs), 'SUSTAINED_LATENCY_DISTRIBUTION_MISSING', observed.sustained);
+require(observed.sustained.httpErrorRate < thresholds.unexpectedErrorRate, 'SUSTAINED_HTTP_ERROR_RATE_EXCEEDED', observed.sustained);
 require(observed.sustained.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'SUSTAINED_ERROR_RATE_EXCEEDED', observed.sustained);
 require(atLeast(observed.burst.iterations, thresholds.burstRps * thresholds.burstSeconds), 'BURST_RATE_NOT_ACHIEVED', observed.burst);
 require(observed.burst.droppedIterations === 0, 'BURST_DROPPED_ITERATIONS', observed.burst);
 require(observed.burst.p95ReadMs <= thresholds.readP95Ms, 'BURST_READ_P95_EXCEEDED', observed.burst);
+require(observed.burst.achievedRps >= thresholds.burstRps * 0.99, 'BURST_RPS_NOT_ACHIEVED', observed.burst);
+require(Number.isFinite(observed.burst.p50ReadMs) && Number.isFinite(observed.burst.p95ReadMs) && Number.isFinite(observed.burst.p99ReadMs), 'BURST_LATENCY_DISTRIBUTION_MISSING', observed.burst);
+require(observed.burst.httpErrorRate < thresholds.unexpectedErrorRate, 'BURST_HTTP_ERROR_RATE_EXCEEDED', observed.burst);
 require(observed.burst.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'BURST_ERROR_RATE_EXCEEDED', observed.burst);
 require(atLeast(observed.commands.iterations, 150 * 240), 'COMMAND_RATE_NOT_ACHIEVED', observed.commands);
 require(observed.commands.accepted === observed.commands.iterations, 'COMMAND_ACCEPTANCE_GAP', observed.commands);
 require(observed.commands.p95Ms <= thresholds.commandP95Ms, 'COMMAND_P95_EXCEEDED', observed.commands);
+require(observed.commands.achievedRps >= 150 * 0.99, 'COMMAND_RPS_NOT_ACHIEVED', observed.commands);
+require(Number.isFinite(observed.commands.p50Ms) && Number.isFinite(observed.commands.p95Ms) && Number.isFinite(observed.commands.p99Ms), 'COMMAND_LATENCY_DISTRIBUTION_MISSING', observed.commands);
+require(observed.commands.httpErrorRate < thresholds.unexpectedErrorRate, 'COMMAND_HTTP_ERROR_RATE_EXCEEDED', observed.commands);
 require(observed.commands.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'COMMAND_ERROR_RATE_EXCEEDED', observed.commands);
 require(atLeast(observed.auction.iterations, thresholds.auctionAttemptsPerSecond * thresholds.auctionSeconds), 'AUCTION_ATTEMPT_RATE_NOT_ACHIEVED', observed.auction);
 require(observed.auction.accepted + observed.auction.expectedConflicts === observed.auction.iterations, 'AUCTION_UNCLASSIFIED_RESULTS', observed.auction);
 require(observed.auction.p95Ms <= thresholds.commandP95Ms, 'AUCTION_P95_EXCEEDED', observed.auction);
+require(observed.auction.achievedRps >= thresholds.auctionAttemptsPerSecond * 0.99, 'AUCTION_RPS_NOT_ACHIEVED', observed.auction);
+require(Number.isFinite(observed.auction.p50Ms) && Number.isFinite(observed.auction.p95Ms) && Number.isFinite(observed.auction.p99Ms), 'AUCTION_LATENCY_DISTRIBUTION_MISSING', observed.auction);
+require(observed.auction.httpErrorRate < thresholds.unexpectedErrorRate, 'AUCTION_HTTP_ERROR_RATE_EXCEEDED', observed.auction);
 require(observed.auction.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'AUCTION_ERROR_RATE_EXCEEDED', observed.auction);
 require(atLeast(observed.callbacks.iterations, thresholds.callbackAttemptsPerSecond * thresholds.callbackSeconds), 'CALLBACK_RATE_NOT_ACHIEVED', observed.callbacks);
 require(observed.callbacks.accepted === observed.callbacks.iterations, 'CALLBACK_ACCEPTANCE_GAP', observed.callbacks);
 require(observed.callbacks.p95Ms <= thresholds.commandP95Ms, 'CALLBACK_P95_EXCEEDED', observed.callbacks);
+require(observed.callbacks.achievedRps >= thresholds.callbackAttemptsPerSecond * 0.99, 'CALLBACK_RPS_NOT_ACHIEVED', observed.callbacks);
+require(Number.isFinite(observed.callbacks.p50Ms) && Number.isFinite(observed.callbacks.p95Ms) && Number.isFinite(observed.callbacks.p99Ms), 'CALLBACK_LATENCY_DISTRIBUTION_MISSING', observed.callbacks);
+require(observed.callbacks.httpErrorRate < thresholds.unexpectedErrorRate, 'CALLBACK_HTTP_ERROR_RATE_EXCEEDED', observed.callbacks);
 require(observed.callbacks.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'CALLBACK_ERROR_RATE_EXCEEDED', observed.callbacks);
 
 require(Number(db.activeSessions) === thresholds.activeSessions, 'ACTIVE_SESSION_COUNT_MISMATCH', db.activeSessions);
@@ -195,4 +243,32 @@ const evidence = {
 };
 
 fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
-console.log(JSON.stringify({ outputPath, decision: evidence.decision, violationCount: violations.length }, null, 2));
+
+const junitPath = path.join(evidenceDir, 'target-load-acceptance.junit.xml');
+const xmlEscape = (value) => String(value)
+  .replaceAll('&', '&amp;')
+  .replaceAll('<', '&lt;')
+  .replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;')
+  .replaceAll("'", '&apos;');
+const cases = violations.length === 0
+  ? ['  <testcase classname="industrial-readiness.load" name="target-load-and-burst-acceptance"/>']
+  : violations.map((violation) => [
+      `  <testcase classname="industrial-readiness.load" name="${xmlEscape(violation.code)}">`,
+      `    <failure message="${xmlEscape(violation.code)}">${xmlEscape(JSON.stringify(violation.details))}</failure>`,
+      '  </testcase>',
+    ].join('\n'));
+fs.writeFileSync(junitPath, [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  `<testsuite name="target-load-and-burst-acceptance" tests="${cases.length}" failures="${violations.length}" time="0">`,
+  ...cases,
+  '</testsuite>',
+  '',
+].join('\n'));
+
+console.log(JSON.stringify({
+  outputPath,
+  junitPath,
+  decision: evidence.decision,
+  violationCount: violations.length,
+}, null, 2));

--- a/scripts/release/target-load-build-evidence.mjs
+++ b/scripts/release/target-load-build-evidence.mjs
@@ -1,0 +1,198 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const exactHead = process.env.EXACT_HEAD || process.env.GITHUB_SHA || 'unknown';
+const evidenceDir = process.env.EVIDENCE_DIR || 'artifacts/industrial-readiness/load';
+const rawDir = path.join(evidenceDir, 'raw');
+const outputPath = path.join(evidenceDir, 'target-load-acceptance.json');
+
+const profiles = ['sessions', 'isolation', 'sustained', 'burst', 'commands', 'auction', 'callbacks'];
+const summaries = Object.fromEntries(profiles.map((profile) => {
+  const file = path.join(rawDir, `k6-${profile}-summary.json`);
+  if (!fs.existsSync(file)) throw new Error(`Missing k6 summary: ${file}`);
+  return [profile, JSON.parse(fs.readFileSync(file, 'utf8'))];
+}));
+
+const db = JSON.parse(fs.readFileSync(path.join(rawDir, 'db-invariants.json'), 'utf8'));
+const topology = JSON.parse(fs.readFileSync(path.join(rawDir, 'topology.json'), 'utf8'));
+const scaleEvents = JSON.parse(fs.readFileSync(path.join(rawDir, 'scale-events.json'), 'utf8'));
+const k6Image = fs.readFileSync(path.join(rawDir, 'k6-image.txt'), 'utf8').trim();
+
+function metric(profile, name, key, fallback = 0) {
+  return summaries[profile]?.metrics?.[name]?.values?.[key] ?? fallback;
+}
+function count(profile, name = 'iterations') {
+  return Number(metric(profile, name, 'count', 0));
+}
+function rate(profile, name) {
+  return Number(metric(profile, name, 'rate', 0));
+}
+function p95(profile, name) {
+  return Number(metric(profile, name, 'p(95)', Number.POSITIVE_INFINITY));
+}
+function deployment(name) {
+  return topology.deployments.find((item) => item.name === name);
+}
+
+const observed = {
+  sessions: {
+    iterations: count('sessions'),
+    unexpectedErrorRate: rate('sessions', 'unexpected_errors'),
+  },
+  isolation: {
+    iterations: count('isolation'),
+    leakageCount: count('isolation', 'tenant_leakage'),
+    unexpectedErrorRate: rate('isolation', 'unexpected_errors'),
+  },
+  sustained: {
+    iterations: count('sustained'),
+    droppedIterations: count('sustained', 'dropped_iterations'),
+    p95ReadMs: p95('sustained', 'authoritative_read_duration'),
+    p99ReadMs: Number(metric('sustained', 'authoritative_read_duration', 'p(99)', Number.POSITIVE_INFINITY)),
+    unexpectedErrorRate: rate('sustained', 'unexpected_errors'),
+    durationMs: Number(summaries.sustained.state?.testRunDurationMs ?? 0),
+  },
+  burst: {
+    iterations: count('burst'),
+    droppedIterations: count('burst', 'dropped_iterations'),
+    p95ReadMs: p95('burst', 'authoritative_read_duration'),
+    p99ReadMs: Number(metric('burst', 'authoritative_read_duration', 'p(99)', Number.POSITIVE_INFINITY)),
+    unexpectedErrorRate: rate('burst', 'unexpected_errors'),
+    durationMs: Number(summaries.burst.state?.testRunDurationMs ?? 0),
+  },
+  commands: {
+    iterations: count('commands'),
+    accepted: count('commands', 'command_accepted'),
+    droppedIterations: count('commands', 'dropped_iterations'),
+    p95Ms: p95('commands', 'authoritative_command_duration'),
+    unexpectedErrorRate: rate('commands', 'unexpected_errors'),
+  },
+  auction: {
+    iterations: count('auction'),
+    accepted: count('auction', 'auction_accepted'),
+    expectedConflicts: count('auction', 'auction_expected_conflicts'),
+    droppedIterations: count('auction', 'dropped_iterations'),
+    p95Ms: p95('auction', 'auction_command_duration'),
+    unexpectedErrorRate: rate('auction', 'unexpected_errors'),
+  },
+  callbacks: {
+    iterations: count('callbacks'),
+    accepted: count('callbacks', 'callback_accepted'),
+    droppedIterations: count('callbacks', 'dropped_iterations'),
+    p95Ms: p95('callbacks', 'bank_callback_duration'),
+    unexpectedErrorRate: rate('callbacks', 'unexpected_errors'),
+  },
+};
+
+const thresholds = {
+  activeSessions: 5000,
+  loadDeals: 50000,
+  totalPersistedEvents: 10000000,
+  sustainedRps: 500,
+  sustainedSeconds: 1800,
+  burstRps: 1000,
+  burstSeconds: 300,
+  auctionAttemptsPerSecond: 200,
+  auctionSeconds: 120,
+  callbackAttemptsPerSecond: 200,
+  callbackSeconds: 120,
+  readP95Ms: 500,
+  commandP95Ms: 1000,
+  unexpectedErrorRate: 0.005,
+  tenantLeakage: 0,
+  duplicateMoneyEffects: 0,
+  doubleAuctionWinners: 0,
+  lostCommittedEvents: 0,
+};
+
+const violations = [];
+const require = (condition, code, details) => { if (!condition) violations.push({ code, details }); };
+const atLeast = (actual, expected) => actual >= Math.floor(expected * 0.99);
+
+require(observed.sessions.iterations >= thresholds.activeSessions, 'SESSION_CONCURRENCY_NOT_PROVEN', observed.sessions);
+require(observed.sessions.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'SESSION_ERROR_RATE_EXCEEDED', observed.sessions);
+require(observed.isolation.iterations >= 1000, 'TENANT_ISOLATION_SAMPLE_INCOMPLETE', observed.isolation);
+require(observed.isolation.leakageCount === 0, 'TENANT_LEAKAGE_DETECTED', observed.isolation);
+require(atLeast(observed.sustained.iterations, thresholds.sustainedRps * thresholds.sustainedSeconds), 'SUSTAINED_RATE_NOT_ACHIEVED', observed.sustained);
+require(observed.sustained.droppedIterations === 0, 'SUSTAINED_DROPPED_ITERATIONS', observed.sustained);
+require(observed.sustained.p95ReadMs <= thresholds.readP95Ms, 'SUSTAINED_READ_P95_EXCEEDED', observed.sustained);
+require(observed.sustained.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'SUSTAINED_ERROR_RATE_EXCEEDED', observed.sustained);
+require(atLeast(observed.burst.iterations, thresholds.burstRps * thresholds.burstSeconds), 'BURST_RATE_NOT_ACHIEVED', observed.burst);
+require(observed.burst.droppedIterations === 0, 'BURST_DROPPED_ITERATIONS', observed.burst);
+require(observed.burst.p95ReadMs <= thresholds.readP95Ms, 'BURST_READ_P95_EXCEEDED', observed.burst);
+require(observed.burst.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'BURST_ERROR_RATE_EXCEEDED', observed.burst);
+require(atLeast(observed.commands.iterations, 150 * 240), 'COMMAND_RATE_NOT_ACHIEVED', observed.commands);
+require(observed.commands.accepted === observed.commands.iterations, 'COMMAND_ACCEPTANCE_GAP', observed.commands);
+require(observed.commands.p95Ms <= thresholds.commandP95Ms, 'COMMAND_P95_EXCEEDED', observed.commands);
+require(observed.commands.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'COMMAND_ERROR_RATE_EXCEEDED', observed.commands);
+require(atLeast(observed.auction.iterations, thresholds.auctionAttemptsPerSecond * thresholds.auctionSeconds), 'AUCTION_ATTEMPT_RATE_NOT_ACHIEVED', observed.auction);
+require(observed.auction.accepted + observed.auction.expectedConflicts === observed.auction.iterations, 'AUCTION_UNCLASSIFIED_RESULTS', observed.auction);
+require(observed.auction.p95Ms <= thresholds.commandP95Ms, 'AUCTION_P95_EXCEEDED', observed.auction);
+require(observed.auction.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'AUCTION_ERROR_RATE_EXCEEDED', observed.auction);
+require(atLeast(observed.callbacks.iterations, thresholds.callbackAttemptsPerSecond * thresholds.callbackSeconds), 'CALLBACK_RATE_NOT_ACHIEVED', observed.callbacks);
+require(observed.callbacks.accepted === observed.callbacks.iterations, 'CALLBACK_ACCEPTANCE_GAP', observed.callbacks);
+require(observed.callbacks.p95Ms <= thresholds.commandP95Ms, 'CALLBACK_P95_EXCEEDED', observed.callbacks);
+require(observed.callbacks.unexpectedErrorRate < thresholds.unexpectedErrorRate, 'CALLBACK_ERROR_RATE_EXCEEDED', observed.callbacks);
+
+require(Number(db.activeSessions) === thresholds.activeSessions, 'ACTIVE_SESSION_COUNT_MISMATCH', db.activeSessions);
+require(Number(db.loadDeals) === thresholds.loadDeals, 'LOAD_DEAL_COUNT_MISMATCH', db.loadDeals);
+require(Number(db.totalSeededEvents) === thresholds.totalPersistedEvents, 'PERSISTED_EVENT_COUNT_MISMATCH', db.totalSeededEvents);
+require(Number(db.callbackRows) === observed.callbacks.accepted, 'CALLBACK_PERSISTENCE_MISMATCH', { db: db.callbackRows, accepted: observed.callbacks.accepted });
+require(Number(db.confirmedReserveOperations) === observed.callbacks.accepted, 'CONFIRMED_OPERATION_MISMATCH', db.confirmedReserveOperations);
+require(Number(db.confirmedPayments) === observed.callbacks.accepted, 'CONFIRMED_PAYMENT_MISMATCH', db.confirmedPayments);
+require(Number(db.duplicateLedgerEffects) === 0, 'DUPLICATE_MONEY_EFFECT', db.duplicateLedgerEffects);
+require(Number(db.doubleAuctionWinners) === 0, 'DOUBLE_AUCTION_WINNER', db.doubleAuctionWinners);
+require(Number(db.activeLeaseDuplicates) === 0, 'DUPLICATE_ACTIVE_LEASE_TOKEN', db.activeLeaseDuplicates);
+
+const api = deployment('grainflow-api');
+const worker = deployment('grainflow-outbox-worker');
+const pgbouncer = deployment('pgbouncer');
+require(api?.desired === 4 && api?.ready === 4 && api?.available === 4, 'API_SCALE_FINAL_STATE_INVALID', api);
+require(worker?.desired === 4 && worker?.ready === 4 && worker?.available === 4, 'WORKER_SCALE_FINAL_STATE_INVALID', worker);
+require(pgbouncer?.desired === 2 && pgbouncer?.ready === 2, 'PGBOUNCER_STATE_INVALID', pgbouncer);
+require(scaleEvents.some((item) => item.event === 'api_scale_out' && item.apiReplicas === 6), 'API_SCALE_OUT_NOT_PROVEN', scaleEvents);
+require(scaleEvents.some((item) => item.event === 'api_scale_in' && item.apiReplicas === 4), 'API_SCALE_IN_NOT_PROVEN', scaleEvents);
+require(k6Image.includes(':1.7.1@sha256:'), 'K6_IMAGE_NOT_IMMUTABLE', k6Image);
+
+const evidence = {
+  schemaVersion: 1,
+  evidenceClass: 'TARGET_LOAD_AND_BURST',
+  exactCommit: exactHead,
+  environment: 'production-like-multi-node-kind',
+  generatedAt: new Date().toISOString(),
+  decision: violations.length === 0 ? 'PASS' : 'FAIL',
+  pass: violations.length === 0,
+  workload: {
+    authenticatedSessions: 5000,
+    loadDeals: 50000,
+    persistedEvents: 10000000,
+    sustained: { rps: 500, durationSeconds: 1800 },
+    burst: { rps: 1000, durationSeconds: 300 },
+    dealCommands: { rps: 150, durationSeconds: 240 },
+    auctionHotLot: { attemptsPerSecond: 200, durationSeconds: 120 },
+    signedBankCallbacks: { attemptsPerSecond: 200, durationSeconds: 120 },
+  },
+  observed,
+  databaseInvariants: db,
+  topology,
+  scaleEvents,
+  supplyChain: { k6Image },
+  thresholds,
+  violations,
+  maturity: {
+    acceptedLevel: violations.length === 0 ? 'PRODUCTION_LIKE_ACCEPTED' : 'NOT_ACCEPTED',
+    permittedClaim: violations.length === 0
+      ? 'Target sustained, burst and canonical Deal workload capacity is accepted on the tested production-like infrastructure.'
+      : null,
+    prohibitedClaims: [
+      'fully operational production',
+      'capacity of an unselected real cloud provider',
+      'live user behaviour',
+      'live external integrations',
+      'permanent production history',
+    ],
+  },
+};
+
+fs.writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+console.log(JSON.stringify({ outputPath, decision: evidence.decision, violationCount: violations.length }, null, 2));

--- a/scripts/release/target-load-fallback-evidence.mjs
+++ b/scripts/release/target-load-fallback-evidence.mjs
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const exactHead = process.env.EXACT_HEAD || process.env.GITHUB_SHA || 'unknown';
+const evidenceDir = process.env.EVIDENCE_DIR || 'artifacts/industrial-readiness/load';
+const evidencePath = path.join(evidenceDir, 'target-load-acceptance.json');
+const failurePath = path.join(evidenceDir, 'failure-reason.txt');
+
+fs.mkdirSync(evidenceDir, { recursive: true });
+if (!fs.existsSync(evidencePath)) {
+  const failureReason = fs.existsSync(failurePath)
+    ? fs.readFileSync(failurePath, 'utf8').trim()
+    : 'target-load acceptance did not produce canonical evidence';
+  fs.writeFileSync(evidencePath, `${JSON.stringify({
+    schemaVersion: 1,
+    evidenceClass: 'TARGET_LOAD_AND_BURST',
+    exactCommit: exactHead,
+    environment: 'production-like-multi-node-kind',
+    generatedAt: new Date().toISOString(),
+    decision: 'FAIL',
+    pass: false,
+    failureReason,
+    violations: [{ code: 'ACCEPTANCE_INCOMPLETE', details: failureReason }],
+    maturity: {
+      acceptedLevel: 'NOT_ACCEPTED',
+      prohibitedClaims: [
+        'fully operational production',
+        'real-provider production capacity',
+        'live user behaviour',
+        'live external integrations',
+      ],
+    },
+  }, null, 2)}\n`);
+}

--- a/scripts/release/target-load-fallback-evidence.mjs
+++ b/scripts/release/target-load-fallback-evidence.mjs
@@ -5,12 +5,13 @@ const exactHead = process.env.EXACT_HEAD || process.env.GITHUB_SHA || 'unknown';
 const evidenceDir = process.env.EVIDENCE_DIR || 'artifacts/industrial-readiness/load';
 const evidencePath = path.join(evidenceDir, 'target-load-acceptance.json');
 const failurePath = path.join(evidenceDir, 'failure-reason.txt');
+const junitPath = path.join(evidenceDir, 'target-load-acceptance.junit.xml');
 
 fs.mkdirSync(evidenceDir, { recursive: true });
+const failureReason = fs.existsSync(failurePath)
+  ? fs.readFileSync(failurePath, 'utf8').trim()
+  : 'target-load acceptance did not produce canonical evidence';
 if (!fs.existsSync(evidencePath)) {
-  const failureReason = fs.existsSync(failurePath)
-    ? fs.readFileSync(failurePath, 'utf8').trim()
-    : 'target-load acceptance did not produce canonical evidence';
   fs.writeFileSync(evidencePath, `${JSON.stringify({
     schemaVersion: 1,
     evidenceClass: 'TARGET_LOAD_AND_BURST',
@@ -31,4 +32,22 @@ if (!fs.existsSync(evidencePath)) {
       ],
     },
   }, null, 2)}\n`);
+}
+
+if (!fs.existsSync(junitPath)) {
+  const xmlEscape = (value) => String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+  fs.writeFileSync(junitPath, [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<testsuite name="target-load-and-burst-acceptance" tests="1" failures="1" time="0">',
+    '  <testcase classname="industrial-readiness.load" name="acceptance-incomplete">',
+    `    <failure message="ACCEPTANCE_INCOMPLETE">${xmlEscape(failureReason)}</failure>`,
+    '  </testcase>',
+    '</testsuite>',
+    '',
+  ].join('\n'));
 }

--- a/scripts/release/target-load-generate-tokens.mjs
+++ b/scripts/release/target-load-generate-tokens.mjs
@@ -1,0 +1,67 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const secret = process.env.JWT_SECRET;
+const output = process.env.TOKENS_PATH;
+const sessionCount = Number(process.env.SESSION_COUNT || 5000);
+const buyerCount = Number(process.env.BUYER_COUNT || 2500);
+const isolatedCount = Number(process.env.ISOLATED_COUNT || 10);
+
+if (!secret || secret.length < 32) throw new Error('JWT_SECRET must be at least 32 characters');
+if (!output) throw new Error('TOKENS_PATH is required');
+if (!Number.isInteger(sessionCount) || sessionCount < 5000) throw new Error('SESSION_COUNT must be >= 5000');
+if (!Number.isInteger(buyerCount) || buyerCount < 1 || buyerCount >= sessionCount) throw new Error('BUYER_COUNT invalid');
+if (!Number.isInteger(isolatedCount) || isolatedCount < 1 || isolatedCount >= sessionCount - buyerCount) throw new Error('ISOLATED_COUNT invalid');
+
+const base64url = (value) => Buffer.from(value).toString('base64url');
+const now = Math.floor(Date.now() / 1000);
+const expires = now + 4 * 60 * 60;
+
+function tokenFor(index) {
+  const padded = String(index).padStart(6, '0');
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify({
+    typ: 'access',
+    sub: `user-load-${padded}`,
+    sid: `session-load-${padded}`,
+    cv: 1,
+    iss: 'transparent-price-api',
+    aud: 'transparent-price-platform',
+    iat: now,
+    exp: expires,
+    jti: `load-access-${padded}-${now}`,
+  }));
+  const signature = crypto.createHmac('sha256', secret).update(`${header}.${payload}`).digest('base64url');
+  return `${header}.${payload}.${signature}`;
+}
+
+const all = [];
+const buyers = [];
+const compliance = [];
+const isolated = [];
+const isolatedStart = sessionCount - isolatedCount + 1;
+
+for (let index = 1; index <= sessionCount; index += 1) {
+  const token = tokenFor(index);
+  all.push(token);
+  if (index <= buyerCount) buyers.push(token);
+  else if (index >= isolatedStart) isolated.push(token);
+  else compliance.push(token);
+}
+
+fs.mkdirSync(path.dirname(output), { recursive: true });
+fs.writeFileSync(output, `${JSON.stringify({
+  generatedAt: new Date().toISOString(),
+  expiresAt: new Date(expires * 1000).toISOString(),
+  sessionCount,
+  buyerCount,
+  complianceCount: compliance.length,
+  isolatedCount,
+  all,
+  buyers,
+  compliance,
+  isolated,
+}, null, 2)}\n`, { mode: 0o600 });
+
+console.log(JSON.stringify({ output, sessionCount, buyerCount, complianceCount: compliance.length, isolatedCount }));

--- a/scripts/release/target-load.k6.js
+++ b/scripts/release/target-load.k6.js
@@ -119,6 +119,7 @@ export const options = {
       : {}),
     tenant_leakage: ['count==0'],
   },
+  summaryTrendStats: ['min', 'med', 'avg', 'p(90)', 'p(95)', 'p(99)', 'max'],
   noConnectionReuse: false,
   userAgent: `grainflow-industrial-load/${profile}`,
 };

--- a/scripts/release/target-load.k6.js
+++ b/scripts/release/target-load.k6.js
@@ -155,6 +155,7 @@ export function isolationProbe() {
   const response = http.get(`${baseUrl}/api/deals/DEAL-INDUSTRIAL-001/workspace`, {
     headers: headers(token),
     tags: { operation: 'tenant_isolation' },
+    responseCallback: http.expectedStatuses(403, 404),
   });
   if (response.status === 200) tenantLeakage.add(1);
   recordExpected(response, [403, 404]);
@@ -219,6 +220,7 @@ export function placeHotLotBid() {
   }), {
     headers: headers(token),
     tags: { operation: 'auction_hot_lot_bid' },
+    responseCallback: http.expectedStatuses(200, 201, 409),
   });
 
   auctionDuration.add(response.timings.duration);

--- a/scripts/release/target-load.k6.js
+++ b/scripts/release/target-load.k6.js
@@ -1,0 +1,294 @@
+import http from 'k6/http';
+import crypto from 'k6/crypto';
+import exec from 'k6/execution';
+import { SharedArray } from 'k6/data';
+import { Counter, Rate, Trend } from 'k6/metrics';
+
+const profile = __ENV.PROFILE || 'sessions';
+const baseUrl = __ENV.BASE_URL || 'http://127.0.0.1:8080';
+const hostHeader = __ENV.HOST_HEADER || 'api.acceptance.grainflow.invalid';
+const tokensPath = __ENV.TOKENS_PATH || '/evidence/tokens.json';
+const bankSecret = __ENV.BANK_HMAC_SECRET || '';
+const bankPartnerId = __ENV.BANK_PARTNER_ID || 'safe-deals';
+const bankKeyId = __ENV.BANK_HMAC_KEY_ID || 'load-primary';
+const dealUpdatedAt = __ENV.DEAL_UPDATED_AT || '2026-07-17T00:00:00.000Z';
+
+const tokenDocument = new SharedArray('load-tokens', () => {
+  const parsed = JSON.parse(open(tokensPath));
+  return [parsed];
+})[0];
+
+const unexpectedErrors = new Rate('unexpected_errors');
+const tenantLeakage = new Counter('tenant_leakage');
+const readDuration = new Trend('authoritative_read_duration', true);
+const commandDuration = new Trend('authoritative_command_duration', true);
+const auctionDuration = new Trend('auction_command_duration', true);
+const callbackDuration = new Trend('bank_callback_duration', true);
+const commandAccepted = new Counter('command_accepted');
+const auctionAccepted = new Counter('auction_accepted');
+const auctionConflicts = new Counter('auction_expected_conflicts');
+const callbackAccepted = new Counter('callback_accepted');
+
+const defaultThresholds = {
+  unexpected_errors: ['rate<0.005'],
+  http_req_failed: ['rate<0.005'],
+  dropped_iterations: ['count==0'],
+};
+
+const scenarios = {
+  sessions: {
+    executor: 'per-vu-iterations',
+    vus: 5000,
+    iterations: 1,
+    maxDuration: '5m',
+    exec: 'sessionProbe',
+  },
+  isolation: {
+    executor: 'shared-iterations',
+    vus: 50,
+    iterations: 1000,
+    maxDuration: '2m',
+    exec: 'isolationProbe',
+  },
+  sustained: {
+    executor: 'constant-arrival-rate',
+    rate: 500,
+    timeUnit: '1s',
+    duration: '30m',
+    preAllocatedVUs: 750,
+    maxVUs: 3000,
+    exec: 'readWorkspace',
+  },
+  burst: {
+    executor: 'constant-arrival-rate',
+    rate: 1000,
+    timeUnit: '1s',
+    duration: '5m',
+    preAllocatedVUs: 1500,
+    maxVUs: 5000,
+    exec: 'readWorkspace',
+  },
+  commands: {
+    executor: 'constant-arrival-rate',
+    rate: 150,
+    timeUnit: '1s',
+    duration: '4m',
+    preAllocatedVUs: 300,
+    maxVUs: 2000,
+    exec: 'executeDealCommand',
+  },
+  auction: {
+    executor: 'constant-arrival-rate',
+    rate: 200,
+    timeUnit: '1s',
+    duration: '2m',
+    preAllocatedVUs: 500,
+    maxVUs: 2500,
+    exec: 'placeHotLotBid',
+  },
+  callbacks: {
+    executor: 'constant-arrival-rate',
+    rate: 200,
+    timeUnit: '1s',
+    duration: '2m',
+    preAllocatedVUs: 500,
+    maxVUs: 2500,
+    exec: 'sendBankCallback',
+  },
+};
+
+if (!scenarios[profile]) throw new Error(`Unknown PROFILE=${profile}`);
+if (profile === 'callbacks' && bankSecret.length < 32) throw new Error('BANK_HMAC_SECRET is required for callback profile');
+
+export const options = {
+  discardResponseBodies: profile === 'sustained' || profile === 'burst' || profile === 'sessions',
+  scenarios: { [profile]: scenarios[profile] },
+  thresholds: {
+    ...defaultThresholds,
+    ...(profile === 'sustained' || profile === 'burst'
+      ? { authoritative_read_duration: ['p(95)<500'] }
+      : {}),
+    ...(profile === 'commands'
+      ? { authoritative_command_duration: ['p(95)<1000'] }
+      : {}),
+    ...(profile === 'auction'
+      ? { auction_command_duration: ['p(95)<1000'] }
+      : {}),
+    ...(profile === 'callbacks'
+      ? { bank_callback_duration: ['p(95)<1000'] }
+      : {}),
+    tenant_leakage: ['count==0'],
+  },
+  noConnectionReuse: false,
+  userAgent: `grainflow-industrial-load/${profile}`,
+};
+
+function headers(token, extra = {}) {
+  return {
+    Host: hostHeader,
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    ...extra,
+  };
+}
+
+function tokenAt(list, offset = 0) {
+  return list[(exec.scenario.iterationInTest + offset) % list.length];
+}
+
+function recordExpected(response, expectedStatuses, durationMetric) {
+  if (durationMetric) durationMetric.add(response.timings.duration);
+  const expected = expectedStatuses.includes(response.status);
+  unexpectedErrors.add(!expected);
+  return expected;
+}
+
+export function sessionProbe() {
+  const token = tokenDocument.all[(__VU - 1) % tokenDocument.all.length];
+  const response = http.get(`${baseUrl}/api/auth/me`, { headers: headers(token), tags: { operation: 'auth_me' } });
+  recordExpected(response, [200]);
+}
+
+export function isolationProbe() {
+  const token = tokenAt(tokenDocument.isolated);
+  const response = http.get(`${baseUrl}/api/deals/DEAL-INDUSTRIAL-001/workspace`, {
+    headers: headers(token),
+    tags: { operation: 'tenant_isolation' },
+  });
+  if (response.status === 200) tenantLeakage.add(1);
+  recordExpected(response, [403, 404]);
+}
+
+export function readWorkspace() {
+  const mainCount = tokenDocument.all.length - tokenDocument.isolated.length;
+  const token = tokenDocument.all[exec.scenario.iterationInTest % mainCount];
+  const response = http.get(`${baseUrl}/api/deals/DEAL-INDUSTRIAL-001/workspace`, {
+    headers: headers(token),
+    tags: { operation: 'deal_workspace_read' },
+  });
+  recordExpected(response, [200], readDuration);
+}
+
+export function executeDealCommand() {
+  const index = exec.scenario.iterationInTest + 1;
+  const dealIndex = String(index).padStart(6, '0');
+  const token = tokenAt(tokenDocument.compliance);
+  const body = JSON.stringify({
+    commandId: `load-command-${dealIndex}`,
+    idempotencyKey: `load-command-idem-${dealIndex}`,
+    expectedUpdatedAt: dealUpdatedAt,
+    expectedVersion: '0',
+    payload: { source: 'industrial-target-load', sequence: index },
+  });
+  const response = http.post(`${baseUrl}/api/deals/DEAL-LOAD-${dealIndex}/commands/approve_admission`, body, {
+    headers: headers(token),
+    tags: { operation: 'deal_authoritative_command' },
+  });
+  if (recordExpected(response, [200, 201], commandDuration)) commandAccepted.add(1);
+}
+
+export function placeHotLotBid() {
+  const token = tokenAt(tokenDocument.buyers);
+  const view = http.get(`${baseUrl}/api/auctions/lots/lot-load-hot/workspace`, {
+    headers: headers(token),
+    tags: { operation: 'auction_workspace_read' },
+  });
+  let version = 1;
+  if (view.status === 200) {
+    try {
+      const payload = view.json();
+      version = Number(payload.version ?? payload.lot?.version ?? 1);
+    } catch (_) {
+      unexpectedErrors.add(true);
+      return;
+    }
+  } else {
+    recordExpected(view, [200]);
+    return;
+  }
+
+  const iteration = exec.scenario.iterationInTest + 1;
+  const amountKopecksPerTon = 1200000 + iteration * 10000;
+  const response = http.post(`${baseUrl}/api/auctions/lots/lot-load-hot/bids`, JSON.stringify({
+    amountKopecksPerTon: String(amountKopecksPerTon),
+    volumeTons: '1.000000',
+    expectedVersion: String(version),
+    commandId: `load-auction-command-${iteration}`,
+    idempotencyKey: `load-auction-idem-${iteration}`,
+  }), {
+    headers: headers(token),
+    tags: { operation: 'auction_hot_lot_bid' },
+  });
+
+  auctionDuration.add(response.timings.duration);
+  if ([200, 201].includes(response.status)) {
+    auctionAccepted.add(1);
+    unexpectedErrors.add(false);
+  } else if (response.status === 409) {
+    auctionConflicts.add(1);
+    unexpectedErrors.add(false);
+  } else {
+    unexpectedErrors.add(true);
+  }
+}
+
+function stable(value) {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === 'object') {
+    const output = {};
+    Object.keys(value).sort().forEach((key) => { output[key] = stable(value[key]); });
+    return output;
+  }
+  return value;
+}
+
+export function sendBankCallback() {
+  const index = exec.scenario.iterationInTest + 1;
+  const padded = String(index).padStart(6, '0');
+  const eventId = `load-callback-${padded}`;
+  const bodyObject = {
+    bankRef: `load-bank-ref-${padded}`,
+    dealId: `DEAL-LOAD-${padded}`,
+    eventId,
+    operation: 'RESERVE',
+    operationId: `operation-load-${padded}`,
+    status: 'SUCCESS',
+  };
+  const body = JSON.stringify(bodyObject);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const bodyHash = crypto.sha256(JSON.stringify(stable(bodyObject)), 'hex');
+  const signaturePayload = [
+    'POST',
+    '/api/settlement-engine/bank-callback',
+    bankPartnerId,
+    bankKeyId,
+    String(timestamp),
+    eventId,
+    bodyHash,
+  ].join('\n');
+  const signature = `hmac-sha256=${crypto.hmac('sha256', bankSecret, signaturePayload, 'hex')}`;
+
+  const response = http.post(`${baseUrl}/api/settlement-engine/bank-callback`, body, {
+    headers: {
+      Host: hostHeader,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'x-bank-signature': signature,
+      'x-bank-timestamp': String(timestamp),
+      'x-bank-event-id': eventId,
+      'x-bank-partner-id': bankPartnerId,
+      'x-bank-key-id': bankKeyId,
+    },
+    tags: { operation: 'bank_callback_authoritative' },
+  });
+  if (recordExpected(response, [200], callbackDuration)) callbackAccepted.add(1);
+}
+
+export function handleSummary(data) {
+  const summaryPath = __ENV.K6_SUMMARY_PATH || `summary-${profile}.json`;
+  return {
+    [summaryPath]: `${JSON.stringify(data, null, 2)}\n`,
+    stdout: `target-load profile=${profile} durationMs=${data.state?.testRunDurationMs ?? 'unknown'}\n`,
+  };
+}


### PR DESCRIPTION
## Scope

Closes #2694.
Supersedes #2700, whose exact-head run failed before load generation and whose head no longer merged cleanly with `main`.

This PR restores the dedicated production-like target-load acceptance contour on the current `main` and keeps the change inside `infra/kind/target-load/scope.json`.

## Root cause fixed

The wrapper embedded `${DEAL_UPDATED_AT}` in a JavaScript template literal without escaping it. Node evaluated it as a JavaScript identifier and aborted before dataset seeding or k6 execution. The generated shell now receives the literal shell interpolation token, and the wrapper is explicitly listed in the scope manifest.

## Acceptance executed by CI

- 5,000 authenticated sessions
- 50,000 Deals
- 10,000,000 persisted events
- 500 RPS for 30 minutes
- 1,000 RPS burst for 5 minutes
- authoritative Deal commands, hot-lot auction contention, signed bank callbacks
- tenant-isolation, money-effect, winner, lease and topology invariants
- exact-head machine-readable evidence in `artifacts/industrial-readiness/load/target-load-acceptance.json`

## Maturity boundary

Production-like target sustained and burst capacity evidence only. This is not a claim of live-provider production capacity, live-user behaviour, real external integrations, or permanent production history.