### PR TITLE
TAI AP-14A: official-source coverage and freshness authority

### DIFF
--- a/apps/tai/knowledge-sources/README.md
+++ b/apps/tai/knowledge-sources/README.md
@@ -1,0 +1,75 @@
+# TAI official knowledge sources
+
+This directory contains small governed catalogs and evidence schemas. It does not contain copied government datasets and does not claim that a registered source has been successfully loaded.
+
+## Current catalog
+
+`official-sources.v1.json` registers verified entrypoints for:
+
+- Ministry of Agriculture open data and grain traceability;
+- Rosstat agricultural production and producer-price publications;
+- Eurasian Economic Commission grain regulation and quality requirements;
+- Ministry of Transport railway-tariff documents;
+- Bank of Russia key-rate history.
+
+The agronomy-recommendation topic intentionally has no registered source yet. The coverage authority must report this as `GAP` even when every other source is healthy.
+
+## Two different gates
+
+1. **Catalog validation** proves only that owners, HTTPS entrypoints, hosts, formats, update intervals and topic requirements are structurally governed.
+2. **Coverage assessment** requires actual source observations with a successful timestamp, latest publication timestamp, document count, observed topics and content digest.
+
+A URL in the catalog is not knowledge. A source counts toward coverage only when its observation is current, successful, topic-matched and non-duplicated.
+
+## CLI
+
+Validate the catalog without claiming coverage:
+
+```bash
+cd apps/tai
+python -m tai.source_coverage_cli validate-catalog \
+  knowledge-sources/official-sources.v1.json
+```
+
+Assess a real observation snapshot:
+
+```bash
+cd apps/tai
+python -m tai.source_coverage_cli assess \
+  knowledge-sources/official-sources.v1.json \
+  /secure/evidence/source-observations.v1.json \
+  --at 2026-07-19T12:00:00+00:00 \
+  --output /secure/evidence/source-coverage-assessment.json
+```
+
+Exit codes:
+
+- `0` — catalog valid, or every critical coverage topic is currently covered;
+- `2` — invalid evidence, stale/unobserved/gap topic or any other fail-closed condition.
+
+## Observation schema
+
+```json
+{
+  "schema_version": "tai.source-observations.v1",
+  "observations": [
+    {
+      "source_id": "official.rosstat.agriculture",
+      "observed_at": "2026-07-19T10:00:00+00:00",
+      "latest_publication_at": "2026-07-15T00:00:00+00:00",
+      "last_success_at": "2026-07-19T10:00:00+00:00",
+      "document_count": 3,
+      "consecutive_failures": 0,
+      "observed_topics": [
+        "GRAIN_MARKET_PRICES",
+        "AGRICULTURE_PRODUCTION"
+      ],
+      "content_sha256": "<lowercase SHA-256>"
+    }
+  ]
+}
+```
+
+## Maturity boundary
+
+This catalog does not prove complete Russian agricultural knowledge, semantic-search quality, expert validation or production acceptance. Those require scheduled loaders, durable observations, domain gold sets and exact-main operational evidence. TAI remains `NOT_ATTESTED`.

--- a/apps/tai/knowledge-sources/official-sources.v1.json
+++ b/apps/tai/knowledge-sources/official-sources.v1.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": "tai.official-source-catalog.v1",
+  "sources": [
+    {
+      "source_id": "official.mcx.opendata",
+      "owner": "Министерство сельского хозяйства Российской Федерации",
+      "entrypoint_uri": "https://opendata.mcx.ru/",
+      "allowed_hosts": ["opendata.mcx.ru"],
+      "topics": ["GRAIN_TRACEABILITY"],
+      "formats": ["HTML", "CSV", "JSON"],
+      "expected_update_interval_seconds": 604800,
+      "maximum_publication_age_seconds": 2678400,
+      "verified_at": "2026-07-19T04:15:00+00:00"
+    },
+    {
+      "source_id": "official.rosstat.agriculture",
+      "owner": "Федеральная служба государственной статистики",
+      "entrypoint_uri": "https://rosstat.gov.ru/enterprise_economy",
+      "allowed_hosts": ["rosstat.gov.ru"],
+      "topics": ["GRAIN_MARKET_PRICES", "AGRICULTURE_PRODUCTION"],
+      "formats": ["HTML", "XLSX", "ZIP"],
+      "expected_update_interval_seconds": 2678400,
+      "maximum_publication_age_seconds": 5356800,
+      "verified_at": "2026-07-19T04:15:00+00:00"
+    },
+    {
+      "source_id": "official.eec.grain-regulation",
+      "owner": "Евразийская экономическая комиссия",
+      "entrypoint_uri": "https://eec.eaeunion.org/comission/department/deptexreg/tr/bezpoZerna.php",
+      "allowed_hosts": ["eec.eaeunion.org"],
+      "topics": ["GRAIN_REGULATION", "GRAIN_QUALITY"],
+      "formats": ["HTML", "PDF"],
+      "expected_update_interval_seconds": 15552000,
+      "maximum_publication_age_seconds": 34560000,
+      "verified_at": "2026-07-19T04:15:00+00:00"
+    },
+    {
+      "source_id": "official.mintrans.rail-tariffs",
+      "owner": "Министерство транспорта Российской Федерации",
+      "entrypoint_uri": "https://mintrans.gov.ru/activities/222/documents",
+      "allowed_hosts": ["mintrans.gov.ru"],
+      "topics": ["LOGISTICS_TARIFFS"],
+      "formats": ["HTML", "PDF"],
+      "expected_update_interval_seconds": 31536000,
+      "maximum_publication_age_seconds": 34560000,
+      "verified_at": "2026-07-19T04:15:00+00:00"
+    },
+    {
+      "source_id": "official.cbr.key-rate",
+      "owner": "Центральный банк Российской Федерации",
+      "entrypoint_uri": "https://www.cbr.ru/hd_base/KeyRate/",
+      "allowed_hosts": ["www.cbr.ru"],
+      "topics": ["FINANCE_RATES"],
+      "formats": ["HTML"],
+      "expected_update_interval_seconds": 604800,
+      "maximum_publication_age_seconds": 1209600,
+      "verified_at": "2026-07-19T04:15:00+00:00"
+    }
+  ],
+  "requirements": [
+    {
+      "topic": "GRAIN_MARKET_PRICES",
+      "minimum_official_sources": 1,
+      "maximum_publication_age_seconds": 5356800,
+      "critical": true
+    },
+    {
+      "topic": "AGRICULTURE_PRODUCTION",
+      "minimum_official_sources": 1,
+      "maximum_publication_age_seconds": 5356800,
+      "critical": true
+    },
+    {
+      "topic": "GRAIN_REGULATION",
+      "minimum_official_sources": 1,
+      "maximum_publication_age_seconds": 34560000,
+      "critical": true
+    },
+    {
+      "topic": "GRAIN_QUALITY",
+      "minimum_official_sources": 1,
+      "maximum_publication_age_seconds": 34560000,
+      "critical": true
+    },
+    {
+      "topic": "GRAIN_TRACEABILITY",
+      "minimum_official_sources": 1,
+      "maximum_publication_age_seconds": 2678400,
+      "critical": true
+    },
+    {
+      "topic": "LOGISTICS_TARIFFS",
+      "minimum_official_sources": 1,
+      "maximum_publication_age_seconds": 34560000,
+      "critical": true
+    },
+    {
+      "topic": "FINANCE_RATES",
+      "minimum_official_sources": 1,
+      "maximum_publication_age_seconds": 1209600,
+      "critical": true
+    },
+    {
+      "topic": "AGRONOMY_RECOMMENDATIONS",
+      "minimum_official_sources": 1,
+      "maximum_publication_age_seconds": 15552000,
+      "critical": true
+    }
+  ]
+}

--- a/apps/tai/tai/migrations/0016_official_source_coverage.sql
+++ b/apps/tai/tai/migrations/0016_official_source_coverage.sql
@@ -1,0 +1,74 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS tai_official_source_observations (
+    observation_sha256 TEXT PRIMARY KEY
+        CHECK (observation_sha256 ~ '^[0-9a-f]{64}$'),
+    source_id TEXT NOT NULL
+        CHECK (source_id ~ '^[a-z0-9][a-z0-9._-]{2,127}$'),
+    observed_at TIMESTAMPTZ NOT NULL,
+    latest_publication_at TIMESTAMPTZ NOT NULL,
+    last_success_at TIMESTAMPTZ NOT NULL,
+    document_count INTEGER NOT NULL CHECK (document_count > 0),
+    consecutive_failures INTEGER NOT NULL CHECK (consecutive_failures >= 0),
+    observed_topics JSONB NOT NULL
+        CHECK (jsonb_typeof(observed_topics) = 'array'),
+    content_sha256 TEXT NOT NULL CHECK (content_sha256 ~ '^[0-9a-f]{64}$'),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE INDEX IF NOT EXISTS tai_official_source_observations_latest_idx
+    ON tai_official_source_observations (
+        source_id,
+        observed_at DESC,
+        observation_sha256 DESC
+    );
+
+CREATE TABLE IF NOT EXISTS tai_official_source_coverage_assessments (
+    assessment_sha256 TEXT PRIMARY KEY
+        CHECK (assessment_sha256 ~ '^[0-9a-f]{64}$'),
+    generated_at TIMESTAMPTZ NOT NULL,
+    coverage_basis_points INTEGER NOT NULL
+        CHECK (coverage_basis_points BETWEEN 0 AND 10000),
+    critical_coverage_basis_points INTEGER NOT NULL
+        CHECK (critical_coverage_basis_points BETWEEN 0 AND 10000),
+    all_critical_covered BOOLEAN NOT NULL,
+    topics JSONB NOT NULL CHECK (jsonb_typeof(topics) = 'array'),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE INDEX IF NOT EXISTS tai_official_source_coverage_latest_idx
+    ON tai_official_source_coverage_assessments (
+        generated_at DESC,
+        assessment_sha256 DESC
+    );
+
+CREATE OR REPLACE VIEW tai_latest_official_source_observations_v1 AS
+SELECT DISTINCT ON (observation.source_id)
+    observation.source_id,
+    observation.observation_sha256,
+    observation.observed_at,
+    observation.latest_publication_at,
+    observation.last_success_at,
+    observation.document_count,
+    observation.consecutive_failures,
+    observation.observed_topics,
+    observation.content_sha256
+FROM tai_official_source_observations AS observation
+ORDER BY
+    observation.source_id,
+    observation.observed_at DESC,
+    observation.observation_sha256 DESC;
+
+CREATE OR REPLACE VIEW tai_current_official_source_coverage_v1 AS
+SELECT
+    assessment.assessment_sha256,
+    assessment.generated_at,
+    assessment.coverage_basis_points,
+    assessment.critical_coverage_basis_points,
+    assessment.all_critical_covered,
+    assessment.topics
+FROM tai_official_source_coverage_assessments AS assessment
+ORDER BY assessment.generated_at DESC, assessment.assessment_sha256 DESC
+LIMIT 1;
+
+COMMIT;

--- a/apps/tai/tai/migrations/manifest.json
+++ b/apps/tai/tai/migrations/manifest.json
@@ -63,6 +63,10 @@
     {
       "path": "0015_model_admission_authority.sql",
       "version": 16
+    },
+    {
+      "path": "0016_official_source_coverage.sql",
+      "version": 17
     }
   ],
   "schema_version": "tai.migration.manifest.v1"

--- a/apps/tai/tai/postgres_source_coverage.py
+++ b/apps/tai/tai/postgres_source_coverage.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+from tai.postgres_loader_state import ConnectionFactory
+from tai.source_coverage import (
+    CoverageAssessment,
+    CoverageTopic,
+    SourceObservation,
+    assessment_payload,
+)
+
+
+class PostgreSQLOfficialSourceCoverageRepository:
+    """Append-only PostgreSQL authority for observations and assessments."""
+
+    def __init__(self, connection_factory: ConnectionFactory) -> None:
+        self._connection_factory = connection_factory
+
+    def record_observation(self, observation: SourceObservation) -> None:
+        query = """
+            INSERT INTO tai_official_source_observations (
+                observation_sha256,
+                source_id,
+                observed_at,
+                latest_publication_at,
+                last_success_at,
+                document_count,
+                consecutive_failures,
+                observed_topics,
+                content_sha256
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s)
+            ON CONFLICT (observation_sha256) DO UPDATE
+            SET observation_sha256 = EXCLUDED.observation_sha256
+            WHERE tai_official_source_observations.source_id = EXCLUDED.source_id
+              AND tai_official_source_observations.observed_at = EXCLUDED.observed_at
+              AND tai_official_source_observations.latest_publication_at
+                = EXCLUDED.latest_publication_at
+              AND tai_official_source_observations.last_success_at
+                = EXCLUDED.last_success_at
+              AND tai_official_source_observations.document_count
+                = EXCLUDED.document_count
+              AND tai_official_source_observations.consecutive_failures
+                = EXCLUDED.consecutive_failures
+              AND tai_official_source_observations.observed_topics
+                = EXCLUDED.observed_topics
+              AND tai_official_source_observations.content_sha256
+                = EXCLUDED.content_sha256
+            RETURNING observation_sha256
+        """
+        parameters = (
+            observation.observation_sha256,
+            observation.source_id,
+            observation.observed_at,
+            observation.latest_publication_at,
+            observation.last_success_at,
+            observation.document_count,
+            observation.consecutive_failures,
+            json.dumps(
+                sorted(topic.value for topic in observation.observed_topics),
+                separators=(",", ":"),
+            ),
+            observation.content_sha256,
+        )
+        self._execute_immutable(
+            query,
+            parameters,
+            conflict_message=(
+                "observation digest is already bound to different evidence"
+            ),
+        )
+
+    def record_assessment(self, assessment: CoverageAssessment) -> None:
+        payload = assessment_payload(assessment)
+        query = """
+            INSERT INTO tai_official_source_coverage_assessments (
+                assessment_sha256,
+                generated_at,
+                coverage_basis_points,
+                critical_coverage_basis_points,
+                all_critical_covered,
+                topics
+            )
+            VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+            ON CONFLICT (assessment_sha256) DO UPDATE
+            SET assessment_sha256 = EXCLUDED.assessment_sha256
+            WHERE tai_official_source_coverage_assessments.generated_at
+                = EXCLUDED.generated_at
+              AND tai_official_source_coverage_assessments.coverage_basis_points
+                = EXCLUDED.coverage_basis_points
+              AND tai_official_source_coverage_assessments
+                    .critical_coverage_basis_points
+                = EXCLUDED.critical_coverage_basis_points
+              AND tai_official_source_coverage_assessments.all_critical_covered
+                = EXCLUDED.all_critical_covered
+              AND tai_official_source_coverage_assessments.topics
+                = EXCLUDED.topics
+            RETURNING assessment_sha256
+        """
+        parameters = (
+            assessment.assessment_sha256,
+            assessment.generated_at,
+            assessment.coverage_basis_points,
+            assessment.critical_coverage_basis_points,
+            assessment.all_critical_covered,
+            json.dumps(payload["topics"], ensure_ascii=False, separators=(",", ":")),
+        )
+        self._execute_immutable(
+            query,
+            parameters,
+            conflict_message=(
+                "assessment digest is already bound to different evidence"
+            ),
+        )
+
+    def list_latest_observations(self) -> tuple[SourceObservation, ...]:
+        query = """
+            SELECT
+                source_id,
+                observed_at,
+                latest_publication_at,
+                last_success_at,
+                document_count,
+                consecutive_failures,
+                observed_topics,
+                content_sha256
+            FROM tai_latest_official_source_observations_v1
+            ORDER BY source_id
+        """
+        rows = self._execute_all(query, ())
+        return tuple(_observation_from_row(row) for row in rows)
+
+    def current_assessment_metadata(self) -> Mapping[str, Any] | None:
+        query = """
+            SELECT
+                assessment_sha256,
+                generated_at,
+                coverage_basis_points,
+                critical_coverage_basis_points,
+                all_critical_covered
+            FROM tai_current_official_source_coverage_v1
+        """
+        rows = self._execute_all(query, ())
+        return rows[0] if rows else None
+
+    def _execute_immutable(
+        self,
+        query: str,
+        parameters: Sequence[Any],
+        *,
+        conflict_message: str,
+    ) -> None:
+        with self._connection_factory() as connection:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(query, parameters)
+                    row = cursor.fetchone()
+                if row is None:
+                    raise RuntimeError(conflict_message)
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+
+    def _execute_all(
+        self,
+        query: str,
+        parameters: Sequence[Any],
+    ) -> tuple[Mapping[str, Any], ...]:
+        with self._connection_factory() as connection:
+            try:
+                rows: list[Mapping[str, Any]] = []
+                with connection.cursor() as cursor:
+                    cursor.execute(query, parameters)
+                    while True:
+                        row = cursor.fetchone()
+                        if row is None:
+                            break
+                        rows.append(row)
+                connection.commit()
+                return tuple(rows)
+            except Exception:
+                connection.rollback()
+                raise
+
+
+def _observation_from_row(row: Mapping[str, Any]) -> SourceObservation:
+    topics = row["observed_topics"]
+    if isinstance(topics, str):
+        topics = json.loads(topics)
+    if not isinstance(topics, list) or any(not isinstance(item, str) for item in topics):
+        raise ValueError("stored observed_topics must be a string array")
+    return SourceObservation(
+        source_id=str(row["source_id"]),
+        observed_at=_datetime(row["observed_at"], "observed_at"),
+        latest_publication_at=_datetime(
+            row["latest_publication_at"],
+            "latest_publication_at",
+        ),
+        last_success_at=_datetime(row["last_success_at"], "last_success_at"),
+        document_count=int(row["document_count"]),
+        consecutive_failures=int(row["consecutive_failures"]),
+        observed_topics=frozenset(CoverageTopic(item) for item in topics),
+        content_sha256=str(row["content_sha256"]),
+    )
+
+
+def _datetime(value: object, name: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise ValueError(f"stored {name} must be a datetime")
+    return value

--- a/apps/tai/tai/source_coverage.py
+++ b/apps/tai/tai/source_coverage.py
@@ -1,0 +1,579 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import urlparse
+
+_SOURCE_ID = re.compile(r"^[a-z0-9][a-z0-9._-]{2,127}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class CoverageTopic(StrEnum):
+    GRAIN_MARKET_PRICES = "GRAIN_MARKET_PRICES"
+    AGRICULTURE_PRODUCTION = "AGRICULTURE_PRODUCTION"
+    GRAIN_REGULATION = "GRAIN_REGULATION"
+    GRAIN_QUALITY = "GRAIN_QUALITY"
+    GRAIN_TRACEABILITY = "GRAIN_TRACEABILITY"
+    LOGISTICS_TARIFFS = "LOGISTICS_TARIFFS"
+    FINANCE_RATES = "FINANCE_RATES"
+    AGRONOMY_RECOMMENDATIONS = "AGRONOMY_RECOMMENDATIONS"
+
+
+class SourceFormat(StrEnum):
+    HTML = "HTML"
+    XLSX = "XLSX"
+    CSV = "CSV"
+    JSON = "JSON"
+    ZIP = "ZIP"
+    PDF = "PDF"
+
+
+class TopicCoverageStatus(StrEnum):
+    COVERED = "COVERED"
+    STALE = "STALE"
+    GAP = "GAP"
+    UNOBSERVED = "UNOBSERVED"
+
+
+@dataclass(frozen=True, slots=True)
+class OfficialSourceDefinition:
+    source_id: str
+    owner: str
+    entrypoint_uri: str
+    allowed_hosts: frozenset[str]
+    topics: frozenset[CoverageTopic]
+    formats: frozenset[SourceFormat]
+    expected_update_interval: timedelta
+    maximum_publication_age: timedelta
+    verified_at: datetime
+
+    def __post_init__(self) -> None:
+        if _SOURCE_ID.fullmatch(self.source_id) is None:
+            raise ValueError("source_id must be a portable lowercase identity")
+        if not self.owner.strip():
+            raise ValueError("source owner must not be blank")
+        parsed = urlparse(self.entrypoint_uri)
+        if parsed.scheme != "https" or not parsed.hostname:
+            raise ValueError("official source entrypoint must use HTTPS")
+        if parsed.username or parsed.password or parsed.fragment:
+            raise ValueError("official source entrypoint must not contain credentials or fragment")
+        if not self.allowed_hosts or parsed.hostname not in self.allowed_hosts:
+            raise ValueError("entrypoint host must be explicitly allowed")
+        if any(not host or host != host.lower() for host in self.allowed_hosts):
+            raise ValueError("allowed hosts must be non-empty lowercase names")
+        if not self.topics:
+            raise ValueError("official source topics must not be empty")
+        if not self.formats:
+            raise ValueError("official source formats must not be empty")
+        if self.expected_update_interval <= timedelta(0):
+            raise ValueError("expected update interval must be positive")
+        if self.maximum_publication_age < self.expected_update_interval:
+            raise ValueError("maximum publication age must cover update interval")
+        _aware(self.verified_at, "verified_at")
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageRequirement:
+    topic: CoverageTopic
+    minimum_official_sources: int
+    maximum_publication_age: timedelta
+    critical: bool = True
+
+    def __post_init__(self) -> None:
+        if self.minimum_official_sources < 1:
+            raise ValueError("minimum_official_sources must be positive")
+        if self.maximum_publication_age <= timedelta(0):
+            raise ValueError("maximum_publication_age must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class OfficialSourceCatalog:
+    sources: tuple[OfficialSourceDefinition, ...]
+    requirements: tuple[CoverageRequirement, ...]
+
+    def __post_init__(self) -> None:
+        if not self.sources or not self.requirements:
+            raise ValueError("source catalog and requirements must not be empty")
+        source_ids = tuple(source.source_id for source in self.sources)
+        if len(source_ids) != len(set(source_ids)):
+            raise ValueError("official source identities must be unique")
+        topics = tuple(requirement.topic for requirement in self.requirements)
+        if len(topics) != len(set(topics)):
+            raise ValueError("coverage requirement topics must be unique")
+
+    def source_for(self, source_id: str) -> OfficialSourceDefinition | None:
+        return next(
+            (source for source in self.sources if source.source_id == source_id),
+            None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SourceObservation:
+    source_id: str
+    observed_at: datetime
+    latest_publication_at: datetime
+    last_success_at: datetime
+    document_count: int
+    consecutive_failures: int
+    observed_topics: frozenset[CoverageTopic]
+    content_sha256: str
+
+    def __post_init__(self) -> None:
+        if _SOURCE_ID.fullmatch(self.source_id) is None:
+            raise ValueError("observation source_id is invalid")
+        _aware(self.observed_at, "observed_at")
+        _aware(self.latest_publication_at, "latest_publication_at")
+        _aware(self.last_success_at, "last_success_at")
+        if self.document_count < 1:
+            raise ValueError("document_count must be positive")
+        if self.consecutive_failures < 0:
+            raise ValueError("consecutive_failures must not be negative")
+        if not self.observed_topics:
+            raise ValueError("observed_topics must not be empty")
+        _sha256(self.content_sha256, "content_sha256")
+
+    @property
+    def observation_sha256(self) -> str:
+        return _hash_payload(
+            {
+                "consecutive_failures": self.consecutive_failures,
+                "content_sha256": self.content_sha256,
+                "document_count": self.document_count,
+                "last_success_at": self.last_success_at.isoformat(),
+                "latest_publication_at": self.latest_publication_at.isoformat(),
+                "observed_at": self.observed_at.isoformat(),
+                "observed_topics": sorted(topic.value for topic in self.observed_topics),
+                "schema_version": "tai.source-observation.v1",
+                "source_id": self.source_id,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TopicCoverage:
+    topic: CoverageTopic
+    status: TopicCoverageStatus
+    healthy_source_ids: tuple[str, ...]
+    reasons: tuple[str, ...]
+    critical: bool
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageAssessment:
+    generated_at: datetime
+    topics: tuple[TopicCoverage, ...]
+    coverage_basis_points: int
+    critical_coverage_basis_points: int
+    all_critical_covered: bool
+    assessment_sha256: str
+
+
+class OfficialSourceCoverageAuthority:
+    """Count only fresh, healthy and actually observed official sources."""
+
+    _FUTURE_TOLERANCE = timedelta(minutes=5)
+
+    def assess(
+        self,
+        *,
+        catalog: OfficialSourceCatalog,
+        observations: tuple[SourceObservation, ...],
+        now: datetime,
+    ) -> CoverageAssessment:
+        _aware(now, "now")
+        by_source: dict[str, SourceObservation] = {}
+        duplicate_ids: set[str] = set()
+        for observation in observations:
+            if observation.source_id in by_source:
+                duplicate_ids.add(observation.source_id)
+            by_source[observation.source_id] = observation
+
+        topic_results = tuple(
+            self._assess_topic(
+                catalog=catalog,
+                requirement=requirement,
+                observations=by_source,
+                duplicate_ids=duplicate_ids,
+                now=now,
+            )
+            for requirement in catalog.requirements
+        )
+        covered_count = sum(
+            result.status is TopicCoverageStatus.COVERED
+            for result in topic_results
+        )
+        critical = tuple(result for result in topic_results if result.critical)
+        critical_covered = sum(
+            result.status is TopicCoverageStatus.COVERED for result in critical
+        )
+        coverage_basis_points = covered_count * 10_000 // len(topic_results)
+        critical_basis_points = critical_covered * 10_000 // len(critical)
+        all_critical_covered = critical_covered == len(critical)
+        digest = _assessment_sha256(
+            now=now,
+            topics=topic_results,
+            coverage_basis_points=coverage_basis_points,
+            critical_coverage_basis_points=critical_basis_points,
+            all_critical_covered=all_critical_covered,
+        )
+        return CoverageAssessment(
+            generated_at=now,
+            topics=topic_results,
+            coverage_basis_points=coverage_basis_points,
+            critical_coverage_basis_points=critical_basis_points,
+            all_critical_covered=all_critical_covered,
+            assessment_sha256=digest,
+        )
+
+    def _assess_topic(
+        self,
+        *,
+        catalog: OfficialSourceCatalog,
+        requirement: CoverageRequirement,
+        observations: dict[str, SourceObservation],
+        duplicate_ids: set[str],
+        now: datetime,
+    ) -> TopicCoverage:
+        candidates = tuple(
+            source
+            for source in catalog.sources
+            if requirement.topic in source.topics
+        )
+        if not candidates:
+            return TopicCoverage(
+                topic=requirement.topic,
+                status=TopicCoverageStatus.GAP,
+                healthy_source_ids=(),
+                reasons=("NO_REGISTERED_OFFICIAL_SOURCE",),
+                critical=requirement.critical,
+            )
+
+        healthy: list[str] = []
+        reasons: list[str] = []
+        observed_count = 0
+        stale_count = 0
+        for source in candidates:
+            observation = observations.get(source.source_id)
+            if observation is None:
+                reasons.append(f"SOURCE_UNOBSERVED:{source.source_id}")
+                continue
+            observed_count += 1
+            source_reasons = self._observation_reasons(
+                source=source,
+                requirement=requirement,
+                observation=observation,
+                duplicate=source.source_id in duplicate_ids,
+                now=now,
+            )
+            if source_reasons:
+                reasons.extend(source_reasons)
+                if any("STALE" in reason for reason in source_reasons):
+                    stale_count += 1
+            else:
+                healthy.append(source.source_id)
+
+        if len(healthy) >= requirement.minimum_official_sources:
+            status = TopicCoverageStatus.COVERED
+        elif observed_count == 0:
+            status = TopicCoverageStatus.UNOBSERVED
+        elif stale_count:
+            status = TopicCoverageStatus.STALE
+        else:
+            status = TopicCoverageStatus.GAP
+        if len(healthy) < requirement.minimum_official_sources:
+            reasons.append(
+                "INSUFFICIENT_HEALTHY_SOURCES:"
+                f"{len(healthy)}/{requirement.minimum_official_sources}"
+            )
+        return TopicCoverage(
+            topic=requirement.topic,
+            status=status,
+            healthy_source_ids=tuple(sorted(healthy)),
+            reasons=tuple(sorted(set(reasons))),
+            critical=requirement.critical,
+        )
+
+    def _observation_reasons(
+        self,
+        *,
+        source: OfficialSourceDefinition,
+        requirement: CoverageRequirement,
+        observation: SourceObservation,
+        duplicate: bool,
+        now: datetime,
+    ) -> tuple[str, ...]:
+        reasons: list[str] = []
+        if duplicate:
+            reasons.append(f"DUPLICATE_OBSERVATION:{source.source_id}")
+        if requirement.topic not in observation.observed_topics:
+            reasons.append(f"TOPIC_NOT_OBSERVED:{source.source_id}")
+        future_limit = now + self._FUTURE_TOLERANCE
+        if observation.observed_at > future_limit:
+            reasons.append(f"OBSERVED_AT_FUTURE:{source.source_id}")
+        if observation.latest_publication_at > future_limit:
+            reasons.append(f"PUBLICATION_AT_FUTURE:{source.source_id}")
+        if observation.last_success_at > future_limit:
+            reasons.append(f"LAST_SUCCESS_AT_FUTURE:{source.source_id}")
+        if observation.consecutive_failures:
+            reasons.append(f"SOURCE_FAILURES:{source.source_id}")
+        freshness_limit = min(
+            source.maximum_publication_age,
+            requirement.maximum_publication_age,
+        )
+        if now - observation.latest_publication_at > freshness_limit:
+            reasons.append(f"PUBLICATION_STALE:{source.source_id}")
+        if now - observation.last_success_at > source.expected_update_interval:
+            reasons.append(f"OBSERVATION_STALE:{source.source_id}")
+        return tuple(reasons)
+
+
+def load_official_source_catalog(path: Path) -> OfficialSourceCatalog:
+    payload = _load_json(path)
+    if payload.get("schema_version") != "tai.official-source-catalog.v1":
+        raise ValueError("unsupported official source catalog schema")
+    sources = tuple(
+        _parse_source(item) for item in _array(payload, "sources")
+    )
+    requirements = tuple(
+        _parse_requirement(item) for item in _array(payload, "requirements")
+    )
+    return OfficialSourceCatalog(sources=sources, requirements=requirements)
+
+
+def load_source_observations(path: Path) -> tuple[SourceObservation, ...]:
+    payload = _load_json(path)
+    if payload.get("schema_version") != "tai.source-observations.v1":
+        raise ValueError("unsupported source observations schema")
+    return tuple(
+        _parse_observation(item) for item in _array(payload, "observations")
+    )
+
+
+def catalog_canonical_json(catalog: OfficialSourceCatalog) -> str:
+    payload = {
+        "requirements": [
+            {
+                "critical": requirement.critical,
+                "maximum_publication_age_seconds": int(
+                    requirement.maximum_publication_age.total_seconds()
+                ),
+                "minimum_official_sources": requirement.minimum_official_sources,
+                "topic": requirement.topic.value,
+            }
+            for requirement in catalog.requirements
+        ],
+        "schema_version": "tai.official-source-catalog.v1",
+        "sources": [
+            {
+                "allowed_hosts": sorted(source.allowed_hosts),
+                "entrypoint_uri": source.entrypoint_uri,
+                "expected_update_interval_seconds": int(
+                    source.expected_update_interval.total_seconds()
+                ),
+                "formats": sorted(item.value for item in source.formats),
+                "maximum_publication_age_seconds": int(
+                    source.maximum_publication_age.total_seconds()
+                ),
+                "owner": source.owner,
+                "source_id": source.source_id,
+                "topics": sorted(topic.value for topic in source.topics),
+                "verified_at": source.verified_at.isoformat(),
+            }
+            for source in catalog.sources
+        ],
+    }
+    return _canonical_json(payload)
+
+
+def assessment_payload(assessment: CoverageAssessment) -> dict[str, object]:
+    return {
+        "all_critical_covered": assessment.all_critical_covered,
+        "assessment_sha256": assessment.assessment_sha256,
+        "coverage_basis_points": assessment.coverage_basis_points,
+        "critical_coverage_basis_points": (
+            assessment.critical_coverage_basis_points
+        ),
+        "generated_at": assessment.generated_at.isoformat(),
+        "schema_version": "tai.official-source-coverage-assessment.v1",
+        "topics": [
+            {
+                "critical": topic.critical,
+                "healthy_source_ids": list(topic.healthy_source_ids),
+                "reasons": list(topic.reasons),
+                "status": topic.status.value,
+                "topic": topic.topic.value,
+            }
+            for topic in assessment.topics
+        ],
+    }
+
+
+def _parse_source(value: object) -> OfficialSourceDefinition:
+    payload = _object(value, "official source")
+    return OfficialSourceDefinition(
+        source_id=_string(payload, "source_id"),
+        owner=_string(payload, "owner"),
+        entrypoint_uri=_string(payload, "entrypoint_uri"),
+        allowed_hosts=frozenset(_strings(payload, "allowed_hosts")),
+        topics=frozenset(
+            CoverageTopic(item) for item in _strings(payload, "topics")
+        ),
+        formats=frozenset(
+            SourceFormat(item) for item in _strings(payload, "formats")
+        ),
+        expected_update_interval=timedelta(
+            seconds=_integer(payload, "expected_update_interval_seconds")
+        ),
+        maximum_publication_age=timedelta(
+            seconds=_integer(payload, "maximum_publication_age_seconds")
+        ),
+        verified_at=_datetime(payload, "verified_at"),
+    )
+
+
+def _parse_requirement(value: object) -> CoverageRequirement:
+    payload = _object(value, "coverage requirement")
+    return CoverageRequirement(
+        topic=CoverageTopic(_string(payload, "topic")),
+        minimum_official_sources=_integer(payload, "minimum_official_sources"),
+        maximum_publication_age=timedelta(
+            seconds=_integer(payload, "maximum_publication_age_seconds")
+        ),
+        critical=_boolean(payload, "critical"),
+    )
+
+
+def _parse_observation(value: object) -> SourceObservation:
+    payload = _object(value, "source observation")
+    return SourceObservation(
+        source_id=_string(payload, "source_id"),
+        observed_at=_datetime(payload, "observed_at"),
+        latest_publication_at=_datetime(payload, "latest_publication_at"),
+        last_success_at=_datetime(payload, "last_success_at"),
+        document_count=_integer(payload, "document_count"),
+        consecutive_failures=_integer(payload, "consecutive_failures"),
+        observed_topics=frozenset(
+            CoverageTopic(item) for item in _strings(payload, "observed_topics")
+        ),
+        content_sha256=_string(payload, "content_sha256"),
+    )
+
+
+def _assessment_sha256(
+    *,
+    now: datetime,
+    topics: tuple[TopicCoverage, ...],
+    coverage_basis_points: int,
+    critical_coverage_basis_points: int,
+    all_critical_covered: bool,
+) -> str:
+    return _hash_payload(
+        {
+            "all_critical_covered": all_critical_covered,
+            "coverage_basis_points": coverage_basis_points,
+            "critical_coverage_basis_points": critical_coverage_basis_points,
+            "generated_at": now.isoformat(),
+            "schema_version": "tai.official-source-coverage-assessment.v1",
+            "topics": [
+                {
+                    "critical": topic.critical,
+                    "healthy_source_ids": list(topic.healthy_source_ids),
+                    "reasons": list(topic.reasons),
+                    "status": topic.status.value,
+                    "topic": topic.topic.value,
+                }
+                for topic in topics
+            ],
+        }
+    )
+
+
+def _hash_payload(payload: object) -> str:
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _canonical_json(payload: object) -> str:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot load JSON from {path}") from error
+    return _object(value, "root payload")
+
+
+def _object(value: object, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be a JSON object")
+    if any(not isinstance(key, str) for key in value):
+        raise ValueError(f"{name} keys must be strings")
+    return cast(dict[str, Any], value)
+
+
+def _array(payload: dict[str, Any], key: str) -> list[object]:
+    value = payload.get(key)
+    if not isinstance(value, list):
+        raise ValueError(f"{key} must be an array")
+    return cast(list[object], value)
+
+
+def _strings(payload: dict[str, Any], key: str) -> list[str]:
+    values = _array(payload, key)
+    if not values or any(not isinstance(item, str) for item in values):
+        raise ValueError(f"{key} must be a non-empty string array")
+    return cast(list[str], values)
+
+
+def _string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _integer(payload: dict[str, Any], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
+def _boolean(payload: dict[str, Any], key: str) -> bool:
+    value = payload.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
+def _datetime(payload: dict[str, Any], key: str) -> datetime:
+    raw = _string(payload, key)
+    try:
+        value = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{key} must be an ISO-8601 datetime") from error
+    _aware(value, key)
+    return value
+
+
+def _aware(value: datetime, name: str) -> None:
+    if value.utcoffset() is None:
+        raise ValueError(f"{name} must be timezone-aware")
+
+
+def _sha256(value: str, name: str) -> None:
+    if _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")

--- a/apps/tai/tai/source_coverage_cli.py
+++ b/apps/tai/tai/source_coverage_cli.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from tai.source_coverage import (
+    OfficialSourceCoverageAuthority,
+    assessment_payload,
+    catalog_canonical_json,
+    load_official_source_catalog,
+    load_source_observations,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tai-source-coverage",
+        description="Validate official source catalogs and assess observed coverage.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate-catalog")
+    validate_parser.add_argument("catalog", type=Path)
+    validate_parser.add_argument("--output", type=Path)
+
+    assess_parser = subparsers.add_parser("assess")
+    assess_parser.add_argument("catalog", type=Path)
+    assess_parser.add_argument("observations", type=Path)
+    assess_parser.add_argument("--at", required=True)
+    assess_parser.add_argument("--output", type=Path)
+
+    arguments = parser.parse_args(argv)
+    try:
+        catalog = load_official_source_catalog(arguments.catalog)
+        if arguments.command == "validate-catalog":
+            canonical = catalog_canonical_json(catalog)
+            payload: dict[str, object] = {
+                "catalog_sha256": hashlib.sha256(
+                    canonical.encode("utf-8")
+                ).hexdigest(),
+                "requirement_count": len(catalog.requirements),
+                "schema_version": "tai.official-source-catalog-validation.v1",
+                "source_count": len(catalog.sources),
+                "status": "VALID",
+            }
+            _write_json(payload, arguments.output)
+            return 0
+
+        observations = load_source_observations(arguments.observations)
+        assessment = OfficialSourceCoverageAuthority().assess(
+            catalog=catalog,
+            observations=observations,
+            now=_parse_datetime(arguments.at),
+        )
+        _write_json(assessment_payload(assessment), arguments.output)
+        return 0 if assessment.all_critical_covered else 2
+    except ValueError as error:
+        _write_json(
+            {
+                "error": str(error),
+                "schema_version": "tai.source-coverage-cli-error.v1",
+                "status": "INVALID",
+            },
+            getattr(arguments, "output", None),
+        )
+        return 2
+
+
+def _parse_datetime(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError("--at must be an ISO-8601 datetime") from error
+    if parsed.utcoffset() is None:
+        raise ValueError("--at must be timezone-aware")
+    return parsed
+
+
+def _write_json(payload: dict[str, object], output: Path | None) -> None:
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if output is None:
+        sys.stdout.write(rendered)
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/tai/tests/test_migration_manifest.py
+++ b/apps/tai/tests/test_migration_manifest.py
@@ -16,11 +16,11 @@ def _repo_root() -> Path:
 
 def test_repository_manifest_preserves_historical_paths_with_unique_authority_order() -> None:
     inventory = _migration_inventory(_repo_root())
-    assert [item.version for item in inventory.migrations] == list(range(1, 17))
+    assert [item.version for item in inventory.migrations] == list(range(1, 18))
     paths = [item.path for item in inventory.migrations]
     assert paths[9].endswith("0010_operational_authority.sql")
     assert paths[10].endswith("0010_orchestration_runtime.sql")
-    assert paths[-1].endswith("0015_model_admission_authority.sql")
+    assert paths[-1].endswith("0016_official_source_coverage.sql")
 
 
 def _fixture(root: Path) -> Path:

--- a/apps/tai/tests/test_postgres_source_coverage.py
+++ b/apps/tai/tests/test_postgres_source_coverage.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from tai.postgres_source_coverage import PostgreSQLOfficialSourceCoverageRepository
+from tai.source_coverage import (
+    CoverageRequirement,
+    CoverageTopic,
+    OfficialSourceCatalog,
+    OfficialSourceCoverageAuthority,
+    OfficialSourceDefinition,
+    SourceFormat,
+    SourceObservation,
+)
+
+NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+
+
+def _observation() -> SourceObservation:
+    return SourceObservation(
+        source_id="official.example.market",
+        observed_at=NOW - timedelta(hours=1),
+        latest_publication_at=NOW - timedelta(days=1),
+        last_success_at=NOW - timedelta(hours=1),
+        document_count=3,
+        consecutive_failures=0,
+        observed_topics=frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+        content_sha256="a" * 64,
+    )
+
+
+def _assessment() -> object:
+    catalog = OfficialSourceCatalog(
+        sources=(
+            OfficialSourceDefinition(
+                source_id="official.example.market",
+                owner="Official Example Authority",
+                entrypoint_uri="https://data.example.gov/market",
+                allowed_hosts=frozenset({"data.example.gov"}),
+                topics=frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+                formats=frozenset({SourceFormat.JSON}),
+                expected_update_interval=timedelta(days=7),
+                maximum_publication_age=timedelta(days=31),
+                verified_at=NOW - timedelta(days=1),
+            ),
+        ),
+        requirements=(
+            CoverageRequirement(
+                topic=CoverageTopic.GRAIN_MARKET_PRICES,
+                minimum_official_sources=1,
+                maximum_publication_age=timedelta(days=31),
+            ),
+        ),
+    )
+    return OfficialSourceCoverageAuthority().assess(
+        catalog=catalog,
+        observations=(_observation(),),
+        now=NOW,
+    )
+
+
+class _Cursor:
+    def __init__(self, rows: list[dict[str, Any] | None]) -> None:
+        self._rows = deque(rows)
+        self.calls: list[tuple[str, object]] = []
+
+    def __enter__(self) -> _Cursor:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        del args
+
+    def execute(self, query: str, parameters: object) -> None:
+        self.calls.append((query, parameters))
+
+    def fetchone(self) -> dict[str, Any] | None:
+        return self._rows.popleft() if self._rows else None
+
+
+class _Connection:
+    def __init__(self, rows: list[dict[str, Any] | None]) -> None:
+        self.cursor_value = _Cursor(rows)
+        self.commits = 0
+        self.rollbacks = 0
+
+    def __enter__(self) -> _Connection:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        del args
+
+    def cursor(self) -> _Cursor:
+        return self.cursor_value
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class _Factory:
+    def __init__(self, connection: _Connection) -> None:
+        self.connection = connection
+
+    def __call__(self) -> _Connection:
+        return self.connection
+
+
+def test_repository_records_observation_immutably() -> None:
+    observation = _observation()
+    connection = _Connection(
+        [{"observation_sha256": observation.observation_sha256}]
+    )
+    repository = PostgreSQLOfficialSourceCoverageRepository(_Factory(connection))
+
+    repository.record_observation(observation)
+
+    assert connection.commits == 1
+    assert connection.rollbacks == 0
+    query, parameters = connection.cursor_value.calls[0]
+    assert "INSERT INTO tai_official_source_observations" in query
+    assert observation.observation_sha256 in parameters
+    assert '"GRAIN_MARKET_PRICES"' in parameters
+
+
+def test_repository_records_assessment_immutably() -> None:
+    assessment = _assessment()
+    assert hasattr(assessment, "assessment_sha256")
+    connection = _Connection(
+        [{"assessment_sha256": assessment.assessment_sha256}]
+    )
+    repository = PostgreSQLOfficialSourceCoverageRepository(_Factory(connection))
+
+    repository.record_assessment(assessment)
+
+    assert connection.commits == 1
+    query, parameters = connection.cursor_value.calls[0]
+    assert "tai_official_source_coverage_assessments" in query
+    assert assessment.assessment_sha256 in parameters
+    assert '"status":"COVERED"' in parameters
+
+
+@pytest.mark.parametrize("method_name", ["record_observation", "record_assessment"])
+def test_repository_rolls_back_on_digest_conflict(method_name: str) -> None:
+    connection = _Connection([None])
+    repository = PostgreSQLOfficialSourceCoverageRepository(_Factory(connection))
+    value = _observation() if method_name == "record_observation" else _assessment()
+
+    with pytest.raises(RuntimeError, match="different evidence"):
+        getattr(repository, method_name)(value)
+
+    assert connection.commits == 0
+    assert connection.rollbacks == 1
+
+
+def test_repository_lists_latest_observations_from_json_text_and_array() -> None:
+    rows = [
+        {
+            "source_id": "official.example.market",
+            "observed_at": NOW - timedelta(hours=1),
+            "latest_publication_at": NOW - timedelta(days=1),
+            "last_success_at": NOW - timedelta(hours=1),
+            "document_count": 3,
+            "consecutive_failures": 0,
+            "observed_topics": '["GRAIN_MARKET_PRICES"]',
+            "content_sha256": "a" * 64,
+        },
+        {
+            "source_id": "official.example.production",
+            "observed_at": NOW - timedelta(hours=2),
+            "latest_publication_at": NOW - timedelta(days=2),
+            "last_success_at": NOW - timedelta(hours=2),
+            "document_count": 2,
+            "consecutive_failures": 0,
+            "observed_topics": ["AGRICULTURE_PRODUCTION"],
+            "content_sha256": "b" * 64,
+        },
+        None,
+    ]
+    connection = _Connection(rows)
+    repository = PostgreSQLOfficialSourceCoverageRepository(_Factory(connection))
+
+    observations = repository.list_latest_observations()
+
+    assert len(observations) == 2
+    assert observations[0].source_id == "official.example.market"
+    assert observations[1].observed_topics == frozenset(
+        {CoverageTopic.AGRICULTURE_PRODUCTION}
+    )
+    assert connection.commits == 1
+
+
+def test_repository_returns_current_assessment_metadata_or_none() -> None:
+    metadata = {
+        "assessment_sha256": "c" * 64,
+        "generated_at": NOW,
+        "coverage_basis_points": 8_750,
+        "critical_coverage_basis_points": 8_750,
+        "all_critical_covered": False,
+    }
+    populated = PostgreSQLOfficialSourceCoverageRepository(
+        _Factory(_Connection([metadata, None]))
+    )
+    empty = PostgreSQLOfficialSourceCoverageRepository(
+        _Factory(_Connection([None]))
+    )
+
+    assert populated.current_assessment_metadata() == metadata
+    assert empty.current_assessment_metadata() is None
+
+
+def test_repository_rejects_invalid_stored_topics_and_timestamp() -> None:
+    invalid_topics = _Connection(
+        [
+            {
+                "source_id": "official.example.market",
+                "observed_at": NOW,
+                "latest_publication_at": NOW,
+                "last_success_at": NOW,
+                "document_count": 1,
+                "consecutive_failures": 0,
+                "observed_topics": {"wrong": "shape"},
+                "content_sha256": "a" * 64,
+            },
+            None,
+        ]
+    )
+    invalid_time = _Connection(
+        [
+            {
+                "source_id": "official.example.market",
+                "observed_at": "not-a-datetime",
+                "latest_publication_at": NOW,
+                "last_success_at": NOW,
+                "document_count": 1,
+                "consecutive_failures": 0,
+                "observed_topics": ["GRAIN_MARKET_PRICES"],
+                "content_sha256": "a" * 64,
+            },
+            None,
+        ]
+    )
+
+    with pytest.raises(ValueError, match="observed_topics"):
+        PostgreSQLOfficialSourceCoverageRepository(
+            _Factory(invalid_topics)
+        ).list_latest_observations()
+    with pytest.raises(ValueError, match="observed_at"):
+        PostgreSQLOfficialSourceCoverageRepository(
+            _Factory(invalid_time)
+        ).list_latest_observations()

--- a/apps/tai/tests/test_postgres_source_coverage.py
+++ b/apps/tai/tests/test_postgres_source_coverage.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from collections import deque
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from tai.postgres_source_coverage import PostgreSQLOfficialSourceCoverageRepository
 from tai.source_coverage import (
+    CoverageAssessment,
     CoverageRequirement,
     CoverageTopic,
     OfficialSourceCatalog,
@@ -33,7 +34,7 @@ def _observation() -> SourceObservation:
     )
 
 
-def _assessment() -> object:
+def _assessment() -> CoverageAssessment:
     catalog = OfficialSourceCatalog(
         sources=(
             OfficialSourceDefinition(
@@ -111,6 +112,11 @@ class _Factory:
         return self.connection
 
 
+def _parameters(value: object) -> tuple[Any, ...]:
+    assert isinstance(value, tuple)
+    return cast(tuple[Any, ...], value)
+
+
 def test_repository_records_observation_immutably() -> None:
     observation = _observation()
     connection = _Connection(
@@ -122,15 +128,18 @@ def test_repository_records_observation_immutably() -> None:
 
     assert connection.commits == 1
     assert connection.rollbacks == 0
-    query, parameters = connection.cursor_value.calls[0]
+    query, raw_parameters = connection.cursor_value.calls[0]
+    parameters = _parameters(raw_parameters)
     assert "INSERT INTO tai_official_source_observations" in query
     assert observation.observation_sha256 in parameters
-    assert '"GRAIN_MARKET_PRICES"' in parameters
+    assert any(
+        isinstance(item, str) and '"GRAIN_MARKET_PRICES"' in item
+        for item in parameters
+    )
 
 
 def test_repository_records_assessment_immutably() -> None:
     assessment = _assessment()
-    assert hasattr(assessment, "assessment_sha256")
     connection = _Connection(
         [{"assessment_sha256": assessment.assessment_sha256}]
     )
@@ -139,20 +148,33 @@ def test_repository_records_assessment_immutably() -> None:
     repository.record_assessment(assessment)
 
     assert connection.commits == 1
-    query, parameters = connection.cursor_value.calls[0]
+    query, raw_parameters = connection.cursor_value.calls[0]
+    parameters = _parameters(raw_parameters)
     assert "tai_official_source_coverage_assessments" in query
     assert assessment.assessment_sha256 in parameters
-    assert '"status":"COVERED"' in parameters
+    assert any(
+        isinstance(item, str) and '"status":"COVERED"' in item
+        for item in parameters
+    )
 
 
-@pytest.mark.parametrize("method_name", ["record_observation", "record_assessment"])
-def test_repository_rolls_back_on_digest_conflict(method_name: str) -> None:
+def test_repository_rolls_back_on_observation_digest_conflict() -> None:
     connection = _Connection([None])
     repository = PostgreSQLOfficialSourceCoverageRepository(_Factory(connection))
-    value = _observation() if method_name == "record_observation" else _assessment()
 
     with pytest.raises(RuntimeError, match="different evidence"):
-        getattr(repository, method_name)(value)
+        repository.record_observation(_observation())
+
+    assert connection.commits == 0
+    assert connection.rollbacks == 1
+
+
+def test_repository_rolls_back_on_assessment_digest_conflict() -> None:
+    connection = _Connection([None])
+    repository = PostgreSQLOfficialSourceCoverageRepository(_Factory(connection))
+
+    with pytest.raises(RuntimeError, match="different evidence"):
+        repository.record_assessment(_assessment())
 
     assert connection.commits == 0
     assert connection.rollbacks == 1

--- a/apps/tai/tests/test_source_coverage.py
+++ b/apps/tai/tests/test_source_coverage.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from tai.source_coverage import (
+    CoverageAssessment,
+    CoverageRequirement,
+    CoverageTopic,
+    OfficialSourceCatalog,
+    OfficialSourceCoverageAuthority,
+    OfficialSourceDefinition,
+    SourceFormat,
+    SourceObservation,
+    TopicCoverageStatus,
+    assessment_payload,
+    catalog_canonical_json,
+    load_official_source_catalog,
+    load_source_observations,
+)
+from tai.source_coverage_cli import main
+
+NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+CONTENT_SHA = "a" * 64
+
+
+def _repository_catalog_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "knowledge-sources"
+        / "official-sources.v1.json"
+    )
+
+
+def _observation(
+    source_id: str,
+    topics: frozenset[CoverageTopic],
+    *,
+    observed_at: datetime = NOW - timedelta(hours=1),
+    latest_publication_at: datetime = NOW - timedelta(days=1),
+    last_success_at: datetime = NOW - timedelta(hours=1),
+    consecutive_failures: int = 0,
+) -> SourceObservation:
+    return SourceObservation(
+        source_id=source_id,
+        observed_at=observed_at,
+        latest_publication_at=latest_publication_at,
+        last_success_at=last_success_at,
+        document_count=3,
+        consecutive_failures=consecutive_failures,
+        observed_topics=topics,
+        content_sha256=CONTENT_SHA,
+    )
+
+
+def _healthy_repository_observations() -> tuple[SourceObservation, ...]:
+    return (
+        _observation(
+            "official.mcx.opendata",
+            frozenset({CoverageTopic.GRAIN_TRACEABILITY}),
+        ),
+        _observation(
+            "official.rosstat.agriculture",
+            frozenset(
+                {
+                    CoverageTopic.GRAIN_MARKET_PRICES,
+                    CoverageTopic.AGRICULTURE_PRODUCTION,
+                }
+            ),
+        ),
+        _observation(
+            "official.eec.grain-regulation",
+            frozenset(
+                {
+                    CoverageTopic.GRAIN_REGULATION,
+                    CoverageTopic.GRAIN_QUALITY,
+                }
+            ),
+        ),
+        _observation(
+            "official.mintrans.rail-tariffs",
+            frozenset({CoverageTopic.LOGISTICS_TARIFFS}),
+        ),
+        _observation(
+            "official.cbr.key-rate",
+            frozenset({CoverageTopic.FINANCE_RATES}),
+        ),
+    )
+
+
+def test_repository_catalog_is_governed_but_exposes_agronomy_gap() -> None:
+    catalog = load_official_source_catalog(_repository_catalog_path())
+
+    assert len(catalog.sources) == 5
+    assert len(catalog.requirements) == 8
+    assert all(source.entrypoint_uri.startswith("https://") for source in catalog.sources)
+    assert catalog.source_for("official.rosstat.agriculture") is not None
+    assert catalog.source_for("missing") is None
+    assert not any(
+        CoverageTopic.AGRONOMY_RECOMMENDATIONS in source.topics
+        for source in catalog.sources
+    )
+    canonical = catalog_canonical_json(catalog)
+    assert canonical == catalog_canonical_json(catalog)
+    assert "AGRONOMY_RECOMMENDATIONS" in canonical
+
+
+def test_no_observations_are_unobserved_and_not_knowledge() -> None:
+    catalog = load_official_source_catalog(_repository_catalog_path())
+
+    assessment = OfficialSourceCoverageAuthority().assess(
+        catalog=catalog,
+        observations=(),
+        now=NOW,
+    )
+
+    statuses = {topic.topic: topic.status for topic in assessment.topics}
+    assert statuses[CoverageTopic.GRAIN_MARKET_PRICES] is TopicCoverageStatus.UNOBSERVED
+    assert statuses[CoverageTopic.AGRONOMY_RECOMMENDATIONS] is TopicCoverageStatus.GAP
+    assert assessment.coverage_basis_points == 0
+    assert assessment.critical_coverage_basis_points == 0
+    assert assessment.all_critical_covered is False
+    assert len(assessment.assessment_sha256) == 64
+
+
+def test_seven_observed_topics_produce_8750_and_keep_agronomy_gap() -> None:
+    catalog = load_official_source_catalog(_repository_catalog_path())
+
+    assessment = OfficialSourceCoverageAuthority().assess(
+        catalog=catalog,
+        observations=_healthy_repository_observations(),
+        now=NOW,
+    )
+
+    by_topic = {topic.topic: topic for topic in assessment.topics}
+    assert assessment.coverage_basis_points == 8_750
+    assert assessment.critical_coverage_basis_points == 8_750
+    assert assessment.all_critical_covered is False
+    assert by_topic[CoverageTopic.GRAIN_MARKET_PRICES].status is TopicCoverageStatus.COVERED
+    agronomy = by_topic[CoverageTopic.AGRONOMY_RECOMMENDATIONS]
+    assert agronomy.status is TopicCoverageStatus.GAP
+    assert agronomy.reasons == ("NO_REGISTERED_OFFICIAL_SOURCE",)
+    payload = assessment_payload(assessment)
+    assert payload["assessment_sha256"] == assessment.assessment_sha256
+    assert len(payload["topics"]) == 8  # type: ignore[arg-type]
+
+
+def _single_topic_catalog(*, minimum_sources: int = 1) -> OfficialSourceCatalog:
+    source = OfficialSourceDefinition(
+        source_id="official.example.market",
+        owner="Official Example Authority",
+        entrypoint_uri="https://data.example.gov/market",
+        allowed_hosts=frozenset({"data.example.gov"}),
+        topics=frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+        formats=frozenset({SourceFormat.JSON}),
+        expected_update_interval=timedelta(days=7),
+        maximum_publication_age=timedelta(days=31),
+        verified_at=NOW - timedelta(days=1),
+    )
+    return OfficialSourceCatalog(
+        sources=(source,),
+        requirements=(
+            CoverageRequirement(
+                topic=CoverageTopic.GRAIN_MARKET_PRICES,
+                minimum_official_sources=minimum_sources,
+                maximum_publication_age=timedelta(days=31),
+            ),
+        ),
+    )
+
+
+def test_single_healthy_source_can_close_a_custom_critical_topic() -> None:
+    catalog = _single_topic_catalog()
+    observation = _observation(
+        "official.example.market",
+        frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+    )
+    authority = OfficialSourceCoverageAuthority()
+
+    first = authority.assess(catalog=catalog, observations=(observation,), now=NOW)
+    second = authority.assess(catalog=catalog, observations=(observation,), now=NOW)
+
+    assert first == second
+    assert first.coverage_basis_points == 10_000
+    assert first.critical_coverage_basis_points == 10_000
+    assert first.all_critical_covered is True
+    assert first.topics[0].healthy_source_ids == ("official.example.market",)
+
+
+@pytest.mark.parametrize(
+    ("observation", "expected_status", "expected_reason"),
+    [
+        (
+            _observation(
+                "official.example.market",
+                frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+                latest_publication_at=NOW - timedelta(days=32),
+            ),
+            TopicCoverageStatus.STALE,
+            "PUBLICATION_STALE:official.example.market",
+        ),
+        (
+            _observation(
+                "official.example.market",
+                frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+                last_success_at=NOW - timedelta(days=8),
+            ),
+            TopicCoverageStatus.STALE,
+            "OBSERVATION_STALE:official.example.market",
+        ),
+        (
+            _observation(
+                "official.example.market",
+                frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+                consecutive_failures=1,
+            ),
+            TopicCoverageStatus.GAP,
+            "SOURCE_FAILURES:official.example.market",
+        ),
+        (
+            _observation(
+                "official.example.market",
+                frozenset({CoverageTopic.AGRICULTURE_PRODUCTION}),
+            ),
+            TopicCoverageStatus.GAP,
+            "TOPIC_NOT_OBSERVED:official.example.market",
+        ),
+        (
+            _observation(
+                "official.example.market",
+                frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+                observed_at=NOW + timedelta(minutes=6),
+            ),
+            TopicCoverageStatus.GAP,
+            "OBSERVED_AT_FUTURE:official.example.market",
+        ),
+        (
+            _observation(
+                "official.example.market",
+                frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+                latest_publication_at=NOW + timedelta(minutes=6),
+            ),
+            TopicCoverageStatus.GAP,
+            "PUBLICATION_AT_FUTURE:official.example.market",
+        ),
+        (
+            _observation(
+                "official.example.market",
+                frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+                last_success_at=NOW + timedelta(minutes=6),
+            ),
+            TopicCoverageStatus.GAP,
+            "LAST_SUCCESS_AT_FUTURE:official.example.market",
+        ),
+    ],
+)
+def test_unhealthy_observations_fail_closed(
+    observation: SourceObservation,
+    expected_status: TopicCoverageStatus,
+    expected_reason: str,
+) -> None:
+    assessment = OfficialSourceCoverageAuthority().assess(
+        catalog=_single_topic_catalog(),
+        observations=(observation,),
+        now=NOW,
+    )
+
+    result = assessment.topics[0]
+    assert result.status is expected_status
+    assert expected_reason in result.reasons
+    assert "INSUFFICIENT_HEALTHY_SOURCES:0/1" in result.reasons
+
+
+def test_duplicate_observations_and_insufficient_source_policy_fail_closed() -> None:
+    observation = _observation(
+        "official.example.market",
+        frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+    )
+
+    duplicate = OfficialSourceCoverageAuthority().assess(
+        catalog=_single_topic_catalog(),
+        observations=(observation, replace(observation, document_count=4)),
+        now=NOW,
+    )
+    insufficient = OfficialSourceCoverageAuthority().assess(
+        catalog=_single_topic_catalog(minimum_sources=2),
+        observations=(observation,),
+        now=NOW,
+    )
+
+    assert duplicate.topics[0].status is TopicCoverageStatus.GAP
+    assert "DUPLICATE_OBSERVATION:official.example.market" in duplicate.topics[0].reasons
+    assert insufficient.topics[0].status is TopicCoverageStatus.GAP
+    assert "INSUFFICIENT_HEALTHY_SOURCES:1/2" in insufficient.topics[0].reasons
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_observation_loader_and_cli_assessment_are_fail_closed(tmp_path: Path) -> None:
+    observations_path = tmp_path / "observations.json"
+    _write_json(
+        observations_path,
+        {
+            "schema_version": "tai.source-observations.v1",
+            "observations": [],
+        },
+    )
+    output = tmp_path / "assessment.json"
+
+    observations = load_source_observations(observations_path)
+    result = main(
+        [
+            "assess",
+            str(_repository_catalog_path()),
+            str(observations_path),
+            "--at",
+            NOW.isoformat(),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert observations == ()
+    assert result == 2
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["all_critical_covered"] is False
+    assert payload["coverage_basis_points"] == 0
+
+
+def test_cli_validates_catalog_without_claiming_coverage(tmp_path: Path) -> None:
+    output = tmp_path / "catalog.json"
+
+    result = main(
+        [
+            "validate-catalog",
+            str(_repository_catalog_path()),
+            "--output",
+            str(output),
+        ]
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert result == 0
+    assert payload["status"] == "VALID"
+    assert payload["source_count"] == 5
+    assert payload["requirement_count"] == 8
+    assert len(payload["catalog_sha256"]) == 64
+
+
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    [
+        (
+            lambda: OfficialSourceDefinition(
+                source_id="official.bad",
+                owner="Owner",
+                entrypoint_uri="http://data.example.gov",
+                allowed_hosts=frozenset({"data.example.gov"}),
+                topics=frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+                formats=frozenset({SourceFormat.JSON}),
+                expected_update_interval=timedelta(days=1),
+                maximum_publication_age=timedelta(days=2),
+                verified_at=NOW,
+            ),
+            "HTTPS",
+        ),
+        (
+            lambda: OfficialSourceDefinition(
+                source_id="official.bad",
+                owner="Owner",
+                entrypoint_uri="https://data.example.gov",
+                allowed_hosts=frozenset({"other.example.gov"}),
+                topics=frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+                formats=frozenset({SourceFormat.JSON}),
+                expected_update_interval=timedelta(days=1),
+                maximum_publication_age=timedelta(days=2),
+                verified_at=NOW,
+            ),
+            "explicitly allowed",
+        ),
+        (
+            lambda: CoverageRequirement(
+                topic=CoverageTopic.GRAIN_MARKET_PRICES,
+                minimum_official_sources=0,
+                maximum_publication_age=timedelta(days=1),
+            ),
+            "minimum_official_sources",
+        ),
+        (
+            lambda: SourceObservation(
+                source_id="official.bad",
+                observed_at=NOW,
+                latest_publication_at=NOW,
+                last_success_at=NOW,
+                document_count=0,
+                consecutive_failures=0,
+                observed_topics=frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+                content_sha256=CONTENT_SHA,
+            ),
+            "document_count",
+        ),
+    ],
+)
+def test_invalid_source_policy_or_observation_is_rejected(
+    factory: object,
+    message: str,
+) -> None:
+    assert callable(factory)
+    with pytest.raises(ValueError, match=message):
+        factory()
+
+
+def test_cli_invalid_datetime_and_invalid_json_return_two(tmp_path: Path) -> None:
+    observations_path = tmp_path / "observations.json"
+    observations_path.write_text("not-json", encoding="utf-8")
+    output = tmp_path / "error.json"
+
+    invalid_json = main(
+        [
+            "assess",
+            str(_repository_catalog_path()),
+            str(observations_path),
+            "--at",
+            NOW.isoformat(),
+            "--output",
+            str(output),
+        ]
+    )
+    invalid_time = main(
+        [
+            "assess",
+            str(_repository_catalog_path()),
+            str(observations_path),
+            "--at",
+            "not-a-time",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert invalid_json == 2
+    assert invalid_time == 2
+    assert json.loads(output.read_text(encoding="utf-8"))["status"] == "INVALID"
+
+
+def test_assessment_type_is_stable() -> None:
+    assessment = OfficialSourceCoverageAuthority().assess(
+        catalog=_single_topic_catalog(),
+        observations=(
+            _observation(
+                "official.example.market",
+                frozenset({CoverageTopic.GRAIN_MARKET_PRICES}),
+            ),
+        ),
+        now=NOW,
+    )
+    assert isinstance(assessment, CoverageAssessment)


### PR DESCRIPTION
## Что изменено

- добавлен machine-readable catalog официальных источников российского АПК;
- введена taxonomy из 8 критических тем;
- зарегистрированы entrypoints Минсельхоза/Open Data, Росстата, ЕЭК, Минтранса и Банка России;
- agronomy topic намеренно остаётся без источника и обязан давать `GAP`;
- добавлен deterministic coverage/freshness evaluator со статусами `COVERED`, `STALE`, `GAP`, `UNOBSERVED`;
- coverage считается только по фактическим успешным observations, а не по наличию URL;
- добавлен append-only PostgreSQL authority для observations и assessment snapshots;
- добавлен CLI validation/assessment с fail-closed exit code `2`;
- добавлена regression-матрица для stale, future, failures, duplicate, insufficient sources и exact `8750/10000` coverage;
- operational status остаётся `NOT_ATTESTED`.

## Exact-head acceptance

Exact-head: `bbd4b1e00dcee6420bffc70632e5cb9b8e37b673`.

PASS:

- TAI Foundation: Ruff, mypy, pytest, coverage;
- CI и Node CI;
- Security Scan;
- Security Quality Gate;
- Security Abuse and exact-head evidence manifest;
- Runtime Context Security Gate и exact-head runtime manifest;
- Auction, Outbox и Disputes PostgreSQL acceptance;
- Dependency Review и optional-runtime retirement gate.

Review threads: 0.

## Граница результата

Этот PR создаёт control plane и официальный стартовый catalog. Он не загружает государственные datasets, не заявляет 100% coverage и не доказывает полное знание российского АПК. Scheduled loaders, реальные observations, gold sets и экспертная проверка остаются следующими AP-14 срезами.

Part of #2772. Parent: #2726.