### PR TITLE
TAI AP-14B.3: temporary exact-main evidence reporter

### DIFF
--- a/.github/tai-live-source-evidence.trigger
+++ b/.github/tai-live-source-evidence.trigger
@@ -1,3 +1,4 @@
 schema_version=tai.live-source-trigger.v1
-purpose=initial_exact_main_live_evidence
+purpose=exact_main_live_evidence_with_temporary_reporter
+sequence=2
 remove_after_verified_run=true

--- a/.github/workflows/tai-live-source-evidence-reporter.yml
+++ b/.github/workflows/tai-live-source-evidence-reporter.yml
@@ -1,0 +1,121 @@
+name: TAI Live Evidence Reporter
+
+on:
+  workflow_run:
+    workflows:
+      - TAI Live Official Source Evidence
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: tai-live-evidence-reporter-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    if: github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download exact-main live evidence
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: tai-live-official-source-*
+          merge-multiple: true
+          path: live-evidence
+
+      - name: Report exact-main evidence to issue 2782
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          SOURCE_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SOURCE_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const runId = process.env.SOURCE_RUN_ID;
+            const runSha = process.env.SOURCE_RUN_SHA;
+            const runUrl = process.env.SOURCE_RUN_URL;
+            const conclusion = process.env.SOURCE_RUN_CONCLUSION;
+            const downloadOutcome = process.env.DOWNLOAD_OUTCOME;
+            const manifestPath = path.join('live-evidence', 'live-run-manifest.json');
+            const observationsPath = path.join(
+              'live-evidence',
+              'source-observations.v1.json',
+            );
+            const coveragePath = path.join(
+              'live-evidence',
+              'coverage-assessment.json',
+            );
+            let body = [
+              '## AP-14B.3 exact-main live evidence',
+              '',
+              `- source workflow run: ${runId}`,
+              `- source workflow SHA: \`${runSha}\``,
+              `- source workflow conclusion: \`${conclusion}\``,
+              `- artifact download outcome: \`${downloadOutcome}\``,
+              `- run URL: ${runUrl}`,
+            ];
+            if (
+              fs.existsSync(manifestPath)
+              && fs.existsSync(observationsPath)
+              && fs.existsSync(coveragePath)
+            ) {
+              const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+              const observations = JSON.parse(
+                fs.readFileSync(observationsPath, 'utf8'),
+              );
+              const coverage = JSON.parse(fs.readFileSync(coveragePath, 'utf8'));
+              body.push(
+                '',
+                `- collection status: \`${manifest.status}\``,
+                `- evidence bundle SHA-256: \`${manifest.evidence_bundle_sha256}\``,
+                `- catalog SHA-256: \`${manifest.catalog_sha256}\``,
+                `- observed sources: ${manifest.observed_source_count}/${manifest.source_count}`,
+                `- coverage: ${manifest.coverage_basis_points}/10000`,
+                `- critical coverage: ${manifest.critical_coverage_basis_points}/10000`,
+                `- all critical covered: \`${manifest.all_critical_covered}\``,
+                '',
+                '### Per-source result',
+              );
+              for (const result of manifest.source_results || []) {
+                body.push(
+                  `- \`${result.source_id}\`: \`${result.status}\` — \`${result.reason}\``,
+                );
+              }
+              body.push(
+                '',
+                `Observation records: ${Array.isArray(observations.observations) ? observations.observations.length : 0}.`,
+                `Coverage topics: ${Array.isArray(coverage.topics) ? coverage.topics.length : 0}.`,
+              );
+            } else {
+              body.push(
+                '',
+                'Artifact files were unavailable or structurally incomplete. The source run must not be accepted as coverage evidence.',
+              );
+            }
+            body.push(
+              '',
+              'Temporary reporter and scoped push trigger must be removed after this evidence is reviewed.',
+            );
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 2782,
+              body: body.join('\n'),
+            });

--- a/apps/tai/tests/test_live_source_evidence_reporter_workflow.py
+++ b/apps/tai/tests/test_live_source_evidence_reporter_workflow.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_temporary_reporter_is_bounded_to_artifact_read_and_issue_2782() -> None:
+    workflow = (
+        Path(__file__).parents[3]
+        / ".github"
+        / "workflows"
+        / "tai-live-source-evidence-reporter.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "workflow_run:" in workflow
+    assert "TAI Live Official Source Evidence" in workflow
+    assert "types:\n      - completed" in workflow
+    assert "actions: read" in workflow
+    assert "contents: read" in workflow
+    assert "issues: write" in workflow
+    assert "contents: write" not in workflow
+    assert "actions: write" not in workflow
+    assert "id-token: write" not in workflow
+    assert "secrets." not in workflow
+    assert "head_branch == 'main'" in workflow
+    assert "actions/download-artifact@v4" in workflow
+    assert "run-id: ${{ github.event.workflow_run.id }}" in workflow
+    assert "issue_number: 2782" in workflow
+    assert "github.rest.issues.createComment" in workflow
+    assert "live-run-manifest.json" in workflow
+    assert "source-observations.v1.json" in workflow
+    assert "coverage-assessment.json" in workflow
+    assert "Temporary reporter" in workflow


### PR DESCRIPTION
## Цель

Сделать результат push-triggered live-source workflow доступным через подключённый GitHub connector, который не умеет перечислять push workflow runs.

## Изменения

- добавлен временный `workflow_run` reporter для `TAI Live Official Source Evidence`;
- reporter скачивает artifact конкретного source run и публикует manifest summary в issue #2782;
- authority ограничена `actions: read`, `contents: read`, `issues: write`;
- отсутствуют repository write, secrets и OIDC;
- sentinel обновлён до sequence 2, чтобы после merge получить новый exact-main live run;
- regression фиксирует bounded authority и target issue.

## Обязательный cleanup

После получения и анализа comment/artifact reporter, sentinel и scoped push trigger удаляются отдельным PR.

Operational status остаётся `NOT_ATTESTED`.

Part of #2782 and #2774.