### PR TITLE
TAI AP-12B: confirmed assign logistics authority

### DIFF
--- a/apps/api/src/modules/tai-tools/tai-tool-assertion.spec.ts
+++ b/apps/api/src/modules/tai-tools/tai-tool-assertion.spec.ts
@@ -72,6 +72,70 @@ describe('TaiToolAssertionVerifier', () => {
     });
   });
 
+  it('accepts only the registered confirmed mode for assignLogistics', () => {
+    const verifier = new TaiToolAssertionVerifier();
+    const path = '/api/internal/tai/tools/assignLogistics';
+    const body = {
+      arguments: {
+        dealId: 'deal-2408',
+        carrierOrgId: 'carrier-1',
+        driverUserId: 'driver-1',
+        vehicleId: 'vehicle-1',
+        routeFromFacilityId: 'facility-1',
+        routeToFacilityId: 'facility-2',
+        expectedUpdatedAt: '2026-07-19T01:59:00.000Z',
+        expectedVersion: '7',
+      },
+    };
+    const signed = signedAssertion({
+      tool_name: 'assignLogistics',
+      mode: 'CONFIRMED_WRITE',
+      request_sha256: canonicalTaiToolRequestSha256({
+        method: 'POST',
+        path,
+        payload: body,
+        idempotencyKey: IDEMPOTENCY,
+      }),
+    });
+
+    expect(
+      verifier.verify({
+        ...signed,
+        toolName: 'assignLogistics',
+        method: 'POST',
+        path,
+        body,
+        idempotencyKey: IDEMPOTENCY,
+        now: NOW,
+      }),
+    ).toMatchObject({
+      toolName: 'assignLogistics',
+      mode: 'CONFIRMED_WRITE',
+    });
+
+    const rebound = signedAssertion({
+      tool_name: 'assignLogistics',
+      mode: 'DRAFT',
+      request_sha256: canonicalTaiToolRequestSha256({
+        method: 'POST',
+        path,
+        payload: body,
+        idempotencyKey: IDEMPOTENCY,
+      }),
+    });
+    expect(() =>
+      verifier.verify({
+        ...rebound,
+        toolName: 'assignLogistics',
+        method: 'POST',
+        path,
+        body,
+        idempotencyKey: IDEMPOTENCY,
+        now: NOW,
+      }),
+    ).toThrow(UnauthorizedException);
+  });
+
   it('rejects body rebinding and expired assertions', () => {
     const verifier = new TaiToolAssertionVerifier();
     const signed = signedAssertion();

--- a/apps/api/src/modules/tai-tools/tai-tool-assertion.ts
+++ b/apps/api/src/modules/tai-tools/tai-tool-assertion.ts
@@ -1,12 +1,13 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { createHash, createHmac, timingSafeEqual } from 'crypto';
 
-export type TaiToolMode = 'READ_ONLY' | 'DRAFT';
+export type TaiToolMode = 'READ_ONLY' | 'DRAFT' | 'CONFIRMED_WRITE';
 
 export const TAI_PLATFORM_TOOL_MODES = {
   getDealSummary: 'READ_ONLY',
   getRoleNextActions: 'READ_ONLY',
   prepareCommandDraft: 'DRAFT',
+  assignLogistics: 'CONFIRMED_WRITE',
 } as const satisfies Record<string, TaiToolMode>;
 
 export type TaiPlatformToolName = keyof typeof TAI_PLATFORM_TOOL_MODES;

--- a/apps/api/src/modules/tai-tools/tai-tools.service.spec.ts
+++ b/apps/api/src/modules/tai-tools/tai-tools.service.spec.ts
@@ -13,6 +13,17 @@ const IDENTITY: TaiDelegatedIdentity = {
   idempotencyKey: 'tai.tool.request.0001',
 };
 
+const LOGISTICS_ARGUMENTS = {
+  dealId: 'deal-2408',
+  carrierOrgId: 'carrier-1',
+  driverUserId: 'driver-1',
+  vehicleId: 'vehicle-1',
+  routeFromFacilityId: 'facility-1',
+  routeToFacilityId: 'facility-2',
+  expectedUpdatedAt: '2026-07-19T01:59:00.000Z',
+  expectedVersion: '7',
+};
+
 function workspace() {
   return {
     deal: {
@@ -112,5 +123,90 @@ describe('TaiToolsService', () => {
         { ...IDENTITY, toolName: 'prepareCommandDraft', mode: 'DRAFT' },
       ),
     ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('maps one confirmed tool to one canonical assign_logistics command', async () => {
+    const executeUser = jest.fn().mockResolvedValue({
+      ok: true,
+      dealId: 'deal-2408',
+      actionId: 'assign_logistics',
+      status: 'LOGISTICS_ASSIGNED',
+      eventId: 'event-1',
+      auditId: 'audit-1',
+    });
+    const gateway = { workspace: jest.fn(), executeUser };
+    const service = new TaiToolsService(gateway as any);
+    const identity: TaiDelegatedIdentity = {
+      ...IDENTITY,
+      callId: 'planner-call-1',
+      toolName: 'assignLogistics',
+      mode: 'CONFIRMED_WRITE',
+      idempotencyKey: 'a'.repeat(64),
+    };
+
+    const result = await service.execute(
+      'assignLogistics',
+      { arguments: LOGISTICS_ARGUMENTS },
+      identity,
+    );
+
+    expect(executeUser).toHaveBeenCalledTimes(1);
+    expect(executeUser).toHaveBeenCalledWith(
+      'deal-2408',
+      'assign_logistics',
+      {
+        commandId:
+          'tai:44444444-4444-4444-8444-444444444444:planner-call-1',
+        idempotencyKey: 'a'.repeat(64),
+        expectedUpdatedAt: '2026-07-19T01:59:00.000Z',
+        expectedVersion: '7',
+        payload: {
+          carrierOrgId: 'carrier-1',
+          driverUserId: 'driver-1',
+          vehicleId: 'vehicle-1',
+          routeFromFacilityId: 'facility-1',
+          routeToFacilityId: 'facility-2',
+        },
+      },
+      expect.objectContaining({
+        id: identity.userId,
+        tenantId: identity.tenantId,
+        sessionId: identity.sessionId,
+      }),
+    );
+    expect(result).toMatchObject({
+      schemaVersion: 'platform.assign-logistics-result.v1',
+      authority: 'TAI_CONFIRMED_WRITE',
+      status: 'LOGISTICS_ASSIGNED',
+      auditId: 'audit-1',
+    });
+  });
+
+  it('rejects extra authority fields and malformed concurrency data', async () => {
+    const executeUser = jest.fn();
+    const gateway = { workspace: jest.fn(), executeUser };
+    const service = new TaiToolsService(gateway as any);
+    const identity: TaiDelegatedIdentity = {
+      ...IDENTITY,
+      toolName: 'assignLogistics',
+      mode: 'CONFIRMED_WRITE',
+      idempotencyKey: 'a'.repeat(64),
+    };
+
+    await expect(
+      service.execute(
+        'assignLogistics',
+        { arguments: { ...LOGISTICS_ARGUMENTS, actionId: 'authorize_payout' } },
+        identity,
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    await expect(
+      service.execute(
+        'assignLogistics',
+        { arguments: { ...LOGISTICS_ARGUMENTS, expectedVersion: '-1' } },
+        identity,
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(executeUser).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/tai-tools/tai-tools.service.ts
+++ b/apps/api/src/modules/tai-tools/tai-tools.service.ts
@@ -45,6 +45,27 @@ function optionalPortable(value: JsonRecord, name: string): string | undefined {
   return requiredPortable(value, name);
 }
 
+function requiredIso(value: JsonRecord, name: string): string {
+  const raw = value[name];
+  if (
+    typeof raw !== 'string' ||
+    raw.length > 64 ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:Z|[+-]\d{2}:\d{2})$/.test(raw) ||
+    !Number.isFinite(new Date(raw).getTime())
+  ) {
+    throw new BadRequestException({ code: 'TAI_TOOL_ARGUMENT_INVALID', field: name });
+  }
+  return raw;
+}
+
+function requiredVersion(value: JsonRecord, name: string): string {
+  const raw = value[name];
+  if (typeof raw !== 'string' || !/^(?:0|[1-9][0-9]{0,19})$/.test(raw)) {
+    throw new BadRequestException({ code: 'TAI_TOOL_ARGUMENT_INVALID', field: name });
+  }
+  return raw;
+}
+
 function delegatedUser(identity: TaiDelegatedIdentity): RequestUser {
   if (!identity.tenantId) {
     throw new ForbiddenException({ code: 'TENANT_CONTEXT_REQUIRED' });
@@ -89,6 +110,8 @@ export class TaiToolsService {
         return this.getRoleNextActions(args, user);
       case 'prepareCommandDraft':
         return this.prepareCommandDraft(args, user, identity);
+      case 'assignLogistics':
+        return this.assignLogistics(args, user, identity);
       default:
         return unreachable(toolName);
     }
@@ -169,6 +192,57 @@ export class TaiToolsService {
       requiresExplicitUserConfirmation: true,
       generatedFromStatus: deal.status ?? null,
       role: roleProjection.role ?? null,
+    };
+  }
+
+  private async assignLogistics(
+    args: JsonRecord,
+    user: RequestUser,
+    identity: TaiDelegatedIdentity,
+  ): Promise<JsonRecord> {
+    if (identity.mode !== 'CONFIRMED_WRITE' || identity.toolName !== 'assignLogistics') {
+      throw new ForbiddenException({ code: 'TAI_CONFIRMED_WRITE_AUTHORITY_REQUIRED' });
+    }
+    exactKeys(args, [
+      'dealId',
+      'carrierOrgId',
+      'driverUserId',
+      'vehicleId',
+      'routeFromFacilityId',
+      'routeToFacilityId',
+      'expectedUpdatedAt',
+      'expectedVersion',
+    ]);
+    const dealId = requiredPortable(args, 'dealId');
+    const carrierOrgId = requiredPortable(args, 'carrierOrgId');
+    const driverUserId = requiredPortable(args, 'driverUserId');
+    const vehicleId = requiredPortable(args, 'vehicleId');
+    const routeFromFacilityId = requiredPortable(args, 'routeFromFacilityId');
+    const routeToFacilityId = requiredPortable(args, 'routeToFacilityId');
+    const expectedUpdatedAt = requiredIso(args, 'expectedUpdatedAt');
+    const expectedVersion = requiredVersion(args, 'expectedVersion');
+    const result = await this.deals.executeUser(
+      dealId,
+      'assign_logistics',
+      {
+        commandId: `tai:${identity.traceId}:${identity.callId}`,
+        idempotencyKey: identity.idempotencyKey,
+        expectedUpdatedAt,
+        expectedVersion,
+        payload: {
+          carrierOrgId,
+          driverUserId,
+          vehicleId,
+          routeFromFacilityId,
+          routeToFacilityId,
+        },
+      },
+      user,
+    );
+    return {
+      schemaVersion: 'platform.assign-logistics-result.v1',
+      authority: 'TAI_CONFIRMED_WRITE',
+      ...record(result, 'result'),
     };
   }
 }

--- a/apps/tai/tai/migrations/0015_confirmed_logistics_authority.sql
+++ b/apps/tai/tai/migrations/0015_confirmed_logistics_authority.sql
@@ -1,0 +1,54 @@
+BEGIN;
+
+ALTER TABLE tai_tool_planner_decisions
+    DROP CONSTRAINT IF EXISTS tai_tool_planner_decisions_catalog_version_check;
+ALTER TABLE tai_tool_planner_decisions
+    ADD CONSTRAINT tai_tool_planner_decisions_catalog_version_check
+    CHECK (
+        catalog_version IN (
+            'tai.tool-catalog.safe.v1',
+            'tai.tool-catalog.governed.v2'
+        )
+    );
+
+CREATE OR REPLACE VIEW tai_confirmed_tool_trace_v1 AS
+SELECT
+    decision.trace_id,
+    decision.plan_id,
+    decision.request_id,
+    decision.tenant_id,
+    decision.user_id,
+    decision.session_id,
+    decision.catalog_version,
+    decision.input_sha256,
+    decision.selected_calls,
+    decision.reason_codes,
+    decision.generated_at AS planned_at,
+    decision.decision_sha256,
+    confirmation.confirmation_id,
+    confirmation.call_id AS confirmed_call_id,
+    confirmation.request_sha256 AS confirmation_request_sha256,
+    confirmation.idempotency_key AS confirmation_idempotency_key,
+    confirmation.used_at AS confirmed_at,
+    event.tool_name,
+    event.mode AS tool_mode,
+    event.status AS tool_status,
+    event.request_sha256 AS tool_request_sha256,
+    event.result_sha256 AS tool_result_sha256,
+    event.reason AS tool_reason,
+    event.occurred_at AS tool_completed_at,
+    event.event_sha256 AS tool_event_sha256
+FROM tai_tool_planner_decisions AS decision
+LEFT JOIN tai_agent_tool_events AS event
+    ON event.trace_id = decision.trace_id
+    AND event.plan_id = decision.plan_id
+    AND event.mode = 'CONFIRMED_WRITE'
+LEFT JOIN tai_tool_confirmation_uses AS confirmation
+    ON confirmation.call_id = event.call_id
+    AND confirmation.request_sha256 = event.request_sha256
+    AND confirmation.idempotency_key = event.idempotency_key
+    AND confirmation.user_id = event.user_id
+    AND confirmation.tenant_id IS NOT DISTINCT FROM event.tenant_id
+    AND confirmation.session_id = event.session_id;
+
+COMMIT;

--- a/apps/tai/tai/migrations/manifest.json
+++ b/apps/tai/tai/migrations/manifest.json
@@ -59,6 +59,10 @@
     {
       "path": "0014_governed_tool_planner.sql",
       "version": 15
+    },
+    {
+      "path": "0015_confirmed_logistics_authority.sql",
+      "version": 16
     }
   ],
   "schema_version": "tai.migration.manifest.v1"

--- a/apps/tai/tai/platform_tools.py
+++ b/apps/tai/tai/platform_tools.py
@@ -20,6 +20,7 @@ _PLATFORM_TOOL_MODES: dict[str, ToolMode] = {
     "getDealSummary": ToolMode.READ_ONLY,
     "getRoleNextActions": ToolMode.READ_ONLY,
     "prepareCommandDraft": ToolMode.DRAFT,
+    "assignLogistics": ToolMode.CONFIRMED_WRITE,
 }
 _MAX_ARGUMENT_BYTES = 32_768
 _MAX_RESPONSE_BYTES = 262_144

--- a/apps/tai/tai/policy.py
+++ b/apps/tai/tai/policy.py
@@ -67,6 +67,18 @@ TOOL_REGISTRY: dict[str, ToolDefinition] = {
             }
         ),
     ),
+    "assignLogistics": ToolDefinition(
+        name="assignLogistics",
+        mode=ToolMode.CONFIRMED_WRITE,
+        allowed_roles=frozenset(
+            {
+                "logistics",
+                "operator",
+                "administrator",
+            }
+        ),
+        requires_mfa=True,
+    ),
     "acknowledgeRisk": ToolDefinition(
         name="acknowledgeRisk",
         mode=ToolMode.CONFIRMED_WRITE,

--- a/apps/tai/tai/release_acceptance_cli.py
+++ b/apps/tai/tai/release_acceptance_cli.py
@@ -50,7 +50,7 @@ _IGNORED_SOURCE_PARTS = frozenset(
     }
 )
 _IGNORED_SOURCE_SUFFIXES = frozenset({".pyc", ".pyo"})
-_MINIMUM_RELEASE_MIGRATION_VERSION = 15
+_MINIMUM_RELEASE_MIGRATION_VERSION = 16
 
 
 def main() -> int:

--- a/apps/tai/tai/tool_planner.py
+++ b/apps/tai/tai/tool_planner.py
@@ -88,7 +88,11 @@ _INTENTS = (
         mode=ToolMode.CONFIRMED_WRITE,
         patterns=(
             re.compile(r"\bназнач\w*\s+(?:логистик\w*|перевоз\w*|водител\w*)", re.I),
-            re.compile(r"\b(?:assign|appoint)\s+(?:the\s+)?(?:logistics|carrier|driver|transport)", re.I),
+            re.compile(
+                r"\b(?:assign|appoint)\s+(?:the\s+)?"
+                r"(?:logistics|carrier|driver|transport)",
+                re.I,
+            ),
             re.compile(r"(?:分配|指派)(?:物流|承运商|司机)"),
         ),
     ),

--- a/apps/tai/tai/tool_planner.py
+++ b/apps/tai/tai/tool_planner.py
@@ -19,9 +19,19 @@ if TYPE_CHECKING:
     from tai.orchestration import OrchestrationRequest
     from tai.rag_pipeline import GroundedAnswerResponse
 
-_CATALOG_VERSION = "tai.tool-catalog.safe.v1"
+_CATALOG_VERSION = "tai.tool-catalog.governed.v2"
 _PORTABLE = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+_VERSION = re.compile(r"^(?:0|[1-9][0-9]{0,19})$")
 _WHITESPACE = re.compile(r"\s+")
+_ASSIGN_LOGISTICS_FIELDS = (
+    "carrierOrgId",
+    "driverUserId",
+    "vehicleId",
+    "routeFromFacilityId",
+    "routeToFacilityId",
+    "expectedUpdatedAt",
+    "expectedVersion",
+)
 
 
 class PlannerDecisionStatus(StrEnum):
@@ -73,6 +83,15 @@ class _IntentContract:
 
 
 _INTENTS = (
+    _IntentContract(
+        tool_name="assignLogistics",
+        mode=ToolMode.CONFIRMED_WRITE,
+        patterns=(
+            re.compile(r"\bназнач\w*\s+(?:логистик\w*|перевоз\w*|водител\w*)", re.I),
+            re.compile(r"\b(?:assign|appoint)\s+(?:the\s+)?(?:logistics|carrier|driver|transport)", re.I),
+            re.compile(r"(?:分配|指派)(?:物流|承运商|司机)"),
+        ),
+    ),
     _IntentContract(
         tool_name="prepareCommandDraft",
         mode=ToolMode.DRAFT,
@@ -131,7 +150,7 @@ _INJECTION_SIGNALS: tuple[tuple[str, re.Pattern[str]], ...] = (
         re.compile(
             r"(?:tool_call|function_call|<tool|<system|\{\s*\"tool_name\")|"
             r"(?:вызови|запусти|invoke|call)\s+"
-            r"(?:getDealSummary|getRoleNextActions|prepareCommandDraft)",
+            r"(?:getDealSummary|getRoleNextActions|prepareCommandDraft|assignLogistics)",
             re.I,
         ),
     ),
@@ -165,7 +184,7 @@ _ACTION_PATTERNS = (
 
 
 class GovernedToolPlanner:
-    """Select at most one registered safe tool from explicit user intent."""
+    """Select at most one explicitly governed platform tool."""
 
     def __init__(
         self,
@@ -173,14 +192,15 @@ class GovernedToolPlanner:
         available_tools: frozenset[str],
         decision_sink: PlannerDecisionSink | None = None,
     ) -> None:
-        catalog_names = {contract.tool_name for contract in _INTENTS}
-        unsupported = available_tools - catalog_names
+        contracts = {contract.tool_name: contract for contract in _INTENTS}
+        unsupported = available_tools - set(contracts)
         if unsupported:
             raise ValueError(f"planner received unsupported tools: {sorted(unsupported)}")
         for name in available_tools:
             definition = TOOL_REGISTRY.get(name)
-            if definition is None or definition.mode not in {ToolMode.READ_ONLY, ToolMode.DRAFT}:
-                raise ValueError("planner catalog may contain only registered read or draft tools")
+            contract = contracts[name]
+            if definition is None or definition.mode is not contract.mode:
+                raise ValueError("planner catalog mode does not match registered authority")
         self._available_tools = available_tools
         self._decision_sink = decision_sink or NullPlannerDecisionSink()
 
@@ -278,6 +298,8 @@ class GovernedToolPlanner:
         definition = TOOL_REGISTRY[contract.tool_name]
         if not request.identity.roles.intersection(definition.allowed_roles):
             return (), PlannerDecisionStatus.REJECTED, ("ROLE_NOT_AUTHORIZED",)
+        if definition.requires_mfa and not request.identity.mfa_verified:
+            return (), PlannerDecisionStatus.REJECTED, ("MFA_REQUIRED",)
         deal_ids = _extract_unique(_DEAL_PATTERNS, normalized)
         if len(deal_ids) != 1:
             reason = "DEAL_ID_AMBIGUOUS" if deal_ids else "DEAL_ID_REQUIRED"
@@ -289,6 +311,16 @@ class GovernedToolPlanner:
                 return (), PlannerDecisionStatus.NO_MATCH, ("ACTION_ID_AMBIGUOUS",)
             if action_ids:
                 arguments["actionId"] = action_ids[0]
+        elif contract.tool_name == "assignLogistics":
+            extracted = {
+                field: _extract_named_value(normalized, field)
+                for field in _ASSIGN_LOGISTICS_FIELDS
+            }
+            if any(value is None for value in extracted.values()):
+                return (), PlannerDecisionStatus.NO_MATCH, (
+                    "ASSIGN_LOGISTICS_FIELDS_REQUIRED",
+                )
+            arguments.update({key: value for key, value in extracted.items() if value})
         _validate_arguments(contract.tool_name, arguments)
         call_sha256 = _sha256({"arguments": arguments, "tool_name": contract.tool_name})
         call = PlannedToolCall(
@@ -324,17 +356,44 @@ def _extract_unique(patterns: tuple[re.Pattern[str], ...], value: str) -> tuple[
     return tuple(found)
 
 
+def _extract_named_value(value: str, name: str) -> str | None:
+    pattern = re.compile(rf"\b{re.escape(name)}\s*[:=]\s*([^\s,;]+)", re.I)
+    matches = {match.group(1) for match in pattern.finditer(value)}
+    if len(matches) != 1:
+        return None
+    return next(iter(matches))
+
+
 def _validate_arguments(tool_name: str, arguments: Mapping[str, Any]) -> None:
     allowed = {
         "getDealSummary": frozenset({"dealId"}),
         "getRoleNextActions": frozenset({"dealId"}),
         "prepareCommandDraft": frozenset({"dealId", "actionId"}),
+        "assignLogistics": frozenset({"dealId", *_ASSIGN_LOGISTICS_FIELDS}),
     }[tool_name]
-    if not set(arguments).issubset(allowed) or "dealId" not in arguments:
+    if set(arguments) - allowed or "dealId" not in arguments:
         raise ValueError("planner generated an invalid argument schema")
+    if tool_name == "assignLogistics" and set(arguments) != allowed:
+        raise ValueError("planner generated an incomplete logistics argument schema")
     for key, value in arguments.items():
-        if not isinstance(value, str) or _PORTABLE.fullmatch(value) is None:
+        if not isinstance(value, str):
+            raise ValueError(f"planner argument {key} must be a string")
+        if key == "expectedUpdatedAt":
+            _validate_iso(value)
+        elif key == "expectedVersion":
+            if _VERSION.fullmatch(value) is None:
+                raise ValueError("planner expectedVersion is invalid")
+        elif _PORTABLE.fullmatch(value) is None:
             raise ValueError(f"planner argument {key} is not portable")
+
+
+def _validate_iso(value: str) -> None:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError("planner expectedUpdatedAt is invalid") from error
+    if parsed.utcoffset() is None:
+        raise ValueError("planner expectedUpdatedAt must be timezone-aware")
 
 
 def _input_sha256(identity: IdentityContext, request_id: str, question: str) -> str:

--- a/apps/tai/tests/test_migration_manifest.py
+++ b/apps/tai/tests/test_migration_manifest.py
@@ -16,11 +16,12 @@ def _repo_root() -> Path:
 
 def test_repository_manifest_preserves_historical_paths_with_unique_authority_order() -> None:
     inventory = _migration_inventory(_repo_root())
-    assert [item.version for item in inventory.migrations] == list(range(1, 16))
+    assert [item.version for item in inventory.migrations] == list(range(1, 17))
     paths = [item.path for item in inventory.migrations]
     assert paths[9].endswith("0010_operational_authority.sql")
     assert paths[10].endswith("0010_orchestration_runtime.sql")
-    assert paths[-1].endswith("0014_governed_tool_planner.sql")
+    assert paths[-2].endswith("0014_governed_tool_planner.sql")
+    assert paths[-1].endswith("0015_confirmed_logistics_authority.sql")
 
 
 def _fixture(root: Path) -> Path:

--- a/apps/tai/tests/test_platform_tools.py
+++ b/apps/tai/tests/test_platform_tools.py
@@ -56,6 +56,7 @@ def _invocation(
     *,
     tool_name: str = "getDealSummary",
     mode: ToolMode = ToolMode.READ_ONLY,
+    arguments: Mapping[str, Any] | None = None,
 ) -> AuthorizedToolInvocation:
     return AuthorizedToolInvocation(
         trace_id=UUID("44444444-4444-4444-8444-444444444444"),
@@ -63,7 +64,7 @@ def _invocation(
         call_id="call-1",
         tool_name=tool_name,
         mode=mode,
-        arguments={"dealId": "deal-1"},
+        arguments=arguments or {"dealId": "deal-1"},
         user_id=UUID("55555555-5555-4555-8555-555555555555"),
         tenant_id=UUID("33333333-3333-4333-8333-333333333333"),
         session_id=UUID("22222222-2222-4222-8222-222222222222"),
@@ -80,16 +81,19 @@ def _decode_assertion(encoded: str) -> tuple[bytes, dict[str, Any]]:
     return canonical, decoded
 
 
-def test_safe_tool_handler_binds_identity_request_and_idempotency() -> None:
-    transport = _Transport()
-    handler = PlatformSafeToolHandler(
+def _handler(transport: _Transport) -> PlatformSafeToolHandler:
+    return PlatformSafeToolHandler(
         base_url="http://platform-api.svc",
         assertion_authority=PlatformToolAssertionAuthority(SECRET),
         transport=transport,
         clock=lambda: NOW,
     )
 
-    result = handler.execute(_invocation())
+
+def test_safe_tool_handler_binds_identity_request_and_idempotency() -> None:
+    transport = _Transport()
+
+    result = _handler(transport).execute(_invocation())
 
     assert result["deal"] == {"id": "deal-1"}
     assert len(transport.calls) == 1
@@ -113,18 +117,44 @@ def test_safe_tool_handler_binds_identity_request_and_idempotency() -> None:
     assert call["headers"]["X-TAI-Tool-Signature"] == expected_signature
 
 
-def test_safe_tool_handler_rejects_unregistered_or_mode_rebound_tools() -> None:
-    handler = PlatformSafeToolHandler(
-        base_url="http://platform-api.svc",
-        assertion_authority=PlatformToolAssertionAuthority(SECRET),
-        transport=_Transport(),
-        clock=lambda: NOW,
+def test_confirmed_logistics_handler_is_bound_to_exact_mode_and_arguments() -> None:
+    transport = _Transport()
+    arguments = {
+        "dealId": "deal-1",
+        "carrierOrgId": "carrier-1",
+        "driverUserId": "driver-1",
+        "vehicleId": "vehicle-1",
+        "routeFromFacilityId": "facility-1",
+        "routeToFacilityId": "facility-2",
+        "expectedUpdatedAt": "2026-07-19T01:59:00.000Z",
+        "expectedVersion": "7",
+    }
+
+    _handler(transport).execute(
+        _invocation(
+            tool_name="assignLogistics",
+            mode=ToolMode.CONFIRMED_WRITE,
+            arguments=arguments,
+        )
     )
+
+    call = transport.calls[0]
+    assert call["path"] == "/api/internal/tai/tools/assignLogistics"
+    assert call["payload"] == {"arguments": arguments}
+    _, assertion = _decode_assertion(call["headers"]["X-TAI-Tool-Assertion"])
+    assert assertion["tool_name"] == "assignLogistics"
+    assert assertion["mode"] == "CONFIRMED_WRITE"
+
+
+def test_safe_tool_handler_rejects_unregistered_or_mode_rebound_tools() -> None:
+    handler = _handler(_Transport())
 
     with pytest.raises(PermissionError, match="not executable"):
         handler.execute(_invocation(tool_name="createSupportCase", mode=ToolMode.CONFIRMED_WRITE))
     with pytest.raises(PermissionError, match="not executable"):
         handler.execute(_invocation(mode=ToolMode.DRAFT))
+    with pytest.raises(PermissionError, match="not executable"):
+        handler.execute(_invocation(tool_name="assignLogistics", mode=ToolMode.DRAFT))
 
 
 def test_platform_tool_endpoint_policy_rejects_public_and_pathful_origins() -> None:
@@ -137,12 +167,7 @@ def test_platform_tool_endpoint_policy_rejects_public_and_pathful_origins() -> N
 
 
 def test_platform_tool_contract_rejects_floating_point_arguments() -> None:
-    handler = PlatformSafeToolHandler(
-        base_url="http://platform-api.svc",
-        assertion_authority=PlatformToolAssertionAuthority(SECRET),
-        transport=_Transport(),
-        clock=lambda: NOW,
-    )
+    handler = _handler(_Transport())
     invocation = _invocation()
     rebound = AuthorizedToolInvocation(
         trace_id=invocation.trace_id,

--- a/apps/tai/tests/test_production_platform_tools.py
+++ b/apps/tai/tests/test_production_platform_tools.py
@@ -45,7 +45,7 @@ def test_platform_tools_are_disabled_when_bridge_is_not_configured() -> None:
     assert production_platform_tool_handlers(environment, config) == {}
 
 
-def test_platform_tools_register_only_read_and_draft_handlers() -> None:
+def test_platform_tools_register_safe_tools_and_one_confirmed_handler() -> None:
     environment = _environment()
     environment.update(
         {
@@ -65,6 +65,7 @@ def test_platform_tools_register_only_read_and_draft_handlers() -> None:
         "getDealSummary",
         "getRoleNextActions",
         "prepareCommandDraft",
+        "assignLogistics",
     }
     assert "acknowledgeRisk" not in handlers
     assert "createSupportCase" not in handlers

--- a/apps/tai/tests/test_release_acceptance_cli.py
+++ b/apps/tai/tests/test_release_acceptance_cli.py
@@ -25,6 +25,7 @@ def _repository(root: Path) -> None:
         "0012_git_object_id_contract.sql",
         "0013_production_composition.sql",
         "0014_governed_tool_planner.sql",
+        "0015_confirmed_logistics_authority.sql",
     ]
     for version, name in enumerate(migration_names, start=1):
         (migration_root / name).write_text(f"-- migration {version}\nSELECT {version};\n")
@@ -157,18 +158,18 @@ def test_cli_builds_accepted_application_attestation(tmp_path: Path, monkeypatch
     assert attestation["exact_main_sha"] == HEAD
     assert attestation["production_operational_status"] == "NOT_ATTESTED"
     assert attestation["reasons"] == []
-    assert len(attestation["migration_inventory"]) == 15
+    assert len(attestation["migration_inventory"]) == 16
     assert len(attestation["attestation_sha256"]) == 64
     assert len(attestation["source_tree_sha256"]) == 64
 
 
-def test_cli_rejects_release_below_planner_migration_authority(
+def test_cli_rejects_release_below_confirmed_action_migration_authority(
     tmp_path: Path, monkeypatch
 ) -> None:
     _repository(tmp_path)
     migration_root = tmp_path / "apps/tai/tai/migrations"
-    planner_migration = migration_root / "0014_governed_tool_planner.sql"
-    planner_migration.unlink()
+    confirmed_migration = migration_root / "0015_confirmed_logistics_authority.sql"
+    confirmed_migration.unlink()
     manifest_path = migration_root / "manifest.json"
     manifest = json.loads(manifest_path.read_text())
     manifest["migrations"] = manifest["migrations"][:-1]

--- a/apps/tai/tests/test_tool_planner.py
+++ b/apps/tai/tests/test_tool_planner.py
@@ -27,22 +27,26 @@ class _Sink:
         self.decisions.append(decision)
 
 
-def _identity(*roles: str) -> IdentityContext:
+def _identity(*roles: str, mfa_verified: bool = True) -> IdentityContext:
     return IdentityContext(
         user_id=UUID("10000000-0000-0000-0000-000000000001"),
         tenant_id=UUID("20000000-0000-0000-0000-000000000002"),
         roles=frozenset(roles or ("buyer",)),
         session_id=UUID("30000000-0000-0000-0000-000000000003"),
-        mfa_verified=True,
+        mfa_verified=mfa_verified,
     )
 
 
-def _request(question: str, *roles: str) -> OrchestrationRequest:
+def _request(
+    question: str,
+    *roles: str,
+    mfa_verified: bool = True,
+) -> OrchestrationRequest:
     return OrchestrationRequest(
         request_id="planner-request-1",
         idempotency_key="-".join(("planner", "test", "retry", "0001")),
         question=question,
-        identity=_identity(*roles),
+        identity=_identity(*roles, mfa_verified=mfa_verified),
         requested_at=NOW,
         deadline_at=NOW + timedelta(seconds=30),
     )
@@ -52,12 +56,22 @@ def _plan(
     planner: GovernedToolPlanner,
     question: str,
     *roles: str,
+    mfa_verified: bool = True,
 ) -> AgentToolPlan:
     return planner.plan(
-        request=_request(question, *roles),
+        request=_request(question, *roles, mfa_verified=mfa_verified),
         grounded=cast(Any, object()),
         trace_id=TRACE_ID,
         now=NOW,
+    )
+
+
+def _logistics_question() -> str:
+    return (
+        "Назначь логистику по сделке №deal-42 "
+        "carrierOrgId=carrier-7 driverUserId=driver-8 vehicleId=vehicle-9 "
+        "routeFromFacilityId=facility-1 routeToFacilityId=facility-2 "
+        "expectedUpdatedAt=2026-07-19T11:59:00.000Z expectedVersion=17"
     )
 
 
@@ -102,6 +116,58 @@ def test_planner_prepares_only_a_draft_and_never_infers_payload() -> None:
         "actionId": "accept-quality",
     }
     assert "payload" not in plan.calls[0].arguments
+
+
+def test_planner_builds_one_mfa_bound_confirmed_logistics_call() -> None:
+    sink = _Sink()
+    planner = GovernedToolPlanner(
+        available_tools=frozenset({"assignLogistics"}),
+        decision_sink=sink,
+    )
+
+    plan = _plan(planner, _logistics_question(), "logistics")
+
+    assert len(plan.calls) == 1
+    call = plan.calls[0]
+    assert call.tool_name == "assignLogistics"
+    assert call.requested_mode is ToolMode.CONFIRMED_WRITE
+    assert call.arguments == {
+        "dealId": "deal-42",
+        "carrierOrgId": "carrier-7",
+        "driverUserId": "driver-8",
+        "vehicleId": "vehicle-9",
+        "routeFromFacilityId": "facility-1",
+        "routeToFacilityId": "facility-2",
+        "expectedUpdatedAt": "2026-07-19T11:59:00.000Z",
+        "expectedVersion": "17",
+    }
+    assert sink.decisions[-1].catalog_version == "tai.tool-catalog.governed.v2"
+
+
+def test_planner_fails_closed_for_incomplete_or_non_mfa_logistics_request() -> None:
+    sink = _Sink()
+    planner = GovernedToolPlanner(
+        available_tools=frozenset({"assignLogistics"}),
+        decision_sink=sink,
+    )
+
+    incomplete = _plan(
+        planner,
+        _logistics_question().replace(" expectedVersion=17", ""),
+        "logistics",
+    )
+    no_mfa = _plan(
+        planner,
+        _logistics_question(),
+        "logistics",
+        mfa_verified=False,
+    )
+
+    assert incomplete.calls == ()
+    assert sink.decisions[-2].reason_codes == ("ASSIGN_LOGISTICS_FIELDS_REQUIRED",)
+    assert no_mfa.calls == ()
+    assert sink.decisions[-1].status is PlannerDecisionStatus.REJECTED
+    assert sink.decisions[-1].reason_codes == ("MFA_REQUIRED",)
 
 
 def test_planner_rejects_prompt_injection_before_intent_selection() -> None:
@@ -163,6 +229,6 @@ def test_planner_rechecks_role_before_runtime_preflight() -> None:
     assert sink.decisions[-1].reason_codes == ("ROLE_NOT_AUTHORIZED",)
 
 
-def test_planner_catalog_rejects_any_tool_outside_safe_allowlist() -> None:
+def test_planner_catalog_rejects_any_tool_outside_governed_allowlist() -> None:
     with pytest.raises(ValueError, match="unsupported tools"):
         GovernedToolPlanner(available_tools=frozenset({"acknowledgeRisk"}))


### PR DESCRIPTION
## Scope

First bounded confirmed-write authority slice for TAI. This PR enables exactly one real state-changing platform tool: `assignLogistics` → canonical Deal command `assign_logistics`.

It does not add money, signatures, legal decisions, disputes, universal command execution, distributed model admission control or operational attestation.

## Confirmation chain

1. deterministic planner selects `assignLogistics` only from explicit user intent;
2. all logistics identifiers plus `expectedUpdatedAt` and `expectedVersion` must be explicit;
3. TAI generic confirmation contour creates a user-readable prepared action;
4. separate confirmation endpoint verifies HMAC, identity, TTL and exact request digest;
5. one-time PostgreSQL confirmation claim prevents replay;
6. only after confirmation the signed platform assertion is issued with mode `CONFIRMED_WRITE`;
7. platform API revalidates assertion TTL/request/idempotency/tool/mode;
8. platform resolves real membership, tenant and RLS;
9. canonical Deal gateway rechecks current status, expected timestamp/version, role, logistics admission and driver/vehicle conflicts;
10. existing atomic audit, deal event, outbox and idempotent receipt are written.

## Fail-closed boundaries

- planner never infers missing logistics fields;
- MFA is required by TAI policy;
- at most one tool call per request;
- no free-form `actionId` or arbitrary payload reaches the write endpoint;
- extra keys, malformed IDs, stale state and invalid version are rejected;
- the model cannot mint or submit a confirmation token;
- retries use existing TAI confirmation authority and Deal command idempotency;
- placeholder confirmed tools remain unregistered in production;
- `production_operational_status` remains `NOT_ATTESTED`.

## Authority and evidence

- planner catalog authority upgraded to `tai.tool-catalog.governed.v2`;
- migration `0015_confirmed_logistics_authority.sql` adds confirmed-action trace view joining planner decision, one-time confirmation use and tool audit event;
- migration manifest authority raised to version 16;
- release acceptance rejects any candidate below version 16;
- platform API and TAI sources remain covered by integrated release digest.

## Validation added

- explicit confirmed logistics planning and MFA gate;
- missing-field fail-closed behavior;
- signed platform mode binding;
- exact mapping to `assign_logistics`;
- rejection of action injection and malformed concurrency values;
- production handler inventory;
- migration ordering and release rejection below v16.

## Base

Exact base: `f99955ba69a85cd9e3afcfc17864a8314c66d122` (merged AP-12A).
