### PR TITLE
Add exact-head target load acceptance

### DIFF
--- a/.github/workflows/target-load-acceptance.yml
+++ b/.github/workflows/target-load-acceptance.yml
@@ -1,0 +1,105 @@
+name: Target Load Acceptance
+
+on:
+  push:
+    branches:
+      - ir-load/target-load-acceptance-2694
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: target qualifies capacity; smoke validates only the harness
+        required: true
+        type: choice
+        default: target
+        options:
+          - target
+          - smoke
+
+permissions:
+  contents: read
+
+concurrency:
+  group: target-load-${{ github.ref }}-${{ inputs.profile || 'target' }}
+  cancel-in-progress: true
+
+env:
+  EXACT_HEAD: ${{ github.sha }}
+  EVIDENCE_DIR: artifacts/industrial-readiness
+  TARGET_LOAD_PROFILE: ${{ inputs.profile || 'target' }}
+  PRODUCTION_LIKE_POSTGRES_TARGET_LOAD: 'true'
+
+jobs:
+  target-load:
+    name: Exact-head Kubernetes · ${{ inputs.profile || 'target' }} load
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout exact head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.EXACT_HEAD }}
+          fetch-depth: 0
+
+      - name: Reclaim runner disk
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          docker system prune --all --force || true
+          df -h
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.18.4
+
+      - name: Install pinned kind and kubectl
+        run: |
+          set -euo pipefail
+          KIND_VERSION=v0.23.0
+          curl --fail --location --retry 5 \
+            "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64" \
+            -o /tmp/kind-linux-amd64
+          curl --fail --location --retry 5 \
+            "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64.sha256sum" \
+            -o /tmp/kind-linux-amd64.sha256sum
+          (cd /tmp && sha256sum --check kind-linux-amd64.sha256sum)
+          sudo install -m 0755 /tmp/kind-linux-amd64 /usr/local/bin/kind
+
+          KUBECTL_VERSION=v1.30.4
+          curl --fail --location --retry 5 \
+            "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+            -o /tmp/kubectl
+          curl --fail --location --retry 5 \
+            "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" \
+            -o /tmp/kubectl.sha256
+          echo "$(cat /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum --check
+          sudo install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+
+      - name: Install pinned k6
+        uses: grafana/setup-k6-action@v1
+        with:
+          k6-version: '0.52.0'
+
+      - name: Build exact-head production-like Kubernetes environment
+        run: bash scripts/release/production-like-kubernetes-acceptance.sh
+
+      - name: Execute target acceptance and reconcile PostgreSQL authority
+        run: bash scripts/release/target-load-acceptance.sh
+
+      - name: Upload exact-head load evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: target-load-${{ inputs.profile || 'target' }}-${{ env.EXACT_HEAD }}
+          path: ${{ env.EVIDENCE_DIR }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Cleanup disposable acceptance environment
+        if: always()
+        run: |
+          kind delete cluster --name grainflow-acceptance || true
+          docker rm -f kind-registry || true
+          docker system df || true

--- a/infra/k6/target-load-acceptance.js
+++ b/infra/k6/target-load-acceptance.js
@@ -1,0 +1,491 @@
+import http from 'k6/http';
+import crypto from 'k6/crypto';
+import exec from 'k6/execution';
+import { check, sleep } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+import { SharedArray } from 'k6/data';
+
+const TOKENS_FILE = __ENV.TARGET_LOAD_TOKENS_FILE || './target-load-tokens.json';
+const BASE_URL = __ENV.TARGET_LOAD_BASE_URL || 'http://127.0.0.1:8080';
+const INGRESS_HOST = __ENV.TARGET_LOAD_INGRESS_HOST || 'api.acceptance.grainflow.invalid';
+const SCENARIO = __ENV.TARGET_LOAD_SCENARIO || 'session';
+const RESULT_PATH = __ENV.TARGET_LOAD_RESULT_PATH || `target-load-${SCENARIO}.json`;
+
+const BUYER_COUNT = numberEnv('TARGET_LOAD_BUYER_SESSIONS', 5000);
+const COMPLIANCE_COUNT = numberEnv('TARGET_LOAD_COMPLIANCE_SESSIONS', 100);
+const SESSION_COUNT = numberEnv('TARGET_LOAD_SESSIONS', BUYER_COUNT);
+const DEAL_COUNT = numberEnv('TARGET_LOAD_DEALS', 50000);
+const BANK_COUNT = numberEnv('TARGET_LOAD_BANK_OPERATIONS', 1000);
+const SUSTAINED_RPS = numberEnv('TARGET_LOAD_SUSTAINED_RPS', 500);
+const COMMAND_RPS = numberEnv('TARGET_LOAD_COMMAND_RPS', 20);
+const BURST_RPS = numberEnv('TARGET_LOAD_BURST_RPS', 1000);
+const BID_RPS = numberEnv('TARGET_LOAD_BID_RPS', 200);
+const BANK_BATCH_RPS = numberEnv('TARGET_LOAD_BANK_BATCH_RPS', 100);
+const READ_P95_MS = numberEnv('TARGET_LOAD_READ_P95_MS', 500);
+const COMMAND_P95_MS = numberEnv('TARGET_LOAD_COMMAND_P95_MS', 1000);
+const ERROR_RATE = numberEnv('TARGET_LOAD_ERROR_RATE', 0.005);
+
+const buyers = new SharedArray('target-load-buyers', () => JSON.parse(open(TOKENS_FILE)).buyers);
+const compliance = new SharedArray('target-load-compliance', () => JSON.parse(open(TOKENS_FILE)).compliance);
+const farmer = new SharedArray('target-load-farmer', () => [JSON.parse(open(TOKENS_FILE)).farmer]);
+
+const businessFailures = new Rate('business_failures');
+const sessionSuccesses = new Counter('session_successes');
+const tenantIsolationSuccesses = new Counter('tenant_isolation_successes');
+const readSuccesses = new Counter('read_successes');
+const commandSuccesses = new Counter('command_successes');
+const bidSuccesses = new Counter('bid_successes');
+const bidConflicts = new Counter('bid_conflicts');
+const bankHttpSuccesses = new Counter('bank_http_successes');
+const closeSuccesses = new Counter('close_successes');
+const readDuration = new Trend('read_duration', true);
+const commandDuration = new Trend('command_duration', true);
+const bidDuration = new Trend('bid_duration', true);
+const bankDuration = new Trend('bank_duration', true);
+
+export const options = buildOptions();
+
+function numberEnv(name, fallback) {
+  const value = Number(__ENV[name] || fallback);
+  if (!Number.isFinite(value) || value <= 0) throw new Error(`${name} must be positive`);
+  return value;
+}
+
+function durationEnv(name, fallback) {
+  return String(__ENV[name] || fallback);
+}
+
+function buildOptions() {
+  const common = {
+    discardResponseBodies: true,
+    noConnectionReuse: false,
+    userAgent: `grainflow-target-load/${SCENARIO}`,
+    thresholds: {
+      business_failures: [`rate<${ERROR_RATE}`],
+    },
+  };
+
+  if (SCENARIO === 'session') {
+    return {
+      ...common,
+      scenarios: {
+        session_floor: {
+          executor: 'per-vu-iterations',
+          exec: 'sessionFloor',
+          vus: SESSION_COUNT,
+          iterations: 1,
+          maxDuration: durationEnv('TARGET_LOAD_SESSION_MAX_DURATION', '8m'),
+          gracefulStop: '30s',
+        },
+      },
+      thresholds: {
+        ...common.thresholds,
+        session_successes: [`count>=${SESSION_COUNT}`],
+        tenant_isolation_successes: [`count>=${SESSION_COUNT}`],
+      },
+    };
+  }
+
+  if (SCENARIO === 'sustained') {
+    const readRate = SUSTAINED_RPS - (COMMAND_RPS * 2);
+    if (readRate < 1) throw new Error('Sustained RPS must exceed two HTTP requests per command iteration');
+    const duration = durationEnv('TARGET_LOAD_SUSTAINED_DURATION', '30m');
+    return {
+      ...common,
+      scenarios: {
+        sustained_reads: {
+          executor: 'constant-arrival-rate',
+          exec: 'readDeal',
+          rate: readRate,
+          timeUnit: '1s',
+          duration,
+          preAllocatedVUs: Math.min(BUYER_COUNT, numberEnv('TARGET_LOAD_READ_PREALLOCATED_VUS', 800)),
+          maxVUs: BUYER_COUNT,
+          gracefulStop: '30s',
+        },
+        sustained_commands: {
+          executor: 'constant-arrival-rate',
+          exec: 'approveDeal',
+          rate: COMMAND_RPS,
+          timeUnit: '1s',
+          duration,
+          preAllocatedVUs: Math.min(COMPLIANCE_COUNT, numberEnv('TARGET_LOAD_COMMAND_PREALLOCATED_VUS', COMPLIANCE_COUNT)),
+          maxVUs: Math.max(COMPLIANCE_COUNT, 200),
+          gracefulStop: '30s',
+        },
+      },
+      thresholds: {
+        ...common.thresholds,
+        read_duration: [`p(95)<${READ_P95_MS}`],
+        command_duration: [`p(95)<${COMMAND_P95_MS}`],
+        dropped_iterations: ['count==0'],
+      },
+    };
+  }
+
+  if (SCENARIO === 'burst') {
+    return {
+      ...common,
+      scenarios: {
+        burst_reads: {
+          executor: 'constant-arrival-rate',
+          exec: 'readDeal',
+          rate: BURST_RPS,
+          timeUnit: '1s',
+          duration: durationEnv('TARGET_LOAD_BURST_DURATION', '5m'),
+          preAllocatedVUs: Math.min(BUYER_COUNT, numberEnv('TARGET_LOAD_BURST_PREALLOCATED_VUS', 1500)),
+          maxVUs: BUYER_COUNT,
+          gracefulStop: '30s',
+        },
+      },
+      thresholds: {
+        ...common.thresholds,
+        read_duration: [`p(95)<${READ_P95_MS}`],
+        dropped_iterations: ['count==0'],
+      },
+    };
+  }
+
+  if (SCENARIO === 'bid') {
+    return {
+      ...common,
+      scenarios: {
+        hot_lot: {
+          executor: 'constant-arrival-rate',
+          exec: 'placeHotBid',
+          rate: BID_RPS,
+          timeUnit: '1s',
+          duration: durationEnv('TARGET_LOAD_BID_DURATION', '5m'),
+          preAllocatedVUs: Math.min(BUYER_COUNT, numberEnv('TARGET_LOAD_BID_PREALLOCATED_VUS', 1000)),
+          maxVUs: BUYER_COUNT,
+          gracefulStop: '1m',
+        },
+      },
+      thresholds: {
+        ...common.thresholds,
+        bid_successes: [`rate>=${BID_RPS * (1 - ERROR_RATE)}`],
+        bid_duration: [`p(95)<${COMMAND_P95_MS}`],
+        dropped_iterations: ['count==0'],
+      },
+    };
+  }
+
+  if (SCENARIO === 'bank') {
+    return {
+      ...common,
+      scenarios: {
+        callback_storm: {
+          executor: 'constant-arrival-rate',
+          exec: 'bankCallbackStorm',
+          rate: BANK_BATCH_RPS,
+          timeUnit: '1s',
+          duration: durationEnv('TARGET_LOAD_BANK_DURATION', '1m'),
+          preAllocatedVUs: numberEnv('TARGET_LOAD_BANK_PREALLOCATED_VUS', 400),
+          maxVUs: BUYER_COUNT,
+          gracefulStop: '1m',
+        },
+      },
+      thresholds: {
+        ...common.thresholds,
+        bank_http_successes: [`rate>=${BANK_BATCH_RPS * 3 * (1 - ERROR_RATE)}`],
+        bank_duration: [`p(95)<${COMMAND_P95_MS}`],
+        dropped_iterations: ['count==0'],
+      },
+    };
+  }
+
+  if (SCENARIO === 'close') {
+    return {
+      ...common,
+      scenarios: {
+        close_hot_lot: {
+          executor: 'shared-iterations',
+          exec: 'closeHotLot',
+          vus: 1,
+          iterations: 1,
+          maxDuration: '2m',
+        },
+      },
+      thresholds: {
+        ...common.thresholds,
+        close_successes: ['count==1'],
+      },
+    };
+  }
+
+  throw new Error(`Unknown TARGET_LOAD_SCENARIO=${SCENARIO}`);
+}
+
+function suffix(value, width) {
+  return String(value).padStart(width, '0');
+}
+
+function commonHeaders(token, extra = {}) {
+  return {
+    Host: INGRESS_HOST,
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    ...extra,
+  };
+}
+
+function params(token, kind, expected = [200]) {
+  return {
+    headers: commonHeaders(token),
+    tags: { kind, scenario: SCENARIO },
+    responseType: 'text',
+    responseCallback: http.expectedStatuses(...expected),
+    timeout: '30s',
+  };
+}
+
+function parseJson(response) {
+  try {
+    return response.json();
+  } catch (_) {
+    return null;
+  }
+}
+
+function dealForBuyer(iteration, buyer) {
+  const cycle = Math.floor(iteration / BUYER_COUNT);
+  const candidate = buyer.index + ((cycle % Math.ceil(DEAL_COUNT / BUYER_COUNT)) * BUYER_COUNT);
+  return Math.min(candidate, DEAL_COUNT);
+}
+
+export function sessionFloor() {
+  const buyer = buyers[(__VU - 1) % buyers.length];
+  const me = http.get(`${BASE_URL}/api/auth/me`, params(buyer.token, 'session'));
+  const sessionOk = check(me, { 'authenticated session accepted': (r) => r.status === 200 });
+  sessionSuccesses.add(sessionOk ? 1 : 0);
+
+  const otherBuyerIndex = (buyer.index % BUYER_COUNT) + 1;
+  const inaccessibleDeal = suffix(otherBuyerIndex, 6);
+  const denied = http.get(
+    `${BASE_URL}/api/deals/load-deal-${inaccessibleDeal}/execution-workspace`,
+    params(buyer.token, 'tenant-probe', [403, 404]),
+  );
+  const isolationOk = check(denied, { 'cross-scope Deal denied': (r) => r.status === 403 || r.status === 404 });
+  tenantIsolationSuccesses.add(isolationOk ? 1 : 0);
+  businessFailures.add(!(sessionOk && isolationOk));
+}
+
+export function readDeal() {
+  const iteration = exec.scenario.iterationInTest;
+  const buyer = buyers[iteration % buyers.length];
+  const dealNumber = dealForBuyer(iteration, buyer);
+  const response = http.get(
+    `${BASE_URL}/api/deals/load-deal-${suffix(dealNumber, 6)}/execution-workspace`,
+    params(buyer.token, 'read'),
+  );
+  readDuration.add(response.timings.duration);
+  const ok = check(response, { 'Deal workspace read accepted': (r) => r.status === 200 });
+  readSuccesses.add(ok ? 1 : 0);
+  businessFailures.add(!ok);
+}
+
+export function approveDeal() {
+  const iteration = exec.scenario.iterationInTest;
+  if (iteration >= DEAL_COUNT) {
+    businessFailures.add(true);
+    return;
+  }
+  const dealNumber = iteration + 1;
+  const dealId = `load-deal-${suffix(dealNumber, 6)}`;
+  const actor = compliance[(dealNumber - 1) % compliance.length];
+  const read = http.get(`${BASE_URL}/api/deals/${dealId}`, params(actor.token, 'command-read'));
+  const snapshot = parseJson(read);
+  if (read.status !== 200 || !snapshot?.updatedAt || snapshot?.version === undefined) {
+    businessFailures.add(true);
+    return;
+  }
+
+  const payload = JSON.stringify({
+    commandId: `load-command-${dealNumber}`,
+    idempotencyKey: `load-command-idempotency-${dealNumber}`,
+    expectedUpdatedAt: snapshot.updatedAt,
+    expectedVersion: String(snapshot.version),
+    payload: {},
+  });
+  const started = Date.now();
+  const response = http.post(
+    `${BASE_URL}/api/deals/${dealId}/commands/approve_admission`,
+    payload,
+    params(actor.token, 'command', [200, 201]),
+  );
+  commandDuration.add(Date.now() - started);
+  const ok = check(response, { 'Deal command committed': (r) => r.status === 200 || r.status === 201 });
+  commandSuccesses.add(ok ? 1 : 0);
+  businessFailures.add(!ok);
+}
+
+export function placeHotBid() {
+  const iteration = exec.scenario.iterationInTest;
+  const buyer = buyers[iteration % buyers.length];
+  const started = Date.now();
+  let ok = false;
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const workspace = http.get(
+      `${BASE_URL}/api/auctions/lots/load-hot-lot/workspace`,
+      params(buyer.token, 'bid-read'),
+    );
+    const snapshot = parseJson(workspace);
+    const version = Number(snapshot?.authority?.version);
+    if (workspace.status !== 200 || !Number.isFinite(version)) break;
+
+    const amount = 1_000_000 + ((version + 1) * 100);
+    const response = http.post(
+      `${BASE_URL}/api/auctions/lots/load-hot-lot/bids`,
+      JSON.stringify({
+        amountKopecksPerTon: String(amount),
+        volumeTons: '100',
+        expectedVersion: String(version),
+        idempotencyKey: `load-bid-${iteration}-${attempt}`,
+      }),
+      params(buyer.token, 'bid', [200, 201, 409]),
+    );
+    if (response.status === 200 || response.status === 201) {
+      ok = true;
+      break;
+    }
+    if (response.status !== 409) break;
+    bidConflicts.add(1);
+    sleep(Math.random() * 0.02);
+  }
+
+  bidDuration.add(Date.now() - started);
+  bidSuccesses.add(ok ? 1 : 0);
+  businessFailures.add(!ok);
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function bankCallbackStorm() {
+  const iteration = exec.scenario.iterationInTest;
+  const index = (iteration % BANK_COUNT) + 1;
+  const id = suffix(index, 5);
+  const eventId = `load-bank-event-${id}`;
+  const body = {
+    bankRef: `LOAD-BANK-REF-${id}`,
+    dealId: `load-bank-deal-${id}`,
+    eventId,
+    operation: 'RESERVE',
+    operationId: `load-bank-operation-${id}`,
+    status: 'SUCCESS',
+  };
+  const encoded = stableStringify(body);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const bodyHash = crypto.sha256(encoded, 'hex');
+  const signedPayload = [
+    'POST',
+    '/api/settlement-engine/bank-callback',
+    'safe-deals',
+    'primary',
+    String(timestamp),
+    eventId,
+    bodyHash,
+  ].join('\n');
+  const signature = `hmac-sha256=${crypto.hmac('sha256', __ENV.BANK_HMAC_SECRET, signedPayload, 'hex')}`;
+  const callbackParams = {
+    headers: commonHeaders('', {
+      Authorization: undefined,
+      'x-bank-signature': signature,
+      'x-bank-timestamp': String(timestamp),
+      'x-bank-event-id': eventId,
+      'x-bank-partner-id': 'safe-deals',
+      'x-bank-key-id': 'primary',
+    }),
+    tags: { kind: 'bank', scenario: SCENARIO },
+    responseType: 'text',
+    responseCallback: http.expectedStatuses(200),
+    timeout: '30s',
+  };
+  delete callbackParams.headers.Authorization;
+
+  const request = ['POST', `${BASE_URL}/api/settlement-engine/bank-callback`, encoded, callbackParams];
+  const started = Date.now();
+  const responses = http.batch([request, request, request]);
+  bankDuration.add(Date.now() - started);
+  const succeeded = responses.filter((response) => response.status === 200).length;
+  bankHttpSuccesses.add(succeeded);
+  businessFailures.add(succeeded !== 3);
+}
+
+export function closeHotLot() {
+  const actor = farmer[0];
+  const workspace = http.get(
+    `${BASE_URL}/api/auctions/lots/load-hot-lot/workspace`,
+    params(actor.token, 'close-read'),
+  );
+  const snapshot = parseJson(workspace);
+  const version = snapshot?.authority?.version;
+  if (workspace.status !== 200 || version === undefined) {
+    businessFailures.add(true);
+    return;
+  }
+  const response = http.post(
+    `${BASE_URL}/api/auctions/lots/load-hot-lot/close`,
+    JSON.stringify({ expectedVersion: String(version), idempotencyKey: 'load-hot-lot-close-idempotency' }),
+    params(actor.token, 'close', [200, 201]),
+  );
+  const ok = response.status === 200 || response.status === 201;
+  closeSuccesses.add(ok ? 1 : 0);
+  businessFailures.add(!ok);
+}
+
+export function handleSummary(data) {
+  const metrics = {};
+  for (const [name, metric] of Object.entries(data.metrics || {})) {
+    if (
+      name.startsWith('http_')
+      || name.endsWith('_duration')
+      || name.endsWith('_successes')
+      || name === 'business_failures'
+      || name === 'dropped_iterations'
+      || name === 'iterations'
+      || name === 'bid_conflicts'
+    ) {
+      metrics[name] = {
+        type: metric.type,
+        values: metric.values || {},
+        thresholds: metric.thresholds || {},
+      };
+    }
+  }
+  const failedThresholds = Object.entries(metrics).flatMap(([metricName, metric]) =>
+    Object.entries(metric.thresholds || {})
+      .filter(([, threshold]) => threshold.ok === false)
+      .map(([expression]) => ({ metric: metricName, expression })),
+  );
+  const normalized = {
+    schemaVersion: 1,
+    exactHead: __ENV.EXACT_HEAD || null,
+    scenario: SCENARIO,
+    generatedAt: new Date().toISOString(),
+    passed: failedThresholds.length === 0,
+    failedThresholds,
+    targets: {
+      sessions: SESSION_COUNT,
+      deals: DEAL_COUNT,
+      sustainedRps: SUSTAINED_RPS,
+      commandRps: COMMAND_RPS,
+      burstRps: BURST_RPS,
+      bidRps: BID_RPS,
+      bankBatchRps: BANK_BATCH_RPS,
+      readP95Ms: READ_P95_MS,
+      commandP95Ms: COMMAND_P95_MS,
+      maxBusinessErrorRate: ERROR_RATE,
+    },
+    metrics,
+  };
+  const encoded = `${JSON.stringify(normalized, null, 2)}\n`;
+  return { stdout: encoded, [RESULT_PATH]: encoded };
+}

--- a/infra/kind/production-like/postgresql-target-load-patch.yaml
+++ b/infra/kind/production-like/postgresql-target-load-patch.yaml
@@ -1,0 +1,16 @@
+spec:
+  template:
+    spec:
+      containers:
+        - name: postgresql
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+      volumes:
+        - name: data
+          emptyDir:
+            sizeLimit: 20Gi

--- a/scripts/release/build-target-load-tokens.mjs
+++ b/scripts/release/build-target-load-tokens.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import { writeFile } from 'node:fs/promises';
+import { createHmac } from 'node:crypto';
+import process from 'node:process';
+
+const output = process.argv[2];
+if (!output) throw new Error('Usage: build-target-load-tokens.mjs <output.json>');
+
+const secret = String(process.env.JWT_SECRET ?? '').trim();
+if (secret.length < 32) throw new Error('JWT_SECRET with at least 32 characters is required');
+
+const buyerCount = positiveInteger('TARGET_LOAD_BUYER_SESSIONS', 5_000);
+const complianceCount = positiveInteger('TARGET_LOAD_COMPLIANCE_SESSIONS', 100);
+const dealCount = positiveInteger('TARGET_LOAD_DEALS', 50_000);
+const tokenTtlSeconds = positiveInteger('TARGET_LOAD_TOKEN_TTL_SECONDS', 6 * 60 * 60);
+
+function positiveInteger(name, fallback) {
+  const value = Number(process.env[name] ?? fallback);
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${name} must be a positive integer`);
+  return value;
+}
+
+function padded(value, width = 5) {
+  return String(value).padStart(width, '0');
+}
+
+function sign(userId, sessionId) {
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify({
+    typ: 'access',
+    sid: sessionId,
+    cv: 1,
+    sub: userId,
+    iss: 'transparent-price-api',
+    aud: 'transparent-price-platform',
+    iat: issuedAt,
+    exp: issuedAt + tokenTtlSeconds,
+    jti: `load-jti-${sessionId}`,
+  }));
+  const signingInput = `${header}.${payload}`;
+  const signature = createHmac('sha256', secret).update(signingInput).digest('base64url');
+  return `${signingInput}.${signature}`;
+}
+
+function base64url(value) {
+  return Buffer.from(value, 'utf8').toString('base64url');
+}
+
+const buyers = Array.from({ length: buyerCount }, (_, offset) => {
+  const index = offset + 1;
+  const suffix = padded(index);
+  const userId = `load-buyer-user-${suffix}`;
+  const sessionId = `load-buyer-session-${suffix}`;
+  return {
+    index,
+    userId,
+    sessionId,
+    organizationId: `load-buyer-org-${suffix}`,
+    token: sign(userId, sessionId),
+  };
+});
+
+const compliance = Array.from({ length: complianceCount }, (_, offset) => {
+  const index = offset + 1;
+  const suffix = padded(index, 3);
+  const userId = `load-compliance-user-${suffix}`;
+  const sessionId = `load-compliance-session-${suffix}`;
+  return {
+    index,
+    userId,
+    sessionId,
+    organizationId: 'load-compliance-org',
+    token: sign(userId, sessionId),
+  };
+});
+
+const farmerUserId = 'load-farmer-user-001';
+const farmerSessionId = 'load-farmer-session-001';
+const result = {
+  schemaVersion: 1,
+  generatedAt: new Date().toISOString(),
+  buyerCount,
+  complianceCount,
+  dealCount,
+  buyers,
+  compliance,
+  farmer: {
+    userId: farmerUserId,
+    sessionId: farmerSessionId,
+    organizationId: 'load-seller-org',
+    token: sign(farmerUserId, farmerSessionId),
+  },
+};
+
+await writeFile(output, `${JSON.stringify(result)}\n`, { mode: 0o600 });
+process.stdout.write(`${JSON.stringify({ output, buyerCount, complianceCount, dealCount })}\n`);

--- a/scripts/release/build-target-load-verdict.mjs
+++ b/scripts/release/build-target-load-verdict.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const evidenceDir = process.argv[2] || process.env.EVIDENCE_DIR || 'artifacts/industrial-readiness/load';
+const profile = process.env.TARGET_LOAD_PROFILE || 'target';
+const exactHead = process.env.EXACT_HEAD || null;
+const scenarios = ['session', 'sustained', 'burst', 'bid', 'bank', 'close'];
+
+async function jsonFile(name) {
+  try {
+    return JSON.parse(await readFile(path.join(evidenceDir, name), 'utf8'));
+  } catch (error) {
+    return { missing: true, error: String(error) };
+  }
+}
+
+function numeric(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function metric(document, name, key = 'count') {
+  return numeric(document?.metrics?.[name]?.values?.[key]);
+}
+
+const seed = await jsonFile('seed-summary.json');
+const reconciliation = await jsonFile('database-reconciliation.json');
+const environment = await jsonFile('environment.json');
+const runs = Object.fromEntries(await Promise.all(
+  scenarios.map(async (scenario) => [scenario, await jsonFile(`${scenario}.json`)]),
+));
+
+const checks = [];
+function requireCheck(id, passed, observed, expected) {
+  checks.push({ id, passed: Boolean(passed), observed, expected });
+}
+
+for (const scenario of scenarios) {
+  const run = runs[scenario];
+  requireCheck(
+    `scenario.${scenario}.evidence`,
+    !run.missing && run.scenario === scenario,
+    run.missing ? run.error : run.scenario,
+    scenario,
+  );
+  requireCheck(
+    `scenario.${scenario}.thresholds`,
+    !run.missing && run.passed === true,
+    run.missing ? 'missing' : run.failedThresholds,
+    'all k6 thresholds pass',
+  );
+  requireCheck(
+    `scenario.${scenario}.exactHead`,
+    !exactHead || run.exactHead === exactHead,
+    run.exactHead ?? null,
+    exactHead,
+  );
+}
+
+const sessionTarget = numeric(seed.buyerSessions);
+const bankTarget = Math.min(numeric(seed.bankOperations), metric(runs.bank, 'iterations'));
+const bidSuccesses = metric(runs.bid, 'bid_successes');
+const commandSuccesses = metric(runs.sustained, 'command_successes');
+
+requireCheck('sessions.seeded', numeric(reconciliation?.sessions?.buyersSeeded) >= sessionTarget,
+  reconciliation?.sessions?.buyersSeeded, `>= ${sessionTarget}`);
+requireCheck('sessions.concurrentAuthenticatedFloor', metric(runs.session, 'session_successes') >= sessionTarget,
+  metric(runs.session, 'session_successes'), `>= ${sessionTarget}`);
+requireCheck('sessions.persistentlyTouched', numeric(reconciliation?.sessions?.buyersTouched) >= sessionTarget,
+  reconciliation?.sessions?.buyersTouched, `>= ${sessionTarget}`);
+requireCheck('tenantIsolation.http', metric(runs.session, 'tenant_isolation_successes') >= sessionTarget,
+  metric(runs.session, 'tenant_isolation_successes'), `>= ${sessionTarget}`);
+
+requireCheck('deals.seeded', numeric(reconciliation?.deals?.seeded) >= numeric(seed.deals),
+  reconciliation?.deals?.seeded, `>= ${numeric(seed.deals)}`);
+requireCheck('events.persisted', numeric(reconciliation?.events?.baseline) >= numeric(seed.domainEvents),
+  reconciliation?.events?.baseline, `>= ${numeric(seed.domainEvents)}`);
+requireCheck('commands.committed', commandSuccesses > 0 && numeric(reconciliation?.deals?.admissionApproved) >= commandSuccesses,
+  { httpSuccesses: commandSuccesses, persisted: reconciliation?.deals?.admissionApproved },
+  'persisted >= successful command responses > 0');
+
+requireCheck('auction.bidsPersisted', bidSuccesses > 0 && numeric(reconciliation?.auction?.bids) >= bidSuccesses,
+  { httpSuccesses: bidSuccesses, persisted: reconciliation?.auction?.bids },
+  'persisted >= successful bid responses > 0');
+requireCheck('auction.singleWinner', numeric(reconciliation?.auction?.winningBids) === 1,
+  reconciliation?.auction?.winningBids, 1);
+requireCheck('auction.singleAward', numeric(reconciliation?.auction?.awards) === 1,
+  reconciliation?.auction?.awards, 1);
+requireCheck('auction.singleDealBinding', numeric(reconciliation?.auction?.dealAwards) === 1,
+  reconciliation?.auction?.dealAwards, 1);
+
+requireCheck('settlement.callbacksPersisted', bankTarget > 0 && numeric(reconciliation?.settlement?.callbacks) >= bankTarget,
+  reconciliation?.settlement?.callbacks, `>= ${bankTarget}`);
+requireCheck('settlement.callbackUniqueness',
+  numeric(reconciliation?.settlement?.callbacks) === numeric(reconciliation?.settlement?.distinctCallbackEvents),
+  { callbacks: reconciliation?.settlement?.callbacks, distinct: reconciliation?.settlement?.distinctCallbackEvents },
+  'callbacks = distinct(partner,event)');
+requireCheck('settlement.oneLedgerPerOperation',
+  numeric(reconciliation?.settlement?.ledgerEntries) === numeric(reconciliation?.settlement?.confirmedOperations),
+  { ledger: reconciliation?.settlement?.ledgerEntries, confirmed: reconciliation?.settlement?.confirmedOperations },
+  'ledger entries = confirmed operations');
+requireCheck('settlement.noDuplicateLedgerOperation', numeric(reconciliation?.settlement?.duplicateLedgerOperations) === 0,
+  reconciliation?.settlement?.duplicateLedgerOperations, 0);
+requireCheck('settlement.noDuplicateLedgerKey', numeric(reconciliation?.settlement?.duplicateLedgerIdempotencyKeys) === 0,
+  reconciliation?.settlement?.duplicateLedgerIdempotencyKeys, 0);
+
+requireCheck('database.noUngrantedLocks', numeric(reconciliation?.database?.ungrantedLocks) === 0,
+  reconciliation?.database?.ungrantedLocks, 0);
+requireCheck('database.connectionBound', numeric(reconciliation?.database?.activeConnections) <= 100,
+  reconciliation?.database?.activeConnections, '<= 100 PostgreSQL connections');
+requireCheck('outbox.drained', numeric(reconciliation?.outbox?.pending) === 0,
+  reconciliation?.outbox?.pending, 0);
+requireCheck('outbox.noDeadLetters', numeric(reconciliation?.outbox?.deadLetters) === 0,
+  reconciliation?.outbox?.deadLetters, 0);
+
+const failedChecks = checks.filter((check) => !check.passed);
+const passed = failedChecks.length === 0;
+const qualification = profile === 'target';
+const verdict = qualification
+  ? (passed ? 'PASS' : 'FAIL')
+  : (passed ? 'SMOKE_PASS' : 'SMOKE_FAIL');
+
+const result = {
+  schemaVersion: 1,
+  generatedAt: new Date().toISOString(),
+  exactHead,
+  profile,
+  qualification,
+  verdict,
+  passed,
+  note: qualification
+    ? 'PASS is valid only for this exact Git commit and the recorded disposable environment.'
+    : 'Smoke mode validates the harness only and is not a capacity qualification.',
+  seed,
+  environment,
+  scenarioSummary: Object.fromEntries(scenarios.map((scenario) => [scenario, {
+    passed: runs[scenario]?.passed === true,
+    failedThresholds: runs[scenario]?.failedThresholds ?? [],
+    metrics: runs[scenario]?.metrics ?? {},
+  }])),
+  reconciliation,
+  checks,
+  failedChecks,
+};
+
+const output = path.join(evidenceDir, 'target-load-acceptance.json');
+await mkdir(evidenceDir, { recursive: true });
+await writeFile(output, `${JSON.stringify(result, null, 2)}\n`);
+process.stdout.write(`${JSON.stringify({ output, verdict, failedChecks: failedChecks.map((check) => check.id) }, null, 2)}\n`);

--- a/scripts/release/production-like-kubernetes-cluster.sh
+++ b/scripts/release/production-like-kubernetes-cluster.sh
@@ -75,6 +75,11 @@ kubectl apply -f infra/kind/production-like/dependencies.yaml > "$K8S_DIR/depend
 kubectl patch statefulset postgresql -n "$NAMESPACE" --type=strategic \
   --patch-file infra/kind/production-like/postgresql-runtime-patch.yaml \
   > "$K8S_DIR/postgresql-runtime-patch.log"
+if [[ "${PRODUCTION_LIKE_POSTGRES_TARGET_LOAD:-false}" = "true" ]]; then
+  kubectl patch statefulset postgresql -n "$NAMESPACE" --type=strategic \
+    --patch-file infra/kind/production-like/postgresql-target-load-patch.yaml \
+    > "$K8S_DIR/postgresql-target-load-patch.log"
+fi
 kubectl patch deployment kafka -n "$NAMESPACE" --type=strategic \
   --patch-file infra/kind/production-like/kafka-runtime-patch.yaml \
   > "$K8S_DIR/kafka-runtime-patch.log"

--- a/scripts/release/target-load-acceptance.sh
+++ b/scripts/release/target-load-acceptance.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+NAMESPACE="${NAMESPACE:-grainflow-acceptance}"
+PROFILE="${TARGET_LOAD_PROFILE:-target}"
+ROOT_EVIDENCE_DIR="${EVIDENCE_DIR:-artifacts/industrial-readiness}"
+EVIDENCE_DIR="${TARGET_LOAD_EVIDENCE_DIR:-${ROOT_EVIDENCE_DIR}/target-load}"
+EXACT_HEAD="${EXACT_HEAD:?EXACT_HEAD is required}"
+TARGET_LOAD_BASE_URL="${TARGET_LOAD_BASE_URL:-http://127.0.0.1:8080}"
+TARGET_LOAD_INGRESS_HOST="${TARGET_LOAD_INGRESS_HOST:-api.acceptance.grainflow.invalid}"
+TOKENS_FILE="$(mktemp /tmp/grainflow-target-load-tokens.XXXXXX.json)"
+STARTED_EPOCH="$(date +%s)"
+FINALIZED=false
+
+mkdir -p "$EVIDENCE_DIR"
+chmod 700 "$EVIDENCE_DIR"
+
+for command in kubectl k6 node jq base64 git; do
+  command -v "$command" >/dev/null || { echo "Missing required command: $command" >&2; exit 2; }
+done
+test "$(git rev-parse HEAD)" = "$EXACT_HEAD"
+
+case "$PROFILE" in
+  target)
+    export TARGET_LOAD_BUYER_SESSIONS="${TARGET_LOAD_BUYER_SESSIONS:-5000}"
+    export TARGET_LOAD_COMPLIANCE_SESSIONS="${TARGET_LOAD_COMPLIANCE_SESSIONS:-100}"
+    export TARGET_LOAD_SESSIONS="${TARGET_LOAD_SESSIONS:-5000}"
+    export TARGET_LOAD_DEALS="${TARGET_LOAD_DEALS:-50000}"
+    export TARGET_LOAD_EVENTS="${TARGET_LOAD_EVENTS:-10000000}"
+    export TARGET_LOAD_BANK_OPERATIONS="${TARGET_LOAD_BANK_OPERATIONS:-1000}"
+    export TARGET_LOAD_SUSTAINED_RPS="${TARGET_LOAD_SUSTAINED_RPS:-500}"
+    export TARGET_LOAD_COMMAND_RPS="${TARGET_LOAD_COMMAND_RPS:-20}"
+    export TARGET_LOAD_SUSTAINED_DURATION="${TARGET_LOAD_SUSTAINED_DURATION:-30m}"
+    export TARGET_LOAD_BURST_RPS="${TARGET_LOAD_BURST_RPS:-1000}"
+    export TARGET_LOAD_BURST_DURATION="${TARGET_LOAD_BURST_DURATION:-5m}"
+    export TARGET_LOAD_BID_RPS="${TARGET_LOAD_BID_RPS:-200}"
+    export TARGET_LOAD_BID_DURATION="${TARGET_LOAD_BID_DURATION:-5m}"
+    export TARGET_LOAD_BANK_BATCH_RPS="${TARGET_LOAD_BANK_BATCH_RPS:-100}"
+    export TARGET_LOAD_BANK_DURATION="${TARGET_LOAD_BANK_DURATION:-1m}"
+    ;;
+  smoke)
+    export TARGET_LOAD_BUYER_SESSIONS="${TARGET_LOAD_BUYER_SESSIONS:-100}"
+    export TARGET_LOAD_COMPLIANCE_SESSIONS="${TARGET_LOAD_COMPLIANCE_SESSIONS:-10}"
+    export TARGET_LOAD_SESSIONS="${TARGET_LOAD_SESSIONS:-100}"
+    export TARGET_LOAD_DEALS="${TARGET_LOAD_DEALS:-1000}"
+    export TARGET_LOAD_EVENTS="${TARGET_LOAD_EVENTS:-100000}"
+    export TARGET_LOAD_BANK_OPERATIONS="${TARGET_LOAD_BANK_OPERATIONS:-100}"
+    export TARGET_LOAD_EVENT_BATCH_SIZE="${TARGET_LOAD_EVENT_BATCH_SIZE:-50000}"
+    export TARGET_LOAD_SUSTAINED_RPS="${TARGET_LOAD_SUSTAINED_RPS:-25}"
+    export TARGET_LOAD_COMMAND_RPS="${TARGET_LOAD_COMMAND_RPS:-2}"
+    export TARGET_LOAD_SUSTAINED_DURATION="${TARGET_LOAD_SUSTAINED_DURATION:-1m}"
+    export TARGET_LOAD_BURST_RPS="${TARGET_LOAD_BURST_RPS:-50}"
+    export TARGET_LOAD_BURST_DURATION="${TARGET_LOAD_BURST_DURATION:-30s}"
+    export TARGET_LOAD_BID_RPS="${TARGET_LOAD_BID_RPS:-10}"
+    export TARGET_LOAD_BID_DURATION="${TARGET_LOAD_BID_DURATION:-30s}"
+    export TARGET_LOAD_BANK_BATCH_RPS="${TARGET_LOAD_BANK_BATCH_RPS:-5}"
+    export TARGET_LOAD_BANK_DURATION="${TARGET_LOAD_BANK_DURATION:-15s}"
+    export TARGET_LOAD_READ_PREALLOCATED_VUS="${TARGET_LOAD_READ_PREALLOCATED_VUS:-50}"
+    export TARGET_LOAD_BURST_PREALLOCATED_VUS="${TARGET_LOAD_BURST_PREALLOCATED_VUS:-100}"
+    export TARGET_LOAD_BID_PREALLOCATED_VUS="${TARGET_LOAD_BID_PREALLOCATED_VUS:-100}"
+    export TARGET_LOAD_BANK_PREALLOCATED_VUS="${TARGET_LOAD_BANK_PREALLOCATED_VUS:-50}"
+    ;;
+  *) echo "TARGET_LOAD_PROFILE must be target or smoke" >&2; exit 2 ;;
+esac
+
+export TARGET_LOAD_PROFILE="$PROFILE"
+export TARGET_LOAD_BASE_URL TARGET_LOAD_INGRESS_HOST EVIDENCE_DIR EXACT_HEAD
+export TARGET_LOAD_STARTED_EPOCH="$STARTED_EPOCH"
+
+secret_value() {
+  local secret_name="$1"
+  local key="$2"
+  kubectl get secret "$secret_name" -n "$NAMESPACE" -o "jsonpath={.data.${key}}" | base64 --decode
+}
+
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-$(secret_value grainflow-postgresql-secrets POSTGRES_PASSWORD)}"
+export JWT_SECRET="${JWT_SECRET:-$(secret_value grainflow-api-secrets JWT_SECRET)}"
+export BANK_HMAC_SECRET="${BANK_HMAC_SECRET:-$(secret_value grainflow-api-secrets BANK_HMAC_SECRET)}"
+printf '::add-mask::%s\n' "$POSTGRES_PASSWORD"
+printf '::add-mask::%s\n' "$JWT_SECRET"
+printf '::add-mask::%s\n' "$BANK_HMAC_SECRET"
+
+psql_admin() {
+  kubectl exec -i -n "$NAMESPACE" statefulset/postgresql -- \
+    env PGPASSWORD="$POSTGRES_PASSWORD" psql -X -v ON_ERROR_STOP=1 -U postgres -d grainflow "$@"
+}
+
+write_environment() {
+  local api_replicas web_replicas worker_replicas pgbouncer_replicas
+  api_replicas="$(kubectl get deployment grainflow-api -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+  web_replicas="$(kubectl get deployment grainflow-web -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+  worker_replicas="$(kubectl get deployment grainflow-outbox-worker -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+  pgbouncer_replicas="$(kubectl get deployment pgbouncer -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+  jq -n \
+    --arg exactHead "$EXACT_HEAD" \
+    --arg profile "$PROFILE" \
+    --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg kernel "$(uname -srmo)" \
+    --argjson cpuCount "$(getconf _NPROCESSORS_ONLN)" \
+    --arg memory "$(awk '/MemTotal/ {print $2 " " $3}' /proc/meminfo)" \
+    --arg k6 "$(k6 version | head -1)" \
+    --arg kubernetes "$(kubectl version --client -o json | jq -r '.clientVersion.gitVersion')" \
+    --arg apiReplicas "${api_replicas:-0}" \
+    --arg webReplicas "${web_replicas:-0}" \
+    --arg workerReplicas "${worker_replicas:-0}" \
+    --arg pgbouncerReplicas "${pgbouncer_replicas:-0}" \
+    '{schemaVersion:1,exactHead:$exactHead,profile:$profile,generatedAt:$generatedAt,runner:{kernel:$kernel,cpuCount:$cpuCount,memory:$memory},tools:{k6:$k6,kubernetes:$kubernetes},readyReplicas:{api:($apiReplicas|tonumber),web:($webReplicas|tonumber),outboxWorker:($workerReplicas|tonumber),pgbouncer:($pgbouncerReplicas|tonumber)}}' \
+    > "$EVIDENCE_DIR/environment.json"
+}
+
+finalize() {
+  local status="$1"
+  [[ "$FINALIZED" = true ]] && return
+  FINALIZED=true
+  rm -f "$TOKENS_FILE"
+  write_environment || true
+  if [[ ! -f "$EVIDENCE_DIR/database-reconciliation.json" ]]; then
+    EVIDENCE_DIR="$EVIDENCE_DIR" TARGET_LOAD_STARTED_EPOCH="$STARTED_EPOCH" \
+      bash scripts/release/target-load-reconcile.sh || true
+  fi
+  EVIDENCE_DIR="$EVIDENCE_DIR" TARGET_LOAD_PROFILE="$PROFILE" EXACT_HEAD="$EXACT_HEAD" \
+    node scripts/release/build-target-load-verdict.mjs "$EVIDENCE_DIR" || true
+  kubectl get events -n "$NAMESPACE" --sort-by=.lastTimestamp \
+    > "$EVIDENCE_DIR/kubernetes-events.txt" 2>&1 || true
+  kubectl logs -n "$NAMESPACE" -l app.kubernetes.io/name=grainflow-api \
+    --all-containers=true --prefix=true --tail=2000 \
+    > "$EVIDENCE_DIR/api-tail.log" 2>&1 || true
+  return "$status"
+}
+
+on_exit() {
+  local status=$?
+  trap - EXIT
+  finalize "$status" || true
+  exit "$status"
+}
+trap on_exit EXIT
+
+write_environment
+
+echo "[target-load] raising only acceptance-environment rate ceilings"
+kubectl set env deployment/grainflow-api -n "$NAMESPACE" \
+  RATE_LIMIT_GENERAL=100000 \
+  RATE_LIMIT_GENERAL_WINDOW_SECONDS=60 \
+  RATE_LIMIT_BANK_CALLBACK=100000 \
+  RATE_LIMIT_BANK_CALLBACK_WINDOW_SECONDS=60 \
+  LOG_LEVEL=warn \
+  > "$EVIDENCE_DIR/api-load-runtime-env.log"
+kubectl rollout status deployment/grainflow-api -n "$NAMESPACE" --timeout=600s
+
+EVIDENCE_DIR="$EVIDENCE_DIR" bash scripts/release/target-load-seed.sh
+node scripts/release/build-target-load-tokens.mjs "$TOKENS_FILE" \
+  > "$EVIDENCE_DIR/token-generation-summary.json"
+
+run_k6() {
+  local scenario="$1"
+  local exit_status
+  echo "[target-load] running ${scenario} scenario"
+  set +e
+  TARGET_LOAD_SCENARIO="$scenario" \
+  TARGET_LOAD_TOKENS_FILE="$TOKENS_FILE" \
+  TARGET_LOAD_RESULT_PATH="$EVIDENCE_DIR/${scenario}.json" \
+  k6 run --quiet infra/k6/target-load-acceptance.js \
+    > "$EVIDENCE_DIR/${scenario}.stdout.log" \
+    2> "$EVIDENCE_DIR/${scenario}.stderr.log"
+  exit_status=$?
+  set -e
+  printf '%s\n' "$exit_status" > "$EVIDENCE_DIR/${scenario}.exit-status.txt"
+}
+
+run_k6 session
+run_k6 sustained
+
+echo "[target-load] scaling API independently from two to three replicas for burst/concurrency phases"
+kubectl scale deployment/grainflow-api -n "$NAMESPACE" --replicas=3 \
+  > "$EVIDENCE_DIR/api-scale-out.log"
+kubectl rollout status deployment/grainflow-api -n "$NAMESPACE" --timeout=600s
+test "$(kubectl get deployment grainflow-api -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}')" = "3"
+
+echo "[target-load] scaling the outbox plane independently for write-heavy phases"
+kubectl set env deployment/grainflow-outbox-worker -n "$NAMESPACE" \
+  OUTBOX_WORKER_BATCH_SIZE=200 \
+  > "$EVIDENCE_DIR/outbox-worker-load-runtime-env.log"
+kubectl scale deployment/grainflow-outbox-worker -n "$NAMESPACE" --replicas=3 \
+  > "$EVIDENCE_DIR/outbox-worker-scale-out.log"
+kubectl rollout status deployment/grainflow-outbox-worker -n "$NAMESPACE" --timeout=600s
+test "$(kubectl get deployment grainflow-outbox-worker -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}')" = "3"
+
+run_k6 burst
+run_k6 bid
+
+# The duplicate-callback scenario starts from the exact persisted state that a
+# bank request transaction leaves behind. Pause the generic Kafka outbox worker
+# while these callback-specific rows are installed and consumed, otherwise it
+# would race the callback by moving the same PENDING receipt to SENT.
+echo "[target-load] preparing isolated pending bank-request receipts"
+kubectl scale deployment/grainflow-outbox-worker -n "$NAMESPACE" --replicas=0 \
+  > "$EVIDENCE_DIR/outbox-worker-bank-pause.log"
+kubectl wait --for=delete pod -n "$NAMESPACE" \
+  -l app.kubernetes.io/name=grainflow-outbox-worker --timeout=300s
+psql_admin <<'SQL' > "$EVIDENCE_DIR/bank-request-outbox-seed.log"
+INSERT INTO public.outbox_entries (
+  id, type, "dealId", payload, status, "idempotencyKey", "maxRetries",
+  "retryCount", "nextRetryAt", "correlationId", "createdAt"
+)
+SELECT
+  'load-bank-outbox-' || substring(operation.id from '([0-9]+)$'),
+  'BANK_RESERVE_REQUEST', operation.deal_id,
+  jsonb_build_object(
+    'dealId', operation.deal_id,
+    'operationId', operation.id,
+    'operation', operation.operation_type,
+    'amountKopecks', operation.amount_minor::text,
+    'partnerId', operation.required_partner_id,
+    'requestFingerprint', operation.request_fingerprint
+  ),
+  'PENDING', 'settlement-bank-request:' || operation.id, 8, 0,
+  clock_timestamp(), operation.command_id, clock_timestamp()
+FROM settlement.bank_operations operation
+WHERE operation.id LIKE 'load-bank-operation-%'
+ON CONFLICT (id) DO NOTHING;
+SQL
+run_k6 bank
+
+kubectl scale deployment/grainflow-outbox-worker -n "$NAMESPACE" --replicas=3 \
+  > "$EVIDENCE_DIR/outbox-worker-bank-resume.log"
+kubectl rollout status deployment/grainflow-outbox-worker -n "$NAMESPACE" --timeout=600s
+
+kubectl exec -i -n "$NAMESPACE" statefulset/postgresql -- \
+  env PGPASSWORD="$POSTGRES_PASSWORD" psql -X -v ON_ERROR_STOP=1 -U postgres -d grainflow \
+  -c "UPDATE auction.lots SET auction_ends_at = clock_timestamp() - interval '1 second' WHERE tenant_id = 'load-tenant' AND id = 'load-hot-lot'" \
+  > "$EVIDENCE_DIR/hot-lot-end.log"
+run_k6 close
+
+echo "[target-load] waiting for the durable outbox to drain"
+if [[ "$PROFILE" = target ]]; then
+  drain_timeout_seconds=600
+else
+  drain_timeout_seconds=120
+fi
+drain_deadline=$(( $(date +%s) + drain_timeout_seconds ))
+while true; do
+  pending_outbox="$(psql_admin -Atc "SELECT count(*) FROM public.outbox_entries WHERE status IN ('PENDING','PROCESSING')")"
+  printf '%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$pending_outbox" \
+    >> "$EVIDENCE_DIR/outbox-drain.tsv"
+  [[ "$pending_outbox" = "0" ]] && break
+  (( $(date +%s) >= drain_deadline )) && break
+  sleep 10
+done
+
+EVIDENCE_DIR="$EVIDENCE_DIR" TARGET_LOAD_STARTED_EPOCH="$STARTED_EPOCH" \
+  bash scripts/release/target-load-reconcile.sh
+write_environment
+EVIDENCE_DIR="$EVIDENCE_DIR" TARGET_LOAD_PROFILE="$PROFILE" EXACT_HEAD="$EXACT_HEAD" \
+  node scripts/release/build-target-load-verdict.mjs "$EVIDENCE_DIR"
+
+FINALIZED=true
+rm -f "$TOKENS_FILE"
+verdict="$(jq -r '.verdict' "$EVIDENCE_DIR/target-load-acceptance.json")"
+cat "$EVIDENCE_DIR/target-load-acceptance.json"
+if [[ "$PROFILE" = target ]]; then
+  test "$verdict" = PASS
+else
+  test "$verdict" = SMOKE_PASS
+fi

--- a/scripts/release/target-load-reconcile.sh
+++ b/scripts/release/target-load-reconcile.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+NAMESPACE="${NAMESPACE:-grainflow-acceptance}"
+EVIDENCE_DIR="${EVIDENCE_DIR:-artifacts/industrial-readiness/load}"
+STARTED_EPOCH="${TARGET_LOAD_STARTED_EPOCH:-0}"
+
+mkdir -p "$EVIDENCE_DIR"
+
+if [[ -z "${POSTGRES_PASSWORD:-}" ]]; then
+  POSTGRES_PASSWORD="$(
+    kubectl get secret grainflow-postgresql-secrets -n "$NAMESPACE" \
+      -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 --decode
+  )"
+fi
+[[ -n "$POSTGRES_PASSWORD" ]] || { echo "POSTGRES_PASSWORD could not be resolved" >&2; exit 2; }
+
+psql_admin() {
+  kubectl exec -i -n "$NAMESPACE" statefulset/postgresql -- \
+    env PGPASSWORD="$POSTGRES_PASSWORD" psql -X -v ON_ERROR_STOP=1 -U postgres -d grainflow "$@"
+}
+
+echo "[target-load] reconciling PostgreSQL authority"
+psql_admin -At -v started_epoch="$STARTED_EPOCH" <<'SQL' > "$EVIDENCE_DIR/database-reconciliation.json"
+SELECT jsonb_pretty(jsonb_build_object(
+  'schemaVersion', 1,
+  'observedAt', clock_timestamp(),
+  'sessions', jsonb_build_object(
+    'buyersSeeded', (SELECT count(*) FROM auth.sessions WHERE id LIKE 'load-buyer-session-%'),
+    'buyersTouched', (SELECT count(*) FROM auth.sessions WHERE id LIKE 'load-buyer-session-%' AND last_seen_at >= to_timestamp(:'started_epoch'::bigint)),
+    'complianceSeeded', (SELECT count(*) FROM auth.sessions WHERE id LIKE 'load-compliance-session-%'),
+    'active', (SELECT count(*) FROM auth.sessions WHERE id LIKE 'load-%-session-%' AND status = 'ACTIVE')
+  ),
+  'deals', jsonb_build_object(
+    'seeded', (SELECT count(*) FROM public.deals WHERE id LIKE 'load-deal-%'),
+    'admissionApproved', (SELECT count(*) FROM public.deals WHERE id LIKE 'load-deal-%' AND status = 'ADMISSION_APPROVED'),
+    'bankConfirmed', (SELECT count(*) FROM public.deals WHERE id LIKE 'load-bank-deal-%' AND status = 'RESERVED')
+  ),
+  'events', jsonb_build_object(
+    'baseline', (SELECT count(*) FROM public.deal_events WHERE id LIKE 'load-domain-event-%'),
+    'loadTotal', (SELECT count(*) FROM public.deal_events WHERE "tenantId" = 'load-tenant'),
+    'commandEvents', (SELECT count(*) FROM public.deal_events WHERE "tenantId" = 'load-tenant' AND "eventType" <> 'LOAD_BASELINE')
+  ),
+  'auction', jsonb_build_object(
+    'lotStatus', COALESCE((SELECT status FROM auction.lots WHERE tenant_id = 'load-tenant' AND id = 'load-hot-lot'), 'MISSING'),
+    'bids', (SELECT count(*) FROM auction.bids WHERE tenant_id = 'load-tenant' AND lot_id = 'load-hot-lot'),
+    'winningBids', (SELECT count(*) FROM auction.bids WHERE tenant_id = 'load-tenant' AND lot_id = 'load-hot-lot' AND status = 'WINNING'),
+    'awards', (SELECT count(*) FROM auction.awards WHERE tenant_id = 'load-tenant' AND lot_id = 'load-hot-lot'),
+    'dealAwards', (SELECT count(*) FROM auction.awards WHERE tenant_id = 'load-tenant' AND lot_id = 'load-hot-lot' AND status = 'DEAL_CREATED' AND deal_id IS NOT NULL)
+  ),
+  'settlement', jsonb_build_object(
+    'operations', (SELECT count(*) FROM settlement.bank_operations WHERE id LIKE 'load-bank-operation-%'),
+    'confirmedOperations', (SELECT count(*) FROM settlement.bank_operations WHERE id LIKE 'load-bank-operation-%' AND status = 'CONFIRMED'),
+    'callbacks', (SELECT count(*) FROM settlement.bank_callbacks WHERE event_id LIKE 'load-bank-event-%'),
+    'distinctCallbackEvents', (SELECT count(DISTINCT (partner_id, event_id)) FROM settlement.bank_callbacks WHERE event_id LIKE 'load-bank-event-%'),
+    'ledgerEntries', (SELECT count(*) FROM settlement.ledger_entries WHERE operation_id LIKE 'load-bank-operation-%'),
+    'duplicateLedgerOperations', (SELECT count(*) FROM (SELECT operation_id FROM settlement.ledger_entries WHERE operation_id LIKE 'load-bank-operation-%' GROUP BY operation_id HAVING count(*) > 1) duplicate_operations),
+    'duplicateLedgerIdempotencyKeys', (SELECT count(*) FROM (SELECT idempotency_key FROM settlement.ledger_entries WHERE operation_id LIKE 'load-bank-operation-%' GROUP BY idempotency_key HAVING count(*) > 1) duplicate_keys)
+  ),
+  'outbox', jsonb_build_object(
+    'pending', (SELECT count(*) FROM public.outbox_entries WHERE status IN ('PENDING','PROCESSING')),
+    'deadLetters', (SELECT count(*) FROM public.outbox_entries WHERE status = 'DEAD_LETTER'),
+    'oldestPendingSeconds', COALESCE((SELECT floor(extract(epoch FROM (clock_timestamp() - min("createdAt"))))::bigint FROM public.outbox_entries WHERE status IN ('PENDING','PROCESSING')), 0)
+  ),
+  'database', jsonb_build_object(
+    'sizeBytes', pg_database_size(current_database()),
+    'activeConnections', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database()),
+    'waitingConnections', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND wait_event IS NOT NULL),
+    'ungrantedLocks', (SELECT count(*) FROM pg_locks WHERE NOT granted)
+  )
+));
+SQL
+
+psql_admin -P pager=off -c "SELECT pid, usename, application_name, state, wait_event_type, wait_event, backend_xid, backend_xmin, left(query, 240) AS query FROM pg_stat_activity WHERE datname = current_database() ORDER BY state, pid" \
+  > "$EVIDENCE_DIR/pg-stat-activity.txt"
+psql_admin -P pager=off -c "SELECT locktype, mode, granted, count(*) FROM pg_locks GROUP BY locktype, mode, granted ORDER BY locktype, mode, granted" \
+  > "$EVIDENCE_DIR/pg-locks.txt"
+psql_admin -P pager=off -c "SELECT relname, n_live_tup, n_dead_tup, seq_scan, idx_scan FROM pg_stat_user_tables ORDER BY n_live_tup DESC LIMIT 40" \
+  > "$EVIDENCE_DIR/pg-table-statistics.txt"
+
+kubectl get pods -n "$NAMESPACE" -o wide > "$EVIDENCE_DIR/kubernetes-pods.txt" 2>&1 || true
+kubectl get deployments,statefulsets -n "$NAMESPACE" -o wide > "$EVIDENCE_DIR/kubernetes-workloads.txt" 2>&1 || true
+kubectl top pods -n "$NAMESPACE" > "$EVIDENCE_DIR/kubernetes-top-pods.txt" 2>&1 || true
+kubectl logs -n "$NAMESPACE" deployment/pgbouncer --tail=500 > "$EVIDENCE_DIR/pgbouncer-tail.log" 2>&1 || true
+
+cat "$EVIDENCE_DIR/database-reconciliation.json"

--- a/scripts/release/target-load-seed.sh
+++ b/scripts/release/target-load-seed.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+NAMESPACE="${NAMESPACE:-grainflow-acceptance}"
+EVIDENCE_DIR="${EVIDENCE_DIR:-artifacts/industrial-readiness/load}"
+BUYER_SESSIONS="${TARGET_LOAD_BUYER_SESSIONS:-5000}"
+COMPLIANCE_SESSIONS="${TARGET_LOAD_COMPLIANCE_SESSIONS:-100}"
+DEAL_COUNT="${TARGET_LOAD_DEALS:-50000}"
+EVENT_COUNT="${TARGET_LOAD_EVENTS:-10000000}"
+BANK_OPERATION_COUNT="${TARGET_LOAD_BANK_OPERATIONS:-1000}"
+EVENT_BATCH_SIZE="${TARGET_LOAD_EVENT_BATCH_SIZE:-250000}"
+AUCTION_END_DELAY_SECONDS="${TARGET_LOAD_AUCTION_END_DELAY_SECONDS:-3600}"
+
+mkdir -p "$EVIDENCE_DIR"
+started_epoch="$(date +%s)"
+
+if [[ -z "${POSTGRES_PASSWORD:-}" ]]; then
+  POSTGRES_PASSWORD="$(
+    kubectl get secret grainflow-postgresql-secrets -n "$NAMESPACE" \
+      -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 --decode
+  )"
+fi
+[[ -n "$POSTGRES_PASSWORD" ]] || { echo "POSTGRES_PASSWORD could not be resolved" >&2; exit 2; }
+
+for value in \
+  "$BUYER_SESSIONS" "$COMPLIANCE_SESSIONS" "$DEAL_COUNT" \
+  "$EVENT_COUNT" "$BANK_OPERATION_COUNT" "$EVENT_BATCH_SIZE" "$AUCTION_END_DELAY_SECONDS"; do
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || { echo "Target-load counts must be positive integers" >&2; exit 2; }
+done
+
+psql_admin() {
+  kubectl exec -i -n "$NAMESPACE" statefulset/postgresql -- \
+    env PGPASSWORD="$POSTGRES_PASSWORD" psql -X -v ON_ERROR_STOP=1 -U postgres -d grainflow "$@"
+}
+
+echo "[target-load] seeding identities, sessions, Deals, settlement and auction fixtures"
+psql_admin \
+  -v buyer_count="$BUYER_SESSIONS" \
+  -v compliance_count="$COMPLIANCE_SESSIONS" \
+  -v deal_count="$DEAL_COUNT" \
+  -v bank_count="$BANK_OPERATION_COUNT" \
+  -v auction_end_delay="$AUCTION_END_DELAY_SECONDS" <<'SQL'
+SET synchronous_commit = off;
+SET statement_timeout = 0;
+SET lock_timeout = '30s';
+
+INSERT INTO public.organizations (
+  id, inn, name, type, status, "tenantId", "kycStatus", "amlStatus", "sanctionHit"
+) VALUES
+  ('load-seller-org', '7700000001', 'Load Proof Seller', 'LEGAL', 'VERIFIED', 'load-tenant', 'APPROVED', 'CLEAR', false),
+  ('load-compliance-org', '7700000002', 'Load Proof Compliance', 'LEGAL', 'VERIFIED', 'load-tenant', 'APPROVED', 'CLEAR', false)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.organizations (
+  id, inn, name, type, status, "tenantId", "kycStatus", "amlStatus", "sanctionHit"
+)
+SELECT
+  'load-buyer-org-' || lpad(g::text, 5, '0'),
+  '78' || lpad(g::text, 8, '0'),
+  'Load Proof Buyer ' || g,
+  'LEGAL', 'VERIFIED', 'load-tenant', 'APPROVED', 'CLEAR', false
+FROM generate_series(1, :'buyer_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.users (
+  id, email, "passwordHash", "fullName", status, "mfaEnabled"
+) VALUES (
+  'load-farmer-user-001', 'load-farmer-001@example.invalid', 'load-proof-no-login',
+  'Load Proof Farmer', 'ACTIVE', false
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.users (id, email, "passwordHash", "fullName", status, "mfaEnabled")
+SELECT
+  'load-buyer-user-' || lpad(g::text, 5, '0'),
+  'load-buyer-' || lpad(g::text, 5, '0') || '@example.invalid',
+  'load-proof-no-login',
+  'Load Proof Buyer ' || g,
+  'ACTIVE', true
+FROM generate_series(1, :'buyer_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.users (id, email, "passwordHash", "fullName", status, "mfaEnabled")
+SELECT
+  'load-compliance-user-' || lpad(g::text, 3, '0'),
+  'load-compliance-' || lpad(g::text, 3, '0') || '@example.invalid',
+  'load-proof-no-login',
+  'Load Proof Compliance ' || g,
+  'ACTIVE', true
+FROM generate_series(1, :'compliance_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.user_orgs (id, "userId", "organizationId", role, "isDefault")
+VALUES (
+  'load-farmer-membership-001', 'load-farmer-user-001', 'load-seller-org', 'FARMER', true
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.user_orgs (id, "userId", "organizationId", role, "isDefault")
+SELECT
+  'load-buyer-membership-' || lpad(g::text, 5, '0'),
+  'load-buyer-user-' || lpad(g::text, 5, '0'),
+  'load-buyer-org-' || lpad(g::text, 5, '0'),
+  'BUYER', true
+FROM generate_series(1, :'buyer_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.user_orgs (id, "userId", "organizationId", role, "isDefault")
+SELECT
+  'load-compliance-membership-' || lpad(g::text, 3, '0'),
+  'load-compliance-user-' || lpad(g::text, 3, '0'),
+  'load-compliance-org',
+  'COMPLIANCE_OFFICER', true
+FROM generate_series(1, :'compliance_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.credential_states (user_id, credential_version, mfa_enabled, consent_version, consent_at)
+SELECT id, 1, "mfaEnabled", 'load-proof-v1', now()
+FROM public.users
+WHERE id LIKE 'load-%-user-%'
+ON CONFLICT (user_id) DO NOTHING;
+
+INSERT INTO auth.sessions (
+  id, user_id, membership_id, organization_id, tenant_id, status,
+  refresh_family_id, credential_version, mfa_level, mfa_verified_at,
+  expires_at, last_seen_at
+)
+SELECT
+  'load-buyer-session-' || lpad(g::text, 5, '0'),
+  'load-buyer-user-' || lpad(g::text, 5, '0'),
+  'load-buyer-membership-' || lpad(g::text, 5, '0'),
+  'load-buyer-org-' || lpad(g::text, 5, '0'),
+  'load-tenant', 'ACTIVE',
+  'load-buyer-family-' || lpad(g::text, 5, '0'), 1, 'TOTP', now(),
+  now() + interval '8 hours', now() - interval '2 hours'
+FROM generate_series(1, :'buyer_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.sessions (
+  id, user_id, membership_id, organization_id, tenant_id, status,
+  refresh_family_id, credential_version, mfa_level, mfa_verified_at,
+  expires_at, last_seen_at
+)
+SELECT
+  'load-compliance-session-' || lpad(g::text, 3, '0'),
+  'load-compliance-user-' || lpad(g::text, 3, '0'),
+  'load-compliance-membership-' || lpad(g::text, 3, '0'),
+  'load-compliance-org', 'load-tenant', 'ACTIVE',
+  'load-compliance-family-' || lpad(g::text, 3, '0'), 1, 'TOTP', now(),
+  now() + interval '8 hours', now() - interval '2 hours'
+FROM generate_series(1, :'compliance_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.sessions (
+  id, user_id, membership_id, organization_id, tenant_id, status,
+  refresh_family_id, credential_version, mfa_level, expires_at, last_seen_at
+) VALUES (
+  'load-farmer-session-001', 'load-farmer-user-001', 'load-farmer-membership-001',
+  'load-seller-org', 'load-tenant', 'ACTIVE', 'load-farmer-family-001', 1,
+  'NONE', now() + interval '8 hours', now() - interval '2 hours'
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.deals (
+  id, "dealNumber", status, "tenantId", "sellerOrgId", "buyerOrgId",
+  "totalKopecks", "pricePerTonDec", "volumeTonsDec", currency,
+  culture, "cropClass", region, "nextAction", "sagaState", version
+)
+SELECT
+  'load-deal-' || lpad(g::text, 6, '0'),
+  'LOAD-' || lpad(g::text, 8, '0'),
+  'DRAFT', 'load-tenant', 'load-seller-org',
+  'load-buyer-org-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0'),
+  100000000::bigint, 1000000::numeric, 100::numeric, 'RUB',
+  'Пшеница', '4', 'Load Region', 'Подтвердить допуск участников', '{}'::jsonb, 0
+FROM generate_series(1, :'deal_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.deal_participants (
+  id, "dealId", "tenantId", "organizationId", "userId", role,
+  "accessLevel", status, "assignedByUserId"
+)
+SELECT
+  'load-buyer-participant-' || lpad(g::text, 6, '0'),
+  'load-deal-' || lpad(g::text, 6, '0'), 'load-tenant',
+  'load-buyer-org-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0'),
+  'load-buyer-user-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0'),
+  'BUYER', 'WORK', 'ACTIVE', 'load-farmer-user-001'
+FROM generate_series(1, :'deal_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.deal_participants (
+  id, "dealId", "tenantId", "organizationId", "userId", role,
+  "accessLevel", status, "assignedByUserId"
+)
+SELECT
+  'load-compliance-participant-' || lpad(g::text, 6, '0'),
+  'load-deal-' || lpad(g::text, 6, '0'), 'load-tenant', 'load-compliance-org',
+  'load-compliance-user-' || lpad((((g - 1) % :'compliance_count'::integer) + 1)::text, 3, '0'),
+  'COMPLIANCE_OFFICER', 'APPROVE', 'ACTIVE', 'load-farmer-user-001'
+FROM generate_series(1, :'deal_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+-- Independent settlement fixtures for duplicate callback storms.
+INSERT INTO public.deals (
+  id, "dealNumber", status, "tenantId", "sellerOrgId", "buyerOrgId",
+  "totalKopecks", currency, "nextAction", "sagaState", version
+)
+SELECT
+  'load-bank-deal-' || lpad(g::text, 5, '0'),
+  'LOAD-BANK-' || lpad(g::text, 6, '0'),
+  'RESERVE_REQUESTED', 'load-tenant', 'load-seller-org',
+  'load-buyer-org-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0'),
+  1000000::bigint, 'RUB', 'Ожидается подтверждение резерва банка', '{}'::jsonb, 6
+FROM generate_series(1, :'bank_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO settlement.payment_terms (
+  id, tenant_id, deal_id, version, currency, reserve_amount_minor,
+  release_basis, status, command_id, idempotency_key, request_fingerprint,
+  created_by_user_id, created_by_org_id
+)
+SELECT
+  'load-bank-terms-' || lpad(g::text, 5, '0'), 'load-tenant',
+  'load-bank-deal-' || lpad(g::text, 5, '0'), 1, 'RUB', 1000000,
+  '{}'::jsonb, 'ACTIVE', 'load-bank-terms-command-' || g,
+  'load-bank-terms-idem-' || g, repeat('a', 64),
+  'load-buyer-user-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0'),
+  'load-buyer-org-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0')
+FROM generate_series(1, :'bank_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO settlement.payments (
+  id, tenant_id, deal_id, payment_terms_id, status, currency,
+  pending_reserved_minor, version
+)
+SELECT
+  'load-bank-payment-' || lpad(g::text, 5, '0'), 'load-tenant',
+  'load-bank-deal-' || lpad(g::text, 5, '0'),
+  'load-bank-terms-' || lpad(g::text, 5, '0'),
+  'RESERVE_PENDING', 'RUB', 1000000, 0
+FROM generate_series(1, :'bank_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO settlement.bank_operations (
+  id, tenant_id, deal_id, payment_id, payment_terms_id, operation_type,
+  status, amount_minor, currency, required_partner_id, request_fingerprint,
+  command_id, idempotency_key, expected_payment_version, request_payload,
+  initiated_by_user_id
+)
+SELECT
+  'load-bank-operation-' || lpad(g::text, 5, '0'), 'load-tenant',
+  'load-bank-deal-' || lpad(g::text, 5, '0'),
+  'load-bank-payment-' || lpad(g::text, 5, '0'),
+  'load-bank-terms-' || lpad(g::text, 5, '0'),
+  'RESERVE', 'PENDING', 1000000, 'RUB', 'safe-deals', repeat('b', 64),
+  'load-bank-command-' || g, 'load-bank-operation-idem-' || g, 0,
+  jsonb_build_object('source', 'target-load-acceptance'),
+  'load-buyer-user-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0')
+FROM generate_series(1, :'bank_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auction.lots (
+  id, tenant_id, seller_org_id, seller_user_id, title, culture, grade,
+  volume_tons, start_price_rub_per_ton, step_price_rub_per_ton,
+  start_price_kopecks_per_ton, step_price_kopecks_per_ton,
+  region, address, status, auction_ends_at, source_type,
+  source_external_id, source_verified_at, admission_status,
+  auto_extend_enabled, auto_extend_window_minutes, auto_extend_minutes, version
+) VALUES (
+  'load-hot-lot', 'load-tenant', 'load-seller-org', 'load-farmer-user-001',
+  'Target load hot lot', 'Пшеница', '4', 1000000,
+  10000, 1, 1000000, 100,
+  'Load Region', 'Load address', 'BIDDING',
+  now() + (:'auction_end_delay'::integer * interval '1 second'),
+  'ERP', 'load-hot-lot-source', now(), 'ADMITTED', false, 0, 0, 1
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auction.admissions (
+  id, tenant_id, lot_id, participant_org_id, participant_user_id,
+  participant_role, status, valid_until, reason, decided_by_actor_id
+)
+SELECT
+  'load-hot-admission-' || lpad(g::text, 5, '0'), 'load-tenant', 'load-hot-lot',
+  'load-buyer-org-' || lpad(g::text, 5, '0'),
+  'load-buyer-user-' || lpad(g::text, 5, '0'),
+  'BUYER', 'ADMITTED', now() + interval '8 hours',
+  'Target-load verified admission', 'load-compliance-user-001'
+FROM generate_series(1, :'buyer_count'::integer) AS g
+ON CONFLICT (id) DO NOTHING;
+SQL
+
+echo "[target-load] seeding $EVENT_COUNT persisted domain events in batches of $EVENT_BATCH_SIZE"
+event_start=1
+while (( event_start <= EVENT_COUNT )); do
+  event_end=$((event_start + EVENT_BATCH_SIZE - 1))
+  (( event_end > EVENT_COUNT )) && event_end="$EVENT_COUNT"
+  psql_admin \
+    -v event_start="$event_start" \
+    -v event_end="$event_end" \
+    -v deal_count="$DEAL_COUNT" \
+    -v buyer_count="$BUYER_SESSIONS" <<'SQL'
+SET synchronous_commit = off;
+SET statement_timeout = 0;
+INSERT INTO public.deal_events (
+  id, "dealId", "eventType", "actorId", "actorRole", "tenantId",
+  payload, hash, "prevHash", "createdAt"
+)
+SELECT
+  'load-domain-event-' || lpad(g::text, 10, '0'),
+  'load-deal-' || lpad((((g - 1) % :'deal_count'::integer) + 1)::text, 6, '0'),
+  'LOAD_BASELINE',
+  'load-buyer-user-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0'),
+  'BUYER', 'load-tenant', '{}'::jsonb, md5(g::text), NULL,
+  now() - ((:'event_end'::bigint - g) * interval '1 millisecond')
+FROM generate_series(:'event_start'::bigint, :'event_end'::bigint) AS g
+ON CONFLICT (id) DO NOTHING;
+SQL
+  printf '[target-load] domain events: %s/%s\n' "$event_end" "$EVENT_COUNT"
+  event_start=$((event_end + 1))
+done
+
+echo "[target-load] analyzing seeded relations"
+psql_admin <<'SQL'
+ANALYZE public.organizations;
+ANALYZE public.users;
+ANALYZE public.user_orgs;
+ANALYZE auth.sessions;
+ANALYZE public.deals;
+ANALYZE public.deal_participants;
+ANALYZE public.deal_events;
+ANALYZE settlement.payments;
+ANALYZE settlement.bank_operations;
+ANALYZE auction.lots;
+ANALYZE auction.admissions;
+SQL
+
+completed_epoch="$(date +%s)"
+jq -n \
+  --argjson buyers "$BUYER_SESSIONS" \
+  --argjson compliance "$COMPLIANCE_SESSIONS" \
+  --argjson deals "$DEAL_COUNT" \
+  --argjson events "$EVENT_COUNT" \
+  --argjson bankOperations "$BANK_OPERATION_COUNT" \
+  --argjson seconds "$((completed_epoch - started_epoch))" \
+  '{schemaVersion:1,buyerSessions:$buyers,complianceSessions:$compliance,deals:$deals,domainEvents:$events,bankOperations:$bankOperations,seedSeconds:$seconds}' \
+  > "$EVIDENCE_DIR/seed-summary.json"
+
+cat "$EVIDENCE_DIR/seed-summary.json"

--- a/scripts/release/target-load-seed.sh
+++ b/scripts/release/target-load-seed.sh
@@ -45,48 +45,48 @@ SET statement_timeout = 0;
 SET lock_timeout = '30s';
 
 INSERT INTO public.organizations (
-  id, inn, name, type, status, "tenantId", "kycStatus", "amlStatus", "sanctionHit"
+  id, inn, name, type, status, "tenantId", "kycStatus", "amlStatus", "sanctionHit", "updatedAt"
 ) VALUES
-  ('load-seller-org', '7700000001', 'Load Proof Seller', 'LEGAL', 'VERIFIED', 'load-tenant', 'APPROVED', 'CLEAR', false),
-  ('load-compliance-org', '7700000002', 'Load Proof Compliance', 'LEGAL', 'VERIFIED', 'load-tenant', 'APPROVED', 'CLEAR', false)
+  ('load-seller-org', '7700000001', 'Load Proof Seller', 'LEGAL', 'VERIFIED', 'load-tenant', 'APPROVED', 'CLEAR', false, now()),
+  ('load-compliance-org', '7700000002', 'Load Proof Compliance', 'LEGAL', 'VERIFIED', 'load-tenant', 'APPROVED', 'CLEAR', false, now())
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO public.organizations (
-  id, inn, name, type, status, "tenantId", "kycStatus", "amlStatus", "sanctionHit"
+  id, inn, name, type, status, "tenantId", "kycStatus", "amlStatus", "sanctionHit", "updatedAt"
 )
 SELECT
   'load-buyer-org-' || lpad(g::text, 5, '0'),
   '78' || lpad(g::text, 8, '0'),
   'Load Proof Buyer ' || g,
-  'LEGAL', 'VERIFIED', 'load-tenant', 'APPROVED', 'CLEAR', false
+  'LEGAL', 'VERIFIED', 'load-tenant', 'APPROVED', 'CLEAR', false, now()
 FROM generate_series(1, :'buyer_count'::integer) AS g
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO public.users (
-  id, email, "passwordHash", "fullName", status, "mfaEnabled"
+  id, email, "passwordHash", "fullName", status, "mfaEnabled", "updatedAt"
 ) VALUES (
   'load-farmer-user-001', 'load-farmer-001@example.invalid', 'load-proof-no-login',
-  'Load Proof Farmer', 'ACTIVE', false
+  'Load Proof Farmer', 'ACTIVE', false, now()
 )
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.users (id, email, "passwordHash", "fullName", status, "mfaEnabled")
+INSERT INTO public.users (id, email, "passwordHash", "fullName", status, "mfaEnabled", "updatedAt")
 SELECT
   'load-buyer-user-' || lpad(g::text, 5, '0'),
   'load-buyer-' || lpad(g::text, 5, '0') || '@example.invalid',
   'load-proof-no-login',
   'Load Proof Buyer ' || g,
-  'ACTIVE', true
+  'ACTIVE', true, now()
 FROM generate_series(1, :'buyer_count'::integer) AS g
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.users (id, email, "passwordHash", "fullName", status, "mfaEnabled")
+INSERT INTO public.users (id, email, "passwordHash", "fullName", status, "mfaEnabled", "updatedAt")
 SELECT
   'load-compliance-user-' || lpad(g::text, 3, '0'),
   'load-compliance-' || lpad(g::text, 3, '0') || '@example.invalid',
   'load-proof-no-login',
   'Load Proof Compliance ' || g,
-  'ACTIVE', true
+  'ACTIVE', true, now()
 FROM generate_series(1, :'compliance_count'::integer) AS g
 ON CONFLICT (id) DO NOTHING;
 
@@ -164,7 +164,7 @@ ON CONFLICT (id) DO NOTHING;
 INSERT INTO public.deals (
   id, "dealNumber", status, "tenantId", "sellerOrgId", "buyerOrgId",
   "totalKopecks", "pricePerTonDec", "volumeTonsDec", currency,
-  culture, "cropClass", region, "nextAction", "sagaState", version
+  culture, "cropClass", region, "nextAction", "sagaState", version, "updatedAt"
 )
 SELECT
   'load-deal-' || lpad(g::text, 6, '0'),
@@ -172,7 +172,7 @@ SELECT
   'DRAFT', 'load-tenant', 'load-seller-org',
   'load-buyer-org-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0'),
   100000000::bigint, 1000000::numeric, 100::numeric, 'RUB',
-  'Пшеница', '4', 'Load Region', 'Подтвердить допуск участников', '{}'::jsonb, 0
+  'Пшеница', '4', 'Load Region', 'Подтвердить допуск участников', '{}'::jsonb, 0, now()
 FROM generate_series(1, :'deal_count'::integer) AS g
 ON CONFLICT (id) DO NOTHING;
 
@@ -204,14 +204,14 @@ ON CONFLICT (id) DO NOTHING;
 -- Independent settlement fixtures for duplicate callback storms.
 INSERT INTO public.deals (
   id, "dealNumber", status, "tenantId", "sellerOrgId", "buyerOrgId",
-  "totalKopecks", currency, "nextAction", "sagaState", version
+  "totalKopecks", currency, "nextAction", "sagaState", version, "updatedAt"
 )
 SELECT
   'load-bank-deal-' || lpad(g::text, 5, '0'),
   'LOAD-BANK-' || lpad(g::text, 6, '0'),
   'RESERVE_REQUESTED', 'load-tenant', 'load-seller-org',
   'load-buyer-org-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0'),
-  1000000::bigint, 'RUB', 'Ожидается подтверждение резерва банка', '{}'::jsonb, 6
+  1000000::bigint, 'RUB', 'Ожидается подтверждение резерва банка', '{}'::jsonb, 6, now()
 FROM generate_series(1, :'bank_count'::integer) AS g
 ON CONFLICT (id) DO NOTHING;
 

--- a/scripts/release/target-load-seed.sh
+++ b/scripts/release/target-load-seed.sh
@@ -223,7 +223,7 @@ INSERT INTO settlement.payment_terms (
 SELECT
   'load-bank-terms-' || lpad(g::text, 5, '0'), 'load-tenant',
   'load-bank-deal-' || lpad(g::text, 5, '0'), 1, 'RUB', 1000000,
-  '{}'::jsonb, 'ACTIVE', 'load-bank-terms-command-' || g,
+  '{}'::jsonb, 'ISSUED', 'load-bank-terms-command-' || g,
   'load-bank-terms-idem-' || g, repeat('a', 64),
   'load-buyer-user-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0'),
   'load-buyer-org-' || lpad((((g - 1) % :'buyer_count'::integer) + 1)::text, 5, '0')


### PR DESCRIPTION
## What changed

- adds a manually rerunnable and branch-triggered exact-head k6 acceptance for issue #2694
- seeds 5,000 authenticated sessions, 50,000 active Deals, 10,000,000 persisted domain events, bank callback fixtures, and one contended auction lot
- exercises 500 RPS for 30 minutes, a 1,000 RPS burst, 200 bid attempts/s, and duplicate bank callback storms
- scales API and outbox planes independently inside the disposable production-like Kubernetes contour
- reconciles HTTP outcomes with PostgreSQL sessions, Deals, events, auction winner/award facts, settlement callbacks/ledger entries, locks, connections, and durable outbox state
- emits a fail-closed machine-readable verdict tied to the exact commit

## Why

The previous PDF demonstrated only a short, authenticated read-path baseline. It did not establish platform capacity. This PR creates the missing acceptance contour and prevents a capacity PASS unless all target evidence and invariants are present.

## Validation

- `bash -n` on all added/modified shell scripts
- `node --check` on token, verdict, and k6 JavaScript
- workflow YAML parse
- fail-closed verdict contract (missing evidence produces `SMOKE_FAIL`)
- `git diff --check`

The target workflow starts automatically on this branch. Its result is evidence, not a merge authorization.