### PR TITLE
TAI AP-14D.1: exact-main diagnostic live evidence trigger

### DIFF
--- a/.github/tai-live-source-evidence.trigger
+++ b/.github/tai-live-source-evidence.trigger
@@ -1,0 +1,4 @@
+schema_version=tai.live-source-trigger.v1
+purpose=ap14d1_bounded_source_diagnostics
+sequence=4
+remove_after_verified_run=true

--- a/.github/workflows/tai-live-source-evidence-reporter.yml
+++ b/.github/workflows/tai-live-source-evidence-reporter.yml
@@ -1,0 +1,121 @@
+name: TAI Live Evidence Reporter
+
+on:
+  workflow_run:
+    workflows:
+      - TAI Live Official Source Evidence
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: tai-live-evidence-reporter-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    if: github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download exact-main live evidence
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: tai-live-official-source-*
+          merge-multiple: true
+          path: live-evidence
+
+      - name: Report AP-14D.1 diagnostics to issue 2789
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          SOURCE_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SOURCE_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const runId = process.env.SOURCE_RUN_ID;
+            const runSha = process.env.SOURCE_RUN_SHA;
+            const runUrl = process.env.SOURCE_RUN_URL;
+            const conclusion = process.env.SOURCE_RUN_CONCLUSION;
+            const downloadOutcome = process.env.DOWNLOAD_OUTCOME;
+            const manifestPath = path.join('live-evidence', 'live-run-manifest.json');
+            const observationsPath = path.join(
+              'live-evidence',
+              'source-observations.v1.json',
+            );
+            const coveragePath = path.join(
+              'live-evidence',
+              'coverage-assessment.json',
+            );
+            let body = [
+              '## AP-14D.1 exact-main diagnostic live evidence',
+              '',
+              `- source workflow run: ${runId}`,
+              `- source workflow SHA: \`${runSha}\``,
+              `- source workflow conclusion: \`${conclusion}\``,
+              `- artifact download outcome: \`${downloadOutcome}\``,
+              `- run URL: ${runUrl}`,
+            ];
+            if (
+              fs.existsSync(manifestPath)
+              && fs.existsSync(observationsPath)
+              && fs.existsSync(coveragePath)
+            ) {
+              const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+              const observations = JSON.parse(
+                fs.readFileSync(observationsPath, 'utf8'),
+              );
+              const coverage = JSON.parse(fs.readFileSync(coveragePath, 'utf8'));
+              body.push(
+                '',
+                `- collection status: \`${manifest.status}\``,
+                `- evidence bundle SHA-256: \`${manifest.evidence_bundle_sha256}\``,
+                `- catalog SHA-256: \`${manifest.catalog_sha256}\``,
+                `- observed sources: ${manifest.observed_source_count}/${manifest.source_count}`,
+                `- coverage: ${manifest.coverage_basis_points}/10000`,
+                `- critical coverage: ${manifest.critical_coverage_basis_points}/10000`,
+                `- all critical covered: \`${manifest.all_critical_covered}\``,
+                '',
+                '### Per-source diagnostic result',
+              );
+              for (const result of manifest.source_results || []) {
+                body.push(
+                  `- \`${result.source_id}\`: \`${result.status}\` — \`${result.reason}\``,
+                );
+              }
+              body.push(
+                '',
+                `Observation records: ${Array.isArray(observations.observations) ? observations.observations.length : 0}.`,
+                `Coverage topics: ${Array.isArray(coverage.topics) ? coverage.topics.length : 0}.`,
+              );
+            } else {
+              body.push(
+                '',
+                'Artifact files were unavailable or structurally incomplete. The source run must not be accepted as diagnostic evidence.',
+              );
+            }
+            body.push(
+              '',
+              'Temporary reporter, sentinel and scoped push trigger must be removed after this evidence is reviewed.',
+            );
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 2789,
+              body: body.join('\n'),
+            });

--- a/.github/workflows/tai-live-source-evidence.yml
+++ b/.github/workflows/tai-live-source-evidence.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '23 4 * * 2'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/tai-live-source-evidence.trigger'
 
 permissions:
   contents: read

--- a/apps/tai/tests/test_live_source_diagnostic_reporter_workflow.py
+++ b/apps/tai/tests/test_live_source_diagnostic_reporter_workflow.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_temporary_diagnostic_reporter_has_bounded_authority() -> None:
+    workflow = (
+        Path(__file__).parents[3]
+        / ".github"
+        / "workflows"
+        / "tai-live-source-evidence-reporter.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "workflow_run:" in workflow
+    assert "TAI Live Official Source Evidence" in workflow
+    assert "types:\n      - completed" in workflow
+    assert "actions: read" in workflow
+    assert "contents: read" in workflow
+    assert "issues: write" in workflow
+    assert "contents: write" not in workflow
+    assert "actions: write" not in workflow
+    assert "id-token: write" not in workflow
+    assert "secrets." not in workflow
+    assert "head_branch == 'main'" in workflow
+    assert "actions/download-artifact@v4" in workflow
+    assert "run-id: ${{ github.event.workflow_run.id }}" in workflow
+    assert "issue_number: 2789" in workflow
+    assert "github.rest.issues.createComment" in workflow
+    assert "live-run-manifest.json" in workflow
+    assert "source-observations.v1.json" in workflow
+    assert "coverage-assessment.json" in workflow
+    assert "Per-source diagnostic result" in workflow
+    assert "Temporary reporter" in workflow

--- a/apps/tai/tests/test_live_source_evidence_workflow.py
+++ b/apps/tai/tests/test_live_source_evidence_workflow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def test_live_evidence_workflow_is_read_only_exact_main_and_non_merge_blocking() -> None:
+def test_live_evidence_workflow_is_read_only_exact_main_and_scoped() -> None:
     workflow = (
         Path(__file__).parents[3]
         / ".github"
@@ -14,7 +14,10 @@ def test_live_evidence_workflow_is_read_only_exact_main_and_non_merge_blocking()
     assert "workflow_dispatch:" in workflow
     assert "schedule:" in workflow
     assert "pull_request:" not in workflow
-    assert "push:" not in workflow
+    assert "push:" in workflow
+    assert "branches:\n      - main" in workflow
+    assert "paths:\n      - '.github/tai-live-source-evidence.trigger'" in workflow
+    assert "paths-ignore:" not in workflow
     assert "permissions:\n  contents: read" in workflow
     assert "contents: write" not in workflow
     assert "actions: write" not in workflow


### PR DESCRIPTION
## Цель

Однократно выполнить controlled live-source workflow после AP-14D.1 и получить фактические bounded причины MCX/Rosstat/Mintrans в issue #2789.

## Временный контур

- scoped `push` только для `main` и `.github/tai-live-source-evidence.trigger`;
- sentinel sequence 4;
- reporter читает artifact source-run и публикует summary в #2789;
- collector: только `contents: read`;
- reporter: только `actions: read`, `contents: read`, `issues: write`;
- нет repository write, secrets или OIDC.

## Exact-head acceptance

Exact-head: `4eeac883fe55cafa9878a8eda2b67867a4ca7025`.
Base main: `e6f99ddc79ec3936fdd0d988eb83bb73a01fe3a7`.
Test-merge: `466e69f26aec00918cf27360f6cd8bd1b33b1672`.

PASS:

- TAI Foundation: Ruff, strict mypy, pytest/coverage;
- CI и Node CI;
- Security Scan;
- Security Quality Gate;
- Security Abuse exact-head manifest;
- Runtime Context Security Gate и exact-head runtime manifest;
- Auction, Outbox и Disputes PostgreSQL acceptance;
- Dependency Review и optional-runtime retirement gate.

Review threads: 0.

## Обязательный cleanup

После анализа artifact удаляются reporter, sentinel, scoped push trigger и временные tests. Постоянный workflow возвращается к `workflow_dispatch + schedule`.

Operational status остаётся `NOT_ATTESTED`.

Part of #2789. Parent: #2726.