### PR TITLE
TAI AP-14B.3: one-shot exact-main live evidence trigger

### DIFF
--- a/.github/tai-live-source-evidence.trigger
+++ b/.github/tai-live-source-evidence.trigger
@@ -1,0 +1,3 @@
+schema_version=tai.live-source-trigger.v1
+purpose=initial_exact_main_live_evidence
+remove_after_verified_run=true

--- a/.github/workflows/tai-live-source-evidence.yml
+++ b/.github/workflows/tai-live-source-evidence.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '23 4 * * 2'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/tai-live-source-evidence.trigger'
 
 permissions:
   contents: read

--- a/apps/tai/tests/test_live_source_evidence_workflow.py
+++ b/apps/tai/tests/test_live_source_evidence_workflow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def test_live_evidence_workflow_is_read_only_exact_main_and_non_merge_blocking() -> None:
+def test_live_evidence_workflow_is_read_only_exact_main_and_scoped() -> None:
     workflow = (
         Path(__file__).parents[3]
         / ".github"
@@ -14,7 +14,9 @@ def test_live_evidence_workflow_is_read_only_exact_main_and_non_merge_blocking()
     assert "workflow_dispatch:" in workflow
     assert "schedule:" in workflow
     assert "pull_request:" not in workflow
-    assert "push:" not in workflow
+    assert "push:" in workflow
+    assert "branches:\n      - main" in workflow
+    assert "paths:\n      - '.github/tai-live-source-evidence.trigger'" in workflow
     assert "permissions:\n  contents: read" in workflow
     assert "contents: write" not in workflow
     assert "actions: write" not in workflow


### PR DESCRIPTION
## Цель

Однократно запустить уже принятый read-only live-source workflow на exact-main без доступа к `workflow_dispatch` API.

## Изменения

- добавлен `push` trigger только для `main` и только для `.github/tai-live-source-evidence.trigger`;
- добавлен sentinel с обязательным `remove_after_verified_run=true`;
- workflow сохраняет только `contents: read`, не использует secrets и не получает write authority;
- regression запрещает широкий push trigger.

## Exact-head acceptance

Exact-head: `9844e258f49e9214f6c27d2fbf56ce4c5181f90a`.

PASS:

- TAI Foundation: Ruff, strict mypy, pytest, coverage;
- CI и Node CI;
- Security Scan;
- Security Quality Gate;
- Security Abuse and exact-head evidence manifest;
- Runtime Context Security Gate и exact-head runtime manifest;
- Auction, Outbox и Disputes PostgreSQL acceptance;
- Dependency Review и optional-runtime retirement gate.

Review threads: 0.

## Lifecycle

После merge:

1. workflow должен запуститься на merge commit;
2. artifact должен быть скачан и проанализирован;
3. scoped push trigger и sentinel должны быть удалены отдельным cleanup PR.

Operational status остаётся `NOT_ATTESTED`.

Part of #2782 and #2774.