### PR TITLE
Refine public assistant and support mobile UX

### DIFF
--- a/apps/web/styles/platform-v7-unified-modal-fullscreen.css
+++ b/apps/web/styles/platform-v7-unified-modal-fullscreen.css
@@ -55,6 +55,91 @@
   grid-template-columns: 44px minmax(0, 1fr) 48px 48px !important;
 }
 
+/* Shared modal polish: one hierarchy, one focus treatment, no clipped service copy. */
+.pc-public-assistant-identity > div {
+  min-width: 0;
+}
+
+.pc-public-assistant-identity strong,
+.p7-support-chat-head strong {
+  text-wrap: balance;
+}
+
+.pc-public-assistant-identity span:not(.pc-public-assistant-mark) {
+  display: -webkit-box !important;
+  overflow: hidden !important;
+  max-width: min(44vw, 300px) !important;
+  white-space: normal !important;
+  text-overflow: clip !important;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.pc-public-assistant textarea:focus-visible,
+.p7-support-chat-panel input:focus-visible,
+.p7-support-chat-panel select:focus-visible,
+.p7-support-chat-panel textarea:focus-visible {
+  border-color: #15945d !important;
+  outline: none !important;
+  box-shadow: 0 0 0 2px rgba(21, 148, 93, 0.22) !important;
+}
+
+.pc-public-assistant-primary:disabled {
+  border-color: #d4e1da !important;
+  background: #dfe9e4 !important;
+  color: #6f8178 !important;
+  cursor: not-allowed !important;
+  opacity: 1 !important;
+}
+
+.pc-public-assistant-primary:not(:disabled):hover,
+.p7-support-chat-submit:not(:disabled):hover {
+  filter: brightness(1.035);
+}
+
+/* Support is a compact operational form, not a full-page questionnaire. */
+.p7-support-chat-form {
+  gap: 10px !important;
+  padding: 12px 14px max(12px, env(safe-area-inset-bottom, 0px)) !important;
+}
+
+.p7-support-chat-form label {
+  gap: 5px !important;
+}
+
+.p7-support-chat-form label > span {
+  font-size: 12px !important;
+  line-height: 1.25 !important;
+  font-weight: 760 !important;
+}
+
+.p7-support-chat-form input,
+.p7-support-chat-form select {
+  min-height: 46px !important;
+  padding-inline: 12px !important;
+  border-radius: 13px !important;
+}
+
+.p7-support-chat-form textarea {
+  min-height: 96px !important;
+  max-height: 180px !important;
+  padding: 10px 12px !important;
+  border-radius: 13px !important;
+  resize: vertical !important;
+}
+
+.p7-support-chat-consent {
+  gap: 9px !important;
+  padding: 10px 11px !important;
+  border-radius: 13px !important;
+}
+
+.p7-support-chat-submit {
+  min-height: 48px !important;
+  border-radius: 13px !important;
+  box-shadow: 0 -8px 18px rgba(239, 246, 242, 0.84) !important;
+}
+
 @media (min-width: 721px) {
   .pc-public-assistant-panel[data-pc-fullscreen='true'],
   .p7-support-chat-panel[data-pc-fullscreen='true'] {
@@ -76,6 +161,92 @@
     height: auto !important;
     min-height: min(380px, calc(var(--pc-visual-viewport-height) - 8px)) !important;
     max-height: min(68dvh, 560px, calc(var(--pc-visual-viewport-height) - 8px)) !important;
+  }
+
+  /* Initial assistant state is content-sized and intent-first, without a dead zone. */
+  .pc-public-assistant-panel:not([data-pc-fullscreen='true']):not(:has(.pc-public-assistant-answer)) {
+    min-height: 0 !important;
+  }
+
+  .pc-public-assistant-panel:not([data-pc-fullscreen='true']):not(:has(.pc-public-assistant-answer)) .pc-public-assistant-messages {
+    flex: 0 1 auto !important;
+    min-height: 0 !important;
+    max-height: 190px !important;
+    padding-bottom: 8px !important;
+  }
+
+  .pc-public-assistant-panel:not(:has(.pc-public-assistant-answer)) .pc-public-assistant-message {
+    margin-bottom: 0 !important;
+  }
+
+  .pc-public-assistant-panel:not(:has(.pc-public-assistant-answer)) .pc-public-assistant-bubble {
+    max-width: 100% !important;
+    padding: 10px 12px !important;
+    border-radius: 15px !important;
+    box-shadow: 0 4px 14px rgba(16, 46, 35, 0.045) !important;
+  }
+
+  .pc-public-assistant-panel:not(:has(.pc-public-assistant-answer)) .pc-public-assistant-bubble p {
+    font-size: 12.5px !important;
+    line-height: 1.48 !important;
+  }
+
+  .pc-public-assistant-starters {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 8px !important;
+    padding: 4px 12px 12px !important;
+    background: #eff6f2 !important;
+  }
+
+  .pc-public-assistant-starters button {
+    position: relative;
+    min-height: 50px !important;
+    justify-content: flex-start !important;
+    padding: 9px 28px 9px 11px !important;
+    border-color: #c5dbcf !important;
+    border-radius: 13px !important;
+    background: #ffffff !important;
+    color: #155f3c !important;
+    font-size: 11.5px !important;
+    line-height: 1.28 !important;
+    text-align: left !important;
+    box-shadow: 0 4px 12px rgba(16, 46, 35, 0.045);
+  }
+
+  .pc-public-assistant-starters button::after {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    color: #15945d;
+    content: '→';
+    font-size: 16px;
+    line-height: 1;
+    transform: translateY(-50%);
+  }
+
+  .pc-public-assistant-form {
+    position: sticky !important;
+    bottom: 0 !important;
+    padding: 9px 12px calc(9px + env(safe-area-inset-bottom)) !important;
+    box-shadow: 0 -8px 22px rgba(239, 246, 242, 0.92);
+  }
+
+  .pc-public-assistant-form textarea {
+    min-height: 50px !important;
+    max-height: 84px !important;
+    border-radius: 13px !important;
+  }
+
+  .pc-public-assistant-form-actions {
+    gap: 7px !important;
+  }
+
+  .pc-public-assistant-primary,
+  .pc-public-assistant-secondary {
+    min-height: 44px !important;
+    border-radius: 12px !important;
+    font-size: 13px !important;
   }
 
   .pc-public-assistant-panel[data-pc-fullscreen='true'],
@@ -137,10 +308,46 @@
     min-height: 46px !important;
     flex-basis: 46px !important;
   }
+
+  .pc-public-assistant-identity strong {
+    font-size: 14px !important;
+  }
+
+  .pc-public-assistant-identity span:not(.pc-public-assistant-mark) {
+    display: -webkit-box !important;
+    max-width: 44vw !important;
+    font-size: 9.5px !important;
+    line-height: 1.2 !important;
+  }
+
+  .pc-public-assistant-starters {
+    gap: 6px !important;
+  }
+
+  .pc-public-assistant-starters button {
+    min-height: 48px !important;
+    padding: 8px 24px 8px 9px !important;
+    font-size: 10.5px !important;
+  }
+}
+
+@media (max-width: 350px) {
+  .pc-public-assistant-starters {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+
+  .pc-public-assistant-identity span:not(.pc-public-assistant-mark) {
+    display: none !important;
+  }
 }
 
 @media (forced-colors: active) {
   .pc-modal-sheet-fullscreen-button {
     border: 2px solid ButtonText;
+  }
+
+  .pc-public-assistant-starters button {
+    border: 1px solid ButtonText !important;
+    box-shadow: none !important;
   }
 }

--- a/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
+++ b/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
@@ -6,7 +6,7 @@ test.describe('unified public modal sheet fullscreen control', () => {
     await page.goto('/platform-v7?lang=ru', { waitUntil: 'load' });
   });
 
-  test('platform assistant expands to the visual viewport and restores compact mode', async ({ page }) => {
+  test('platform assistant opens as a compact intent-first sheet and preserves fullscreen', async ({ page }) => {
     await page.locator('.pc-public-assistant-shortcut').click();
 
     const dialog = page.getByRole('dialog', { name: 'Помощник по платформе' });
@@ -15,10 +15,25 @@ test.describe('unified public modal sheet fullscreen control', () => {
     await expect(expand).toBeVisible();
     await expect(dialog).toHaveAttribute('data-pc-fullscreen', 'false');
 
+    const starters = dialog.locator('.pc-public-assistant-starters button');
+    await expect(starters.first()).toBeVisible();
+    expect(await starters.count()).toBeGreaterThanOrEqual(3);
+
+    const subtitle = dialog.locator('.pc-public-assistant-identity span:not(.pc-public-assistant-mark)');
+    await expect(subtitle).toBeVisible();
+    await expect(subtitle).toHaveCSS('white-space', 'normal');
+
     const compact = await dialog.boundingBox();
     expect(compact).not.toBeNull();
-    expect(compact!.height).toBeGreaterThanOrEqual(360);
-    expect(compact!.height).toBeLessThanOrEqual(480);
+    expect(compact!.height).toBeGreaterThanOrEqual(300);
+    expect(compact!.height).toBeLessThanOrEqual(570);
+
+    const composer = dialog.locator('.pc-public-assistant-form');
+    const input = composer.locator('textarea');
+    const send = composer.locator('.pc-public-assistant-primary');
+    await expect(input).toBeVisible();
+    await expect(send).toBeDisabled();
+    await expect(send).toHaveCSS('cursor', 'not-allowed');
 
     await expand.click();
     await expect(dialog).toHaveAttribute('data-pc-fullscreen', 'true');
@@ -36,13 +51,29 @@ test.describe('unified public modal sheet fullscreen control', () => {
     await expect(dialog).toHaveAttribute('data-pc-fullscreen', 'false');
   });
 
-  test('support uses the same fullscreen control without changing its short title', async ({ page }) => {
+  test('support is compact, has one focus ring and uses the same fullscreen control', async ({ page }) => {
     await page.locator('.p7-support-chat-button').click();
 
     const dialog = page.getByRole('dialog', { name: 'Поддержка' });
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText('Поддержка', { exact: true })).toBeVisible();
     await expect(dialog.getByText('Поддержка Прозрачной Цены', { exact: true })).toHaveCount(0);
+
+    const topic = dialog.locator('select');
+    const name = dialog.locator('input[autocomplete="name"]');
+    const question = dialog.locator('textarea');
+    await topic.focus();
+    await expect(topic).toHaveCSS('outline-style', 'none');
+    await expect(topic).toHaveCSS('border-color', 'rgb(21, 148, 93)');
+
+    const nameBox = await name.boundingBox();
+    const questionBox = await question.boundingBox();
+    expect(nameBox).not.toBeNull();
+    expect(questionBox).not.toBeNull();
+    expect(nameBox!.height).toBeGreaterThanOrEqual(44);
+    expect(nameBox!.height).toBeLessThanOrEqual(54);
+    expect(questionBox!.height).toBeGreaterThanOrEqual(88);
+    expect(questionBox!.height).toBeLessThanOrEqual(130);
 
     await dialog.getByRole('button', { name: 'На весь экран' }).click();
     await expect(dialog).toHaveAttribute('data-pc-fullscreen', 'true');

--- a/apps/web/tests/unit/platformV7PublicAssistantSupportUx.test.ts
+++ b/apps/web/tests/unit/platformV7PublicAssistantSupportUx.test.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const read = (relative: string) => fs.readFileSync(path.join(root, relative), 'utf8');
+
+const assistant = read('apps/web/components/platform-v7/PublicPlatformAssistant.tsx');
+const support = read('apps/web/components/platform-v7/ChatSupportWidget.tsx');
+const modalCss = read('apps/web/styles/platform-v7-unified-modal-fullscreen.css');
+
+describe('platform-v7 public assistant and support UX', () => {
+  it('preserves the verified public assistant and support boundaries', () => {
+    expect(assistant).toContain("data-public-platform-assistant='true'");
+    expect(assistant).toContain("fetch('/api/public-platform-assistant'");
+    expect(assistant).toContain("dataMode: 'public_knowledge'");
+    expect(support).toContain("fetch('/api/platform-v7/inquiries'");
+    expect(support).toContain("consent: consent ? 'yes' : 'no'");
+  });
+
+  it('shows starter intents on mobile instead of leaving an empty chat region', () => {
+    expect(assistant).toContain("className='pc-public-assistant-starters'");
+    expect(modalCss).toContain('.pc-public-assistant-starters {');
+    expect(modalCss).toContain('display: grid !important');
+    expect(modalCss).toContain('grid-template-columns: repeat(2, minmax(0, 1fr)) !important');
+    expect(modalCss).toContain(":not(:has(.pc-public-assistant-answer)) .pc-public-assistant-messages");
+    expect(modalCss).toContain('max-height: 190px !important');
+  });
+
+  it('keeps the composer fixed, compact and explicit in disabled state', () => {
+    expect(modalCss).toContain('.pc-public-assistant-form {');
+    expect(modalCss).toContain('position: sticky !important');
+    expect(modalCss).toContain('min-height: 50px !important');
+    expect(modalCss).toContain('.pc-public-assistant-primary:disabled');
+    expect(modalCss).toContain('opacity: 1 !important');
+  });
+
+  it('uses a single focus ring instead of a doubled outline and glow', () => {
+    expect(modalCss).toContain('.p7-support-chat-panel select:focus-visible');
+    expect(modalCss).toContain('outline: none !important');
+    expect(modalCss).toContain('box-shadow: 0 0 0 2px rgba(21, 148, 93, 0.22) !important');
+  });
+
+  it('keeps the support form compact while retaining accessible controls', () => {
+    expect(modalCss).toContain('.p7-support-chat-form {');
+    expect(modalCss).toContain('gap: 10px !important');
+    expect(modalCss).toContain('min-height: 46px !important');
+    expect(modalCss).toContain('min-height: 96px !important');
+    expect(modalCss).toContain('.p7-support-chat-submit {');
+    expect(modalCss).toContain('min-height: 48px !important');
+  });
+
+  it('keeps subtitles readable instead of clipping them with an ellipsis', () => {
+    expect(modalCss).toContain('.pc-public-assistant-identity span:not(.pc-public-assistant-mark)');
+    expect(modalCss).toContain('white-space: normal !important');
+    expect(modalCss).toContain('-webkit-line-clamp: 2');
+  });
+
+  it('preserves forced-colors and small-screen fallbacks', () => {
+    expect(modalCss).toContain('@media (max-width: 350px)');
+    expect(modalCss).toContain('@media (forced-colors: active)');
+    expect(modalCss).toContain('border: 1px solid ButtonText !important');
+  });
+});

--- a/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
+++ b/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
@@ -1,7 +1,7 @@
 {
   "branch": "feat/assistant-universal-understanding",
   "status": "active",
-  "purpose": "Broad multilingual assistant understanding with verified prospect knowledge, production transport resilience, mobile viewport hardening, safe unanswered-question handling, a shared fullscreen modal-sheet control and a unified public contact dock for the public assistant, support and an explicit user-initiated phone call.",
+  "purpose": "Broad multilingual assistant understanding with verified prospect knowledge, production transport resilience, mobile viewport hardening, safe unanswered-question handling, a shared fullscreen modal-sheet control, a unified public contact dock and a compact intent-first mobile UX for the public assistant and support form.",
   "approvedBy": "independent-authority-pr",
   "allowedPaths": [
     "apps/api/src/modules/ai-insights/ai-assistant.service.ts",
@@ -20,6 +20,7 @@
     "apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts",
     "apps/web/tests/unit/platformV7AssistantQuestionUnderstanding.test.ts",
     "apps/web/tests/unit/platformV7ProspectAssistantKnowledge.test.ts",
+    "apps/web/tests/unit/platformV7PublicAssistantSupportUx.test.ts",
     "apps/web/tests/unit/platformV7PublicAssistantTransportResilience.test.ts",
     "apps/web/tests/unit/platformV7UnifiedPublicContactDock.test.ts",
     "docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json"


### PR DESCRIPTION
## Что изменено
- начальное окно публичного помощника стало intent-first: быстрые сценарии снова видимы на мобильных;
- убрана большая пустая зона до появления ответа;
- приветствие, composer и disabled-состояние кнопки сделаны компактнее и яснее;
- длинный подзаголовок помощника больше не обрезается в одну строку;
- focus-состояния помощника и поддержки сведены к одной аккуратной рамке без двойного зелёного контура;
- форма поддержки стала плотнее: меньше вертикальные интервалы, поля и textarea, при сохранении touch-targets;
- сохранены full-screen режим, safe-area, RU/EN/ZH, forced-colors и reduced-motion;
- добавлена отдельная unit-регрессия UX-контрактов.

## Граница изменения
Нет доступа к данным Сделок, новых write-команд, внешних моделей, изменений API или логики отправки обращений. Изменяется только UX публичных окон.