### PR TITLE
TAI AP-09: persist exact-main evidence and current roadmap

### DIFF
--- a/apps/tai/README.md
+++ b/apps/tai/README.md
@@ -11,16 +11,36 @@
 5. Любой проверяемый вывод должен иметь provenance, дату актуальности и оценку уверенности.
 6. Tenant и роль берутся только из серверно подтверждённого контекста.
 
-## Текущий этап
+## Текущее состояние
 
-AP-00 / AP-01 foundation:
+AP-00–AP-09 объединены в `main`. Реализованы:
 
-- FastAPI-контур;
-- versioned response contract;
-- deny-by-default policy engine;
-- typed tool registry;
-- audit envelope;
-- CI-gate бесплатности;
-- базовые security tests.
+- FastAPI foundation и versioned contracts;
+- server-authoritative identity contract и deny-by-default policy;
+- governed knowledge ingestion, recovery и PostgreSQL loader authority;
+- generation-fenced lexical retrieval;
+- grounded RAG с обязательными citations и abstention;
+- локальный model registry/router и защищённый private-network transport;
+- bounded agent/tool runtime с durable confirmation authority;
+- deterministic evaluation/red-team authority без LLM-as-judge.
 
-Этот контур не является завершённой промышленной AI-платформой до прохождения evaluation, load, fault, restore, soak, security и legal acceptance.
+AP-09 exact-main: `297149187c552ba8a19057bb80f8bdbd002d9e7b`.
+Machine-readable evidence: `evidence/ap-09-exact-main.json`.
+
+## Следующий этап
+
+Первый обязательный срез AP-10 — единый orchestration runtime:
+
+1. серверно подтверждённая identity;
+2. retrieval → context → local model → citation validation;
+3. безопасное планирование и исполнение tools;
+4. confirmation для write;
+5. единая трасса audit/evaluation;
+6. deadlines, idempotency, limits, concurrency и backpressure;
+7. новый API contract вместо старого словарного `answer_platform_question`.
+
+Полный порядок работ и границы зрелости зафиксированы в `ROADMAP.md`.
+
+TAI не является завершённой промышленной AI-платформой до подключения фактических
+локальных model artifacts и знаний, UI-интеграции, а также прохождения evaluation,
+load, fault, restore, soak, security и legal acceptance.

--- a/apps/tai/ROADMAP.md
+++ b/apps/tai/ROADMAP.md
@@ -1,0 +1,68 @@
+# TAI delivery roadmap
+
+Статус на 18.07.2026. Источник истины — exact-main, а не номера старых этапов
+master-issue #2726.
+
+## Принято в main
+
+| Этап | Содержание | PR | Merge commit |
+| --- | --- | --- | --- |
+| AP-00–AP-02 | Foundation, contracts, policy, базовый Platform Knowledge | #2727 | `bba7ba14164d21954dd6afcd31d935a6662a248b` |
+| AP-03 | Source governance и durable ingestion recovery | #2728 | `b6e765744f88edb5530b946594fc0d742bb669ac` |
+| AP-04 | Managed loaders, leases, checkpoints и recovery audit | #2729 | `d43eef6310cc608bce200c3f0d237bb7930ae8e5` |
+| AP-05 | Governed lexical retrieval и generation fencing | #2730 | `f14f0023f8e4b48a6b135346635bf78111655ea8` |
+| AP-06 | Context assembly, grounded RAG и citation enforcement | #2731 | `30dc18c2526dbe8c0af22d45100b822ab50a7774` |
+| AP-07 | Governed local model runtime/router | #2732 | `182cf17a7779930c13c0066df14ac15bfcb32835` |
+| AP-08 | Safe agent tools и durable confirmation authority | #2734 | `234e2d6ef3a290cee008e2df74c8e3b24fc3a16f` |
+| AP-09 | Deterministic evaluation и red-team authority | #2735 | `297149187c552ba8a19057bb80f8bdbd002d9e7b` |
+
+## Архитектурное решение
+
+TAI остаётся в monorepo в `apps/tai`, но имеет отдельные ownership и release
+boundaries. Это разрешённая целевая архитектура до отдельного решения владельца о
+физическом выносе. Контракты с основной платформой должны быть версионированы;
+AI не получает authority Сделки, денег, ролей, ставок, подписей или споров.
+
+Причина решения: сейчас ценность и риск сосредоточены в корректной интеграции TAI с
+server-authoritative контекстом платформы. Физический перенос репозитория добавит
+операционную стоимость, но не закроет ни один пользовательский или safety-инвариант.
+
+## AP-10 — работающий AI-продукт и эксплуатационные контуры
+
+Последовательность узких authority-срезов:
+
+1. Единый orchestration runtime и новый API contract.
+2. Фактические локальные model artifacts, benchmark и CPU/GPU profiles.
+3. Полная Platform Knowledge Base и измеримый registry coverage.
+4. Реальные governed-источники российского АПК.
+5. Semantic/hybrid retrieval, embeddings и reranker.
+6. Document/vision ingestion с page-level provenance и quarantine.
+7. Platform Expert и Deal Copilot.
+8. Реальные Safe Tool adapters к серверным командам.
+9. UI и операционная административная панель.
+10. Security, legal/licensing, observability, HA/DR, load/fault/soak.
+
+Каждый срез обязан сохранять:
+
+- server-authoritative identity, tenant и roles;
+- 0 autonomous privileged write;
+- confirmation перед разрешённым write;
+- provenance и version для проверяемых утверждений;
+- abstention при недостатке evidence;
+- exact-head tests и machine-readable evidence.
+
+## AP-11 — release и промышленная приёмка
+
+1. Immutable containers, Helm/Kubernetes, staging и controlled rollout/rollback.
+2. Фактические platform/agro gold sets и human/domain review.
+3. CPU, GPU и fallback evaluation.
+4. 12-role end-to-end acceptance по всем этапам Сделки.
+5. Security, tenant isolation, load, fault, restore и soak evidence.
+6. Единый exact-main canonical acceptance manifest с итогом PASS/FAIL.
+
+## Запрет на завышение зрелости
+
+До AP-11 PASS разрешена формулировка: «архитектурное ядро TAI с изолированными
+exact-commit доказательствами». Запрещено заявлять завершённую промышленную
+AI-платформу, production acceptance, полное знание АПК или фактическую работу
+официальных источников без соответствующих model/data/deployment/evaluation evidence.

--- a/apps/tai/evidence/ap-09-exact-main.json
+++ b/apps/tai/evidence/ap-09-exact-main.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": "tai.exact-main-evidence.v1",
+  "stage": "AP-09",
+  "repository": "pachaninm-lab/pachanin-demo",
+  "pullRequest": 2735,
+  "exactHeadSha": "5bc97b73ad4d99a269eac0101e6b550d13303df7",
+  "mergeCommitSha": "297149187c552ba8a19057bb80f8bdbd002d9e7b",
+  "mergedAt": "2026-07-18T11:42:09Z",
+  "reviewThreads": {
+    "total": 0,
+    "unresolved": 0
+  },
+  "taiFoundation": {
+    "runId": 29643017090,
+    "event": "push",
+    "conclusion": "success",
+    "python": "3.12.13",
+    "ruff": "success",
+    "mypy": "success",
+    "tests": {
+      "passed": 245,
+      "failed": 0
+    },
+    "coveragePercent": 93.23,
+    "artifacts": [
+      {
+        "id": 8429188466,
+        "name": "tai-ruff-297149187c552ba8a19057bb80f8bdbd002d9e7b",
+        "zipSha256": "a6a760f1df7a1ea9da4a21a57c925b7e5babc7ede344556d392d935e68d7417b"
+      },
+      {
+        "id": 8429189191,
+        "name": "tai-mypy-297149187c552ba8a19057bb80f8bdbd002d9e7b",
+        "zipSha256": "8aad8389be64a843b9f3c604ab545e3aa88cceba31c4977cae5e572c8305db9c"
+      },
+      {
+        "id": 8429189925,
+        "name": "tai-pytest-297149187c552ba8a19057bb80f8bdbd002d9e7b",
+        "zipSha256": "de16d6fbea472fff5b0e4a481a47a9216566d3d6f0c122b1dcec0e4534911ada"
+      }
+    ]
+  },
+  "requiredExactMainWorkflows": [
+    {"name": "TAI Foundation", "runId": 29643017090, "conclusion": "success"},
+    {"name": "CI", "runId": 29643017076, "conclusion": "success"},
+    {"name": "Node CI", "runId": 29643017139, "conclusion": "success"},
+    {"name": "Security Quality Gate", "runId": 29643017138, "conclusion": "success"},
+    {"name": "Security Abuse and Evidence Acceptance", "runId": 29643017079, "conclusion": "success"},
+    {"name": "Runtime Context Security Gate", "runId": 29643017101, "conclusion": "success"},
+    {"name": "Security Scan", "runId": 29643017077, "conclusion": "success"},
+    {"name": "Auction Atomic Execution Acceptance", "runId": 29643017142, "conclusion": "success"},
+    {"name": "Outbox PostgreSQL Authority Acceptance", "runId": 29643017131, "conclusion": "success"},
+    {"name": "Disputes PostgreSQL Authority Acceptance", "runId": 29643017100, "conclusion": "success"},
+    {"name": "Optional Runtime Retirement Gate", "runId": 29643017083, "conclusion": "success"}
+  ],
+  "accepted": true,
+  "maturity": "ARCHITECTURAL_CORE_ONLY",
+  "remainingAcceptance": [
+    "real-model-and-data-integration",
+    "unified-orchestration-runtime",
+    "security-and-legal-acceptance",
+    "load-fault-restore-soak",
+    "end-to-end-release-acceptance"
+  ]
+}

--- a/apps/tai/pyproject.toml
+++ b/apps/tai/pyproject.toml
@@ -18,6 +18,9 @@ dev = [
   "mypy>=1.15,<2",
 ]
 
+[tool.setuptools]
+packages = ["tai"]
+
 [tool.pytest.ini_options]
 addopts = "-q --strict-markers --disable-warnings"
 testpaths = ["tests"]


### PR DESCRIPTION
## Scope

Formally close the AP-09 documentation/evidence gap after PR #2735 merged.

## Exact head

`08b2fc611e94043e5ffabd772d97dad48988783b`

## Changed files

- `apps/tai/README.md`
- `apps/tai/ROADMAP.md`
- `apps/tai/evidence/ap-09-exact-main.json`
- `apps/tai/pyproject.toml` (explicit `tai` package discovery so the non-package evidence directory cannot break editable builds)

## Evidence

- AP-09 exact-head: `5bc97b73ad4d99a269eac0101e6b550d13303df7`
- AP-09 merge/exact-main: `297149187c552ba8a19057bb80f8bdbd002d9e7b`
- TAI Foundation exact-main run: `29643017090`
- 245 tests passed, coverage 93.23%, Ruff and strict mypy passed
- required exact-main platform/security workflows are recorded by run ID
- review threads on PR #2735: 0
- review threads on this PR: 0 at exact-head update time

## Architecture decision

TAI remains in the monorepo under `apps/tai` with separate ownership and release boundaries. Physical extraction is not an AP-10 acceptance blocker; platform contracts remain versioned and server-authoritative.

## Guards

- documentation, machine-readable evidence, and package-discovery guard only
- no runtime or platform authority changes
- no maturity overstatement

## Checks

- `pip install -e . --no-deps`
- `git diff --check -- apps/tai`
- `jq empty apps/tai/evidence/ap-09-exact-main.json`
- exact-head GitHub gates

## Known limitations

This PR does not claim a completed industrial AI platform. Real models/data, unified runtime, security/legal, load/fault/restore/soak and AP-11 acceptance remain open.