### PR TITLE
Authorize component-level public assistant UX scope

### DIFF
--- a/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
+++ b/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
@@ -1,7 +1,7 @@
 {
   "branch": "feat/assistant-universal-understanding",
   "status": "active",
-  "purpose": "Broad multilingual assistant understanding with verified prospect knowledge, production transport resilience, mobile viewport hardening, safe unanswered-question handling, a shared fullscreen modal-sheet control, a unified public contact dock and a compact intent-first mobile UX for the public assistant and support form.",
+  "purpose": "Broad multilingual assistant understanding with verified prospect knowledge, production transport resilience, mobile viewport hardening, safe unanswered-question handling, a shared fullscreen modal-sheet control, a unified public contact dock and a materially visible intent-first public AI assistant UX.",
   "approvedBy": "independent-authority-pr",
   "allowedPaths": [
     "apps/api/src/modules/ai-insights/ai-assistant.service.ts",
@@ -9,6 +9,7 @@
     "apps/web/app/api/public-platform-assistant/route.ts",
     "apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx",
     "apps/web/components/platform-v7/PublicContactDock.tsx",
+    "apps/web/components/platform-v7/PublicPlatformAssistant.tsx",
     "apps/web/components/platform-v7/UnifiedModalSheetFullscreenController.tsx",
     "apps/web/lib/platform-v7/assistant-question-understanding.ts",
     "apps/web/lib/platform-v7/install-public-assistant-fetch-resilience.ts",


### PR DESCRIPTION
## Цель

Независимо и заранее расширить governed scope ветки `feat/assistant-universal-understanding`, чтобы компонент `PublicPlatformAssistant.tsx` мог изменяться без самоавторизации внутри implementation PR.

## Изменение

- добавлен `apps/web/components/platform-v7/PublicPlatformAssistant.tsx` в существующий source-controlled allow-list;
- purpose уточнён до materially visible intent-first public AI assistant UX;
- forbidden capabilities не ослаблены;
- продуктовый код, CSS, API и runtime не меняются.

После merge implementation PR обязан подтянуть этот commit из `main` до любых дальнейших component-level изменений.