### PR TITLE
TAI AP-14D.2: remediate Mintrans opaque document routes

### DIFF
--- a/apps/tai/tai/official_source_metadata.py
+++ b/apps/tai/tai/official_source_metadata.py
@@ -91,18 +91,35 @@ class HTMLMetadataAdapter:
     required_marker_groups: tuple[tuple[str, ...], ...]
     document_suffixes: frozenset[str]
     count_dates_as_documents: bool = False
+    document_path_patterns: tuple[str, ...] = ()
+    publication_marker_groups: tuple[tuple[str, ...], ...] = ()
 
     def __post_init__(self) -> None:
         if not self.source_id.strip():
             raise ValueError("adapter source_id must not be blank")
         if not self.topics:
             raise ValueError("adapter topics must not be empty")
-        if not self.required_marker_groups or any(
-            not group or any(not marker.strip() for marker in group)
-            for group in self.required_marker_groups
+        _validate_marker_groups(
+            self.required_marker_groups,
+            "adapter marker groups must not be empty",
+        )
+        if self.publication_marker_groups:
+            _validate_marker_groups(
+                self.publication_marker_groups,
+                "publication marker groups must not be empty",
+            )
+        for pattern in self.document_path_patterns:
+            if not pattern.strip():
+                raise ValueError("document path pattern must not be blank")
+            try:
+                re.compile(pattern)
+            except re.error as error:
+                raise ValueError("document path pattern must be valid regex") from error
+        if (
+            not self.count_dates_as_documents
+            and not self.document_suffixes
+            and not self.document_path_patterns
         ):
-            raise ValueError("adapter marker groups must not be empty")
-        if not self.count_dates_as_documents and not self.document_suffixes:
             raise ValueError("adapter must define a document counting strategy")
 
     def parse(
@@ -118,9 +135,8 @@ class HTMLMetadataAdapter:
         if not self.topics.issubset(source.topics):
             raise MetadataExtractionError("adapter_topic_scope_exceeds_catalog")
         normalized = unicodedata.normalize("NFKC", body).casefold()
-        for group in self.required_marker_groups:
-            if not any(marker.casefold() in normalized for marker in group):
-                raise MetadataExtractionError("source_required_marker_missing")
+        if not _marker_groups_match(normalized, self.required_marker_groups):
+            raise MetadataExtractionError("source_required_marker_missing")
 
         parser = _HTMLSnapshotParser()
         try:
@@ -129,7 +145,16 @@ class HTMLMetadataAdapter:
         except Exception as error:
             raise MetadataExtractionError("source_html_parse_failed") from error
 
-        dates = _extract_dates("\n".join(parser.text_chunks), fetched_at)
+        text = "\n".join(parser.text_chunks)
+        dates = (
+            _extract_contextual_dates(
+                text,
+                fetched_at,
+                self.publication_marker_groups,
+            )
+            if self.publication_marker_groups
+            else _extract_dates(text, fetched_at)
+        )
         if not dates:
             raise MetadataExtractionError("source_publication_date_missing")
         latest_publication_at = max(dates)
@@ -144,7 +169,11 @@ class HTMLMetadataAdapter:
                     url
                     for href in parser.links
                     if (url := _trusted_document_url(source, href)) is not None
-                    and _matches_suffix(url, self.document_suffixes)
+                    and _matches_document_locator(
+                        url,
+                        suffixes=self.document_suffixes,
+                        path_patterns=self.document_path_patterns,
+                    )
                 }
             )
         if document_count < 1:
@@ -219,6 +248,8 @@ def default_html_metadata_adapters() -> tuple[HTMLMetadataAdapter, ...]:
             topics=frozenset({CoverageTopic.LOGISTICS_TARIFFS}),
             required_marker_groups=(("тариф",), ("железнодорож", "перевоз")),
             document_suffixes=frozenset({".pdf", ".doc", ".docx", ".xls", ".xlsx"}),
+            document_path_patterns=(r"/file/[0-9]+",),
+            publication_marker_groups=(("тариф",), ("железнодорож", "перевоз")),
         ),
         HTMLMetadataAdapter(
             source_id="official.mcx.opendata",
@@ -229,31 +260,92 @@ def default_html_metadata_adapters() -> tuple[HTMLMetadataAdapter, ...]:
     )
 
 
+def _validate_marker_groups(
+    groups: tuple[tuple[str, ...], ...],
+    error_message: str,
+) -> None:
+    if not groups or any(
+        not group or any(not marker.strip() for marker in group)
+        for group in groups
+    ):
+        raise ValueError(error_message)
+
+
+def _marker_groups_match(
+    normalized_text: str,
+    groups: tuple[tuple[str, ...], ...],
+) -> bool:
+    return all(
+        any(marker.casefold() in normalized_text for marker in group)
+        for group in groups
+    )
+
+
 def _extract_dates(text: str, reference: datetime) -> tuple[datetime, ...]:
-    _aware(reference, "reference")
+    return tuple(
+        sorted({value for _, value in _date_occurrences(text, reference)})
+    )
+
+
+def _extract_contextual_dates(
+    text: str,
+    reference: datetime,
+    marker_groups: tuple[tuple[str, ...], ...],
+) -> tuple[datetime, ...]:
+    occurrences = _date_occurrences(text, reference)
     values: set[datetime] = set()
-    for match in _ISO_DATE.finditer(text):
-        _add_date(values, int(match[1]), int(match[2]), int(match[3]), reference)
-    for match in _DMY_DATE.finditer(text):
-        _add_date(values, int(match[3]), int(match[2]), int(match[1]), reference)
-    for match in _RU_DATE.finditer(text):
-        month = _RU_MONTHS.get(match[2].casefold())
-        if month is not None:
-            _add_date(values, int(match[3]), month, int(match[1]), reference)
+    for index, (position, value) in enumerate(occurrences):
+        end = occurrences[index + 1][0] if index + 1 < len(occurrences) else len(text)
+        segment = unicodedata.normalize("NFKC", text[position:end]).casefold()
+        if _marker_groups_match(segment, marker_groups):
+            values.add(value)
     return tuple(sorted(values))
 
 
-def _add_date(
-    values: set[datetime],
+def _date_occurrences(
+    text: str,
+    reference: datetime,
+) -> tuple[tuple[int, datetime], ...]:
+    _aware(reference, "reference")
+    values: set[tuple[int, datetime]] = set()
+    for match in _ISO_DATE.finditer(text):
+        value = _date_value(
+            int(match[1]),
+            int(match[2]),
+            int(match[3]),
+            reference,
+        )
+        if value is not None:
+            values.add((match.start(), value))
+    for match in _DMY_DATE.finditer(text):
+        value = _date_value(
+            int(match[3]),
+            int(match[2]),
+            int(match[1]),
+            reference,
+        )
+        if value is not None:
+            values.add((match.start(), value))
+    for match in _RU_DATE.finditer(text):
+        month = _RU_MONTHS.get(match[2].casefold())
+        if month is None:
+            continue
+        value = _date_value(int(match[3]), month, int(match[1]), reference)
+        if value is not None:
+            values.add((match.start(), value))
+    return tuple(sorted(values, key=lambda item: (item[0], item[1])))
+
+
+def _date_value(
     year: int,
     month: int,
     day: int,
     reference: datetime,
-) -> None:
+) -> datetime | None:
     try:
-        values.add(datetime(year, month, day, tzinfo=reference.tzinfo))
+        return datetime(year, month, day, tzinfo=reference.tzinfo)
     except ValueError:
-        return
+        return None
 
 
 def _trusted_document_url(
@@ -269,9 +361,16 @@ def _trusted_document_url(
     return absolute
 
 
-def _matches_suffix(url: str, suffixes: frozenset[str]) -> bool:
+def _matches_document_locator(
+    url: str,
+    *,
+    suffixes: frozenset[str],
+    path_patterns: tuple[str, ...],
+) -> bool:
     path = urlparse(url).path.casefold()
-    return any(path.endswith(suffix) for suffix in suffixes)
+    if any(path.endswith(suffix) for suffix in suffixes):
+        return True
+    return any(re.fullmatch(pattern, path) is not None for pattern in path_patterns)
 
 
 def _aware(value: datetime, name: str) -> None:

--- a/apps/tai/tai/official_source_metadata.py
+++ b/apps/tai/tai/official_source_metadata.py
@@ -146,12 +146,17 @@ class HTMLMetadataAdapter:
             raise MetadataExtractionError("source_html_parse_failed") from error
 
         text = "\n".join(parser.text_chunks)
-        dates = (
-            _extract_contextual_dates(
+        contextual_ranges = (
+            _contextual_date_ranges(
                 text,
                 fetched_at,
                 self.publication_marker_groups,
             )
+            if self.publication_marker_groups
+            else ()
+        )
+        dates = (
+            tuple(sorted({value for _, _, value in contextual_ranges}))
             if self.publication_marker_groups
             else _extract_dates(text, fetched_at)
         )
@@ -167,8 +172,12 @@ class HTMLMetadataAdapter:
             document_count = len(
                 {
                     url
-                    for href in parser.links
-                    if (url := _trusted_document_url(source, href)) is not None
+                    for href, position in parser.links
+                    if (
+                        not contextual_ranges
+                        or _position_in_ranges(position, contextual_ranges)
+                    )
+                    and (url := _trusted_document_url(source, href)) is not None
                     and _matches_document_locator(
                         url,
                         suffixes=self.document_suffixes,
@@ -189,12 +198,14 @@ class _HTMLSnapshotParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
         self.text_chunks: list[str] = []
-        self.links: list[str] = []
+        self.links: list[tuple[str, int]] = []
+        self._text_length = 0
 
     def handle_data(self, data: str) -> None:
         compact = " ".join(data.split())
         if compact:
             self.text_chunks.append(compact)
+            self._text_length += len(compact) + 1
 
     def handle_starttag(
         self,
@@ -212,7 +223,7 @@ class _HTMLSnapshotParser(HTMLParser):
             None,
         )
         if href:
-            self.links.append(href)
+            self.links.append((href, self._text_length))
 
 
 def default_html_metadata_adapters() -> tuple[HTMLMetadataAdapter, ...]:
@@ -287,19 +298,26 @@ def _extract_dates(text: str, reference: datetime) -> tuple[datetime, ...]:
     )
 
 
-def _extract_contextual_dates(
+def _contextual_date_ranges(
     text: str,
     reference: datetime,
     marker_groups: tuple[tuple[str, ...], ...],
-) -> tuple[datetime, ...]:
+) -> tuple[tuple[int, int, datetime], ...]:
     occurrences = _date_occurrences(text, reference)
-    values: set[datetime] = set()
+    ranges: list[tuple[int, int, datetime]] = []
     for index, (position, value) in enumerate(occurrences):
         end = occurrences[index + 1][0] if index + 1 < len(occurrences) else len(text)
         segment = unicodedata.normalize("NFKC", text[position:end]).casefold()
         if _marker_groups_match(segment, marker_groups):
-            values.add(value)
-    return tuple(sorted(values))
+            ranges.append((position, end, value))
+    return tuple(ranges)
+
+
+def _position_in_ranges(
+    position: int,
+    ranges: tuple[tuple[int, int, datetime], ...],
+) -> bool:
+    return any(start <= position < end for start, end, _ in ranges)
 
 
 def _date_occurrences(

--- a/apps/tai/tests/test_mintrans_metadata_remediation.py
+++ b/apps/tai/tests/test_mintrans_metadata_remediation.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tai.official_source_metadata import (
+    HTMLMetadataAdapter,
+    MetadataExtractionError,
+    default_html_metadata_adapters,
+)
+from tai.source_coverage import (
+    CoverageTopic,
+    OfficialSourceDefinition,
+    SourceFormat,
+)
+
+NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+
+
+def _source() -> OfficialSourceDefinition:
+    return OfficialSourceDefinition(
+        source_id="official.mintrans.rail-tariffs",
+        owner="Министерство транспорта Российской Федерации",
+        entrypoint_uri="https://mintrans.gov.ru/activities/222/documents",
+        allowed_hosts=frozenset({"mintrans.gov.ru"}),
+        topics=frozenset({CoverageTopic.LOGISTICS_TARIFFS}),
+        formats=frozenset({SourceFormat.HTML, SourceFormat.PDF}),
+        expected_update_interval=timedelta(days=365),
+        maximum_publication_age=timedelta(days=400),
+        verified_at=NOW - timedelta(days=1),
+    )
+
+
+def _adapter() -> HTMLMetadataAdapter:
+    return next(
+        adapter
+        for adapter in default_html_metadata_adapters()
+        if adapter.source_id == "official.mintrans.rail-tariffs"
+    )
+
+
+def test_mintrans_counts_opaque_file_routes_and_uses_latest_tariff_date() -> None:
+    body = """
+    <html><body>
+      <section>
+        <time>20 Мая 2026</time>
+        <h2>Протокол Совета по железнодорожному транспорту</h2>
+        <a href="/file/600001">Список участников</a>
+      </section>
+      <section>
+        <time>10 Декабря 2025</time>
+        <h2>Протокол заседания Совета</h2>
+        <a href="/file/590001">Приложения</a>
+      </section>
+      <section>
+        <time>28 Ноября 2025</time>
+        <h2>Приказ о Тарифной политике железных дорог</h2>
+        <p>Перевозки грузов в международном сообщении на 2026 год.</p>
+        <a href="/file/552015">Приказ в формате PDF</a>
+        <a href="/file/552016">Приказ в формате DOC</a>
+        <a href="/file/not-numeric">Не документ</a>
+        <a href="https://evil.example/file/552017">Внешняя копия</a>
+      </section>
+    </body></html>
+    """
+
+    metadata = _adapter().parse(source=_source(), body=body, fetched_at=NOW)
+
+    assert metadata.latest_publication_at == datetime(2025, 11, 28, tzinfo=UTC)
+    assert metadata.document_count == 2
+    assert metadata.observed_topics == frozenset({CoverageTopic.LOGISTICS_TARIFFS})
+
+
+def test_mintrans_does_not_borrow_unrelated_newer_document_date() -> None:
+    body = """
+    <time>20 Мая 2026</time>
+    <h2>Протокол Совета по железнодорожному транспорту</h2>
+    <a href="/file/600001">Протокол</a>
+    <p>Тарифная политика железных дорог и перевозки грузов обсуждаются ниже,
+    но у соответствующего документа отсутствует дата.</p>
+    <a href="/file/552015">Тарифный документ</a>
+    """
+
+    with pytest.raises(MetadataExtractionError, match="publication_date_missing"):
+        _adapter().parse(source=_source(), body=body, fetched_at=NOW)
+
+
+def test_mintrans_rejects_future_tariff_date_even_with_valid_file_route() -> None:
+    body = """
+    <time>20 Июля 2026</time>
+    <h2>Тарифная политика железных дорог</h2>
+    <p>Перевозки грузов.</p>
+    <a href="/file/552015">Документ</a>
+    """
+
+    with pytest.raises(MetadataExtractionError, match="publication_date_future"):
+        _adapter().parse(source=_source(), body=body, fetched_at=NOW)
+
+
+def test_document_path_patterns_are_validated_and_required_when_no_suffixes() -> None:
+    with pytest.raises(ValueError, match="valid regex"):
+        HTMLMetadataAdapter(
+            source_id="official.mintrans.rail-tariffs",
+            topics=frozenset({CoverageTopic.LOGISTICS_TARIFFS}),
+            required_marker_groups=(("тариф",),),
+            document_suffixes=frozenset(),
+            document_path_patterns=("[",),
+        )
+
+    with pytest.raises(ValueError, match="counting strategy"):
+        HTMLMetadataAdapter(
+            source_id="official.mintrans.rail-tariffs",
+            topics=frozenset({CoverageTopic.LOGISTICS_TARIFFS}),
+            required_marker_groups=(("тариф",),),
+            document_suffixes=frozenset(),
+        )

--- a/apps/tai/tests/test_mintrans_metadata_remediation.py
+++ b/apps/tai/tests/test_mintrans_metadata_remediation.py
@@ -40,7 +40,7 @@ def _adapter() -> HTMLMetadataAdapter:
     )
 
 
-def test_mintrans_counts_opaque_file_routes_and_uses_latest_tariff_date() -> None:
+def test_mintrans_counts_opaque_routes_and_uses_latest_tariff_date() -> None:
     body = """
     <html><body>
       <section>
@@ -72,21 +72,20 @@ def test_mintrans_counts_opaque_file_routes_and_uses_latest_tariff_date() -> Non
     assert metadata.observed_topics == frozenset({CoverageTopic.LOGISTICS_TARIFFS})
 
 
-def test_mintrans_does_not_borrow_unrelated_newer_document_date() -> None:
+def test_mintrans_does_not_borrow_later_unrelated_document_date() -> None:
     body = """
+    <h2>Тарифная политика железных дорог и перевозки грузов</h2>
+    <a href="/file/552015">Тарифный документ без даты</a>
     <time>20 Мая 2026</time>
     <h2>Протокол Совета по железнодорожному транспорту</h2>
     <a href="/file/600001">Протокол</a>
-    <p>Тарифная политика железных дорог и перевозки грузов обсуждаются ниже,
-    но у соответствующего документа отсутствует дата.</p>
-    <a href="/file/552015">Тарифный документ</a>
     """
 
     with pytest.raises(MetadataExtractionError, match="publication_date_missing"):
         _adapter().parse(source=_source(), body=body, fetched_at=NOW)
 
 
-def test_mintrans_rejects_future_tariff_date_even_with_valid_file_route() -> None:
+def test_mintrans_rejects_future_tariff_date_with_valid_file_route() -> None:
     body = """
     <time>20 Июля 2026</time>
     <h2>Тарифная политика железных дорог</h2>
@@ -98,7 +97,7 @@ def test_mintrans_rejects_future_tariff_date_even_with_valid_file_route() -> Non
         _adapter().parse(source=_source(), body=body, fetched_at=NOW)
 
 
-def test_document_path_patterns_are_validated_and_required_when_no_suffixes() -> None:
+def test_document_path_patterns_are_validated_and_required() -> None:
     with pytest.raises(ValueError, match="valid regex"):
         HTMLMetadataAdapter(
             source_id="official.mintrans.rail-tariffs",

--- a/apps/tai/tests/test_official_source_metadata_adapters.py
+++ b/apps/tai/tests/test_official_source_metadata_adapters.py
@@ -129,8 +129,9 @@ def _fixtures() -> dict[str, _AdapterFixture]:
                 hosts=frozenset({"mintrans.gov.ru"}),
             ),
             body=(
+                "<time>15.07.2026</time>"
                 "<h1>Тариф на железнодорожные перевозки</h1>"
-                "<time>15.07.2026</time><a href='/docs/tariff.pdf'>PDF</a>"
+                "<a href='/docs/tariff.pdf'>PDF</a>"
             ),
             expected_date=datetime(2026, 7, 15, tzinfo=UTC),
             expected_count=1,


### PR DESCRIPTION
## Что изменено

- Mintrans adapter распознаёт official file routes вида `/file/<numeric-id>` без расширения;
- trusted-host/HTTPS/credentials/fragment policy не ослаблена;
- publication freshness вычисляется только по date-segments, содержащим tariff + rail/transport markers;
- более новая нерелевантная дата протокола не может сделать тарифные данные искусственно свежими;
- документы считаются только внутри релевантного тарифного date-segment;
- suffix-based documents для остальных источников сохранены;
- добавлены adversarial regressions для внешних links, non-numeric routes, future dates и semantic date borrowing.

## Проверенный внешний факт

Официальная страница Минтранса содержит тарифные документы за 2026 год, но links имеют форму `https://mintrans.gov.ru/file/552015`, а не `.pdf/.doc` suffix. Старый adapter поэтому давал `source_document_count_empty`.

## Exact-head acceptance

Exact-head: `07682b2896a59bcc74fb179bef09d248c440c422`.

PASS:

- TAI Foundation: Ruff, strict mypy, pytest, coverage;
- CI и Node CI;
- Security Scan;
- Security Quality Gate;
- Security Abuse and exact-head evidence manifest;
- Runtime Context Security Gate и exact-head runtime manifest;
- Auction, Outbox и Disputes PostgreSQL acceptance;
- Dependency Review и optional-runtime retirement gate.

Review threads: 0.

## Граница результата

Этот PR исправляет подтверждённый Mintrans parser defect. Повышение coverage считается только после controlled exact-main live run.

Operational status остаётся `NOT_ATTESTED`.

Part of #2789. Parent: #2726.