### PR TITLE
Closed audit: exact-main required workflows did not all trigger

### DIFF
--- a/.github/workflows/tai-exact-main-release-audit.yml
+++ b/.github/workflows/tai-exact-main-release-audit.yml
@@ -1,0 +1,347 @@
+name: TAI Exact-Main Release Audit
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tai-exact-main-release-audit.yml
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  audit-exact-main-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      AUDITED_SHA: 7cde908e3698f2ee6b7ce11c0ab8f8ef7569393f
+    steps:
+      - name: Wait for exact-main release authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > required-workflows.json <<'JSON'
+          [
+            "Auction Atomic Execution Acceptance",
+            "CI",
+            "Dependency Review",
+            "Disputes PostgreSQL Authority Acceptance",
+            "Node CI",
+            "Optional Runtime Retirement Gate",
+            "Outbox PostgreSQL Authority Acceptance",
+            "Runtime Context Security Gate",
+            "Security Abuse and Evidence Acceptance",
+            "Security Quality Gate",
+            "Security Scan",
+            "TAI Foundation",
+            "TAI Release Acceptance"
+          ]
+          JSON
+
+          for attempt in $(seq 1 120); do
+            gh api \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "/repos/${REPOSITORY}/actions/runs?head_sha=${AUDITED_SHA}&per_page=100" \
+              > workflow-runs-raw.json
+
+            set +e
+            python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          required = set(json.loads(Path('required-workflows.json').read_text()))
+          raw = json.loads(Path('workflow-runs-raw.json').read_text())
+          audited_sha = os.environ['AUDITED_SHA']
+          latest = {}
+          for run in raw.get('workflow_runs', []):
+              name = run.get('name')
+              if name not in required or run.get('head_sha') != audited_sha:
+                  continue
+              key = (run.get('run_attempt', 0), run.get('run_number', 0), run.get('id', 0))
+              current = latest.get(name)
+              if current is None or key > current[0]:
+                  latest[name] = (key, run)
+
+          missing = sorted(required - set(latest))
+          pending = sorted(
+              name for name, (_, run) in latest.items()
+              if run.get('status') != 'completed'
+          )
+          failed = sorted(
+              name for name, (_, run) in latest.items()
+              if run.get('status') == 'completed' and run.get('conclusion') != 'success'
+          )
+          wrong_event = sorted(
+              name for name, (_, run) in latest.items()
+              if run.get('event') != 'push' or run.get('head_branch') != 'main'
+          )
+          state = {
+              'failed': failed,
+              'missing': missing,
+              'pending': pending,
+              'wrong_event_or_branch': wrong_event,
+          }
+          Path('wait-state.json').write_text(
+              json.dumps(state, indent=2, sort_keys=True) + '\n'
+          )
+
+          discovered = []
+          for name in sorted(latest):
+              run = latest[name][1]
+              discovered.append({
+                  'conclusion': run.get('conclusion'),
+                  'event': run.get('event'),
+                  'head_branch': run.get('head_branch'),
+                  'head_sha': run.get('head_sha'),
+                  'run_attempt': run.get('run_attempt'),
+                  'run_id': run.get('id'),
+                  'run_number': run.get('run_number'),
+                  'run_url': run.get('html_url'),
+                  'status': run.get('status'),
+                  'workflow_name': name,
+              })
+          Path('discovered-workflows.json').write_text(
+              json.dumps(discovered, indent=2, sort_keys=True) + '\n'
+          )
+
+          if failed or wrong_event:
+              print(json.dumps(state, sort_keys=True))
+              raise SystemExit(2)
+          if missing or pending:
+              print(json.dumps(state, sort_keys=True))
+              raise SystemExit(3)
+
+          Path('exact-main-workflows.json').write_text(
+              json.dumps(discovered, indent=2, sort_keys=True) + '\n'
+          )
+          Path('release-run-id.txt').write_text(
+              str(latest['TAI Release Acceptance'][1]['id']) + '\n'
+          )
+          Path('dependency-run-id.txt').write_text(
+              str(latest['Dependency Review'][1]['id']) + '\n'
+          )
+          PY
+            status=$?
+            set -e
+
+            if [ "$status" -eq 0 ]; then
+              break
+            fi
+            if [ "$status" -eq 2 ]; then
+              cat wait-state.json >&2
+              exit 1
+            fi
+            if [ "$attempt" -eq 120 ]; then
+              cat wait-state.json >&2
+              exit 1
+            fi
+            sleep 20
+          done
+
+      - name: Upload discovery evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tai-exact-main-discovery-${{ env.AUDITED_SHA }}
+          path: |
+            discovered-workflows.json
+            wait-state.json
+            workflow-runs-raw.json
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Download exact-main authority artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_run_id="$(tr -d '\n' < release-run-id.txt)"
+          dependency_run_id="$(tr -d '\n' < dependency-run-id.txt)"
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/${REPOSITORY}/actions/runs/${release_run_id}/artifacts?per_page=100" \
+            > release-artifacts.json
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/${REPOSITORY}/actions/runs/${dependency_run_id}/artifacts?per_page=100" \
+            > dependency-artifacts.json
+
+          mapfile -t artifact_ids < <(python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          sha = os.environ['AUDITED_SHA']
+          specifications = (
+              ('release', Path('release-artifacts.json'), f'tai-release-attestation-{sha}'),
+              ('dependency', Path('dependency-artifacts.json'), f'dependency-audit-{sha}'),
+          )
+          metadata = {}
+          ids = []
+          for label, path, expected in specifications:
+              raw = json.loads(path.read_text())
+              matches = [
+                  artifact for artifact in raw.get('artifacts', [])
+                  if artifact.get('name') == expected and not artifact.get('expired', True)
+              ]
+              if len(matches) != 1:
+                  raise SystemExit(
+                      f'exactly one live {expected} artifact required; found {len(matches)}'
+                  )
+              metadata[label] = matches[0]
+              ids.append(str(matches[0]['id']))
+          Path('authority-artifact-metadata.json').write_text(
+              json.dumps(metadata, indent=2, sort_keys=True) + '\n'
+          )
+          print('\n'.join(ids))
+          PY
+          )
+          release_artifact_id="${artifact_ids[0]}"
+          dependency_artifact_id="${artifact_ids[1]}"
+
+          curl --fail --location --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${REPOSITORY}/actions/artifacts/${release_artifact_id}/zip" \
+            --output release-attestation.zip
+          curl --fail --location --silent --show-error \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${REPOSITORY}/actions/artifacts/${dependency_artifact_id}/zip" \
+            --output dependency-audit.zip
+          mkdir release-attestation dependency-audit
+          unzip -q release-attestation.zip -d release-attestation
+          unzip -q dependency-audit.zip -d dependency-audit
+
+      - name: Validate exact-main authority evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          audited_sha = os.environ['AUDITED_SHA']
+          required = set(json.loads(Path('required-workflows.json').read_text()))
+          required.remove('TAI Release Acceptance')
+          attestation_path = Path('release-attestation/tai-release-attestation.json')
+          workflow_path = Path('release-attestation/workflow-evidence.json')
+          release_wait_path = Path('release-attestation/workflow-wait-state.json')
+          dependency_summary_path = Path('dependency-audit/dependency-policy-summary.json')
+          node_policy_path = Path('dependency-audit/pnpm-audit-policy.json')
+          for path in (
+              attestation_path,
+              workflow_path,
+              release_wait_path,
+              dependency_summary_path,
+              node_policy_path,
+          ):
+              if not path.is_file():
+                  raise SystemExit(f'authority artifact is incomplete: {path}')
+
+          attestation = json.loads(attestation_path.read_text())
+          workflow_evidence = json.loads(workflow_path.read_text())
+          release_wait = json.loads(release_wait_path.read_text())
+          dependency_summary = json.loads(dependency_summary_path.read_text())
+          node_policy = json.loads(node_policy_path.read_text())
+
+          if attestation.get('schema_version') != 'tai.release.attestation.v1':
+              raise SystemExit('unexpected attestation schema')
+          if attestation.get('exact_main_sha') != audited_sha:
+              raise SystemExit('attestation exact_main_sha mismatch')
+          if attestation.get('accepted') is not True:
+              raise SystemExit('application release was not accepted')
+          if attestation.get('production_operational_status') != 'NOT_ATTESTED':
+              raise SystemExit('operational maturity was fabricated')
+          if attestation.get('reasons') != []:
+              raise SystemExit('accepted attestation contains rejection reasons')
+          if release_wait != {'failed': [], 'missing': [], 'pending': []}:
+              raise SystemExit(f'unexpected release wait state: {release_wait}')
+
+          names = {item.get('workflow_name') for item in workflow_evidence}
+          if names != required or len(workflow_evidence) != len(required):
+              raise SystemExit('workflow evidence does not equal the 12 required workflows')
+          for item in workflow_evidence:
+              if item.get('exact_head_sha') != audited_sha:
+                  raise SystemExit('cross-head workflow evidence detected')
+              if item.get('conclusion') != 'success':
+                  raise SystemExit('non-success workflow evidence detected')
+              digest = item.get('evidence_sha256')
+              if not isinstance(digest, str) or len(digest) != 64:
+                  raise SystemExit('invalid workflow evidence digest')
+
+          migrations = attestation.get('migration_inventory')
+          versions = [item.get('version') for item in migrations]
+          if versions != list(range(1, 12)):
+              raise SystemExit(f'migration inventory is not contiguous through 0011: {versions}')
+          for key in (
+              'attestation_sha256',
+              'migration_inventory_sha256',
+              'release_id',
+              'source_tree_sha256',
+          ):
+              value = attestation.get(key)
+              if not isinstance(value, str) or len(value) != 64:
+                  raise SystemExit(f'invalid {key}')
+
+          if dependency_summary.get('schema_version') != 'tai.dependency.audit.v1':
+              raise SystemExit('unexpected dependency authority schema')
+          if dependency_summary.get('accepted') is not True:
+              raise SystemExit('exact-main dependency authority rejected')
+          if dependency_summary.get('python_vulnerable_dependency_count') != 0:
+              raise SystemExit('Python dependency vulnerabilities detected')
+          if node_policy.get('accepted') is not True:
+              raise SystemExit('Node dependency authority rejected')
+          if node_policy.get('policy') != 'critical-only':
+              raise SystemExit('Node dependency policy mismatch')
+          if node_policy.get('vulnerabilities', {}).get('critical') != 0:
+              raise SystemExit('critical Node vulnerabilities detected')
+
+          summary = {
+              'accepted': True,
+              'artifact_attestation_file_sha256': hashlib.sha256(
+                  attestation_path.read_bytes()
+              ).hexdigest(),
+              'attestation_sha256': attestation['attestation_sha256'],
+              'audited_sha': audited_sha,
+              'dependency_authority_accepted': True,
+              'migration_count': len(migrations),
+              'node_critical_vulnerabilities': 0,
+              'production_operational_status': attestation['production_operational_status'],
+              'python_vulnerable_dependencies': 0,
+              'release_id': attestation['release_id'],
+              'required_workflow_count': len(workflow_evidence),
+              'source_tree_sha256': attestation['source_tree_sha256'],
+          }
+          Path('exact-main-release-audit.json').write_text(
+              json.dumps(summary, indent=2, sort_keys=True) + '\n'
+          )
+          print(json.dumps(summary, sort_keys=True))
+          PY
+
+      - name: Upload validated authority evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: tai-exact-main-release-audit-${{ env.AUDITED_SHA }}
+          path: |
+            authority-artifact-metadata.json
+            dependency-audit/dependency-policy-summary.json
+            dependency-audit/pnpm-audit-policy.json
+            exact-main-release-audit.json
+            exact-main-workflows.json
+            release-attestation/tai-release-attestation.json
+            release-attestation/workflow-evidence.json
+            release-attestation/workflow-wait-state.json
+            wait-state.json
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
Одноразовый audit закрыт без merge.

Для exact-main `7cde908e3698f2ee6b7ce11c0ab8f8ef7569393f`:

- failures среди обнаруженных required workflow: 0;
- 9 required workflow завершены SUCCESS;
- `CI`, `Node CI`, `TAI Foundation` отсутствуют из-за push path filters;
- `TAI Release Acceptance` корректно не выпускает attestation при неполном evidence set.

Это trigger-contract defect AP-11, а не failure продукта или зависимостей. Исправление выполняется отдельным PR. Audit workflow в main не попадёт.