### PR TITLE
Superseded: exact-main workflow trigger authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,10 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'apps/**'
-      - 'packages/**'
-      - 'scripts/platform-v7-*'
-      - 'docs/platform-v7/production-database-deployment-runbook.md'
-      - '.github/workflows/ci.yml'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'tsconfig*.json'
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
 
 jobs:
   web-unit:
@@ -235,7 +226,7 @@ jobs:
           --health-retries 20
     env:
       NODE_ENV: test
-      DATABASE_URL: postgresql://auth_admin:ephemeral_auth_admin_only@127.0.0.1:5432/auth_e2e
+      DATABASE_URL: postgresql://auth_admin:ephemeral_industrial_admin_only@127.0.0.1:5432/auth_e2e
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
           --health-retries 20
     env:
       NODE_ENV: test
-      DATABASE_URL: postgresql://auth_admin:ephemeral_industrial_admin_only@127.0.0.1:5432/auth_e2e
+      DATABASE_URL: postgresql://auth_admin:ephemeral_auth_admin_only@127.0.0.1:5432/auth_e2e
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -3,23 +3,19 @@ name: Node CI
 on:
   push:
     branches: [main]
-    paths:
-      - 'apps/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'tsconfig*.json'
   pull_request:
     branches: [main]
     paths:
       - 'apps/**'
+      - '.github/workflows/node-ci.yml'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'tsconfig*.json'
   workflow_dispatch:
 
 concurrency:
-  group: node-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: node-ci-${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
 
 jobs:
   ci:

--- a/.github/workflows/tai-foundation.yml
+++ b/.github/workflows/tai-foundation.yml
@@ -7,12 +7,14 @@ on:
       - '.github/workflows/tai-foundation.yml'
   push:
     branches: [main]
-    paths:
-      - 'apps/tai/**'
-      - '.github/workflows/tai-foundation.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: tai-foundation-${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
 
 jobs:
   test:

--- a/apps/tai/tests/test_release_workflow_triggers.py
+++ b/apps/tai/tests/test_release_workflow_triggers.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW_ROOT = _REPOSITORY_ROOT / ".github/workflows"
+_REQUIRED_EXACT_MAIN_WORKFLOWS = (
+    "ci.yml",
+    "node-ci.yml",
+    "tai-foundation.yml",
+)
+
+
+def _mapping_block(text: str, key: str, indent: int) -> str:
+    prefix = " " * indent
+    marker = f"{prefix}{key}:"
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line != marker:
+            continue
+        block = [line]
+        for candidate in lines[index + 1 :]:
+            if candidate.strip():
+                candidate_indent = len(candidate) - len(candidate.lstrip(" "))
+                if candidate_indent <= indent:
+                    break
+            block.append(candidate)
+        return "\n".join(block)
+    raise AssertionError(f"workflow mapping {key!r} at indent {indent} is missing")
+
+
+def _workflow(name: str) -> str:
+    path = _WORKFLOW_ROOT / name
+    assert path.is_file(), f"required workflow is missing: {path}"
+    return path.read_text()
+
+
+def test_required_workflows_run_for_every_main_sha() -> None:
+    for name in _REQUIRED_EXACT_MAIN_WORKFLOWS:
+        text = _workflow(name)
+        on_block = _mapping_block(text, "on", 0)
+        push_block = _mapping_block(on_block, "push", 2)
+
+        assert "branches:" in push_block
+        assert "main" in push_block
+        assert "paths:" not in push_block, (
+            f"{name} cannot be path-filtered on main because AP-11 requires "
+            "exact-head evidence for every release candidate"
+        )
+
+
+def test_required_workflows_preserve_exact_sha_evidence() -> None:
+    for name in _REQUIRED_EXACT_MAIN_WORKFLOWS:
+        concurrency = _mapping_block(_workflow(name), "concurrency", 0)
+
+        assert "${{ github.sha }}" in concurrency
+        assert "cancel-in-progress: false" in concurrency
+        assert "${{ github.ref }}" not in concurrency
+
+
+def test_node_ci_reviews_its_own_trigger_contract() -> None:
+    text = _workflow("node-ci.yml")
+    on_block = _mapping_block(text, "on", 0)
+    pull_request = _mapping_block(on_block, "pull_request", 2)
+
+    assert ".github/workflows/node-ci.yml" in pull_request
+
+
+def test_tai_foundation_supports_manual_exact_sha_recovery() -> None:
+    on_block = _mapping_block(_workflow("tai-foundation.yml"), "on", 0)
+
+    assert "workflow_dispatch:" in on_block


### PR DESCRIPTION
Закрыт без merge.

Пока ветка разрабатывалась, PR #2746 уже объединил устранение `push.paths` и базовый regression contract в `main` (`eb6927455ed73d119b9f5e6072cbd5fe86df16f2`). Эта ветка теперь конфликтует и дублирует уже принятую работу.

Незакрытый риск — concurrency по `github.ref` с `cancel-in-progress: true`, способная отменять evidence предыдущего exact-main SHA. Он переносится в чистый PR от актуального `main` без дублирования #2746.