### PR TITLE
TAI AP-11B: bind release authority to integrated platform source

### DIFF
--- a/apps/tai/release-source-manifest.json
+++ b/apps/tai/release-source-manifest.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "tai.release.source-manifest.v1",
+  "roots": [
+    ".github/workflows",
+    "apps/api",
+    "apps/tai/tai",
+    "apps/tai/tests",
+    "packages",
+    "scripts"
+  ],
+  "files": [
+    "apps/tai/pyproject.toml",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "tsconfig.base.json"
+  ]
+}

--- a/apps/tai/tai/release_acceptance_cli.py
+++ b/apps/tai/tai/release_acceptance_cli.py
@@ -21,6 +21,25 @@ from tai.release_acceptance import (
 _MIGRATION = re.compile(r"^(\d{4})_[A-Za-z0-9_-]+\.sql$")
 _SOURCE_MANIFEST_SCHEMA = "tai.release.source-manifest.v1"
 _SOURCE_MANIFEST_PATH = "apps/tai/release-source-manifest.json"
+_REQUIRED_SOURCE_ROOTS = frozenset(
+    {
+        ".github/workflows",
+        "apps/api",
+        "apps/tai/tai",
+        "apps/tai/tests",
+        "packages",
+        "scripts",
+    }
+)
+_REQUIRED_SOURCE_FILES = frozenset(
+    {
+        "apps/tai/pyproject.toml",
+        "package.json",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+        "tsconfig.base.json",
+    }
+)
 _IGNORED_SOURCE_PARTS = frozenset(
     {
         "__pycache__",
@@ -204,8 +223,13 @@ def _source_digest(repository_root: Path) -> str:
         raise ValueError("release source manifest schema version is unsupported")
     roots = _manifest_paths(raw.get("roots"), "roots")
     declared_files = _manifest_paths(raw.get("files"), "files")
-    if not roots:
-        raise ValueError("release source manifest roots must not be empty")
+    missing_roots = sorted(_REQUIRED_SOURCE_ROOTS - set(roots))
+    missing_files = sorted(_REQUIRED_SOURCE_FILES - set(declared_files))
+    if missing_roots or missing_files:
+        raise ValueError(
+            "release source manifest is below required integrated scope: "
+            f"missing_roots={missing_roots}, missing_files={missing_files}"
+        )
 
     files: dict[str, bytes] = {
         _SOURCE_MANIFEST_PATH: manifest_path.read_bytes(),

--- a/apps/tai/tai/release_acceptance_cli.py
+++ b/apps/tai/tai/release_acceptance_cli.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import re
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from tai.release_acceptance import (
@@ -19,6 +19,17 @@ from tai.release_acceptance import (
 )
 
 _MIGRATION = re.compile(r"^(\d{4})_[A-Za-z0-9_-]+\.sql$")
+_SOURCE_MANIFEST_SCHEMA = "tai.release.source-manifest.v1"
+_SOURCE_MANIFEST_PATH = "apps/tai/release-source-manifest.json"
+_IGNORED_SOURCE_PARTS = frozenset(
+    {
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+    }
+)
+_IGNORED_SOURCE_SUFFIXES = frozenset({".pyc", ".pyo"})
 
 
 def main() -> int:
@@ -181,31 +192,90 @@ def _migration_inventory(repository_root: Path) -> MigrationInventory:
 
 
 def _source_digest(repository_root: Path) -> str:
-    roots = (
-        repository_root / "apps/tai/tai",
-        repository_root / "apps/tai/tests",
-    )
-    files: dict[str, bytes] = {}
-    for root in roots:
+    manifest_path = repository_root / _SOURCE_MANIFEST_PATH
+    if not manifest_path.is_file() or manifest_path.is_symlink():
+        raise ValueError("release source manifest is required as a regular file")
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("release source manifest must be a JSON object")
+    if set(raw) != {"files", "roots", "schema_version"}:
+        raise ValueError("release source manifest keys are invalid")
+    if raw.get("schema_version") != _SOURCE_MANIFEST_SCHEMA:
+        raise ValueError("release source manifest schema version is unsupported")
+    roots = _manifest_paths(raw.get("roots"), "roots")
+    declared_files = _manifest_paths(raw.get("files"), "files")
+    if not roots:
+        raise ValueError("release source manifest roots must not be empty")
+
+    files: dict[str, bytes] = {
+        _SOURCE_MANIFEST_PATH: manifest_path.read_bytes(),
+    }
+    for raw_root in roots:
+        root = _resolve_governed_path(repository_root, raw_root)
+        if not root.is_dir() or root.is_symlink():
+            raise ValueError(f"release source root is not a regular directory: {raw_root}")
+        found = False
         for path in sorted(root.rglob("*")):
-            if not path.is_file():
-                continue
-            if "__pycache__" in path.parts or path.suffix in {".pyc", ".pyo"}:
+            if path.is_symlink():
+                raise ValueError(
+                    f"release source authority does not allow symlinks: "
+                    f"{path.relative_to(repository_root).as_posix()}"
+                )
+            if not path.is_file() or _ignored_source_path(path):
                 continue
             relative = path.relative_to(repository_root).as_posix()
             files[relative] = path.read_bytes()
+            found = True
+        if not found:
+            raise ValueError(f"release source root contains no governed files: {raw_root}")
 
-    pyproject = repository_root / "apps/tai/pyproject.toml"
-    if pyproject.is_file():
-        files[pyproject.relative_to(repository_root).as_posix()] = pyproject.read_bytes()
-
-    workflow_root = repository_root / ".github/workflows"
-    for pattern in ("*.yml", "*.yaml"):
-        for path in sorted(workflow_root.glob(pattern)):
-            if path.is_file():
-                files[path.relative_to(repository_root).as_posix()] = path.read_bytes()
+    for raw_file in declared_files:
+        path = _resolve_governed_path(repository_root, raw_file)
+        if not path.is_file() or path.is_symlink():
+            raise ValueError(f"release source file is not a regular file: {raw_file}")
+        files[raw_file] = path.read_bytes()
 
     return source_tree_sha256(files)
+
+
+def _manifest_paths(value: object, name: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"release source manifest {name} must be an array")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"release source manifest {name} must contain strings")
+        normalized = _relative_posix_path(item)
+        result.append(normalized)
+    if len(result) != len(set(result)):
+        raise ValueError(f"release source manifest {name} must be unique")
+    return tuple(result)
+
+
+def _relative_posix_path(value: str) -> str:
+    if not value or "\\" in value:
+        raise ValueError("release source paths must use non-empty POSIX form")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("release source paths must be repository-relative and normalized")
+    normalized = path.as_posix()
+    if normalized != value:
+        raise ValueError("release source paths must be normalized")
+    return normalized
+
+
+def _resolve_governed_path(repository_root: Path, relative: str) -> Path:
+    candidate = repository_root.joinpath(*PurePosixPath(relative).parts)
+    resolved = candidate.resolve()
+    if not resolved.is_relative_to(repository_root):
+        raise ValueError("release source path escapes repository root")
+    return resolved
+
+
+def _ignored_source_path(path: Path) -> bool:
+    return bool(_IGNORED_SOURCE_PARTS.intersection(path.parts)) or (
+        path.suffix in _IGNORED_SOURCE_SUFFIXES
+    )
 
 
 def _free_access_proven(runs: tuple[WorkflowRunEvidence, ...]) -> bool:

--- a/apps/tai/tests/test_release_acceptance_cli.py
+++ b/apps/tai/tests/test_release_acceptance_cli.py
@@ -53,7 +53,9 @@ def _repository(root: Path) -> None:
     (api_root / "test").mkdir()
     (api_root / "test/tai-tools.spec.ts").write_text("describe('tools', () => {});\n")
     (api_root / "prisma").mkdir()
-    (api_root / "prisma/schema.prisma").write_text("datasource db { provider = \"postgresql\" }\n")
+    (api_root / "prisma/schema.prisma").write_text(
+        'datasource db { provider = "postgresql" }\n'
+    )
     (api_root / "package.json").write_text('{"name":"api"}\n')
 
     package_root = root / "packages/domain-core/src"
@@ -172,7 +174,7 @@ def test_source_digest_binds_workflows_and_integrated_platform_api(tmp_path: Pat
     after_api_change = _source_digest(tmp_path)
 
     prisma_schema = tmp_path / "apps/api/prisma/schema.prisma"
-    prisma_schema.write_text("datasource db { provider = \"sqlite\" }\n")
+    prisma_schema.write_text('datasource db { provider = "sqlite" }\n')
     after_schema_change = _source_digest(tmp_path)
 
     assert initial != after_workflow_change
@@ -192,18 +194,20 @@ def test_source_digest_rejects_narrowed_integrated_scope(tmp_path: Path) -> None
 
 
 def test_source_digest_rejects_missing_or_traversing_paths(tmp_path: Path) -> None:
-    _repository(tmp_path)
-    (tmp_path / "pnpm-lock.yaml").unlink()
+    missing_root = tmp_path / "missing"
+    _repository(missing_root)
+    (missing_root / "pnpm-lock.yaml").unlink()
     with pytest.raises(ValueError, match="not a regular file"):
-        _source_digest(tmp_path)
+        _source_digest(missing_root)
 
-    _repository(tmp_path)
-    manifest_path = tmp_path / "apps/tai/release-source-manifest.json"
+    traversal_root = tmp_path / "traversal"
+    _repository(traversal_root)
+    manifest_path = traversal_root / "apps/tai/release-source-manifest.json"
     manifest = json.loads(manifest_path.read_text())
     manifest["roots"].append("../outside")
     manifest_path.write_text(json.dumps(manifest))
     with pytest.raises(ValueError, match="repository-relative"):
-        _source_digest(tmp_path)
+        _source_digest(traversal_root)
 
 
 def test_cli_rejects_missing_required_workflow(tmp_path: Path, monkeypatch) -> None:

--- a/apps/tai/tests/test_release_acceptance_cli.py
+++ b/apps/tai/tests/test_release_acceptance_cli.py
@@ -44,6 +44,25 @@ def _repository(root: Path) -> None:
         "def test_value():\n    assert 1 == 1\n"
     )
     (root / "apps/tai/pyproject.toml").write_text("[project]\nname='tai-test'\n")
+
+    api_root = root / "apps/api"
+    (api_root / "src/modules/tai-tools").mkdir(parents=True)
+    (api_root / "src/modules/tai-tools/tool.ts").write_text(
+        "export const TOOL = 'getDealSummary';\n"
+    )
+    (api_root / "test").mkdir()
+    (api_root / "test/tai-tools.spec.ts").write_text("describe('tools', () => {});\n")
+    (api_root / "prisma").mkdir()
+    (api_root / "prisma/schema.prisma").write_text("datasource db { provider = \"postgresql\" }\n")
+    (api_root / "package.json").write_text('{"name":"api"}\n')
+
+    package_root = root / "packages/domain-core/src"
+    package_root.mkdir(parents=True)
+    (package_root / "index.ts").write_text("export const DOMAIN = true;\n")
+    script_root = root / "scripts"
+    script_root.mkdir()
+    (script_root / "acceptance.sh").write_text("#!/bin/sh\nexit 0\n")
+
     workflow_root = root / ".github/workflows"
     workflow_root.mkdir(parents=True)
     (workflow_root / "tai-foundation.yml").write_text("name: TAI Foundation\n")
@@ -51,6 +70,33 @@ def _repository(root: Path) -> None:
         "name: TAI Release Acceptance\n"
     )
     (workflow_root / "security-scan.yaml").write_text("name: Security Scan\n")
+
+    (root / "package.json").write_text('{"private":true}\n')
+    (root / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n")
+    (root / "pnpm-workspace.yaml").write_text("packages:\n  - apps/api\n")
+    (root / "tsconfig.base.json").write_text('{"compilerOptions":{}}\n')
+    (root / "apps/tai/release-source-manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "tai.release.source-manifest.v1",
+                "roots": [
+                    ".github/workflows",
+                    "apps/api",
+                    "apps/tai/tai",
+                    "apps/tai/tests",
+                    "packages",
+                    "scripts",
+                ],
+                "files": [
+                    "apps/tai/pyproject.toml",
+                    "package.json",
+                    "pnpm-lock.yaml",
+                    "pnpm-workspace.yaml",
+                    "tsconfig.base.json",
+                ],
+            }
+        )
+    )
 
 
 def _evidence(path: Path, *, missing: str | None = None) -> None:
@@ -113,20 +159,51 @@ def test_cli_builds_accepted_application_attestation(tmp_path: Path, monkeypatch
     assert len(attestation["source_tree_sha256"]) == 64
 
 
-def test_source_digest_binds_yml_and_yaml_workflow_definitions(tmp_path: Path) -> None:
+def test_source_digest_binds_workflows_and_integrated_platform_api(tmp_path: Path) -> None:
     _repository(tmp_path)
     initial = _source_digest(tmp_path)
 
     yml_workflow = tmp_path / ".github/workflows/tai-foundation.yml"
     yml_workflow.write_text("name: TAI Foundation\njobs: {}\n")
-    after_yml_change = _source_digest(tmp_path)
+    after_workflow_change = _source_digest(tmp_path)
 
-    yaml_workflow = tmp_path / ".github/workflows/security-scan.yaml"
-    yaml_workflow.write_text("name: Security Scan\njobs: {}\n")
-    after_yaml_change = _source_digest(tmp_path)
+    api_tool = tmp_path / "apps/api/src/modules/tai-tools/tool.ts"
+    api_tool.write_text("export const TOOL = 'getRoleNextActions';\n")
+    after_api_change = _source_digest(tmp_path)
 
-    assert initial != after_yml_change
-    assert after_yml_change != after_yaml_change
+    prisma_schema = tmp_path / "apps/api/prisma/schema.prisma"
+    prisma_schema.write_text("datasource db { provider = \"sqlite\" }\n")
+    after_schema_change = _source_digest(tmp_path)
+
+    assert initial != after_workflow_change
+    assert after_workflow_change != after_api_change
+    assert after_api_change != after_schema_change
+
+
+def test_source_digest_rejects_narrowed_integrated_scope(tmp_path: Path) -> None:
+    _repository(tmp_path)
+    manifest_path = tmp_path / "apps/tai/release-source-manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["roots"].remove("apps/api")
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="below required integrated scope"):
+        _source_digest(tmp_path)
+
+
+def test_source_digest_rejects_missing_or_traversing_paths(tmp_path: Path) -> None:
+    _repository(tmp_path)
+    (tmp_path / "pnpm-lock.yaml").unlink()
+    with pytest.raises(ValueError, match="not a regular file"):
+        _source_digest(tmp_path)
+
+    _repository(tmp_path)
+    manifest_path = tmp_path / "apps/tai/release-source-manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["roots"].append("../outside")
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="repository-relative"):
+        _source_digest(tmp_path)
 
 
 def test_cli_rejects_missing_required_workflow(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Defect

AP-10D introduced a real cross-service Safe Tool bridge in `apps/api`, but the AP-11 application release digest still covered only `apps/tai`, TAI tests and workflow definitions. An exact-main release could therefore be accepted without cryptographically binding the platform-side tool gateway, PostgreSQL authority, API tests, Prisma schema or shared packages.

## Fix

- add immutable `tai.release.source-manifest.v1`;
- require the minimum integrated roots: workflows, complete API source/config/schema/tests, TAI runtime/tests, shared packages and acceptance scripts;
- bind package manager and TypeScript authority files;
- include the source manifest itself in the digest;
- reject scope narrowing, missing paths, traversal, symlinks, duplicate or malformed entries;
- preserve deterministic exclusion only for interpreter caches;
- add regression tests proving API tool, Prisma and workflow changes alter the release digest.

## Exact-head evidence

Exact head: `5c49d10032a3c54bd09a513d81476aa22ccb19ab`.

Green mandatory workflows:

- TAI Foundation;
- CI;
- Node CI;
- Dependency Review;
- Security Scan;
- Security Quality Gate;
- Security Abuse and Evidence Acceptance;
- Runtime Context Security Gate;
- Optional Runtime Retirement Gate;
- Auction Atomic Execution Acceptance;
- Outbox PostgreSQL Authority Acceptance;
- Disputes PostgreSQL Authority Acceptance.

Review threads: none.

## Maturity boundary

This repairs integrated application release integrity. It does not claim operational acceptance. `production_operational_status` remains `NOT_ATTESTED`.

## Remaining TAI work

- governed production Tool Planner;
- separate confirmed-write authority contour;
- broader Safe Tool adapters for documents, logistics, laboratory, disputes, money and support;
- distributed admission/backpressure and model draining;
- load, fault, restore, backlog recovery and soak evidence;
- exact-main operational attestation.