### PR TITLE
TAI AP-11: fix exact-main critical-only dependency gate

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify dependency audit policy parser
+        run: node --test scripts/validate-pnpm-audit.test.mjs
+
       # The review API only works when the dependency graph is enabled in
       # repository settings. Probe first so a disabled graph surfaces as a
       # visible warning instead of a permanently red required-looking check.
@@ -63,12 +66,24 @@ jobs:
           set -euo pipefail
           corepack enable
           pnpm install --frozen-lockfile
+          : > pnpm-audit.json
           set +e
-          pnpm audit --prod --audit-level critical --json > pnpm-audit.json
-          status=$?
+          pnpm audit --prod --json > pnpm-audit.json
+          audit_status=$?
           set -e
+          printf '%s\n' "$audit_status" > pnpm-audit-exit-status.txt
+
+          : > pnpm-audit-policy.json
+          set +e
+          node scripts/validate-pnpm-audit.mjs \
+            pnpm-audit.json \
+            "$audit_status" \
+            > pnpm-audit-policy.json
+          policy_status=$?
+          set -e
+          printf '%s\n' "$policy_status" > pnpm-audit-policy-status.txt
           cat pnpm-audit.json
-          exit "$status"
+          cat pnpm-audit-policy.json
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -98,15 +113,72 @@ jobs:
           PY
           python -m pip install --upgrade pip
           python -m pip install 'pip-audit>=2.9,<3'
+          : > python-audit.json
           set +e
           pip-audit \
             --requirement tai-runtime-requirements.txt \
             --format json \
             --output python-audit.json
-          status=$?
+          audit_status=$?
           set -e
+          printf '%s\n' "$audit_status" > python-audit-exit-status.txt
           cat python-audit.json
-          exit "$status"
+
+      - name: Enforce exact-main dependency policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --test scripts/validate-pnpm-audit.test.mjs
+          node_policy_status="$(tr -d '\n' < pnpm-audit-policy-status.txt)"
+          python_audit_status="$(tr -d '\n' < python-audit-exit-status.txt)"
+          python - "$node_policy_status" "$python_audit_status" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          node_policy_status = int(sys.argv[1])
+          python_audit_status = int(sys.argv[2])
+          if node_policy_status != 0:
+              raise SystemExit(
+                  f'Node dependency policy rejected or report was invalid: {node_policy_status}'
+              )
+
+          node_policy = json.loads(Path('pnpm-audit-policy.json').read_text())
+          if node_policy.get('accepted') is not True:
+              raise SystemExit('Node dependency policy result is not accepted')
+          if node_policy.get('policy') != 'critical-only':
+              raise SystemExit('Node dependency policy identifier mismatch')
+          if node_policy.get('vulnerabilities', {}).get('critical') != 0:
+              raise SystemExit('Critical Node vulnerability count is not zero')
+
+          if python_audit_status != 0:
+              raise SystemExit(
+                  f'Python dependency audit rejected or failed operationally: {python_audit_status}'
+              )
+          python_report = json.loads(Path('python-audit.json').read_text())
+          dependencies = python_report.get('dependencies')
+          if not isinstance(dependencies, list) or not dependencies:
+              raise SystemExit('Python dependency audit inventory is empty or invalid')
+          vulnerable = [
+              dependency
+              for dependency in dependencies
+              if dependency.get('vulns')
+          ]
+          if vulnerable:
+              raise SystemExit('Python dependency audit contains vulnerabilities')
+
+          summary = {
+              'accepted': True,
+              'node_policy': node_policy,
+              'python_dependency_count': len(dependencies),
+              'python_vulnerable_dependency_count': 0,
+              'schema_version': 'tai.dependency.audit.v1',
+          }
+          Path('dependency-policy-summary.json').write_text(
+              json.dumps(summary, indent=2, sort_keys=True) + '\n'
+          )
+          print(json.dumps(summary, sort_keys=True))
+          PY
 
       - name: Upload exact-main dependency evidence
         if: always()
@@ -114,8 +186,13 @@ jobs:
         with:
           name: dependency-audit-${{ github.sha }}
           path: |
+            dependency-policy-summary.json
+            pnpm-audit-exit-status.txt
+            pnpm-audit-policy-status.txt
+            pnpm-audit-policy.json
             pnpm-audit.json
+            python-audit-exit-status.txt
             python-audit.json
             tai-runtime-requirements.txt
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 90

--- a/scripts/validate-pnpm-audit.mjs
+++ b/scripts/validate-pnpm-audit.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SEVERITIES = ['info', 'low', 'moderate', 'high', 'critical'];
+
+export function validatePnpmAuditReport(report, options = {}) {
+  const rawExitStatus = normalizeExitStatus(options.rawExitStatus ?? 0);
+  if (!report || typeof report !== 'object' || Array.isArray(report)) {
+    throw new Error('pnpm audit report must be a JSON object');
+  }
+  if (Object.hasOwn(report, 'error')) {
+    throw new Error(`pnpm audit returned an operational error: ${stringifyError(report.error)}`);
+  }
+
+  const vulnerabilities = report.metadata?.vulnerabilities;
+  if (!vulnerabilities || typeof vulnerabilities !== 'object' || Array.isArray(vulnerabilities)) {
+    throw new Error('pnpm audit report is missing metadata.vulnerabilities');
+  }
+
+  const counts = {};
+  for (const severity of SEVERITIES) {
+    const value = vulnerabilities[severity];
+    if (!Number.isInteger(value) || value < 0) {
+      throw new Error(`pnpm audit ${severity} count must be a non-negative integer`);
+    }
+    counts[severity] = value;
+  }
+
+  const advisories = report.advisories ?? {};
+  if (!advisories || typeof advisories !== 'object' || Array.isArray(advisories)) {
+    throw new Error('pnpm audit advisories must be an object');
+  }
+  const criticalAdvisories = Object.values(advisories).filter(
+    (advisory) => advisory?.severity === 'critical',
+  );
+  if (criticalAdvisories.length > counts.critical) {
+    throw new Error(
+      'pnpm audit report is contradictory: critical advisories exceed metadata count',
+    );
+  }
+
+  const totalDependencies = report.metadata?.totalDependencies;
+  if (!Number.isInteger(totalDependencies) || totalDependencies < 1) {
+    throw new Error('pnpm audit report has an invalid totalDependencies count');
+  }
+
+  const accepted = counts.critical === 0;
+  const result = {
+    accepted,
+    policy: 'critical-only',
+    pnpm_exit_status: rawExitStatus,
+    total_dependencies: totalDependencies,
+    vulnerabilities: counts,
+  };
+  if (!accepted) {
+    const error = new Error(
+      `pnpm audit rejected: ${counts.critical} critical vulnerabilities found`,
+    );
+    error.policyResult = result;
+    throw error;
+  }
+  return result;
+}
+
+function normalizeExitStatus(value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 255) {
+    throw new Error('pnpm audit exit status must be an integer between 0 and 255');
+  }
+  return parsed;
+}
+
+function stringifyError(value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function isDirectInvocation() {
+  if (!process.argv[1]) {
+    return false;
+  }
+  return path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+function main() {
+  const reportPath = process.argv[2];
+  const rawExitStatus = process.argv[3] ?? '0';
+  if (!reportPath) {
+    throw new Error(
+      'usage: node scripts/validate-pnpm-audit.mjs <report.json> [raw-exit-status]',
+    );
+  }
+  const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+  try {
+    const result = validatePnpmAuditReport(report, { rawExitStatus });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } catch (error) {
+    if (error?.policyResult) {
+      process.stdout.write(`${JSON.stringify(error.policyResult, null, 2)}\n`);
+    }
+    throw error;
+  }
+}
+
+if (isDirectInvocation()) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/validate-pnpm-audit.test.mjs
+++ b/scripts/validate-pnpm-audit.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { validatePnpmAuditReport } from './validate-pnpm-audit.mjs';
+
+function report(overrides = {}) {
+  return {
+    advisories: {},
+    metadata: {
+      vulnerabilities: {
+        info: 0,
+        low: 0,
+        moderate: 0,
+        high: 0,
+        critical: 0,
+      },
+      dependencies: 589,
+      devDependencies: 0,
+      optionalDependencies: 0,
+      totalDependencies: 589,
+    },
+    ...overrides,
+  };
+}
+
+test('accepts lower-severity findings despite pnpm exit status 1', () => {
+  const value = report();
+  value.metadata.vulnerabilities.moderate = 9;
+
+  assert.deepEqual(validatePnpmAuditReport(value, { rawExitStatus: 1 }), {
+    accepted: true,
+    policy: 'critical-only',
+    pnpm_exit_status: 1,
+    total_dependencies: 589,
+    vulnerabilities: {
+      info: 0,
+      low: 0,
+      moderate: 9,
+      high: 0,
+      critical: 0,
+    },
+  });
+});
+
+test('rejects critical findings', () => {
+  const value = report();
+  value.metadata.vulnerabilities.critical = 1;
+  value.advisories = {
+    '112233': { severity: 'critical' },
+  };
+
+  assert.throws(
+    () => validatePnpmAuditReport(value, { rawExitStatus: 1 }),
+    /1 critical vulnerabilities found/,
+  );
+});
+
+test('rejects operational error payloads', () => {
+  assert.throws(
+    () => validatePnpmAuditReport({ error: { code: 'EAI_AGAIN' } }),
+    /operational error/,
+  );
+});
+
+test('rejects reports without governed severity counts', () => {
+  assert.throws(
+    () => validatePnpmAuditReport({ advisories: {}, metadata: {} }),
+    /missing metadata\.vulnerabilities/,
+  );
+});
+
+test('rejects contradictory critical advisory evidence', () => {
+  const value = report({
+    advisories: {
+      '112233': { severity: 'critical' },
+    },
+  });
+
+  assert.throws(
+    () => validatePnpmAuditReport(value),
+    /critical advisories exceed metadata count/,
+  );
+});
+
+test('rejects malformed counts and exit status', () => {
+  const value = report();
+  value.metadata.vulnerabilities.high = -1;
+  assert.throws(() => validatePnpmAuditReport(value), /non-negative integer/);
+
+  assert.throws(
+    () => validatePnpmAuditReport(report(), { rawExitStatus: 'invalid' }),
+    /exit status must be an integer/,
+  );
+});
+
+test('rejects an empty dependency inventory', () => {
+  const value = report();
+  value.metadata.totalDependencies = 0;
+  assert.throws(
+    () => validatePnpmAuditReport(value),
+    /invalid totalDependencies/,
+  );
+});


### PR DESCRIPTION
## Причина

Exact-main `775b3c552647cbb6d23f711f7c4f17d147fac1f0` получил 11/12 зелёных required workflow. `Dependency Review` упал, потому что `pnpm audit` вернул exit code 1 при девяти moderate findings, хотя configured policy — critical-only. Artifact подтверждает 0 high и 0 critical.

## Исправление

- вводится отдельный fail-closed валидатор `scripts/validate-pnpm-audit.mjs`;
- решение принимается по валидированному JSON evidence, а не по неоднозначному raw exit code;
- operational error, malformed report, missing counts и contradictory advisory data отклоняются;
- critical > 0 отклоняется;
- lower severity при critical = 0 допускается согласно declared policy;
- семь unit tests покрывают moderate, critical, operational error, malformed counts, contradiction и empty inventory;
- Node и Python audit выполняются до единого final policy gate;
- artifact сохраняет raw reports, raw exit statuses, validated policy и итоговый summary.

## Scope

3 файла: workflow, валидатор, tests. AP-10/AP-11 runtime не меняется.

PR не должен объединяться без полного exact-head CI. После merge будет повторно проверен exact-main `TAI Release Acceptance` и его machine-readable artifact.