### PR TITLE
TAI AP-14B.3: controlled live official-source evidence

### DIFF
--- a/.github/workflows/tai-live-source-evidence.yml
+++ b/.github/workflows/tai-live-source-evidence.yml
@@ -53,6 +53,7 @@ jobs:
         shell: bash
         run: |
           set +e
+          mkdir -p live-evidence
           python -m tai.live_source_evidence_cli \
             knowledge-sources/official-sources.v1.json \
             --repository-sha "$GITHUB_SHA" \

--- a/.github/workflows/tai-live-source-evidence.yml
+++ b/.github/workflows/tai-live-source-evidence.yml
@@ -1,0 +1,85 @@
+name: TAI Live Official Source Evidence
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '23 4 * * 2'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tai-live-official-source-evidence
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: apps/tai
+    steps:
+      - name: Checkout exact main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Verify exact checked-out revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$GITHUB_REF" = 'refs/heads/main'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: apps/tai/pyproject.toml
+
+      - name: Install TAI runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Collect governed live-source evidence
+        id: collect
+        shell: bash
+        run: |
+          set +e
+          python -m tai.live_source_evidence_cli \
+            knowledge-sources/official-sources.v1.json \
+            --repository-sha "$GITHUB_SHA" \
+            --output-dir live-evidence \
+            --timeout-seconds 20 \
+            > live-evidence/collector-output.json 2>&1
+          status=$?
+          echo "$status" > live-evidence/collector-exit-code.txt
+          cat live-evidence/collector-output.json
+          exit 0
+
+      - name: Upload exact-main live evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tai-live-official-source-${{ github.sha }}-${{ github.run_id }}
+          path: apps/tai/live-evidence
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce collector structural validity
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f live-evidence/collector-exit-code.txt
+          test "$(cat live-evidence/collector-exit-code.txt)" = '0'
+          test -f live-evidence/live-run-manifest.json
+          test -f live-evidence/source-observations.v1.json
+          test -f live-evidence/coverage-assessment.json

--- a/apps/tai/tai/live_source_evidence.py
+++ b/apps/tai/tai/live_source_evidence.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Callable
+
+from tai.managed_loader import FetchDisposition, FetchRequest, SourceFetcher
+from tai.official_source_fetcher import OfficialFetchPolicy, OfficialSourceHTTPFetcher
+from tai.official_source_observation import (
+    OfficialObservationDefinition,
+    definitions_from_catalog,
+)
+from tai.source_coverage import (
+    CoverageAssessment,
+    OfficialSourceCatalog,
+    OfficialSourceCoverageAuthority,
+    SourceObservation,
+    assessment_payload,
+    catalog_canonical_json,
+)
+
+_GIT_OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+
+
+class LiveCollectionStatus(StrEnum):
+    COMPLETE = "COMPLETE"
+    PARTIAL = "PARTIAL"
+    FAILED = "FAILED"
+
+
+class LiveSourceResultStatus(StrEnum):
+    OBSERVED = "OBSERVED"
+    FAILED = "FAILED"
+
+
+@dataclass(frozen=True, slots=True)
+class LiveSourceResult:
+    source_id: str
+    status: LiveSourceResultStatus
+    started_at: datetime
+    completed_at: datetime
+    reason: str
+    observation: SourceObservation | None
+
+    def __post_init__(self) -> None:
+        if not self.source_id.strip():
+            raise ValueError("live source result source_id must not be blank")
+        _aware(self.started_at, "started_at")
+        _aware(self.completed_at, "completed_at")
+        if self.completed_at < self.started_at:
+            raise ValueError("live source result completed_at precedes started_at")
+        if not self.reason.strip():
+            raise ValueError("live source result reason must not be blank")
+        if self.status is LiveSourceResultStatus.OBSERVED and self.observation is None:
+            raise ValueError("observed live source result requires an observation")
+        if self.status is LiveSourceResultStatus.FAILED and self.observation is not None:
+            raise ValueError("failed live source result cannot carry an observation")
+        if self.observation is not None and self.observation.source_id != self.source_id:
+            raise ValueError("live result observation source_id mismatch")
+
+
+@dataclass(frozen=True, slots=True)
+class LiveEvidenceBundle:
+    repository_sha: str
+    catalog_sha256: str
+    started_at: datetime
+    completed_at: datetime
+    status: LiveCollectionStatus
+    source_results: tuple[LiveSourceResult, ...]
+    assessment: CoverageAssessment
+
+    def __post_init__(self) -> None:
+        if _GIT_OBJECT_ID.fullmatch(self.repository_sha) is None:
+            raise ValueError("repository_sha must be a lowercase Git object id")
+        _sha256(self.catalog_sha256, "catalog_sha256")
+        _aware(self.started_at, "started_at")
+        _aware(self.completed_at, "completed_at")
+        if self.completed_at < self.started_at:
+            raise ValueError("live evidence completed_at precedes started_at")
+        if not self.source_results:
+            raise ValueError("live evidence source_results must not be empty")
+        source_ids = tuple(result.source_id for result in self.source_results)
+        if len(source_ids) != len(set(source_ids)):
+            raise ValueError("live evidence source ids must be unique")
+        observed_count = sum(
+            result.status is LiveSourceResultStatus.OBSERVED
+            for result in self.source_results
+        )
+        expected_status = (
+            LiveCollectionStatus.FAILED
+            if observed_count == 0
+            else LiveCollectionStatus.COMPLETE
+            if observed_count == len(self.source_results)
+            else LiveCollectionStatus.PARTIAL
+        )
+        if self.status is not expected_status:
+            raise ValueError("live evidence collection status is inconsistent")
+
+    @property
+    def observations(self) -> tuple[SourceObservation, ...]:
+        return tuple(
+            result.observation
+            for result in self.source_results
+            if result.observation is not None
+        )
+
+
+class LiveSourceEvidenceCollector:
+    def __init__(
+        self,
+        *,
+        catalog: OfficialSourceCatalog,
+        definitions: tuple[OfficialObservationDefinition, ...],
+        repository_sha: str,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        if _GIT_OBJECT_ID.fullmatch(repository_sha) is None:
+            raise ValueError("repository_sha must be a lowercase Git object id")
+        if not definitions:
+            raise ValueError("live evidence definitions must not be empty")
+        catalog_source_ids = tuple(source.source_id for source in catalog.sources)
+        definition_source_ids = tuple(
+            definition.source.source_id for definition in definitions
+        )
+        if definition_source_ids != catalog_source_ids:
+            raise ValueError(
+                "live evidence definitions must match catalog source order exactly"
+            )
+        self._catalog = catalog
+        self._definitions = definitions
+        self._repository_sha = repository_sha
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    def collect(self) -> LiveEvidenceBundle:
+        started_at = self._now()
+        results = tuple(self._collect_one(definition) for definition in self._definitions)
+        completed_at = self._now()
+        observations = tuple(
+            result.observation for result in results if result.observation is not None
+        )
+        assessment = OfficialSourceCoverageAuthority().assess(
+            catalog=self._catalog,
+            observations=observations,
+            now=completed_at,
+        )
+        observed_count = len(observations)
+        status = (
+            LiveCollectionStatus.FAILED
+            if observed_count == 0
+            else LiveCollectionStatus.COMPLETE
+            if observed_count == len(results)
+            else LiveCollectionStatus.PARTIAL
+        )
+        canonical_catalog = catalog_canonical_json(self._catalog)
+        return LiveEvidenceBundle(
+            repository_sha=self._repository_sha,
+            catalog_sha256=hashlib.sha256(
+                canonical_catalog.encode("utf-8")
+            ).hexdigest(),
+            started_at=started_at,
+            completed_at=completed_at,
+            status=status,
+            source_results=results,
+            assessment=assessment,
+        )
+
+    def _collect_one(
+        self,
+        definition: OfficialObservationDefinition,
+    ) -> LiveSourceResult:
+        started_at = self._now()
+        response = definition.fetcher.fetch(
+            FetchRequest(
+                source_id=definition.source.source_id,
+                source_uri=definition.source.entrypoint_uri,
+            )
+        )
+        completed_at = response.fetched_at
+        _aware(completed_at, "fetched_at")
+        if response.disposition is not FetchDisposition.FETCHED:
+            reason = response.error_code or (
+                "source_not_modified_without_live_baseline"
+                if response.disposition is FetchDisposition.NOT_MODIFIED
+                else "live_source_fetch_failed"
+            )
+            return LiveSourceResult(
+                source_id=definition.source.source_id,
+                status=LiveSourceResultStatus.FAILED,
+                started_at=started_at,
+                completed_at=completed_at,
+                reason=reason,
+                observation=None,
+            )
+        if response.body is None:
+            return LiveSourceResult(
+                source_id=definition.source.source_id,
+                status=LiveSourceResultStatus.FAILED,
+                started_at=started_at,
+                completed_at=completed_at,
+                reason="live_source_fetched_body_missing",
+                observation=None,
+            )
+        try:
+            metadata = definition.adapter.parse(
+                source=definition.source,
+                body=response.body,
+                fetched_at=completed_at,
+            )
+        except ValueError as error:
+            return LiveSourceResult(
+                source_id=definition.source.source_id,
+                status=LiveSourceResultStatus.FAILED,
+                started_at=started_at,
+                completed_at=completed_at,
+                reason=str(error) or "live_source_metadata_invalid",
+                observation=None,
+            )
+        observation = SourceObservation(
+            source_id=definition.source.source_id,
+            observed_at=completed_at,
+            latest_publication_at=metadata.latest_publication_at,
+            last_success_at=completed_at,
+            document_count=metadata.document_count,
+            consecutive_failures=0,
+            observed_topics=metadata.observed_topics,
+            content_sha256=hashlib.sha256(response.body.encode("utf-8")).hexdigest(),
+        )
+        return LiveSourceResult(
+            source_id=definition.source.source_id,
+            status=LiveSourceResultStatus.OBSERVED,
+            started_at=started_at,
+            completed_at=completed_at,
+            reason="official_source_observed",
+            observation=observation,
+        )
+
+    def _now(self) -> datetime:
+        value = self._clock()
+        _aware(value, "clock value")
+        return value
+
+
+def live_definitions(
+    *,
+    catalog: OfficialSourceCatalog,
+    timeout_seconds: float,
+) -> tuple[OfficialObservationDefinition, ...]:
+    fetchers: dict[str, SourceFetcher] = {}
+    for source in catalog.sources:
+        fetchers[source.source_id] = OfficialSourceHTTPFetcher(
+            policy=OfficialFetchPolicy(
+                allowed_hosts=source.allowed_hosts,
+                timeout_seconds=timeout_seconds,
+            )
+        )
+    return definitions_from_catalog(catalog=catalog, fetchers=fetchers)
+
+
+def run_manifest_payload(bundle: LiveEvidenceBundle) -> dict[str, object]:
+    results: list[dict[str, object]] = []
+    for result in bundle.source_results:
+        result_payload: dict[str, object] = {
+            "completed_at": result.completed_at.isoformat(),
+            "reason": result.reason,
+            "source_id": result.source_id,
+            "started_at": result.started_at.isoformat(),
+            "status": result.status.value,
+        }
+        if result.observation is not None:
+            result_payload["content_sha256"] = result.observation.content_sha256
+            result_payload["observation_sha256"] = (
+                result.observation.observation_sha256
+            )
+        results.append(result_payload)
+    return {
+        "all_critical_covered": bundle.assessment.all_critical_covered,
+        "catalog_sha256": bundle.catalog_sha256,
+        "completed_at": bundle.completed_at.isoformat(),
+        "coverage_basis_points": bundle.assessment.coverage_basis_points,
+        "critical_coverage_basis_points": (
+            bundle.assessment.critical_coverage_basis_points
+        ),
+        "observed_source_count": len(bundle.observations),
+        "repository_sha": bundle.repository_sha,
+        "schema_version": "tai.live-official-source-run.v1",
+        "source_count": len(bundle.source_results),
+        "source_results": results,
+        "started_at": bundle.started_at.isoformat(),
+        "status": bundle.status.value,
+    }
+
+
+def observations_payload(bundle: LiveEvidenceBundle) -> dict[str, object]:
+    observations = []
+    for observation in bundle.observations:
+        observations.append(
+            {
+                "consecutive_failures": observation.consecutive_failures,
+                "content_sha256": observation.content_sha256,
+                "document_count": observation.document_count,
+                "last_success_at": observation.last_success_at.isoformat(),
+                "latest_publication_at": observation.latest_publication_at.isoformat(),
+                "observed_at": observation.observed_at.isoformat(),
+                "observed_topics": sorted(
+                    topic.value for topic in observation.observed_topics
+                ),
+                "source_id": observation.source_id,
+            }
+        )
+    return {
+        "observations": observations,
+        "schema_version": "tai.source-observations.v1",
+    }
+
+
+def coverage_payload(bundle: LiveEvidenceBundle) -> dict[str, object]:
+    return assessment_payload(bundle.assessment)
+
+
+def evidence_bundle_sha256(bundle: LiveEvidenceBundle) -> str:
+    payload = {
+        "assessment": coverage_payload(bundle),
+        "manifest": run_manifest_payload(bundle),
+        "observations": observations_payload(bundle),
+    }
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _aware(value: datetime, name: str) -> None:
+    if value.utcoffset() is None:
+        raise ValueError(f"{name} must be timezone-aware")
+
+
+def _sha256(value: str, name: str) -> None:
+    if re.fullmatch(r"[0-9a-f]{64}", value) is None:
+        raise ValueError(f"{name} must be lowercase SHA-256")

--- a/apps/tai/tai/live_source_evidence.py
+++ b/apps/tai/tai/live_source_evidence.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Callable
 
 from tai.managed_loader import FetchDisposition, FetchRequest, SourceFetcher
 from tai.official_source_fetcher import OfficialFetchPolicy, OfficialSourceHTTPFetcher

--- a/apps/tai/tai/live_source_evidence_cli.py
+++ b/apps/tai/tai/live_source_evidence_cli.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from tai.live_source_evidence import (
+    LiveSourceEvidenceCollector,
+    coverage_payload,
+    evidence_bundle_sha256,
+    live_definitions,
+    observations_payload,
+    run_manifest_payload,
+)
+from tai.source_coverage import load_official_source_catalog
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tai-live-source-evidence",
+        description=(
+            "Collect controlled read-only evidence from governed official sources."
+        ),
+    )
+    parser.add_argument("catalog", type=Path)
+    parser.add_argument("--repository-sha", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    arguments = parser.parse_args(argv)
+
+    try:
+        if not 1.0 <= arguments.timeout_seconds <= 60.0:
+            raise ValueError("--timeout-seconds must be between 1 and 60")
+        catalog = load_official_source_catalog(arguments.catalog)
+        definitions = live_definitions(
+            catalog=catalog,
+            timeout_seconds=arguments.timeout_seconds,
+        )
+        bundle = LiveSourceEvidenceCollector(
+            catalog=catalog,
+            definitions=definitions,
+            repository_sha=arguments.repository_sha,
+        ).collect()
+        output_dir: Path = arguments.output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+        manifest = run_manifest_payload(bundle)
+        manifest["evidence_bundle_sha256"] = evidence_bundle_sha256(bundle)
+        _write_json(output_dir / "live-run-manifest.json", manifest)
+        _write_json(
+            output_dir / "source-observations.v1.json",
+            observations_payload(bundle),
+        )
+        _write_json(
+            output_dir / "coverage-assessment.json",
+            coverage_payload(bundle),
+        )
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "all_critical_covered": bundle.assessment.all_critical_covered,
+                    "evidence_bundle_sha256": manifest["evidence_bundle_sha256"],
+                    "observed_source_count": len(bundle.observations),
+                    "status": bundle.status.value,
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        return 0
+    except (OSError, ValueError) as error:
+        output_dir = arguments.output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+        _write_json(
+            output_dir / "collector-error.json",
+            {
+                "error": str(error),
+                "repository_sha": arguments.repository_sha,
+                "schema_version": "tai.live-official-source-error.v1",
+                "status": "INVALID",
+            },
+        )
+        return 2
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/tai/tests/test_live_source_evidence.py
+++ b/apps/tai/tests/test_live_source_evidence.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tai.live_source_evidence import (
+    LiveCollectionStatus,
+    LiveEvidenceBundle,
+    LiveSourceEvidenceCollector,
+    LiveSourceResult,
+    LiveSourceResultStatus,
+    coverage_payload,
+    evidence_bundle_sha256,
+    observations_payload,
+    run_manifest_payload,
+)
+from tai.managed_loader import FetchDisposition, FetchRequest, FetchResponse
+from tai.official_source_observation import (
+    OfficialObservationDefinition,
+    default_html_metadata_adapters,
+)
+from tai.source_coverage import (
+    CoverageRequirement,
+    CoverageTopic,
+    OfficialSourceCatalog,
+    OfficialSourceDefinition,
+    SourceFormat,
+)
+
+NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+REPOSITORY_SHA = "a" * 40
+
+
+class _Fetcher:
+    def __init__(self, response: FetchResponse) -> None:
+        self.response = response
+        self.requests: list[FetchRequest] = []
+
+    def fetch(self, request: FetchRequest) -> FetchResponse:
+        self.requests.append(request)
+        return self.response
+
+
+class _Clock:
+    def __init__(self, values: tuple[datetime, ...]) -> None:
+        self.values = deque(values)
+
+    def __call__(self) -> datetime:
+        return self.values.popleft()
+
+
+def _source(
+    source_id: str,
+    topic: CoverageTopic,
+    uri: str,
+    host: str,
+) -> OfficialSourceDefinition:
+    return OfficialSourceDefinition(
+        source_id=source_id,
+        owner="Official Authority",
+        entrypoint_uri=uri,
+        allowed_hosts=frozenset({host}),
+        topics=frozenset({topic}),
+        formats=frozenset({SourceFormat.HTML}),
+        expected_update_interval=timedelta(days=7),
+        maximum_publication_age=timedelta(days=31),
+        verified_at=NOW - timedelta(days=1),
+    )
+
+
+def _catalog() -> OfficialSourceCatalog:
+    return OfficialSourceCatalog(
+        sources=(
+            _source(
+                "official.cbr.key-rate",
+                CoverageTopic.FINANCE_RATES,
+                "https://www.cbr.ru/hd_base/KeyRate/",
+                "www.cbr.ru",
+            ),
+            _source(
+                "official.mcx.opendata",
+                CoverageTopic.GRAIN_TRACEABILITY,
+                "https://opendata.mcx.ru/",
+                "opendata.mcx.ru",
+            ),
+        ),
+        requirements=(
+            CoverageRequirement(
+                topic=CoverageTopic.FINANCE_RATES,
+                minimum_official_sources=1,
+                maximum_publication_age=timedelta(days=31),
+            ),
+            CoverageRequirement(
+                topic=CoverageTopic.GRAIN_TRACEABILITY,
+                minimum_official_sources=1,
+                maximum_publication_age=timedelta(days=31),
+            ),
+        ),
+    )
+
+
+def _definition(
+    source: OfficialSourceDefinition,
+    response: FetchResponse,
+) -> tuple[OfficialObservationDefinition, _Fetcher]:
+    adapter = next(
+        item
+        for item in default_html_metadata_adapters()
+        if item.source_id == source.source_id
+    )
+    fetcher = _Fetcher(response)
+    return (
+        OfficialObservationDefinition(
+            source=source,
+            adapter=adapter,
+            fetcher=fetcher,
+        ),
+        fetcher,
+    )
+
+
+def _success(source_id: str) -> FetchResponse:
+    body = (
+        "<h1>Ключевая ставка</h1><time>18.07.2026</time>"
+        if source_id == "official.cbr.key-rate"
+        else (
+            "<h1>Открытые данные по зерну</h1><time>18.07.2026</time>"
+            "<a href='/grain.csv'>CSV</a>"
+        )
+    )
+    return FetchResponse(
+        disposition=FetchDisposition.FETCHED,
+        body=body,
+        fetched_at=NOW,
+    )
+
+
+def _collector(
+    responses: tuple[FetchResponse, FetchResponse],
+) -> tuple[LiveSourceEvidenceCollector, tuple[_Fetcher, _Fetcher]]:
+    catalog = _catalog()
+    first, first_fetcher = _definition(catalog.sources[0], responses[0])
+    second, second_fetcher = _definition(catalog.sources[1], responses[1])
+    clock = _Clock(
+        (
+            NOW - timedelta(seconds=3),
+            NOW - timedelta(seconds=2),
+            NOW - timedelta(seconds=1),
+            NOW,
+        )
+    )
+    return (
+        LiveSourceEvidenceCollector(
+            catalog=catalog,
+            definitions=(first, second),
+            repository_sha=REPOSITORY_SHA,
+            clock=clock,
+        ),
+        (first_fetcher, second_fetcher),
+    )
+
+
+def test_complete_collection_produces_observations_assessment_and_digest() -> None:
+    collector, fetchers = _collector(
+        (
+            _success("official.cbr.key-rate"),
+            _success("official.mcx.opendata"),
+        )
+    )
+
+    bundle = collector.collect()
+
+    assert bundle.status is LiveCollectionStatus.COMPLETE
+    assert len(bundle.observations) == 2
+    assert bundle.assessment.all_critical_covered is True
+    assert bundle.assessment.coverage_basis_points == 10000
+    assert [request.source_id for request in fetchers[0].requests] == [
+        "official.cbr.key-rate"
+    ]
+    assert [request.source_id for request in fetchers[1].requests] == [
+        "official.mcx.opendata"
+    ]
+    manifest = run_manifest_payload(bundle)
+    observations = observations_payload(bundle)
+    assessment = coverage_payload(bundle)
+    assert manifest["status"] == "COMPLETE"
+    assert manifest["repository_sha"] == REPOSITORY_SHA
+    assert manifest["observed_source_count"] == 2
+    assert len(observations["observations"]) == 2
+    assert assessment["all_critical_covered"] is True
+    assert len(evidence_bundle_sha256(bundle)) == 64
+    assert evidence_bundle_sha256(bundle) == evidence_bundle_sha256(bundle)
+
+
+def test_partial_collection_keeps_failed_topic_unobserved() -> None:
+    failure = FetchResponse(
+        disposition=FetchDisposition.RETRYABLE_FAILURE,
+        body=None,
+        fetched_at=NOW,
+        error_code="source_http_503",
+    )
+    collector, _ = _collector((_success("official.cbr.key-rate"), failure))
+
+    bundle = collector.collect()
+
+    assert bundle.status is LiveCollectionStatus.PARTIAL
+    assert len(bundle.observations) == 1
+    assert bundle.assessment.all_critical_covered is False
+    assert bundle.assessment.coverage_basis_points == 5000
+    assert bundle.source_results[1].status is LiveSourceResultStatus.FAILED
+    assert bundle.source_results[1].reason == "source_http_503"
+    topic_payloads = {
+        item["topic"]: item for item in coverage_payload(bundle)["topics"]
+    }
+    assert topic_payloads["GRAIN_TRACEABILITY"]["status"] == "UNOBSERVED"
+
+
+def test_all_failed_collection_is_failed_without_fake_observations() -> None:
+    failure = FetchResponse(
+        disposition=FetchDisposition.PERMANENT_FAILURE,
+        body=None,
+        fetched_at=NOW,
+        error_code="source_content_prompt_injection_detected",
+    )
+    not_modified = FetchResponse(
+        disposition=FetchDisposition.NOT_MODIFIED,
+        body=None,
+        fetched_at=NOW,
+    )
+    collector, _ = _collector((failure, not_modified))
+
+    bundle = collector.collect()
+
+    assert bundle.status is LiveCollectionStatus.FAILED
+    assert bundle.observations == ()
+    assert bundle.assessment.coverage_basis_points == 0
+    assert bundle.source_results[0].reason == (
+        "source_content_prompt_injection_detected"
+    )
+    assert bundle.source_results[1].reason == (
+        "source_not_modified_without_live_baseline"
+    )
+
+
+def test_metadata_failure_is_recorded_per_source_not_raised_as_success() -> None:
+    malformed = FetchResponse(
+        disposition=FetchDisposition.FETCHED,
+        body="<html>no governed marker 18.07.2026</html>",
+        fetched_at=NOW,
+    )
+    collector, _ = _collector((malformed, _success("official.mcx.opendata")))
+
+    bundle = collector.collect()
+
+    assert bundle.status is LiveCollectionStatus.PARTIAL
+    assert bundle.source_results[0].status is LiveSourceResultStatus.FAILED
+    assert bundle.source_results[0].reason == "source_required_marker_missing"
+    assert len(bundle.observations) == 1
+
+
+def test_collector_requires_exact_catalog_order_and_valid_repository_sha() -> None:
+    catalog = _catalog()
+    first, _ = _definition(catalog.sources[0], _success(catalog.sources[0].source_id))
+    second, _ = _definition(catalog.sources[1], _success(catalog.sources[1].source_id))
+
+    with pytest.raises(ValueError, match="source order exactly"):
+        LiveSourceEvidenceCollector(
+            catalog=catalog,
+            definitions=(second, first),
+            repository_sha=REPOSITORY_SHA,
+        )
+    with pytest.raises(ValueError, match="Git object id"):
+        LiveSourceEvidenceCollector(
+            catalog=catalog,
+            definitions=(first, second),
+            repository_sha="main",
+        )
+
+
+def test_bundle_and_result_invariants_reject_inconsistent_evidence() -> None:
+    catalog = _catalog()
+    collector, _ = _collector(
+        (
+            _success("official.cbr.key-rate"),
+            _success("official.mcx.opendata"),
+        )
+    )
+    valid = collector.collect()
+
+    with pytest.raises(ValueError, match="inconsistent"):
+        LiveEvidenceBundle(
+            repository_sha=valid.repository_sha,
+            catalog_sha256=valid.catalog_sha256,
+            started_at=valid.started_at,
+            completed_at=valid.completed_at,
+            status=LiveCollectionStatus.PARTIAL,
+            source_results=valid.source_results,
+            assessment=valid.assessment,
+        )
+    with pytest.raises(ValueError, match="requires an observation"):
+        LiveSourceResult(
+            source_id=catalog.sources[0].source_id,
+            status=LiveSourceResultStatus.OBSERVED,
+            started_at=NOW,
+            completed_at=NOW,
+            reason="invalid",
+            observation=None,
+        )

--- a/apps/tai/tests/test_live_source_evidence_cli.py
+++ b/apps/tai/tests/test_live_source_evidence_cli.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from tai import live_source_evidence_cli
+from tai.live_source_evidence import (
+    LiveCollectionStatus,
+    LiveEvidenceBundle,
+    LiveSourceResult,
+    LiveSourceResultStatus,
+)
+from tai.source_coverage import (
+    CoverageAssessment,
+    CoverageTopic,
+    TopicCoverage,
+    TopicCoverageStatus,
+)
+
+NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+REPOSITORY_SHA = "b" * 40
+
+
+class _Collector:
+    bundle: LiveEvidenceBundle
+
+    def __init__(self, **kwargs: object) -> None:
+        assert kwargs["repository_sha"] == REPOSITORY_SHA
+
+    def collect(self) -> LiveEvidenceBundle:
+        return self.bundle
+
+
+def _bundle() -> LiveEvidenceBundle:
+    assessment = CoverageAssessment(
+        generated_at=NOW,
+        coverage_basis_points=0,
+        critical_coverage_basis_points=0,
+        all_critical_covered=False,
+        topics=(
+            TopicCoverage(
+                topic=CoverageTopic.FINANCE_RATES,
+                status=TopicCoverageStatus.UNOBSERVED,
+                required_sources=1,
+                healthy_source_ids=(),
+                stale_source_ids=(),
+                reasons=("no_successful_observation",),
+            ),
+        ),
+    )
+    return LiveEvidenceBundle(
+        repository_sha=REPOSITORY_SHA,
+        catalog_sha256="c" * 64,
+        started_at=NOW - timedelta(seconds=1),
+        completed_at=NOW,
+        status=LiveCollectionStatus.FAILED,
+        source_results=(
+            LiveSourceResult(
+                source_id="official.cbr.key-rate",
+                status=LiveSourceResultStatus.FAILED,
+                started_at=NOW - timedelta(seconds=1),
+                completed_at=NOW,
+                reason="source_http_503",
+                observation=None,
+            ),
+        ),
+        assessment=assessment,
+    )
+
+
+def _read(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_cli_writes_failed_or_partial_live_result_as_valid_artifact(
+    tmp_path: Path,
+    monkeypatch: object,
+    capsys: object,
+) -> None:
+    monkeypatch.setattr(  # type: ignore[attr-defined]
+        live_source_evidence_cli,
+        "load_official_source_catalog",
+        lambda path: object(),
+    )
+    monkeypatch.setattr(  # type: ignore[attr-defined]
+        live_source_evidence_cli,
+        "live_definitions",
+        lambda **kwargs: (object(),),
+    )
+    _Collector.bundle = _bundle()
+    monkeypatch.setattr(  # type: ignore[attr-defined]
+        live_source_evidence_cli,
+        "LiveSourceEvidenceCollector",
+        _Collector,
+    )
+    output = tmp_path / "evidence"
+
+    result = live_source_evidence_cli.main(
+        [
+            str(tmp_path / "catalog.json"),
+            "--repository-sha",
+            REPOSITORY_SHA,
+            "--output-dir",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+    manifest = _read(output / "live-run-manifest.json")
+    observations = _read(output / "source-observations.v1.json")
+    coverage = _read(output / "coverage-assessment.json")
+    assert manifest["status"] == "FAILED"
+    assert len(str(manifest["evidence_bundle_sha256"])) == 64
+    assert observations["observations"] == []
+    assert coverage["all_critical_covered"] is False
+    captured = capsys.readouterr()  # type: ignore[attr-defined]
+    assert '"status": "FAILED"' in captured.out
+
+
+def test_cli_structural_error_is_nonzero_and_still_uploadable(tmp_path: Path) -> None:
+    output = tmp_path / "invalid"
+
+    result = live_source_evidence_cli.main(
+        [
+            str(tmp_path / "missing-catalog.json"),
+            "--repository-sha",
+            REPOSITORY_SHA,
+            "--output-dir",
+            str(output),
+            "--timeout-seconds",
+            "0.1",
+        ]
+    )
+
+    assert result == 2
+    error = _read(output / "collector-error.json")
+    assert error["status"] == "INVALID"
+    assert "between 1 and 60" in str(error["error"])

--- a/apps/tai/tests/test_live_source_evidence_cli.py
+++ b/apps/tai/tests/test_live_source_evidence_cli.py
@@ -5,6 +5,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from tai import live_source_evidence_cli
 from tai.live_source_evidence import (
     LiveCollectionStatus,
@@ -13,10 +15,12 @@ from tai.live_source_evidence import (
     LiveSourceResultStatus,
 )
 from tai.source_coverage import (
-    CoverageAssessment,
+    CoverageRequirement,
     CoverageTopic,
-    TopicCoverage,
-    TopicCoverageStatus,
+    OfficialSourceCatalog,
+    OfficialSourceCoverageAuthority,
+    OfficialSourceDefinition,
+    SourceFormat,
 )
 
 NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
@@ -33,22 +37,37 @@ class _Collector:
         return self.bundle
 
 
-def _bundle() -> LiveEvidenceBundle:
-    assessment = CoverageAssessment(
-        generated_at=NOW,
-        coverage_basis_points=0,
-        critical_coverage_basis_points=0,
-        all_critical_covered=False,
-        topics=(
-            TopicCoverage(
-                topic=CoverageTopic.FINANCE_RATES,
-                status=TopicCoverageStatus.UNOBSERVED,
-                required_sources=1,
-                healthy_source_ids=(),
-                stale_source_ids=(),
-                reasons=("no_successful_observation",),
+def _catalog() -> OfficialSourceCatalog:
+    return OfficialSourceCatalog(
+        sources=(
+            OfficialSourceDefinition(
+                source_id="official.cbr.key-rate",
+                owner="Банк России",
+                entrypoint_uri="https://www.cbr.ru/hd_base/KeyRate/",
+                allowed_hosts=frozenset({"www.cbr.ru"}),
+                topics=frozenset({CoverageTopic.FINANCE_RATES}),
+                formats=frozenset({SourceFormat.HTML}),
+                expected_update_interval=timedelta(days=7),
+                maximum_publication_age=timedelta(days=31),
+                verified_at=NOW - timedelta(days=1),
             ),
         ),
+        requirements=(
+            CoverageRequirement(
+                topic=CoverageTopic.FINANCE_RATES,
+                minimum_official_sources=1,
+                maximum_publication_age=timedelta(days=31),
+            ),
+        ),
+    )
+
+
+def _bundle() -> LiveEvidenceBundle:
+    catalog = _catalog()
+    assessment = OfficialSourceCoverageAuthority().assess(
+        catalog=catalog,
+        observations=(),
+        now=NOW,
     )
     return LiveEvidenceBundle(
         repository_sha=REPOSITORY_SHA,
@@ -76,23 +95,23 @@ def _read(path: Path) -> dict[str, Any]:
     return payload
 
 
-def test_cli_writes_failed_or_partial_live_result_as_valid_artifact(
+def test_cli_writes_failed_live_result_as_valid_artifact(
     tmp_path: Path,
-    monkeypatch: object,
-    capsys: object,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    monkeypatch.setattr(  # type: ignore[attr-defined]
+    monkeypatch.setattr(
         live_source_evidence_cli,
         "load_official_source_catalog",
-        lambda path: object(),
+        lambda path: _catalog(),
     )
-    monkeypatch.setattr(  # type: ignore[attr-defined]
+    monkeypatch.setattr(
         live_source_evidence_cli,
         "live_definitions",
         lambda **kwargs: (object(),),
     )
     _Collector.bundle = _bundle()
-    monkeypatch.setattr(  # type: ignore[attr-defined]
+    monkeypatch.setattr(
         live_source_evidence_cli,
         "LiveSourceEvidenceCollector",
         _Collector,
@@ -117,8 +136,7 @@ def test_cli_writes_failed_or_partial_live_result_as_valid_artifact(
     assert len(str(manifest["evidence_bundle_sha256"])) == 64
     assert observations["observations"] == []
     assert coverage["all_critical_covered"] is False
-    captured = capsys.readouterr()  # type: ignore[attr-defined]
-    assert '"status": "FAILED"' in captured.out
+    assert '"status": "FAILED"' in capsys.readouterr().out
 
 
 def test_cli_structural_error_is_nonzero_and_still_uploadable(tmp_path: Path) -> None:

--- a/apps/tai/tests/test_live_source_evidence_workflow.py
+++ b/apps/tai/tests/test_live_source_evidence_workflow.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_live_evidence_workflow_is_read_only_exact_main_and_non_merge_blocking() -> None:
+    workflow = (
+        Path(__file__).parents[3]
+        / ".github"
+        / "workflows"
+        / "tai-live-source-evidence.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "schedule:" in workflow
+    assert "pull_request:" not in workflow
+    assert "push:" not in workflow
+    assert "permissions:\n  contents: read" in workflow
+    assert "contents: write" not in workflow
+    assert "actions: write" not in workflow
+    assert "id-token: write" not in workflow
+    assert "secrets." not in workflow
+    assert "github.ref == 'refs/heads/main'" in workflow
+    assert "test \"$(git rev-parse HEAD)\" = \"$GITHUB_SHA\"" in workflow
+    assert "ref: main" in workflow
+    assert "mkdir -p live-evidence" in workflow
+    assert "--repository-sha \"$GITHUB_SHA\"" in workflow
+    assert "actions/upload-artifact@v4" in workflow
+    assert workflow.index("Upload exact-main live evidence") < workflow.index(
+        "Enforce collector structural validity"
+    )
+    assert "test -f live-evidence/live-run-manifest.json" in workflow
+    assert "continue-on-error" not in workflow


### PR DESCRIPTION
## Что изменено

- добавлен deterministic live-source evidence collector поверх governed catalog, AP-14B.1 fetcher и AP-14B.2 adapters;
- per-source результат всегда `OBSERVED` или `FAILED` с отдельной причиной;
- collection status различает `COMPLETE`, `PARTIAL`, `FAILED` и не равен coverage status;
- формируются live run manifest, `source-observations.v1`, coverage assessment и canonical bundle SHA-256;
- добавлен CLI с bounded timeout и структурным exit code;
- добавлен controlled `workflow_dispatch` + ограниченный schedule только на exact `main`;
- workflow имеет только `contents: read`, не использует secrets и не изменяет repository/database/production state;
- live network failures сохраняются как evidence, а structural invalidity остаётся красным workflow;
- CI проверяет collector только через injected fixtures, без живой сети.

## Exact-head acceptance

Exact-head: `269d9a6570ec2032d4e88aeb3d2d68aab696acfd`.

Current integration test-merge: `49716a4f00d6f641f90152854020fa50fa1d27a4` = exact-head поверх актуального base `0a25340ff2bceb9c9e273a8243396105744f52c8`.

PASS:

- TAI Foundation: Ruff, strict mypy, pytest, coverage;
- CI и Node CI;
- Security Scan;
- Security Quality Gate;
- Security Abuse and exact-head evidence manifest;
- Runtime Context Security Gate и exact-head runtime manifest;
- Auction, Outbox и Disputes PostgreSQL acceptance;
- Dependency Review и optional-runtime retirement gate.

Review threads: 0.

## Граница результата

Этот PR создаёт механизм controlled live evidence. Фактический coverage появится только после merge и отдельного exact-main workflow run с проанализированным artifact. Operational status остаётся `NOT_ATTESTED`.

Closes no issue until exact-main live artifact is verified. Part of #2782 and #2774. Parent: #2726.