### PR TITLE
TAI AP-10B: bounded fenced heartbeat for long-running tool actions

### DIFF
--- a/apps/tai/tai/postgres_prepared_action_heartbeat.py
+++ b/apps/tai/tai/postgres_prepared_action_heartbeat.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import threading
+from contextvars import Context, ContextVar, copy_context
+from dataclasses import dataclass
+from datetime import timedelta
+from uuid import UUID
+
+from tai.agent_runtime import AgentExecutionResult
+from tai.orchestration import (
+    PreparedActionClaim,
+    PreparedActionClaimStatus,
+    StoredPreparedAction,
+)
+from tai.postgres_loader_state import ConnectionFactory
+from tai.postgres_orchestration import PostgreSQLPreparedActionRepository
+
+
+class PreparedActionHeartbeatError(RuntimeError):
+    """The executing replica lost control of its durable prepared-action lease."""
+
+
+@dataclass(slots=True)
+class _HeartbeatHandle:
+    stop_event: threading.Event
+    thread: threading.Thread | None = None
+    failure: BaseException | None = None
+
+
+class HeartbeatingPostgreSQLPreparedActionRepository(
+    PostgreSQLPreparedActionRepository
+):
+    """Keep a fenced execution lease alive while a blocking tool call is running.
+
+    The fencing token remains bound to the request context created by the base
+    repository. A copied context is used only by the dedicated heartbeat thread.
+    Process death stops heartbeats, allowing another replica to reclaim the action
+    after database lease expiry. Heartbeat loss or an unresponsive heartbeat thread
+    blocks durable completion, so a stale executor cannot commit a result.
+    """
+
+    def __init__(
+        self,
+        connection_factory: ConnectionFactory,
+        *,
+        execution_lease: timedelta = timedelta(minutes=5),
+        heartbeat_interval: timedelta | None = None,
+        heartbeat_stop_timeout: timedelta | None = None,
+    ) -> None:
+        super().__init__(
+            connection_factory,
+            execution_lease=execution_lease,
+        )
+        effective_lease_seconds = float(self._execution_lease_seconds)
+        interval = heartbeat_interval or timedelta(
+            seconds=effective_lease_seconds / 3
+        )
+        interval_seconds = interval.total_seconds()
+        if interval_seconds < 0.05:
+            raise ValueError("heartbeat_interval must be at least 50 milliseconds")
+        if interval_seconds >= effective_lease_seconds:
+            raise ValueError(
+                "heartbeat_interval must be shorter than the effective execution lease"
+            )
+
+        stop_timeout = heartbeat_stop_timeout or timedelta(
+            seconds=min(max(interval_seconds * 2, 0.1), 5.0)
+        )
+        stop_timeout_seconds = stop_timeout.total_seconds()
+        if not 0.05 <= stop_timeout_seconds <= 30:
+            raise ValueError(
+                "heartbeat_stop_timeout must be between 50 milliseconds and 30 seconds"
+            )
+
+        self._heartbeat_interval_seconds = interval_seconds
+        self._heartbeat_stop_timeout_seconds = stop_timeout_seconds
+        self._heartbeat_handles: ContextVar[dict[UUID, _HeartbeatHandle] | None] = (
+            ContextVar(
+                f"tai_prepared_action_heartbeats_{id(self)}",
+                default=None,
+            )
+        )
+
+    def claim(self, confirmation_id: UUID) -> PreparedActionClaim:
+        claim = super().claim(confirmation_id)
+        if claim.status is PreparedActionClaimStatus.EXECUTE:
+            try:
+                self._start_heartbeat(confirmation_id)
+            except Exception:
+                super().abandon(confirmation_id)
+                raise
+        return claim
+
+    def complete(
+        self,
+        confirmation_id: UUID,
+        result: AgentExecutionResult,
+    ) -> StoredPreparedAction:
+        self._stop_heartbeat(confirmation_id, raise_on_failure=True)
+        return super().complete(confirmation_id, result)
+
+    def abandon(self, confirmation_id: UUID) -> None:
+        self._stop_heartbeat(confirmation_id, raise_on_failure=False)
+        super().abandon(confirmation_id)
+
+    def _start_heartbeat(self, confirmation_id: UUID) -> None:
+        handles = self._handles()
+        if confirmation_id in handles:
+            raise RuntimeError("prepared action heartbeat is already active")
+        execution_context = copy_context()
+        handle = _HeartbeatHandle(stop_event=threading.Event())
+        handle.thread = threading.Thread(
+            target=self._heartbeat_loop,
+            args=(confirmation_id, execution_context, handle),
+            name=f"tai-action-heartbeat-{confirmation_id}",
+            daemon=True,
+        )
+        updated = dict(handles)
+        updated[confirmation_id] = handle
+        self._heartbeat_handles.set(updated)
+        try:
+            handle.thread.start()
+        except Exception:
+            updated.pop(confirmation_id, None)
+            self._heartbeat_handles.set(updated)
+            raise
+
+    def _stop_heartbeat(
+        self,
+        confirmation_id: UUID,
+        *,
+        raise_on_failure: bool,
+    ) -> None:
+        handles = self._handles()
+        handle = handles.get(confirmation_id)
+        if handle is None:
+            return
+        handle.stop_event.set()
+        thread = handle.thread
+        if thread is not None:
+            thread.join(self._heartbeat_stop_timeout_seconds)
+        updated = dict(handles)
+        updated.pop(confirmation_id, None)
+        self._heartbeat_handles.set(updated)
+
+        if thread is not None and thread.is_alive():
+            failure = PreparedActionHeartbeatError(
+                "prepared action heartbeat thread did not stop within the bounded timeout"
+            )
+            if raise_on_failure:
+                raise failure
+            return
+        if raise_on_failure and handle.failure is not None:
+            raise PreparedActionHeartbeatError(
+                "prepared action execution lease was lost before completion"
+            ) from handle.failure
+
+    def _heartbeat_loop(
+        self,
+        confirmation_id: UUID,
+        execution_context: Context,
+        handle: _HeartbeatHandle,
+    ) -> None:
+        while not handle.stop_event.wait(self._heartbeat_interval_seconds):
+            try:
+                renewed = execution_context.run(
+                    self._renew_execution_lease,
+                    confirmation_id,
+                )
+            except BaseException as error:
+                handle.failure = error
+                handle.stop_event.set()
+                return
+            if not renewed:
+                handle.failure = PreparedActionHeartbeatError(
+                    "prepared action execution lease is stale, expired, or fenced"
+                )
+                handle.stop_event.set()
+                return
+
+    def _renew_execution_lease(self, confirmation_id: UUID) -> bool:
+        execution_token = self._execution_token(confirmation_id)
+        if execution_token is None:
+            return False
+        row = self._execute_returning(
+            """
+                UPDATE tai_prepared_actions
+                SET execution_expires_at = clock_timestamp()
+                        + (%s * INTERVAL '1 second'),
+                    updated_at = clock_timestamp()
+                WHERE confirmation_id = %s
+                  AND status = 'EXECUTING'
+                  AND execution_token = %s
+                  AND execution_expires_at > clock_timestamp()
+                RETURNING confirmation_id
+            """,
+            (
+                self._execution_lease_seconds,
+                confirmation_id,
+                execution_token,
+            ),
+        )
+        return row is not None
+
+    def _handles(self) -> dict[UUID, _HeartbeatHandle]:
+        current = self._heartbeat_handles.get()
+        return {} if current is None else current

--- a/apps/tai/tests/test_postgres_prepared_action_heartbeat.py
+++ b/apps/tai/tests/test_postgres_prepared_action_heartbeat.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from contextlib import AbstractContextManager
+from datetime import timedelta
+from typing import Any, cast
+from uuid import UUID
+
+import pytest
+
+from tai.agent_runtime import AgentExecutionResult
+from tai.orchestration import (
+    PreparedActionClaim,
+    PreparedActionClaimStatus,
+    StoredPreparedAction,
+)
+from tai.postgres_orchestration import PostgreSQLPreparedActionRepository
+from tai.postgres_prepared_action_heartbeat import (
+    HeartbeatingPostgreSQLPreparedActionRepository,
+    PreparedActionHeartbeatError,
+)
+
+CONFIRMATION_ID = UUID("11111111-1111-4111-8111-111111111111")
+EXECUTION_TOKEN = UUID("22222222-2222-4222-8222-222222222222")
+
+
+class _Cursor(AbstractContextManager["_Cursor"]):
+    def __init__(self, row: Mapping[str, Any] | None) -> None:
+        self.row = row
+        self.query = ""
+        self.parameters: tuple[Any, ...] = ()
+
+    def __enter__(self) -> _Cursor:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def execute(self, query: str, parameters: Sequence[Any] = ()) -> None:
+        self.query = query
+        self.parameters = tuple(parameters)
+
+    def fetchone(self) -> Mapping[str, Any] | None:
+        return self.row
+
+
+class _Connection(AbstractContextManager["_Connection"]):
+    def __init__(self, row: Mapping[str, Any] | None) -> None:
+        self.cursor_instance = _Cursor(row)
+        self.committed = False
+        self.rolled_back = False
+
+    def __enter__(self) -> _Connection:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def cursor(self) -> _Cursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+
+class _Factory:
+    def __init__(self, row: Mapping[str, Any] | None) -> None:
+        self.connection = _Connection(row)
+
+    def __call__(self) -> _Connection:
+        return self.connection
+
+
+def _repository(
+    factory: _Factory | None = None,
+    *,
+    lease_seconds: float = 1.0,
+    heartbeat_seconds: float = 0.05,
+    stop_timeout_seconds: float = 0.1,
+) -> HeartbeatingPostgreSQLPreparedActionRepository:
+    return HeartbeatingPostgreSQLPreparedActionRepository(
+        factory or _Factory({"confirmation_id": CONFIRMATION_ID}),
+        execution_lease=timedelta(seconds=lease_seconds),
+        heartbeat_interval=timedelta(seconds=heartbeat_seconds),
+        heartbeat_stop_timeout=timedelta(seconds=stop_timeout_seconds),
+    )
+
+
+def test_heartbeat_policy_requires_safe_interval_and_bounded_stop() -> None:
+    with pytest.raises(ValueError, match="at least 50 milliseconds"):
+        _repository(heartbeat_seconds=0.01)
+    with pytest.raises(ValueError, match="effective execution lease"):
+        _repository(lease_seconds=1.9, heartbeat_seconds=1.1)
+    with pytest.raises(ValueError, match="between 50 milliseconds and 30 seconds"):
+        _repository(stop_timeout_seconds=31)
+
+
+def test_renew_execution_lease_uses_current_fencing_token() -> None:
+    factory = _Factory({"confirmation_id": CONFIRMATION_ID})
+    repository = _repository(factory)
+    repository._remember_execution_token(CONFIRMATION_ID, EXECUTION_TOKEN)
+
+    assert repository._renew_execution_lease(CONFIRMATION_ID) is True
+
+    cursor = factory.connection.cursor_instance
+    assert "execution_expires_at > clock_timestamp()" in cursor.query
+    assert cursor.parameters == (1, CONFIRMATION_ID, EXECUTION_TOKEN)
+    assert factory.connection.committed is True
+    assert factory.connection.rolled_back is False
+
+
+def test_renew_execution_lease_fails_without_token_or_database_row() -> None:
+    repository = _repository(_Factory(None))
+    assert repository._renew_execution_lease(CONFIRMATION_ID) is False
+
+    repository._remember_execution_token(CONFIRMATION_ID, EXECUTION_TOKEN)
+    assert repository._renew_execution_lease(CONFIRMATION_ID) is False
+
+
+def test_heartbeat_runs_in_copied_fencing_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository()
+    repository._remember_execution_token(CONFIRMATION_ID, EXECUTION_TOKEN)
+    renewals: list[UUID | None] = []
+    renewed = threading.Event()
+
+    def renew(confirmation_id: UUID) -> bool:
+        renewals.append(repository._execution_token(confirmation_id))
+        renewed.set()
+        return True
+
+    monkeypatch.setattr(repository, "_renew_execution_lease", renew)
+    repository._start_heartbeat(CONFIRMATION_ID)
+    assert renewed.wait(0.5) is True
+    repository._stop_heartbeat(CONFIRMATION_ID, raise_on_failure=True)
+
+    assert renewals
+    assert set(renewals) == {EXECUTION_TOKEN}
+    assert repository._handles() == {}
+
+
+def test_duplicate_heartbeat_is_rejected_and_abandon_discards_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository()
+    repository._remember_execution_token(CONFIRMATION_ID, EXECUTION_TOKEN)
+    failed = threading.Event()
+
+    def reject(_: UUID) -> bool:
+        failed.set()
+        return False
+
+    monkeypatch.setattr(repository, "_renew_execution_lease", reject)
+    repository._start_heartbeat(CONFIRMATION_ID)
+    with pytest.raises(RuntimeError, match="already active"):
+        repository._start_heartbeat(CONFIRMATION_ID)
+    assert failed.wait(0.5) is True
+    repository._stop_heartbeat(CONFIRMATION_ID, raise_on_failure=False)
+    assert repository._handles() == {}
+
+
+def test_heartbeat_loss_blocks_completion(monkeypatch: pytest.MonkeyPatch) -> None:
+    repository = _repository()
+    repository._remember_execution_token(CONFIRMATION_ID, EXECUTION_TOKEN)
+    failed = threading.Event()
+
+    def reject(_: UUID) -> bool:
+        failed.set()
+        return False
+
+    monkeypatch.setattr(repository, "_renew_execution_lease", reject)
+    repository._start_heartbeat(CONFIRMATION_ID)
+    assert failed.wait(0.5) is True
+
+    with pytest.raises(PreparedActionHeartbeatError, match="lost before completion"):
+        repository._stop_heartbeat(CONFIRMATION_ID, raise_on_failure=True)
+
+
+def test_heartbeat_exception_blocks_completion(monkeypatch: pytest.MonkeyPatch) -> None:
+    repository = _repository()
+    repository._remember_execution_token(CONFIRMATION_ID, EXECUTION_TOKEN)
+    failed = threading.Event()
+
+    def explode(_: UUID) -> bool:
+        failed.set()
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(repository, "_renew_execution_lease", explode)
+    repository._start_heartbeat(CONFIRMATION_ID)
+    assert failed.wait(0.5) is True
+
+    with pytest.raises(PreparedActionHeartbeatError) as error:
+        repository._stop_heartbeat(CONFIRMATION_ID, raise_on_failure=True)
+    assert isinstance(error.value.__cause__, RuntimeError)
+
+
+def test_unresponsive_heartbeat_thread_blocks_completion_within_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(stop_timeout_seconds=0.05)
+    repository._remember_execution_token(CONFIRMATION_ID, EXECUTION_TOKEN)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def block(_: UUID) -> bool:
+        entered.set()
+        release.wait(1)
+        return True
+
+    monkeypatch.setattr(repository, "_renew_execution_lease", block)
+    repository._start_heartbeat(CONFIRMATION_ID)
+    assert entered.wait(0.5) is True
+
+    started = time.monotonic()
+    with pytest.raises(PreparedActionHeartbeatError, match="bounded timeout"):
+        repository._stop_heartbeat(CONFIRMATION_ID, raise_on_failure=True)
+    assert time.monotonic() - started < 0.5
+    release.set()
+
+
+def test_claim_starts_heartbeat_only_for_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository()
+    prepared = cast(StoredPreparedAction, object())
+    started: list[UUID] = []
+
+    monkeypatch.setattr(
+        PostgreSQLPreparedActionRepository,
+        "claim",
+        lambda self, confirmation_id: PreparedActionClaim(
+            PreparedActionClaimStatus.EXECUTE,
+            prepared,
+        ),
+    )
+    monkeypatch.setattr(repository, "_start_heartbeat", started.append)
+    claim = repository.claim(CONFIRMATION_ID)
+    assert claim.status is PreparedActionClaimStatus.EXECUTE
+    assert started == [CONFIRMATION_ID]
+
+    monkeypatch.setattr(
+        PostgreSQLPreparedActionRepository,
+        "claim",
+        lambda self, confirmation_id: PreparedActionClaim(
+            PreparedActionClaimStatus.IN_PROGRESS,
+            prepared,
+        ),
+    )
+    claim = repository.claim(CONFIRMATION_ID)
+    assert claim.status is PreparedActionClaimStatus.IN_PROGRESS
+    assert started == [CONFIRMATION_ID]
+
+
+def test_complete_stops_heartbeat_before_database_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository()
+    result = cast(AgentExecutionResult, object())
+    prepared = cast(StoredPreparedAction, object())
+    order: list[str] = []
+
+    monkeypatch.setattr(
+        repository,
+        "_stop_heartbeat",
+        lambda confirmation_id, *, raise_on_failure: order.append(
+            f"stop:{confirmation_id}:{raise_on_failure}"
+        ),
+    )
+
+    def complete(
+        self: PostgreSQLPreparedActionRepository,
+        confirmation_id: UUID,
+        execution: AgentExecutionResult,
+    ) -> StoredPreparedAction:
+        del self, confirmation_id, execution
+        order.append("complete")
+        return prepared
+
+    monkeypatch.setattr(PostgreSQLPreparedActionRepository, "complete", complete)
+    assert repository.complete(CONFIRMATION_ID, result) is prepared
+    assert order == [f"stop:{CONFIRMATION_ID}:True", "complete"]
+
+
+def test_abandon_stops_heartbeat_without_masking_original_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository()
+    order: list[str] = []
+
+    monkeypatch.setattr(
+        repository,
+        "_stop_heartbeat",
+        lambda confirmation_id, *, raise_on_failure: order.append(
+            f"stop:{confirmation_id}:{raise_on_failure}"
+        ),
+    )
+
+    def abandon(
+        self: PostgreSQLPreparedActionRepository,
+        confirmation_id: UUID,
+    ) -> None:
+        del self, confirmation_id
+        order.append("abandon")
+
+    monkeypatch.setattr(PostgreSQLPreparedActionRepository, "abandon", abandon)
+    repository.abandon(CONFIRMATION_ID)
+    assert order == [f"stop:{CONFIRMATION_ID}:False", "abandon"]
+
+
+def test_stop_without_active_heartbeat_is_a_noop() -> None:
+    repository = _repository()
+    repository._stop_heartbeat(CONFIRMATION_ID, raise_on_failure=True)
+    time.sleep(0)

--- a/apps/tai/tests/test_postgres_prepared_action_heartbeat_startup.py
+++ b/apps/tai/tests/test_postgres_prepared_action_heartbeat_startup.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from contextlib import AbstractContextManager
+from datetime import timedelta
+from typing import Any, cast
+from uuid import UUID
+
+import pytest
+
+from tai.orchestration import (
+    PreparedActionClaim,
+    PreparedActionClaimStatus,
+    StoredPreparedAction,
+)
+from tai.postgres_orchestration import PostgreSQLPreparedActionRepository
+from tai.postgres_prepared_action_heartbeat import (
+    HeartbeatingPostgreSQLPreparedActionRepository,
+)
+
+CONFIRMATION_ID = UUID("33333333-3333-4333-8333-333333333333")
+
+
+class _Cursor(AbstractContextManager["_Cursor"]):
+    def __enter__(self) -> _Cursor:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def execute(self, query: str, parameters: Sequence[Any] = ()) -> None:
+        del query, parameters
+
+    def fetchone(self) -> Mapping[str, Any] | None:
+        return None
+
+
+class _Connection(AbstractContextManager["_Connection"]):
+    def __enter__(self) -> _Connection:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def cursor(self) -> _Cursor:
+        return _Cursor()
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+
+class _Factory:
+    def __call__(self) -> _Connection:
+        return _Connection()
+
+
+def test_claim_is_abandoned_when_heartbeat_thread_cannot_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = HeartbeatingPostgreSQLPreparedActionRepository(
+        _Factory(),
+        execution_lease=timedelta(seconds=1),
+        heartbeat_interval=timedelta(milliseconds=50),
+        heartbeat_stop_timeout=timedelta(milliseconds=50),
+    )
+    prepared = cast(StoredPreparedAction, object())
+    abandoned: list[UUID] = []
+
+    def claim(
+        self: PostgreSQLPreparedActionRepository,
+        confirmation_id: UUID,
+    ) -> PreparedActionClaim:
+        del self, confirmation_id
+        return PreparedActionClaim(
+            PreparedActionClaimStatus.EXECUTE,
+            prepared,
+        )
+
+    def abandon(
+        self: PostgreSQLPreparedActionRepository,
+        confirmation_id: UUID,
+    ) -> None:
+        del self
+        abandoned.append(confirmation_id)
+
+    def fail_to_start(confirmation_id: UUID) -> None:
+        raise RuntimeError(f"thread unavailable: {confirmation_id}")
+
+    monkeypatch.setattr(PostgreSQLPreparedActionRepository, "claim", claim)
+    monkeypatch.setattr(PostgreSQLPreparedActionRepository, "abandon", abandon)
+    monkeypatch.setattr(repository, "_start_heartbeat", fail_to_start)
+
+    with pytest.raises(RuntimeError, match="thread unavailable"):
+        repository.claim(CONFIRMATION_ID)
+
+    assert abandoned == [CONFIRMATION_ID]


### PR DESCRIPTION
## Scope

Rebuild AP-10B from the current exact-main after AP-11 release acceptance. This is a bounded runtime slice and does not claim full AP-10 operational readiness.

## Implemented

- fenced PostgreSQL lease heartbeat for `EXECUTE` prepared-action claims;
- copied execution context preserves the exact fencing token in the heartbeat thread;
- process death stops renewal and permits reclaim after lease expiry;
- stale, expired or fenced claims cannot renew or complete;
- heartbeat failure blocks durable completion;
- heartbeat startup failure abandons the claim;
- abandon stops heartbeat without masking the original tool failure;
- stop uses a bounded timeout instead of an unbounded `thread.join()`;
- heartbeat interval is validated against the effective integer PostgreSQL lease, not the unrounded input timedelta;
- explicit policy bounds heartbeat stop timeout to 50 ms–30 s.

## Tests

Focused tests cover interval/timeout policy, SQL fencing, copied context, duplicate heartbeat, stale lease, DB exception, unresponsive thread timeout, EXECUTE-only startup, stop-before-complete, abandon semantics and startup rollback.

## Exact-head evidence

Exact head: `e8da49f1608ac030958ccb5411172babe89fc5b0`.

Green mandatory workflows:

- TAI Foundation: Ruff, strict mypy, pytest/coverage, free-access architecture;
- CI;
- Node CI;
- Dependency Review;
- Security Scan;
- Security Quality Gate;
- Security Abuse and Evidence Acceptance;
- Runtime Context Security Gate;
- Optional Runtime Retirement Gate;
- Auction Atomic Execution Acceptance;
- Outbox PostgreSQL Authority Acceptance;
- Disputes PostgreSQL Authority Acceptance.

Review threads: none.

## Remaining AP-10 work

- production composition root;
- real platform Safe Tool adapters;
- distributed admission and model draining;
- load/fault/soak and operational attestation.

Exact base: `5b99f65b1cdedd3b21fe7517431f2b0ee8027258`.