### PR TITLE
Closed discovery: exact-main trigger gap identified

### DIFF
--- a/.github/workflows/tai-exact-main-discovery.yml
+++ b/.github/workflows/tai-exact-main-discovery.yml
@@ -1,0 +1,106 @@
+name: TAI Exact-Main Workflow Discovery
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tai-exact-main-discovery.yml
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  discover-exact-main:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      AUDITED_SHA: 7cde908e3698f2ee6b7ce11c0ab8f8ef7569393f
+    steps:
+      - name: Query exact-main workflow runs
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "/repos/${REPOSITORY}/actions/runs?head_sha=${AUDITED_SHA}&per_page=100" \
+            > workflow-runs-raw.json
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          required = {
+              'Auction Atomic Execution Acceptance',
+              'CI',
+              'Dependency Review',
+              'Disputes PostgreSQL Authority Acceptance',
+              'Node CI',
+              'Optional Runtime Retirement Gate',
+              'Outbox PostgreSQL Authority Acceptance',
+              'Runtime Context Security Gate',
+              'Security Abuse and Evidence Acceptance',
+              'Security Quality Gate',
+              'Security Scan',
+              'TAI Foundation',
+              'TAI Release Acceptance',
+          }
+          audited_sha = os.environ['AUDITED_SHA']
+          raw = json.loads(Path('workflow-runs-raw.json').read_text())
+          latest = {}
+          for run in raw.get('workflow_runs', []):
+              name = run.get('name')
+              if name not in required or run.get('head_sha') != audited_sha:
+                  continue
+              key = (run.get('run_attempt', 0), run.get('run_number', 0), run.get('id', 0))
+              current = latest.get(name)
+              if current is None or key > current[0]:
+                  latest[name] = (key, run)
+
+          runs = []
+          for name in sorted(latest):
+              run = latest[name][1]
+              runs.append({
+                  'conclusion': run.get('conclusion'),
+                  'created_at': run.get('created_at'),
+                  'event': run.get('event'),
+                  'head_branch': run.get('head_branch'),
+                  'head_sha': run.get('head_sha'),
+                  'run_attempt': run.get('run_attempt'),
+                  'run_id': run.get('id'),
+                  'run_number': run.get('run_number'),
+                  'run_url': run.get('html_url'),
+                  'status': run.get('status'),
+                  'updated_at': run.get('updated_at'),
+                  'workflow_name': name,
+              })
+          summary = {
+              'audited_sha': audited_sha,
+              'failed': sorted(
+                  item['workflow_name'] for item in runs
+                  if item['status'] == 'completed' and item['conclusion'] != 'success'
+              ),
+              'missing': sorted(required - set(latest)),
+              'pending': sorted(
+                  item['workflow_name'] for item in runs
+                  if item['status'] != 'completed'
+              ),
+              'run_count': len(runs),
+              'runs': runs,
+          }
+          Path('exact-main-discovery.json').write_text(
+              json.dumps(summary, indent=2, sort_keys=True) + '\n'
+          )
+          print(json.dumps(summary, sort_keys=True))
+          PY
+
+      - name: Upload exact-main discovery
+        uses: actions/upload-artifact@v4
+        with:
+          name: tai-exact-main-discovery-${{ env.AUDITED_SHA }}
+          path: exact-main-discovery.json
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
Одноразовый discovery закрыт без merge.

Exact-main `7cde908e3698f2ee6b7ce11c0ab8f8ef7569393f`:

- failures: 0;
- 9 required workflow: SUCCESS;
- `TAI Release Acceptance`: IN_PROGRESS;
- missing: `CI`, `Node CI`, `TAI Foundation`.

Причина: три required workflow имеют push path filters и не запускаются на каждом commit в `main`. Release authority корректно не может принять неполный набор evidence.

Исправление переносится в отдельный продуктовый PR: push без path filters, SHA-scoped non-cancelling concurrency и regression test trigger-контракта.