### PR TITLE
TAI AP-13B: pinned model artifact registry and verifier

### DIFF
--- a/apps/tai/model-artifacts/README.md
+++ b/apps/tai/model-artifacts/README.md
@@ -1,0 +1,78 @@
+# TAI local model artifacts
+
+This directory stores only small machine-readable registries and runbooks. Model weights, GGUF files, tokenizer binaries and license evidence are not committed to Git.
+
+## Current status
+
+`candidates.v1.json` pins two source candidates:
+
+- primary: `Qwen/Qwen3-8B` at revision `895c8d171bc03c30e113cd7a28c02494b5e068b7`;
+- fallback: `mistralai/Mistral-7B-Instruct-v0.3` at revision `c170c708c41dac9275d15a8fff4eca08d52bab71`.
+
+Both candidates remain `PENDING`. The Apache-2.0 metadata in the upstream model card is not treated as completed legal review. The exact license text, tokenizer files, source weights, quantized artifacts and full llama.cpp commit still have to be captured and hashed before a bundle can verify.
+
+## Validate the source registry
+
+```bash
+cd apps/tai
+python -m tai.model_artifact_registry_cli validate-registry \
+  model-artifacts/candidates.v1.json
+```
+
+This validates only schema and immutable source references. It does not claim that local artifacts exist or are admitted.
+
+## Required local bundle layout
+
+A bundle lives outside Git and contains:
+
+```text
+bundle-root/
+  licenses/<model>/LICENSE
+  sources/<model>/tokenizer...
+  sources/<model>/model...safetensors
+  artifacts/<model>-q4-k-m.gguf
+```
+
+A separate `bundle.v1.json` declares every evidence file with exact relative path, SHA-256 and byte size. Each quantized artifact also declares runtime class, quantization and the full 40-character toolchain commit.
+
+## Verify a completed bundle
+
+```bash
+cd apps/tai
+python -m tai.model_artifact_registry_cli verify-bundle \
+  model-artifacts/candidates.v1.json \
+  /secure/evidence/qwen3-8b.bundle.v1.json \
+  /secure/evidence/qwen3-8b \
+  --output /secure/evidence/qwen3-8b.verification.json
+```
+
+Exit codes:
+
+- `0` — all required files, sizes, hashes, recipes, license review and toolchain commit match;
+- `2` — invalid schema, missing evidence, mismatch or pending/rejected license.
+
+## Quantization boundary
+
+The registry currently pins llama.cpp release `b9637`, but intentionally leaves `toolchain_commit` null until the full commit SHA and source/build evidence are captured. A release tag or short SHA alone is insufficient for bundle verification.
+
+The expected sequence is:
+
+1. fetch the exact upstream model revision;
+2. capture and review the exact license text;
+3. hash source weights and tokenizer files;
+4. pin the full llama.cpp commit and build environment;
+5. convert to F16/BF16 GGUF;
+6. quantize to the declared output;
+7. hash the output and create the bundle manifest;
+8. run the verifier;
+9. only then create AP-13A artifact/license evidence;
+10. benchmark in AP-13C before any admission decision.
+
+## Security rules
+
+- Never use `main`, `master`, `latest` or mutable model tags.
+- Never trust a community GGUF without a complete provenance chain.
+- Never commit multi-gigabyte weights or secrets to Git.
+- Never mark a license approved automatically.
+- Never copy benchmark numbers from a model card into admission evidence.
+- Never change `NOT_ATTESTED` until AP-13C and AP-13D exact-main evidence passes.

--- a/apps/tai/model-artifacts/candidates.v1.json
+++ b/apps/tai/model-artifacts/candidates.v1.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "tai.model-candidate-registry.v1",
+  "candidates": [
+    {
+      "role": "PRIMARY",
+      "model_id": "Qwen/Qwen3-8B",
+      "revision": "895c8d171bc03c30e113cd7a28c02494b5e068b7",
+      "source_uri": "https://huggingface.co/Qwen/Qwen3-8B/tree/895c8d171bc03c30e113cd7a28c02494b5e068b7",
+      "model_card_uri": "https://huggingface.co/Qwen/Qwen3-8B/blob/895c8d171bc03c30e113cd7a28c02494b5e068b7/README.md",
+      "license_spdx": "Apache-2.0",
+      "license_review_status": "PENDING",
+      "license_text_path": null,
+      "tokenizer_files": [
+        "sources/qwen3-8b/tokenizer.json",
+        "sources/qwen3-8b/tokenizer_config.json"
+      ],
+      "weight_files": [
+        "sources/qwen3-8b/model-00001-of-00005.safetensors",
+        "sources/qwen3-8b/model-00002-of-00005.safetensors",
+        "sources/qwen3-8b/model-00003-of-00005.safetensors",
+        "sources/qwen3-8b/model-00004-of-00005.safetensors",
+        "sources/qwen3-8b/model-00005-of-00005.safetensors",
+        "sources/qwen3-8b/model.safetensors.index.json"
+      ],
+      "quantization_recipes": [
+        {
+          "runtime_class": "CPU",
+          "format": "GGUF",
+          "quantization": "Q4_K_M",
+          "toolchain_name": "ggml-org/llama.cpp",
+          "toolchain_uri": "https://github.com/ggml-org/llama.cpp",
+          "toolchain_release": "b9637",
+          "toolchain_commit": null,
+          "output_path": "artifacts/qwen3-8b-q4-k-m.gguf"
+        },
+        {
+          "runtime_class": "GPU_SHARED",
+          "format": "GGUF",
+          "quantization": "Q8_0",
+          "toolchain_name": "ggml-org/llama.cpp",
+          "toolchain_uri": "https://github.com/ggml-org/llama.cpp",
+          "toolchain_release": "b9637",
+          "toolchain_commit": null,
+          "output_path": "artifacts/qwen3-8b-q8-0.gguf"
+        }
+      ]
+    },
+    {
+      "role": "FALLBACK",
+      "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+      "revision": "c170c708c41dac9275d15a8fff4eca08d52bab71",
+      "source_uri": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3/tree/c170c708c41dac9275d15a8fff4eca08d52bab71",
+      "model_card_uri": "https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3/blob/c170c708c41dac9275d15a8fff4eca08d52bab71/README.md",
+      "license_spdx": "Apache-2.0",
+      "license_review_status": "PENDING",
+      "license_text_path": null,
+      "tokenizer_files": [
+        "sources/mistral-7b-instruct-v0.3/tokenizer.model.v3",
+        "sources/mistral-7b-instruct-v0.3/tokenizer_config.json"
+      ],
+      "weight_files": [
+        "sources/mistral-7b-instruct-v0.3/model-00001-of-00003.safetensors",
+        "sources/mistral-7b-instruct-v0.3/model-00002-of-00003.safetensors",
+        "sources/mistral-7b-instruct-v0.3/model-00003-of-00003.safetensors",
+        "sources/mistral-7b-instruct-v0.3/model.safetensors.index.json"
+      ],
+      "quantization_recipes": [
+        {
+          "runtime_class": "CPU",
+          "format": "GGUF",
+          "quantization": "Q4_K_M",
+          "toolchain_name": "ggml-org/llama.cpp",
+          "toolchain_uri": "https://github.com/ggml-org/llama.cpp",
+          "toolchain_release": "b9637",
+          "toolchain_commit": null,
+          "output_path": "artifacts/mistral-7b-instruct-v0.3-q4-k-m.gguf"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/tai/tai/model_artifact_registry.py
+++ b/apps/tai/tai/model_artifact_registry.py
@@ -233,7 +233,12 @@ def verify_artifact_bundle(
     else:
         _verify_candidate_contract(candidate, bundle, reasons)
 
-    for declared in (bundle.license_text, *bundle.tokenizers, *bundle.artifacts):
+    declared_files: tuple[DeclaredFile | DeclaredArtifact, ...] = (
+        bundle.license_text,
+        *bundle.tokenizers,
+        *bundle.artifacts,
+    )
+    for declared in declared_files:
         path = _bounded_file(bundle_root, declared.path)
         if not path.is_file():
             reasons.append(f"FILE_MISSING:{declared.path}")

--- a/apps/tai/tai/model_artifact_registry.py
+++ b/apps/tai/tai/model_artifact_registry.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, cast
 
 from tai.model_runtime import ModelRuntimeClass
 
@@ -46,14 +46,14 @@ class QuantizationRecipe:
     def __post_init__(self) -> None:
         if self.format != "GGUF":
             raise ValueError("only GGUF artifacts are permitted in AP-13B")
-        _validate_identity(self.quantization, "quantization")
-        _validate_identity(self.toolchain_name, "toolchain_name")
-        _validate_https(self.toolchain_uri, "toolchain_uri")
+        _identity(self.quantization, "quantization")
+        _identity(self.toolchain_name, "toolchain_name")
+        _https(self.toolchain_uri, "toolchain_uri")
         if _RELEASE_TAG.fullmatch(self.toolchain_release) is None:
             raise ValueError("toolchain_release must be a portable immutable tag")
         if self.toolchain_commit is not None:
-            _validate_revision(self.toolchain_commit, "toolchain_commit")
-        _validate_relative_path(self.output_path, "output_path")
+            _revision(self.toolchain_commit, "toolchain_commit")
+        _relative_path(self.output_path, "output_path")
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,29 +71,32 @@ class ModelSourceCandidate:
     recipes: tuple[QuantizationRecipe, ...]
 
     def __post_init__(self) -> None:
-        _validate_identity(self.model_id, "model_id")
-        _validate_revision(self.revision, "revision")
-        _validate_https(self.source_uri, "source_uri")
-        _validate_https(self.model_card_uri, "model_card_uri")
+        _identity(self.model_id, "model_id")
+        _revision(self.revision, "revision")
+        _https(self.source_uri, "source_uri")
+        _https(self.model_card_uri, "model_card_uri")
         if self.revision not in self.source_uri:
             raise ValueError("source_uri must contain the exact source revision")
         if self.revision not in self.model_card_uri:
             raise ValueError("model_card_uri must contain the exact source revision")
-        _validate_identity(self.license_spdx, "license_spdx")
-        if self.license_review_status is LicenseReviewStatus.APPROVED:
-            if self.license_text_path is None:
-                raise ValueError("approved license requires license_text_path")
+        _identity(self.license_spdx, "license_spdx")
+        if (
+            self.license_review_status is LicenseReviewStatus.APPROVED
+            and self.license_text_path is None
+        ):
+            raise ValueError("approved license requires license_text_path")
         if self.license_text_path is not None:
-            _validate_relative_path(self.license_text_path, "license_text_path")
-        _validate_unique_paths(self.tokenizer_files, "tokenizer_files")
-        _validate_unique_paths(self.weight_files, "weight_files")
+            _relative_path(self.license_text_path, "license_text_path")
+        _unique_paths(self.tokenizer_files, "tokenizer_files")
+        _unique_paths(self.weight_files, "weight_files")
         if not self.recipes:
             raise ValueError("at least one quantization recipe is required")
-        recipe_paths = tuple(item.output_path for item in self.recipes)
-        if len(set(recipe_paths)) != len(recipe_paths):
+        outputs = tuple(recipe.output_path for recipe in self.recipes)
+        if len(outputs) != len(set(outputs)):
             raise ValueError("quantization recipe output paths must be unique")
         if not any(
-            item.runtime_class is ModelRuntimeClass.CPU for item in self.recipes
+            recipe.runtime_class is ModelRuntimeClass.CPU
+            for recipe in self.recipes
         ):
             raise ValueError("every model candidate requires a CPU recipe")
 
@@ -108,7 +111,7 @@ class ModelCandidateRegistry:
         identities = {(item.model_id, item.revision) for item in self.candidates}
         if len(identities) != len(self.candidates):
             raise ValueError("model candidate identities must be unique")
-        roles = [item.role for item in self.candidates]
+        roles = tuple(item.role for item in self.candidates)
         if roles.count(CandidateRole.PRIMARY) != 1:
             raise ValueError("candidate registry requires exactly one primary model")
         if CandidateRole.FALLBACK not in roles:
@@ -122,8 +125,8 @@ class DeclaredFile:
     size_bytes: int
 
     def __post_init__(self) -> None:
-        _validate_relative_path(self.path, "declared file path")
-        _validate_sha256(self.sha256, "declared file sha256")
+        _relative_path(self.path, "declared file path")
+        _sha256(self.sha256, "declared file sha256")
         if self.size_bytes < 1:
             raise ValueError("declared file size must be positive")
 
@@ -138,12 +141,12 @@ class DeclaredArtifact:
     toolchain_commit: str
 
     def __post_init__(self) -> None:
-        _validate_relative_path(self.path, "artifact path")
-        _validate_sha256(self.sha256, "artifact sha256")
+        _relative_path(self.path, "artifact path")
+        _sha256(self.sha256, "artifact sha256")
         if self.size_bytes < 1:
             raise ValueError("artifact size must be positive")
-        _validate_identity(self.quantization, "artifact quantization")
-        _validate_revision(self.toolchain_commit, "artifact toolchain_commit")
+        _identity(self.quantization, "artifact quantization")
+        _revision(self.toolchain_commit, "artifact toolchain_commit")
 
 
 @dataclass(frozen=True, slots=True)
@@ -155,18 +158,16 @@ class LocalModelArtifactBundle:
     artifacts: tuple[DeclaredArtifact, ...]
 
     def __post_init__(self) -> None:
-        _validate_identity(self.model_id, "bundle model_id")
-        _validate_revision(self.revision, "bundle revision")
-        if not self.tokenizers:
-            raise ValueError("bundle tokenizers must not be empty")
-        if not self.artifacts:
-            raise ValueError("bundle artifacts must not be empty")
+        _identity(self.model_id, "bundle model_id")
+        _revision(self.revision, "bundle revision")
+        if not self.tokenizers or not self.artifacts:
+            raise ValueError("bundle tokenizers and artifacts must not be empty")
         paths = (
             self.license_text.path,
             *(item.path for item in self.tokenizers),
             *(item.path for item in self.artifacts),
         )
-        if len(set(paths)) != len(paths):
+        if len(paths) != len(set(paths)):
             raise ValueError("bundle file paths must be unique")
 
 
@@ -185,31 +186,28 @@ class BundleVerificationReport:
 
 
 def load_candidate_registry(path: Path) -> ModelCandidateRegistry:
-    payload = _load_json_object(path)
+    payload = _load(path)
     if payload.get("schema_version") != "tai.model-candidate-registry.v1":
         raise ValueError("unsupported model candidate registry schema")
-    raw_candidates = payload.get("candidates")
-    if not isinstance(raw_candidates, list):
-        raise ValueError("candidate registry candidates must be an array")
-    candidates = tuple(_parse_candidate(item) for item in raw_candidates)
+    candidates = tuple(
+        _candidate(item) for item in _array(payload, "candidates")
+    )
     return ModelCandidateRegistry(candidates)
 
 
 def load_artifact_bundle(path: Path) -> LocalModelArtifactBundle:
-    payload = _load_json_object(path)
+    payload = _load(path)
     if payload.get("schema_version") != "tai.local-model-artifact-bundle.v1":
         raise ValueError("unsupported local artifact bundle schema")
     return LocalModelArtifactBundle(
-        model_id=_required_string(payload, "model_id"),
-        revision=_required_string(payload, "revision"),
-        license_text=_parse_declared_file(payload.get("license_text")),
+        model_id=_string(payload, "model_id"),
+        revision=_string(payload, "revision"),
+        license_text=_declared_file(payload.get("license_text")),
         tokenizers=tuple(
-            _parse_declared_file(item)
-            for item in _required_array(payload, "tokenizers")
+            _declared_file(item) for item in _array(payload, "tokenizers")
         ),
         artifacts=tuple(
-            _parse_declared_artifact(item)
-            for item in _required_array(payload, "artifacts")
+            _declared_artifact(item) for item in _array(payload, "artifacts")
         ),
     )
 
@@ -229,59 +227,22 @@ def verify_artifact_bundle(
         None,
     )
     reasons: list[str] = []
-    verified_files: list[str] = []
+    verified: list[str] = []
     if candidate is None:
         reasons.append("CANDIDATE_NOT_REGISTERED")
     else:
-        if candidate.license_review_status is not LicenseReviewStatus.APPROVED:
-            reasons.append("LICENSE_REVIEW_NOT_APPROVED")
-        if candidate.license_text_path != bundle.license_text.path:
-            reasons.append("LICENSE_TEXT_PATH_MISMATCH")
-        expected_tokenizers = set(candidate.tokenizer_files)
-        declared_tokenizers = {item.path for item in bundle.tokenizers}
-        if expected_tokenizers != declared_tokenizers:
-            reasons.append("TOKENIZER_SET_MISMATCH")
-        expected_recipes = {
-            (
-                item.output_path,
-                item.runtime_class,
-                item.quantization,
-                item.toolchain_commit,
-            )
-            for item in candidate.recipes
-        }
-        declared_artifacts = {
-            (
-                item.path,
-                item.runtime_class,
-                item.quantization,
-                item.toolchain_commit,
-            )
-            for item in bundle.artifacts
-        }
-        if expected_recipes != declared_artifacts:
-            reasons.append("ARTIFACT_RECIPE_SET_MISMATCH")
-        if any(item.toolchain_commit is None for item in candidate.recipes):
-            reasons.append("TOOLCHAIN_FULL_COMMIT_MISSING")
+        _verify_candidate_contract(candidate, bundle, reasons)
 
-    for declared in (
-        bundle.license_text,
-        *bundle.tokenizers,
-        *bundle.artifacts,
-    ):
-        file_path = _bounded_file(bundle_root, declared.path)
-        if not file_path.is_file():
+    for declared in (bundle.license_text, *bundle.tokenizers, *bundle.artifacts):
+        path = _bounded_file(bundle_root, declared.path)
+        if not path.is_file():
             reasons.append(f"FILE_MISSING:{declared.path}")
-            continue
-        actual_size = file_path.stat().st_size
-        if actual_size != declared.size_bytes:
+        elif path.stat().st_size != declared.size_bytes:
             reasons.append(f"FILE_SIZE_MISMATCH:{declared.path}")
-            continue
-        actual_sha256 = _file_sha256(file_path)
-        if actual_sha256 != declared.sha256:
+        elif _file_sha256(path) != declared.sha256:
             reasons.append(f"FILE_SHA256_MISMATCH:{declared.path}")
-            continue
-        verified_files.append(declared.path)
+        else:
+            verified.append(declared.path)
 
     unique_reasons = tuple(sorted(set(reasons)))
     status = (
@@ -289,129 +250,166 @@ def verify_artifact_bundle(
         if not unique_reasons
         else BundleVerificationStatus.REJECTED
     )
-    report_sha256 = _report_sha256(
-        bundle=bundle,
-        status=status,
-        reasons=unique_reasons,
-        verified_files=tuple(sorted(verified_files)),
-    )
+    verified_files = tuple(sorted(verified))
     return BundleVerificationReport(
         model_id=bundle.model_id,
         revision=bundle.revision,
         status=status,
         reasons=unique_reasons,
-        verified_files=tuple(sorted(verified_files)),
-        report_sha256=report_sha256,
+        verified_files=verified_files,
+        report_sha256=_report_sha256(
+            bundle.model_id,
+            bundle.revision,
+            status,
+            unique_reasons,
+            verified_files,
+        ),
     )
 
 
 def registry_to_canonical_json(registry: ModelCandidateRegistry) -> str:
     payload = {
-        "candidates": [
-            {
-                "license_review_status": item.license_review_status.value,
-                "license_spdx": item.license_spdx,
-                "license_text_path": item.license_text_path,
-                "model_card_uri": item.model_card_uri,
-                "model_id": item.model_id,
-                "quantization_recipes": [
-                    {
-                        "format": recipe.format,
-                        "output_path": recipe.output_path,
-                        "quantization": recipe.quantization,
-                        "runtime_class": recipe.runtime_class.value,
-                        "toolchain_commit": recipe.toolchain_commit,
-                        "toolchain_name": recipe.toolchain_name,
-                        "toolchain_release": recipe.toolchain_release,
-                        "toolchain_uri": recipe.toolchain_uri,
-                    }
-                    for recipe in item.recipes
-                ],
-                "revision": item.revision,
-                "role": item.role.value,
-                "source_uri": item.source_uri,
-                "tokenizer_files": list(item.tokenizer_files),
-                "weight_files": list(item.weight_files),
-            }
-            for item in registry.candidates
-        ],
+        "candidates": [_candidate_payload(item) for item in registry.candidates],
         "schema_version": "tai.model-candidate-registry.v1",
     }
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return _canonical_json(payload)
 
 
-def _parse_candidate(value: object) -> ModelSourceCandidate:
-    payload = _require_object(value, "candidate")
-    raw_recipes = _required_array(payload, "quantization_recipes")
+def _verify_candidate_contract(
+    candidate: ModelSourceCandidate,
+    bundle: LocalModelArtifactBundle,
+    reasons: list[str],
+) -> None:
+    if candidate.license_review_status is not LicenseReviewStatus.APPROVED:
+        reasons.append("LICENSE_REVIEW_NOT_APPROVED")
+    if candidate.license_text_path != bundle.license_text.path:
+        reasons.append("LICENSE_TEXT_PATH_MISMATCH")
+    if set(candidate.tokenizer_files) != {item.path for item in bundle.tokenizers}:
+        reasons.append("TOKENIZER_SET_MISMATCH")
+    expected = {
+        (
+            item.output_path,
+            item.runtime_class,
+            item.quantization,
+            item.toolchain_commit,
+        )
+        for item in candidate.recipes
+    }
+    declared = {
+        (
+            item.path,
+            item.runtime_class,
+            item.quantization,
+            item.toolchain_commit,
+        )
+        for item in bundle.artifacts
+    }
+    if expected != declared:
+        reasons.append("ARTIFACT_RECIPE_SET_MISMATCH")
+    if any(item.toolchain_commit is None for item in candidate.recipes):
+        reasons.append("TOOLCHAIN_FULL_COMMIT_MISSING")
+
+
+def _candidate_payload(candidate: ModelSourceCandidate) -> dict[str, object]:
+    return {
+        "license_review_status": candidate.license_review_status.value,
+        "license_spdx": candidate.license_spdx,
+        "license_text_path": candidate.license_text_path,
+        "model_card_uri": candidate.model_card_uri,
+        "model_id": candidate.model_id,
+        "quantization_recipes": [
+            {
+                "format": recipe.format,
+                "output_path": recipe.output_path,
+                "quantization": recipe.quantization,
+                "runtime_class": recipe.runtime_class.value,
+                "toolchain_commit": recipe.toolchain_commit,
+                "toolchain_name": recipe.toolchain_name,
+                "toolchain_release": recipe.toolchain_release,
+                "toolchain_uri": recipe.toolchain_uri,
+            }
+            for recipe in candidate.recipes
+        ],
+        "revision": candidate.revision,
+        "role": candidate.role.value,
+        "source_uri": candidate.source_uri,
+        "tokenizer_files": list(candidate.tokenizer_files),
+        "weight_files": list(candidate.weight_files),
+    }
+
+
+def _candidate(value: object) -> ModelSourceCandidate:
+    payload = _object(value, "candidate")
     return ModelSourceCandidate(
-        role=CandidateRole(_required_string(payload, "role")),
-        model_id=_required_string(payload, "model_id"),
-        revision=_required_string(payload, "revision"),
-        source_uri=_required_string(payload, "source_uri"),
-        model_card_uri=_required_string(payload, "model_card_uri"),
-        license_spdx=_required_string(payload, "license_spdx"),
+        role=CandidateRole(_string(payload, "role")),
+        model_id=_string(payload, "model_id"),
+        revision=_string(payload, "revision"),
+        source_uri=_string(payload, "source_uri"),
+        model_card_uri=_string(payload, "model_card_uri"),
+        license_spdx=_string(payload, "license_spdx"),
         license_review_status=LicenseReviewStatus(
-            _required_string(payload, "license_review_status")
+            _string(payload, "license_review_status")
         ),
         license_text_path=_optional_string(payload, "license_text_path"),
-        tokenizer_files=tuple(_string_array(payload, "tokenizer_files")),
-        weight_files=tuple(_string_array(payload, "weight_files")),
-        recipes=tuple(_parse_recipe(item) for item in raw_recipes),
+        tokenizer_files=tuple(_strings(payload, "tokenizer_files")),
+        weight_files=tuple(_strings(payload, "weight_files")),
+        recipes=tuple(
+            _recipe(item) for item in _array(payload, "quantization_recipes")
+        ),
     )
 
 
-def _parse_recipe(value: object) -> QuantizationRecipe:
-    payload = _require_object(value, "quantization recipe")
+def _recipe(value: object) -> QuantizationRecipe:
+    payload = _object(value, "quantization recipe")
     return QuantizationRecipe(
-        runtime_class=ModelRuntimeClass(_required_string(payload, "runtime_class")),
-        format=_required_string(payload, "format"),
-        quantization=_required_string(payload, "quantization"),
-        toolchain_name=_required_string(payload, "toolchain_name"),
-        toolchain_uri=_required_string(payload, "toolchain_uri"),
-        toolchain_release=_required_string(payload, "toolchain_release"),
+        runtime_class=ModelRuntimeClass(_string(payload, "runtime_class")),
+        format=_string(payload, "format"),
+        quantization=_string(payload, "quantization"),
+        toolchain_name=_string(payload, "toolchain_name"),
+        toolchain_uri=_string(payload, "toolchain_uri"),
+        toolchain_release=_string(payload, "toolchain_release"),
         toolchain_commit=_optional_string(payload, "toolchain_commit"),
-        output_path=_required_string(payload, "output_path"),
+        output_path=_string(payload, "output_path"),
     )
 
 
-def _parse_declared_file(value: object) -> DeclaredFile:
-    payload = _require_object(value, "declared file")
+def _declared_file(value: object) -> DeclaredFile:
+    payload = _object(value, "declared file")
     return DeclaredFile(
-        path=_required_string(payload, "path"),
-        sha256=_required_string(payload, "sha256"),
-        size_bytes=_required_integer(payload, "size_bytes"),
+        path=_string(payload, "path"),
+        sha256=_string(payload, "sha256"),
+        size_bytes=_integer(payload, "size_bytes"),
     )
 
 
-def _parse_declared_artifact(value: object) -> DeclaredArtifact:
-    payload = _require_object(value, "declared artifact")
+def _declared_artifact(value: object) -> DeclaredArtifact:
+    payload = _object(value, "declared artifact")
     return DeclaredArtifact(
-        path=_required_string(payload, "path"),
-        sha256=_required_string(payload, "sha256"),
-        size_bytes=_required_integer(payload, "size_bytes"),
-        runtime_class=ModelRuntimeClass(_required_string(payload, "runtime_class")),
-        quantization=_required_string(payload, "quantization"),
-        toolchain_commit=_required_string(payload, "toolchain_commit"),
+        path=_string(payload, "path"),
+        sha256=_string(payload, "sha256"),
+        size_bytes=_integer(payload, "size_bytes"),
+        runtime_class=ModelRuntimeClass(_string(payload, "runtime_class")),
+        quantization=_string(payload, "quantization"),
+        toolchain_commit=_string(payload, "toolchain_commit"),
     )
 
 
 def _report_sha256(
-    *,
-    bundle: LocalModelArtifactBundle,
+    model_id: str,
+    revision: str,
     status: BundleVerificationStatus,
     reasons: tuple[str, ...],
     verified_files: tuple[str, ...],
 ) -> str:
     payload = {
-        "model_id": bundle.model_id,
+        "model_id": model_id,
         "reasons": list(reasons),
-        "revision": bundle.revision,
+        "revision": revision,
         "schema_version": "tai.model-artifact-verification-report.v1",
         "status": status.value,
         "verified_files": list(verified_files),
     }
-    canonical = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return hashlib.sha256(_canonical_json(payload).encode()).hexdigest()
 
 
 def _file_sha256(path: Path) -> str:
@@ -430,35 +428,36 @@ def _bounded_file(root: Path, relative_path: str) -> Path:
     return candidate
 
 
-def _load_json_object(path: Path) -> dict[str, Any]:
+def _load(path: Path) -> dict[str, Any]:
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
+        return _object(json.loads(path.read_text(encoding="utf-8")), "root payload")
     except (OSError, json.JSONDecodeError) as error:
         raise ValueError(f"cannot load JSON from {path}") from error
-    return _require_object(value, "root payload")
 
 
-def _require_object(value: object, name: str) -> dict[str, Any]:
-    if not isinstance(value, dict) or any(not isinstance(key, str) for key in value):
+def _object(value: object, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
         raise ValueError(f"{name} must be a JSON object")
-    return value
+    if any(not isinstance(key, str) for key in value):
+        raise ValueError(f"{name} keys must be strings")
+    return cast(dict[str, Any], value)
 
 
-def _required_array(payload: dict[str, Any], key: str) -> list[object]:
+def _array(payload: dict[str, Any], key: str) -> list[object]:
     value = payload.get(key)
     if not isinstance(value, list):
         raise ValueError(f"{key} must be an array")
-    return value
+    return cast(list[object], value)
 
 
-def _string_array(payload: dict[str, Any], key: str) -> list[str]:
-    values = _required_array(payload, key)
+def _strings(payload: dict[str, Any], key: str) -> list[str]:
+    values = _array(payload, key)
     if not values or any(not isinstance(item, str) for item in values):
         raise ValueError(f"{key} must be a non-empty string array")
-    return values
+    return cast(list[str], values)
 
 
-def _required_string(payload: dict[str, Any], key: str) -> str:
+def _string(payload: dict[str, Any], key: str) -> str:
     value = payload.get(key)
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{key} must be a non-empty string")
@@ -474,34 +473,43 @@ def _optional_string(payload: dict[str, Any], key: str) -> str | None:
     return value
 
 
-def _required_integer(payload: dict[str, Any], key: str) -> int:
+def _integer(payload: dict[str, Any], key: str) -> int:
     value = payload.get(key)
     if not isinstance(value, int) or isinstance(value, bool):
         raise ValueError(f"{key} must be an integer")
     return value
 
 
-def _validate_identity(value: str, name: str) -> None:
+def _canonical_json(payload: object) -> str:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _identity(value: str, name: str) -> None:
     if _IDENTITY.fullmatch(value) is None:
         raise ValueError(f"{name} must be a portable bounded identity")
 
 
-def _validate_revision(value: str, name: str) -> None:
+def _revision(value: str, name: str) -> None:
     if _REVISION.fullmatch(value) is None:
         raise ValueError(f"{name} must be a pinned lowercase commit digest")
 
 
-def _validate_sha256(value: str, name: str) -> None:
+def _sha256(value: str, name: str) -> None:
     if _SHA256.fullmatch(value) is None:
         raise ValueError(f"{name} must be a lowercase SHA-256 digest")
 
 
-def _validate_https(value: str, name: str) -> None:
+def _https(value: str, name: str) -> None:
     if not value.startswith("https://"):
         raise ValueError(f"{name} must use HTTPS")
 
 
-def _validate_relative_path(value: str, name: str) -> None:
+def _relative_path(value: str, name: str) -> None:
     path = PurePosixPath(value)
     if path.is_absolute() or ".." in path.parts or value.startswith("./"):
         raise ValueError(f"{name} must be a bounded relative path")
@@ -509,10 +517,10 @@ def _validate_relative_path(value: str, name: str) -> None:
         raise ValueError(f"{name} must be a bounded relative path")
 
 
-def _validate_unique_paths(values: tuple[str, ...], name: str) -> None:
+def _unique_paths(values: tuple[str, ...], name: str) -> None:
     if not values:
         raise ValueError(f"{name} must not be empty")
     for value in values:
-        _validate_relative_path(value, name)
-    if len(set(values)) != len(values):
+        _relative_path(value, name)
+    if len(values) != len(set(values)):
         raise ValueError(f"{name} must contain unique paths")

--- a/apps/tai/tai/model_artifact_registry.py
+++ b/apps/tai/tai/model_artifact_registry.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from tai.model_runtime import ModelRuntimeClass
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_REVISION = re.compile(r"^[0-9a-f]{40,64}$")
+_IDENTITY = re.compile(r"^[A-Za-z0-9._:/+-]{1,180}$")
+_RELEASE_TAG = re.compile(r"^[A-Za-z0-9._+-]{1,80}$")
+
+
+class CandidateRole(StrEnum):
+    PRIMARY = "PRIMARY"
+    FALLBACK = "FALLBACK"
+
+
+class LicenseReviewStatus(StrEnum):
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+
+class BundleVerificationStatus(StrEnum):
+    VERIFIED = "VERIFIED"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True, slots=True)
+class QuantizationRecipe:
+    runtime_class: ModelRuntimeClass
+    format: str
+    quantization: str
+    toolchain_name: str
+    toolchain_uri: str
+    toolchain_release: str
+    toolchain_commit: str | None
+    output_path: str
+
+    def __post_init__(self) -> None:
+        if self.format != "GGUF":
+            raise ValueError("only GGUF artifacts are permitted in AP-13B")
+        _validate_identity(self.quantization, "quantization")
+        _validate_identity(self.toolchain_name, "toolchain_name")
+        _validate_https(self.toolchain_uri, "toolchain_uri")
+        if _RELEASE_TAG.fullmatch(self.toolchain_release) is None:
+            raise ValueError("toolchain_release must be a portable immutable tag")
+        if self.toolchain_commit is not None:
+            _validate_revision(self.toolchain_commit, "toolchain_commit")
+        _validate_relative_path(self.output_path, "output_path")
+
+
+@dataclass(frozen=True, slots=True)
+class ModelSourceCandidate:
+    role: CandidateRole
+    model_id: str
+    revision: str
+    source_uri: str
+    model_card_uri: str
+    license_spdx: str
+    license_review_status: LicenseReviewStatus
+    license_text_path: str | None
+    tokenizer_files: tuple[str, ...]
+    weight_files: tuple[str, ...]
+    recipes: tuple[QuantizationRecipe, ...]
+
+    def __post_init__(self) -> None:
+        _validate_identity(self.model_id, "model_id")
+        _validate_revision(self.revision, "revision")
+        _validate_https(self.source_uri, "source_uri")
+        _validate_https(self.model_card_uri, "model_card_uri")
+        if self.revision not in self.source_uri:
+            raise ValueError("source_uri must contain the exact source revision")
+        if self.revision not in self.model_card_uri:
+            raise ValueError("model_card_uri must contain the exact source revision")
+        _validate_identity(self.license_spdx, "license_spdx")
+        if self.license_review_status is LicenseReviewStatus.APPROVED:
+            if self.license_text_path is None:
+                raise ValueError("approved license requires license_text_path")
+        if self.license_text_path is not None:
+            _validate_relative_path(self.license_text_path, "license_text_path")
+        _validate_unique_paths(self.tokenizer_files, "tokenizer_files")
+        _validate_unique_paths(self.weight_files, "weight_files")
+        if not self.recipes:
+            raise ValueError("at least one quantization recipe is required")
+        recipe_paths = tuple(item.output_path for item in self.recipes)
+        if len(set(recipe_paths)) != len(recipe_paths):
+            raise ValueError("quantization recipe output paths must be unique")
+        if not any(
+            item.runtime_class is ModelRuntimeClass.CPU for item in self.recipes
+        ):
+            raise ValueError("every model candidate requires a CPU recipe")
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCandidateRegistry:
+    candidates: tuple[ModelSourceCandidate, ...]
+
+    def __post_init__(self) -> None:
+        if not self.candidates:
+            raise ValueError("candidate registry must not be empty")
+        identities = {(item.model_id, item.revision) for item in self.candidates}
+        if len(identities) != len(self.candidates):
+            raise ValueError("model candidate identities must be unique")
+        roles = [item.role for item in self.candidates]
+        if roles.count(CandidateRole.PRIMARY) != 1:
+            raise ValueError("candidate registry requires exactly one primary model")
+        if CandidateRole.FALLBACK not in roles:
+            raise ValueError("candidate registry requires at least one fallback model")
+
+
+@dataclass(frozen=True, slots=True)
+class DeclaredFile:
+    path: str
+    sha256: str
+    size_bytes: int
+
+    def __post_init__(self) -> None:
+        _validate_relative_path(self.path, "declared file path")
+        _validate_sha256(self.sha256, "declared file sha256")
+        if self.size_bytes < 1:
+            raise ValueError("declared file size must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class DeclaredArtifact:
+    path: str
+    sha256: str
+    size_bytes: int
+    runtime_class: ModelRuntimeClass
+    quantization: str
+    toolchain_commit: str
+
+    def __post_init__(self) -> None:
+        _validate_relative_path(self.path, "artifact path")
+        _validate_sha256(self.sha256, "artifact sha256")
+        if self.size_bytes < 1:
+            raise ValueError("artifact size must be positive")
+        _validate_identity(self.quantization, "artifact quantization")
+        _validate_revision(self.toolchain_commit, "artifact toolchain_commit")
+
+
+@dataclass(frozen=True, slots=True)
+class LocalModelArtifactBundle:
+    model_id: str
+    revision: str
+    license_text: DeclaredFile
+    tokenizers: tuple[DeclaredFile, ...]
+    artifacts: tuple[DeclaredArtifact, ...]
+
+    def __post_init__(self) -> None:
+        _validate_identity(self.model_id, "bundle model_id")
+        _validate_revision(self.revision, "bundle revision")
+        if not self.tokenizers:
+            raise ValueError("bundle tokenizers must not be empty")
+        if not self.artifacts:
+            raise ValueError("bundle artifacts must not be empty")
+        paths = (
+            self.license_text.path,
+            *(item.path for item in self.tokenizers),
+            *(item.path for item in self.artifacts),
+        )
+        if len(set(paths)) != len(paths):
+            raise ValueError("bundle file paths must be unique")
+
+
+@dataclass(frozen=True, slots=True)
+class BundleVerificationReport:
+    model_id: str
+    revision: str
+    status: BundleVerificationStatus
+    reasons: tuple[str, ...]
+    verified_files: tuple[str, ...]
+    report_sha256: str
+
+    @property
+    def verified(self) -> bool:
+        return self.status is BundleVerificationStatus.VERIFIED
+
+
+def load_candidate_registry(path: Path) -> ModelCandidateRegistry:
+    payload = _load_json_object(path)
+    if payload.get("schema_version") != "tai.model-candidate-registry.v1":
+        raise ValueError("unsupported model candidate registry schema")
+    raw_candidates = payload.get("candidates")
+    if not isinstance(raw_candidates, list):
+        raise ValueError("candidate registry candidates must be an array")
+    candidates = tuple(_parse_candidate(item) for item in raw_candidates)
+    return ModelCandidateRegistry(candidates)
+
+
+def load_artifact_bundle(path: Path) -> LocalModelArtifactBundle:
+    payload = _load_json_object(path)
+    if payload.get("schema_version") != "tai.local-model-artifact-bundle.v1":
+        raise ValueError("unsupported local artifact bundle schema")
+    return LocalModelArtifactBundle(
+        model_id=_required_string(payload, "model_id"),
+        revision=_required_string(payload, "revision"),
+        license_text=_parse_declared_file(payload.get("license_text")),
+        tokenizers=tuple(
+            _parse_declared_file(item)
+            for item in _required_array(payload, "tokenizers")
+        ),
+        artifacts=tuple(
+            _parse_declared_artifact(item)
+            for item in _required_array(payload, "artifacts")
+        ),
+    )
+
+
+def verify_artifact_bundle(
+    *,
+    registry: ModelCandidateRegistry,
+    bundle: LocalModelArtifactBundle,
+    bundle_root: Path,
+) -> BundleVerificationReport:
+    candidate = next(
+        (
+            item
+            for item in registry.candidates
+            if (item.model_id, item.revision) == (bundle.model_id, bundle.revision)
+        ),
+        None,
+    )
+    reasons: list[str] = []
+    verified_files: list[str] = []
+    if candidate is None:
+        reasons.append("CANDIDATE_NOT_REGISTERED")
+    else:
+        if candidate.license_review_status is not LicenseReviewStatus.APPROVED:
+            reasons.append("LICENSE_REVIEW_NOT_APPROVED")
+        if candidate.license_text_path != bundle.license_text.path:
+            reasons.append("LICENSE_TEXT_PATH_MISMATCH")
+        expected_tokenizers = set(candidate.tokenizer_files)
+        declared_tokenizers = {item.path for item in bundle.tokenizers}
+        if expected_tokenizers != declared_tokenizers:
+            reasons.append("TOKENIZER_SET_MISMATCH")
+        expected_recipes = {
+            (
+                item.output_path,
+                item.runtime_class,
+                item.quantization,
+                item.toolchain_commit,
+            )
+            for item in candidate.recipes
+        }
+        declared_artifacts = {
+            (
+                item.path,
+                item.runtime_class,
+                item.quantization,
+                item.toolchain_commit,
+            )
+            for item in bundle.artifacts
+        }
+        if expected_recipes != declared_artifacts:
+            reasons.append("ARTIFACT_RECIPE_SET_MISMATCH")
+        if any(item.toolchain_commit is None for item in candidate.recipes):
+            reasons.append("TOOLCHAIN_FULL_COMMIT_MISSING")
+
+    for declared in (
+        bundle.license_text,
+        *bundle.tokenizers,
+        *bundle.artifacts,
+    ):
+        file_path = _bounded_file(bundle_root, declared.path)
+        if not file_path.is_file():
+            reasons.append(f"FILE_MISSING:{declared.path}")
+            continue
+        actual_size = file_path.stat().st_size
+        if actual_size != declared.size_bytes:
+            reasons.append(f"FILE_SIZE_MISMATCH:{declared.path}")
+            continue
+        actual_sha256 = _file_sha256(file_path)
+        if actual_sha256 != declared.sha256:
+            reasons.append(f"FILE_SHA256_MISMATCH:{declared.path}")
+            continue
+        verified_files.append(declared.path)
+
+    unique_reasons = tuple(sorted(set(reasons)))
+    status = (
+        BundleVerificationStatus.VERIFIED
+        if not unique_reasons
+        else BundleVerificationStatus.REJECTED
+    )
+    report_sha256 = _report_sha256(
+        bundle=bundle,
+        status=status,
+        reasons=unique_reasons,
+        verified_files=tuple(sorted(verified_files)),
+    )
+    return BundleVerificationReport(
+        model_id=bundle.model_id,
+        revision=bundle.revision,
+        status=status,
+        reasons=unique_reasons,
+        verified_files=tuple(sorted(verified_files)),
+        report_sha256=report_sha256,
+    )
+
+
+def registry_to_canonical_json(registry: ModelCandidateRegistry) -> str:
+    payload = {
+        "candidates": [
+            {
+                "license_review_status": item.license_review_status.value,
+                "license_spdx": item.license_spdx,
+                "license_text_path": item.license_text_path,
+                "model_card_uri": item.model_card_uri,
+                "model_id": item.model_id,
+                "quantization_recipes": [
+                    {
+                        "format": recipe.format,
+                        "output_path": recipe.output_path,
+                        "quantization": recipe.quantization,
+                        "runtime_class": recipe.runtime_class.value,
+                        "toolchain_commit": recipe.toolchain_commit,
+                        "toolchain_name": recipe.toolchain_name,
+                        "toolchain_release": recipe.toolchain_release,
+                        "toolchain_uri": recipe.toolchain_uri,
+                    }
+                    for recipe in item.recipes
+                ],
+                "revision": item.revision,
+                "role": item.role.value,
+                "source_uri": item.source_uri,
+                "tokenizer_files": list(item.tokenizer_files),
+                "weight_files": list(item.weight_files),
+            }
+            for item in registry.candidates
+        ],
+        "schema_version": "tai.model-candidate-registry.v1",
+    }
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _parse_candidate(value: object) -> ModelSourceCandidate:
+    payload = _require_object(value, "candidate")
+    raw_recipes = _required_array(payload, "quantization_recipes")
+    return ModelSourceCandidate(
+        role=CandidateRole(_required_string(payload, "role")),
+        model_id=_required_string(payload, "model_id"),
+        revision=_required_string(payload, "revision"),
+        source_uri=_required_string(payload, "source_uri"),
+        model_card_uri=_required_string(payload, "model_card_uri"),
+        license_spdx=_required_string(payload, "license_spdx"),
+        license_review_status=LicenseReviewStatus(
+            _required_string(payload, "license_review_status")
+        ),
+        license_text_path=_optional_string(payload, "license_text_path"),
+        tokenizer_files=tuple(_string_array(payload, "tokenizer_files")),
+        weight_files=tuple(_string_array(payload, "weight_files")),
+        recipes=tuple(_parse_recipe(item) for item in raw_recipes),
+    )
+
+
+def _parse_recipe(value: object) -> QuantizationRecipe:
+    payload = _require_object(value, "quantization recipe")
+    return QuantizationRecipe(
+        runtime_class=ModelRuntimeClass(_required_string(payload, "runtime_class")),
+        format=_required_string(payload, "format"),
+        quantization=_required_string(payload, "quantization"),
+        toolchain_name=_required_string(payload, "toolchain_name"),
+        toolchain_uri=_required_string(payload, "toolchain_uri"),
+        toolchain_release=_required_string(payload, "toolchain_release"),
+        toolchain_commit=_optional_string(payload, "toolchain_commit"),
+        output_path=_required_string(payload, "output_path"),
+    )
+
+
+def _parse_declared_file(value: object) -> DeclaredFile:
+    payload = _require_object(value, "declared file")
+    return DeclaredFile(
+        path=_required_string(payload, "path"),
+        sha256=_required_string(payload, "sha256"),
+        size_bytes=_required_integer(payload, "size_bytes"),
+    )
+
+
+def _parse_declared_artifact(value: object) -> DeclaredArtifact:
+    payload = _require_object(value, "declared artifact")
+    return DeclaredArtifact(
+        path=_required_string(payload, "path"),
+        sha256=_required_string(payload, "sha256"),
+        size_bytes=_required_integer(payload, "size_bytes"),
+        runtime_class=ModelRuntimeClass(_required_string(payload, "runtime_class")),
+        quantization=_required_string(payload, "quantization"),
+        toolchain_commit=_required_string(payload, "toolchain_commit"),
+    )
+
+
+def _report_sha256(
+    *,
+    bundle: LocalModelArtifactBundle,
+    status: BundleVerificationStatus,
+    reasons: tuple[str, ...],
+    verified_files: tuple[str, ...],
+) -> str:
+    payload = {
+        "model_id": bundle.model_id,
+        "reasons": list(reasons),
+        "revision": bundle.revision,
+        "schema_version": "tai.model-artifact-verification-report.v1",
+        "status": status.value,
+        "verified_files": list(verified_files),
+    }
+    canonical = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _bounded_file(root: Path, relative_path: str) -> Path:
+    resolved_root = root.resolve()
+    candidate = (resolved_root / relative_path).resolve()
+    if candidate != resolved_root and resolved_root not in candidate.parents:
+        raise ValueError("bundle file escapes bundle root")
+    return candidate
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot load JSON from {path}") from error
+    return _require_object(value, "root payload")
+
+
+def _require_object(value: object, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or any(not isinstance(key, str) for key in value):
+        raise ValueError(f"{name} must be a JSON object")
+    return value
+
+
+def _required_array(payload: dict[str, Any], key: str) -> list[object]:
+    value = payload.get(key)
+    if not isinstance(value, list):
+        raise ValueError(f"{key} must be an array")
+    return value
+
+
+def _string_array(payload: dict[str, Any], key: str) -> list[str]:
+    values = _required_array(payload, key)
+    if not values or any(not isinstance(item, str) for item in values):
+        raise ValueError(f"{key} must be a non-empty string array")
+    return values
+
+
+def _required_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _optional_string(payload: dict[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be null or a non-empty string")
+    return value
+
+
+def _required_integer(payload: dict[str, Any], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
+def _validate_identity(value: str, name: str) -> None:
+    if _IDENTITY.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a portable bounded identity")
+
+
+def _validate_revision(value: str, name: str) -> None:
+    if _REVISION.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a pinned lowercase commit digest")
+
+
+def _validate_sha256(value: str, name: str) -> None:
+    if _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+def _validate_https(value: str, name: str) -> None:
+    if not value.startswith("https://"):
+        raise ValueError(f"{name} must use HTTPS")
+
+
+def _validate_relative_path(value: str, name: str) -> None:
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or value.startswith("./"):
+        raise ValueError(f"{name} must be a bounded relative path")
+    if not path.parts or any(part in {"", "."} for part in path.parts):
+        raise ValueError(f"{name} must be a bounded relative path")
+
+
+def _validate_unique_paths(values: tuple[str, ...], name: str) -> None:
+    if not values:
+        raise ValueError(f"{name} must not be empty")
+    for value in values:
+        _validate_relative_path(value, name)
+    if len(set(values)) != len(values):
+        raise ValueError(f"{name} must contain unique paths")

--- a/apps/tai/tai/model_artifact_registry_cli.py
+++ b/apps/tai/tai/model_artifact_registry_cli.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from tai.model_artifact_registry import (
+    BundleVerificationReport,
+    load_artifact_bundle,
+    load_candidate_registry,
+    registry_to_canonical_json,
+    verify_artifact_bundle,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tai-model-artifacts",
+        description="Validate pinned model candidates and verify local artifact bundles.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate-registry")
+    validate_parser.add_argument("registry", type=Path)
+    validate_parser.add_argument("--output", type=Path)
+
+    verify_parser = subparsers.add_parser("verify-bundle")
+    verify_parser.add_argument("registry", type=Path)
+    verify_parser.add_argument("bundle", type=Path)
+    verify_parser.add_argument("bundle_root", type=Path)
+    verify_parser.add_argument("--output", type=Path)
+
+    arguments = parser.parse_args(argv)
+    try:
+        if arguments.command == "validate-registry":
+            registry = load_candidate_registry(arguments.registry)
+            canonical = registry_to_canonical_json(registry)
+            payload = {
+                "candidate_count": len(registry.candidates),
+                "registry_sha256": _sha256_text(canonical),
+                "schema_version": "tai.model-candidate-registry-validation.v1",
+                "status": "VALID",
+            }
+            _write_json(payload, arguments.output)
+            return 0
+
+        registry = load_candidate_registry(arguments.registry)
+        bundle = load_artifact_bundle(arguments.bundle)
+        report = verify_artifact_bundle(
+            registry=registry,
+            bundle=bundle,
+            bundle_root=arguments.bundle_root,
+        )
+        _write_json(_report_payload(report), arguments.output)
+        return 0 if report.verified else 2
+    except ValueError as error:
+        payload = {
+            "error": str(error),
+            "schema_version": "tai.model-artifact-cli-error.v1",
+            "status": "INVALID",
+        }
+        _write_json(payload, getattr(arguments, "output", None))
+        return 2
+
+
+def _report_payload(report: BundleVerificationReport) -> dict[str, object]:
+    return {
+        "model_id": report.model_id,
+        "reasons": list(report.reasons),
+        "report_sha256": report.report_sha256,
+        "revision": report.revision,
+        "schema_version": "tai.model-artifact-verification-report.v1",
+        "status": report.status.value,
+        "verified_files": list(report.verified_files),
+    }
+
+
+def _write_json(payload: dict[str, object], output: Path | None) -> None:
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if output is None:
+        sys.stdout.write(rendered)
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered, encoding="utf-8")
+
+
+def _sha256_text(value: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/tai/tests/test_model_artifact_registry.py
+++ b/apps/tai/tests/test_model_artifact_registry.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from tai.model_artifact_registry import (
+    BundleVerificationStatus,
+    CandidateRole,
+    LicenseReviewStatus,
+    load_artifact_bundle,
+    load_candidate_registry,
+    registry_to_canonical_json,
+    verify_artifact_bundle,
+)
+from tai.model_artifact_registry_cli import main
+
+REVISION = "a" * 40
+TOOLCHAIN_COMMIT = "b" * 40
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _registry_payload(*, approved: bool = True) -> dict[str, object]:
+    license_path = "licenses/model-a/LICENSE" if approved else None
+    return {
+        "schema_version": "tai.model-candidate-registry.v1",
+        "candidates": [
+            {
+                "role": "PRIMARY",
+                "model_id": "owner/model-a",
+                "revision": REVISION,
+                "source_uri": (
+                    "https://models.example/owner/model-a/tree/" + REVISION
+                ),
+                "model_card_uri": (
+                    "https://models.example/owner/model-a/blob/"
+                    + REVISION
+                    + "/README.md"
+                ),
+                "license_spdx": "Apache-2.0",
+                "license_review_status": "APPROVED" if approved else "PENDING",
+                "license_text_path": license_path,
+                "tokenizer_files": ["sources/model-a/tokenizer.json"],
+                "weight_files": ["sources/model-a/model.safetensors"],
+                "quantization_recipes": [
+                    {
+                        "runtime_class": "CPU",
+                        "format": "GGUF",
+                        "quantization": "Q4_K_M",
+                        "toolchain_name": "ggml-org/llama.cpp",
+                        "toolchain_uri": "https://github.com/ggml-org/llama.cpp",
+                        "toolchain_release": "b9637",
+                        "toolchain_commit": TOOLCHAIN_COMMIT,
+                        "output_path": "artifacts/model-a-q4-k-m.gguf",
+                    },
+                    {
+                        "runtime_class": "GPU_SHARED",
+                        "format": "GGUF",
+                        "quantization": "Q8_0",
+                        "toolchain_name": "ggml-org/llama.cpp",
+                        "toolchain_uri": "https://github.com/ggml-org/llama.cpp",
+                        "toolchain_release": "b9637",
+                        "toolchain_commit": TOOLCHAIN_COMMIT,
+                        "output_path": "artifacts/model-a-q8-0.gguf",
+                    },
+                ],
+            },
+            {
+                "role": "FALLBACK",
+                "model_id": "owner/model-b",
+                "revision": "c" * 40,
+                "source_uri": (
+                    "https://models.example/owner/model-b/tree/" + "c" * 40
+                ),
+                "model_card_uri": (
+                    "https://models.example/owner/model-b/blob/"
+                    + "c" * 40
+                    + "/README.md"
+                ),
+                "license_spdx": "Apache-2.0",
+                "license_review_status": "PENDING",
+                "license_text_path": None,
+                "tokenizer_files": ["sources/model-b/tokenizer.json"],
+                "weight_files": ["sources/model-b/model.safetensors"],
+                "quantization_recipes": [
+                    {
+                        "runtime_class": "CPU",
+                        "format": "GGUF",
+                        "quantization": "Q4_K_M",
+                        "toolchain_name": "ggml-org/llama.cpp",
+                        "toolchain_uri": "https://github.com/ggml-org/llama.cpp",
+                        "toolchain_release": "b9637",
+                        "toolchain_commit": TOOLCHAIN_COMMIT,
+                        "output_path": "artifacts/model-b-q4-k-m.gguf",
+                    }
+                ],
+            },
+        ],
+    }
+
+
+def _prepare_bundle(tmp_path: Path) -> tuple[Path, Path, Path]:
+    registry_path = tmp_path / "registry.json"
+    _write_json(registry_path, _registry_payload())
+
+    files = {
+        "licenses/model-a/LICENSE": b"Apache License evidence\n",
+        "sources/model-a/tokenizer.json": b'{"tokenizer":"pinned"}\n',
+        "artifacts/model-a-q4-k-m.gguf": b"cpu-artifact",
+        "artifacts/model-a-q8-0.gguf": b"gpu-artifact",
+    }
+    for relative_path, content in files.items():
+        target = tmp_path / "bundle" / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+    bundle_path = tmp_path / "bundle.json"
+    _write_json(
+        bundle_path,
+        {
+            "schema_version": "tai.local-model-artifact-bundle.v1",
+            "model_id": "owner/model-a",
+            "revision": REVISION,
+            "license_text": {
+                "path": "licenses/model-a/LICENSE",
+                "sha256": _sha256(files["licenses/model-a/LICENSE"]),
+                "size_bytes": len(files["licenses/model-a/LICENSE"]),
+            },
+            "tokenizers": [
+                {
+                    "path": "sources/model-a/tokenizer.json",
+                    "sha256": _sha256(
+                        files["sources/model-a/tokenizer.json"]
+                    ),
+                    "size_bytes": len(
+                        files["sources/model-a/tokenizer.json"]
+                    ),
+                }
+            ],
+            "artifacts": [
+                {
+                    "path": "artifacts/model-a-q4-k-m.gguf",
+                    "sha256": _sha256(
+                        files["artifacts/model-a-q4-k-m.gguf"]
+                    ),
+                    "size_bytes": len(
+                        files["artifacts/model-a-q4-k-m.gguf"]
+                    ),
+                    "runtime_class": "CPU",
+                    "quantization": "Q4_K_M",
+                    "toolchain_commit": TOOLCHAIN_COMMIT,
+                },
+                {
+                    "path": "artifacts/model-a-q8-0.gguf",
+                    "sha256": _sha256(files["artifacts/model-a-q8-0.gguf"]),
+                    "size_bytes": len(files["artifacts/model-a-q8-0.gguf"]),
+                    "runtime_class": "GPU_SHARED",
+                    "quantization": "Q8_0",
+                    "toolchain_commit": TOOLCHAIN_COMMIT,
+                },
+            ],
+        },
+    )
+    return registry_path, bundle_path, tmp_path / "bundle"
+
+
+def test_repository_candidate_registry_is_pinned_and_intentionally_pending() -> None:
+    registry_path = (
+        Path(__file__).resolve().parents[1]
+        / "model-artifacts"
+        / "candidates.v1.json"
+    )
+
+    registry = load_candidate_registry(registry_path)
+
+    assert [item.role for item in registry.candidates] == [
+        CandidateRole.PRIMARY,
+        CandidateRole.FALLBACK,
+    ]
+    assert all(
+        item.license_review_status is LicenseReviewStatus.PENDING
+        for item in registry.candidates
+    )
+    assert all(item.revision not in {"main", "master"} for item in registry.candidates)
+    assert all(item.revision in item.source_uri for item in registry.candidates)
+    assert len(registry_to_canonical_json(registry)) > 100
+
+
+def test_verified_bundle_requires_exact_files_and_recipes(tmp_path: Path) -> None:
+    registry_path, bundle_path, bundle_root = _prepare_bundle(tmp_path)
+
+    report = verify_artifact_bundle(
+        registry=load_candidate_registry(registry_path),
+        bundle=load_artifact_bundle(bundle_path),
+        bundle_root=bundle_root,
+    )
+
+    assert report.status is BundleVerificationStatus.VERIFIED
+    assert report.reasons == ()
+    assert len(report.verified_files) == 4
+    assert len(report.report_sha256) == 64
+
+
+def test_bundle_verification_fails_closed_on_digest_mismatch(tmp_path: Path) -> None:
+    registry_path, bundle_path, bundle_root = _prepare_bundle(tmp_path)
+    artifact = bundle_root / "artifacts/model-a-q4-k-m.gguf"
+    artifact.write_bytes(b"tampered")
+
+    report = verify_artifact_bundle(
+        registry=load_candidate_registry(registry_path),
+        bundle=load_artifact_bundle(bundle_path),
+        bundle_root=bundle_root,
+    )
+
+    assert report.status is BundleVerificationStatus.REJECTED
+    assert "FILE_SIZE_MISMATCH:artifacts/model-a-q4-k-m.gguf" in report.reasons
+
+
+def test_bundle_verification_rejects_pending_license_and_missing_toolchain_commit(
+    tmp_path: Path,
+) -> None:
+    registry_path, bundle_path, bundle_root = _prepare_bundle(tmp_path)
+    payload = _registry_payload(approved=False)
+    primary = payload["candidates"][0]  # type: ignore[index]
+    primary["quantization_recipes"][0]["toolchain_commit"] = None  # type: ignore[index]
+    primary["quantization_recipes"][1]["toolchain_commit"] = None  # type: ignore[index]
+    _write_json(registry_path, payload)
+
+    report = verify_artifact_bundle(
+        registry=load_candidate_registry(registry_path),
+        bundle=load_artifact_bundle(bundle_path),
+        bundle_root=bundle_root,
+    )
+
+    assert report.status is BundleVerificationStatus.REJECTED
+    assert "LICENSE_REVIEW_NOT_APPROVED" in report.reasons
+    assert "TOOLCHAIN_FULL_COMMIT_MISSING" in report.reasons
+
+
+def test_cli_returns_zero_only_for_verified_bundle(tmp_path: Path) -> None:
+    registry_path, bundle_path, bundle_root = _prepare_bundle(tmp_path)
+    output = tmp_path / "report.json"
+
+    result = main(
+        [
+            "verify-bundle",
+            str(registry_path),
+            str(bundle_path),
+            str(bundle_root),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+    assert json.loads(output.read_text(encoding="utf-8"))["status"] == "VERIFIED"
+
+
+def test_cli_validates_repository_registry_without_claiming_artifacts(
+    tmp_path: Path,
+) -> None:
+    registry_path = (
+        Path(__file__).resolve().parents[1]
+        / "model-artifacts"
+        / "candidates.v1.json"
+    )
+    output = tmp_path / "registry-report.json"
+
+    result = main(
+        [
+            "validate-registry",
+            str(registry_path),
+            "--output",
+            str(output),
+        ]
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert result == 0
+    assert payload["status"] == "VALID"
+    assert payload["candidate_count"] == 2
+    assert len(payload["registry_sha256"]) == 64
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda payload: payload.update({"schema_version": "wrong"}),
+        lambda payload: payload["candidates"][0].update({"revision": "main"}),
+        lambda payload: payload["candidates"][0].update(
+            {"source_uri": "http://insecure"}
+        ),
+        lambda payload: payload["candidates"][0].update(
+            {"license_review_status": "APPROVED", "license_text_path": None}
+        ),
+    ],
+)
+def test_registry_rejects_mutable_or_incomplete_authority(
+    tmp_path: Path,
+    mutation: object,
+) -> None:
+    payload = _registry_payload()
+    assert callable(mutation)
+    mutation(payload)
+    registry_path = tmp_path / "invalid.json"
+    _write_json(registry_path, payload)
+
+    with pytest.raises(ValueError):
+        load_candidate_registry(registry_path)

--- a/apps/tai/tests/test_model_artifact_registry.py
+++ b/apps/tai/tests/test_model_artifact_registry.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -18,7 +20,9 @@ from tai.model_artifact_registry import (
 from tai.model_artifact_registry_cli import main
 
 REVISION = "a" * 40
+FALLBACK_REVISION = "c" * 40
 TOOLCHAIN_COMMIT = "b" * 40
+Mutation = Callable[[dict[str, Any]], None]
 
 
 def _sha256(value: bytes) -> str:
@@ -30,8 +34,24 @@ def _write_json(path: Path, payload: object) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _registry_payload(*, approved: bool = True) -> dict[str, object]:
-    license_path = "licenses/model-a/LICENSE" if approved else None
+def _recipe(
+    runtime_class: str,
+    quantization: str,
+    output_path: str,
+) -> dict[str, object]:
+    return {
+        "runtime_class": runtime_class,
+        "format": "GGUF",
+        "quantization": quantization,
+        "toolchain_name": "ggml-org/llama.cpp",
+        "toolchain_uri": "https://github.com/ggml-org/llama.cpp",
+        "toolchain_release": "b9637",
+        "toolchain_commit": TOOLCHAIN_COMMIT,
+        "output_path": output_path,
+    }
+
+
+def _registry_payload(*, approved: bool = True) -> dict[str, Any]:
     return {
         "schema_version": "tai.model-candidate-registry.v1",
         "candidates": [
@@ -49,42 +69,31 @@ def _registry_payload(*, approved: bool = True) -> dict[str, object]:
                 ),
                 "license_spdx": "Apache-2.0",
                 "license_review_status": "APPROVED" if approved else "PENDING",
-                "license_text_path": license_path,
+                "license_text_path": (
+                    "licenses/model-a/LICENSE" if approved else None
+                ),
                 "tokenizer_files": ["sources/model-a/tokenizer.json"],
                 "weight_files": ["sources/model-a/model.safetensors"],
                 "quantization_recipes": [
-                    {
-                        "runtime_class": "CPU",
-                        "format": "GGUF",
-                        "quantization": "Q4_K_M",
-                        "toolchain_name": "ggml-org/llama.cpp",
-                        "toolchain_uri": "https://github.com/ggml-org/llama.cpp",
-                        "toolchain_release": "b9637",
-                        "toolchain_commit": TOOLCHAIN_COMMIT,
-                        "output_path": "artifacts/model-a-q4-k-m.gguf",
-                    },
-                    {
-                        "runtime_class": "GPU_SHARED",
-                        "format": "GGUF",
-                        "quantization": "Q8_0",
-                        "toolchain_name": "ggml-org/llama.cpp",
-                        "toolchain_uri": "https://github.com/ggml-org/llama.cpp",
-                        "toolchain_release": "b9637",
-                        "toolchain_commit": TOOLCHAIN_COMMIT,
-                        "output_path": "artifacts/model-a-q8-0.gguf",
-                    },
+                    _recipe("CPU", "Q4_K_M", "artifacts/model-a-q4-k-m.gguf"),
+                    _recipe(
+                        "GPU_SHARED",
+                        "Q8_0",
+                        "artifacts/model-a-q8-0.gguf",
+                    ),
                 ],
             },
             {
                 "role": "FALLBACK",
                 "model_id": "owner/model-b",
-                "revision": "c" * 40,
+                "revision": FALLBACK_REVISION,
                 "source_uri": (
-                    "https://models.example/owner/model-b/tree/" + "c" * 40
+                    "https://models.example/owner/model-b/tree/"
+                    + FALLBACK_REVISION
                 ),
                 "model_card_uri": (
                     "https://models.example/owner/model-b/blob/"
-                    + "c" * 40
+                    + FALLBACK_REVISION
                     + "/README.md"
                 ),
                 "license_spdx": "Apache-2.0",
@@ -93,36 +102,39 @@ def _registry_payload(*, approved: bool = True) -> dict[str, object]:
                 "tokenizer_files": ["sources/model-b/tokenizer.json"],
                 "weight_files": ["sources/model-b/model.safetensors"],
                 "quantization_recipes": [
-                    {
-                        "runtime_class": "CPU",
-                        "format": "GGUF",
-                        "quantization": "Q4_K_M",
-                        "toolchain_name": "ggml-org/llama.cpp",
-                        "toolchain_uri": "https://github.com/ggml-org/llama.cpp",
-                        "toolchain_release": "b9637",
-                        "toolchain_commit": TOOLCHAIN_COMMIT,
-                        "output_path": "artifacts/model-b-q4-k-m.gguf",
-                    }
+                    _recipe("CPU", "Q4_K_M", "artifacts/model-b-q4-k-m.gguf")
                 ],
             },
         ],
     }
 
 
+def _primary(payload: dict[str, Any]) -> dict[str, Any]:
+    candidates = cast(list[dict[str, Any]], payload["candidates"])
+    return candidates[0]
+
+
 def _prepare_bundle(tmp_path: Path) -> tuple[Path, Path, Path]:
     registry_path = tmp_path / "registry.json"
     _write_json(registry_path, _registry_payload())
-
     files = {
         "licenses/model-a/LICENSE": b"Apache License evidence\n",
         "sources/model-a/tokenizer.json": b'{"tokenizer":"pinned"}\n',
         "artifacts/model-a-q4-k-m.gguf": b"cpu-artifact",
         "artifacts/model-a-q8-0.gguf": b"gpu-artifact",
     }
+    bundle_root = tmp_path / "bundle"
     for relative_path, content in files.items():
-        target = tmp_path / "bundle" / relative_path
+        target = bundle_root / relative_path
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(content)
+
+    def declared(path: str) -> dict[str, object]:
+        return {
+            "path": path,
+            "sha256": _sha256(files[path]),
+            "size_bytes": len(files[path]),
+        }
 
     bundle_path = tmp_path / "bundle.json"
     _write_json(
@@ -131,39 +143,17 @@ def _prepare_bundle(tmp_path: Path) -> tuple[Path, Path, Path]:
             "schema_version": "tai.local-model-artifact-bundle.v1",
             "model_id": "owner/model-a",
             "revision": REVISION,
-            "license_text": {
-                "path": "licenses/model-a/LICENSE",
-                "sha256": _sha256(files["licenses/model-a/LICENSE"]),
-                "size_bytes": len(files["licenses/model-a/LICENSE"]),
-            },
-            "tokenizers": [
-                {
-                    "path": "sources/model-a/tokenizer.json",
-                    "sha256": _sha256(
-                        files["sources/model-a/tokenizer.json"]
-                    ),
-                    "size_bytes": len(
-                        files["sources/model-a/tokenizer.json"]
-                    ),
-                }
-            ],
+            "license_text": declared("licenses/model-a/LICENSE"),
+            "tokenizers": [declared("sources/model-a/tokenizer.json")],
             "artifacts": [
                 {
-                    "path": "artifacts/model-a-q4-k-m.gguf",
-                    "sha256": _sha256(
-                        files["artifacts/model-a-q4-k-m.gguf"]
-                    ),
-                    "size_bytes": len(
-                        files["artifacts/model-a-q4-k-m.gguf"]
-                    ),
+                    **declared("artifacts/model-a-q4-k-m.gguf"),
                     "runtime_class": "CPU",
                     "quantization": "Q4_K_M",
                     "toolchain_commit": TOOLCHAIN_COMMIT,
                 },
                 {
-                    "path": "artifacts/model-a-q8-0.gguf",
-                    "sha256": _sha256(files["artifacts/model-a-q8-0.gguf"]),
-                    "size_bytes": len(files["artifacts/model-a-q8-0.gguf"]),
+                    **declared("artifacts/model-a-q8-0.gguf"),
                     "runtime_class": "GPU_SHARED",
                     "quantization": "Q8_0",
                     "toolchain_commit": TOOLCHAIN_COMMIT,
@@ -171,16 +161,15 @@ def _prepare_bundle(tmp_path: Path) -> tuple[Path, Path, Path]:
             ],
         },
     )
-    return registry_path, bundle_path, tmp_path / "bundle"
+    return registry_path, bundle_path, bundle_root
 
 
-def test_repository_candidate_registry_is_pinned_and_intentionally_pending() -> None:
+def test_repository_registry_is_pinned_and_intentionally_pending() -> None:
     registry_path = (
         Path(__file__).resolve().parents[1]
         / "model-artifacts"
         / "candidates.v1.json"
     )
-
     registry = load_candidate_registry(registry_path)
 
     assert [item.role for item in registry.candidates] == [
@@ -191,14 +180,12 @@ def test_repository_candidate_registry_is_pinned_and_intentionally_pending() -> 
         item.license_review_status is LicenseReviewStatus.PENDING
         for item in registry.candidates
     )
-    assert all(item.revision not in {"main", "master"} for item in registry.candidates)
     assert all(item.revision in item.source_uri for item in registry.candidates)
     assert len(registry_to_canonical_json(registry)) > 100
 
 
 def test_verified_bundle_requires_exact_files_and_recipes(tmp_path: Path) -> None:
     registry_path, bundle_path, bundle_root = _prepare_bundle(tmp_path)
-
     report = verify_artifact_bundle(
         registry=load_candidate_registry(registry_path),
         bundle=load_artifact_bundle(bundle_path),
@@ -215,7 +202,6 @@ def test_bundle_verification_fails_closed_on_digest_mismatch(tmp_path: Path) -> 
     registry_path, bundle_path, bundle_root = _prepare_bundle(tmp_path)
     artifact = bundle_root / "artifacts/model-a-q4-k-m.gguf"
     artifact.write_bytes(b"tampered")
-
     report = verify_artifact_bundle(
         registry=load_candidate_registry(registry_path),
         bundle=load_artifact_bundle(bundle_path),
@@ -223,17 +209,18 @@ def test_bundle_verification_fails_closed_on_digest_mismatch(tmp_path: Path) -> 
     )
 
     assert report.status is BundleVerificationStatus.REJECTED
-    assert "FILE_SIZE_MISMATCH:artifacts/model-a-q4-k-m.gguf" in report.reasons
+    reason = "FILE_SIZE_MISMATCH:artifacts/model-a-q4-k-m.gguf"
+    assert reason in report.reasons
 
 
-def test_bundle_verification_rejects_pending_license_and_missing_toolchain_commit(
+def test_pending_license_and_missing_toolchain_commit_are_rejected(
     tmp_path: Path,
 ) -> None:
     registry_path, bundle_path, bundle_root = _prepare_bundle(tmp_path)
     payload = _registry_payload(approved=False)
-    primary = payload["candidates"][0]  # type: ignore[index]
-    primary["quantization_recipes"][0]["toolchain_commit"] = None  # type: ignore[index]
-    primary["quantization_recipes"][1]["toolchain_commit"] = None  # type: ignore[index]
+    recipes = cast(list[dict[str, Any]], _primary(payload)["quantization_recipes"])
+    for recipe in recipes:
+        recipe["toolchain_commit"] = None
     _write_json(registry_path, payload)
 
     report = verify_artifact_bundle(
@@ -250,7 +237,6 @@ def test_bundle_verification_rejects_pending_license_and_missing_toolchain_commi
 def test_cli_returns_zero_only_for_verified_bundle(tmp_path: Path) -> None:
     registry_path, bundle_path, bundle_root = _prepare_bundle(tmp_path)
     output = tmp_path / "report.json"
-
     result = main(
         [
             "verify-bundle",
@@ -266,16 +252,13 @@ def test_cli_returns_zero_only_for_verified_bundle(tmp_path: Path) -> None:
     assert json.loads(output.read_text(encoding="utf-8"))["status"] == "VERIFIED"
 
 
-def test_cli_validates_repository_registry_without_claiming_artifacts(
-    tmp_path: Path,
-) -> None:
+def test_cli_validates_registry_without_claiming_artifacts(tmp_path: Path) -> None:
     registry_path = (
         Path(__file__).resolve().parents[1]
         / "model-artifacts"
         / "candidates.v1.json"
     )
     output = tmp_path / "registry-report.json"
-
     result = main(
         [
             "validate-registry",
@@ -284,33 +267,41 @@ def test_cli_validates_repository_registry_without_claiming_artifacts(
             str(output),
         ]
     )
-
     payload = json.loads(output.read_text(encoding="utf-8"))
+
     assert result == 0
     assert payload["status"] == "VALID"
     assert payload["candidate_count"] == 2
     assert len(payload["registry_sha256"]) == 64
 
 
+def _wrong_schema(payload: dict[str, Any]) -> None:
+    payload["schema_version"] = "wrong"
+
+
+def _mutable_revision(payload: dict[str, Any]) -> None:
+    _primary(payload)["revision"] = "main"
+
+
+def _insecure_source(payload: dict[str, Any]) -> None:
+    _primary(payload)["source_uri"] = "http://insecure"
+
+
+def _approved_without_license(payload: dict[str, Any]) -> None:
+    primary = _primary(payload)
+    primary["license_review_status"] = "APPROVED"
+    primary["license_text_path"] = None
+
+
 @pytest.mark.parametrize(
     "mutation",
-    [
-        lambda payload: payload.update({"schema_version": "wrong"}),
-        lambda payload: payload["candidates"][0].update({"revision": "main"}),
-        lambda payload: payload["candidates"][0].update(
-            {"source_uri": "http://insecure"}
-        ),
-        lambda payload: payload["candidates"][0].update(
-            {"license_review_status": "APPROVED", "license_text_path": None}
-        ),
-    ],
+    [_wrong_schema, _mutable_revision, _insecure_source, _approved_without_license],
 )
 def test_registry_rejects_mutable_or_incomplete_authority(
     tmp_path: Path,
-    mutation: object,
+    mutation: Mutation,
 ) -> None:
     payload = _registry_payload()
-    assert callable(mutation)
     mutation(payload)
     registry_path = tmp_path / "invalid.json"
     _write_json(registry_path, payload)


### PR DESCRIPTION
## Что изменено

- добавлен machine-readable source candidate registry для primary/fallback моделей;
- зафиксированы immutable upstream revisions `Qwen/Qwen3-8B@895c8d171bc03c30e113cd7a28c02494b5e068b7` и `mistralai/Mistral-7B-Instruct-v0.3@c170c708c41dac9275d15a8fff4eca08d52bab71`;
- оба кандидата намеренно остаются `PENDING`, без фиктивного license approval;
- добавлен fail-closed verifier локального evidence bundle;
- verifier проверяет exact candidate identity, license state/path, tokenizer set, artifact recipes, полный toolchain commit, размеры и SHA-256 файлов;
- добавлен CLI `validate-registry` / `verify-bundle` с exit code `2` при любом отсутствии или mismatch;
- добавлен runbook хранения weights вне Git и последовательности source → license → quantization → bundle → AP-13A evidence;
- status остаётся `NOT_ATTESTED`.

## Exact-head acceptance

Exact-head: `9f043ac9239e241282592badbb8529eefdaa8b46`.

PASS:

- TAI Foundation: Ruff, mypy, pytest, coverage;
- CI и Node CI;
- Security Scan;
- Security Quality Gate;
- Security Abuse and exact-head evidence manifest;
- Runtime Context Security Gate и exact-head runtime manifest;
- Auction, Outbox и Disputes PostgreSQL acceptance;
- Dependency Review и optional-runtime retirement gate.

Review threads: 0.

## Граница результата

Этот PR фиксирует кандидатов и verification authority. Он не содержит многогигабайтные weights, не выполняет юридическое решение и не заявляет готовые quantized artifacts. Полный llama.cpp commit, license text evidence, реальные SHA-256/размеры и GGUF outputs должны быть собраны до завершения #2770. Production model admission и operational attestation этим PR не выдаются.

Parent: #2726. Part of #2770.