### PR TITLE
TAI AP-14D.3: bounded public-IP failover for MCX and Rosstat

### DIFF
--- a/apps/tai/tai/official_source_diagnostics.py
+++ b/apps/tai/tai/official_source_diagnostics.py
@@ -5,6 +5,7 @@ import http.client
 import socket
 import ssl
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from urllib.parse import urljoin
 
@@ -18,6 +19,7 @@ from tai.official_source_fetcher import (
     FetchSecurityError,
     OfficialFetchPolicy,
     OfficialSourceHTTPFetcher,
+    ResolvedAddress,
     StdlibPinnedHTTPSFetchTransport,
     TransportRequest,
 )
@@ -28,6 +30,10 @@ from tai.official_source_observation import (
 from tai.source_coverage import OfficialSourceCatalog
 
 _REDIRECT_STATUS = frozenset({301, 302, 303, 307, 308})
+_MAXIMUM_ADDRESS_ATTEMPTS = 4
+_SOURCE_MINIMUM_TIMEOUT_SECONDS = {
+    "official.mcx.opendata": 45.0,
+}
 _RETRYABLE_SECURITY_CODES = frozenset(
     {
         "source_dns_resolution_empty",
@@ -46,8 +52,16 @@ _OS_ERROR_CODES = {
 }
 
 
+@dataclass(frozen=True, slots=True)
+class _AddressTarget:
+    host: str
+    port: int
+    ip_address: str
+    path_and_query: str
+
+
 class DiagnosticOfficialSourceHTTPFetcher(OfficialSourceHTTPFetcher):
-    """Official fetcher that preserves bounded transport failure categories."""
+    """Official fetcher with bounded diagnostics and public-IP failover."""
 
     def fetch(self, request: FetchRequest) -> FetchResponse:
         current_url = request.source_uri
@@ -58,41 +72,96 @@ class DiagnosticOfficialSourceHTTPFetcher(OfficialSourceHTTPFetcher):
 
         for redirect_count in range(self.policy.maximum_redirects + 1):
             try:
-                target = self._target(current_url)
-                raw = self.transport.exchange(
-                    TransportRequest(
-                        url=current_url,
-                        host=target.host,
-                        port=target.port,
-                        target_ip=target.ip_address,
-                        path_and_query=target.path_and_query,
-                        headers=request_headers,
-                        timeout_seconds=self.policy.timeout_seconds,
-                        maximum_wire_bytes=self.policy.maximum_wire_bytes,
-                    )
-                )
-                response_headers = _normalize_headers(raw.headers)
-                if raw.status_code in _REDIRECT_STATUS:
-                    location = response_headers.get("location")
-                    if not location:
-                        raise FetchSecurityError("source_redirect_location_missing")
-                    if redirect_count >= self.policy.maximum_redirects:
-                        raise FetchSecurityError("source_redirect_limit_exceeded")
-                    current_url = urljoin(current_url, location)
-                    self._validate_url(current_url)
-                    continue
-                return self._non_redirect_response(raw, response_headers)
+                targets = self._address_targets(current_url)
             except FetchSecurityError as error:
                 return _security_failure(error)
-            except Exception as error:
-                diagnostic = _transport_diagnostic(error)
-                if diagnostic is None:
-                    raise
-                disposition, error_code = diagnostic
+
+            diagnostics: list[tuple[FetchDisposition, str]] = []
+            redirected = False
+            for target in targets:
+                try:
+                    raw = self.transport.exchange(
+                        TransportRequest(
+                            url=current_url,
+                            host=target.host,
+                            port=target.port,
+                            target_ip=target.ip_address,
+                            path_and_query=target.path_and_query,
+                            headers=request_headers,
+                            timeout_seconds=self.policy.timeout_seconds,
+                            maximum_wire_bytes=self.policy.maximum_wire_bytes,
+                        )
+                    )
+                    response_headers = _normalize_headers(raw.headers)
+                    if raw.status_code in _REDIRECT_STATUS:
+                        location = response_headers.get("location")
+                        if not location:
+                            raise FetchSecurityError(
+                                "source_redirect_location_missing"
+                            )
+                        if redirect_count >= self.policy.maximum_redirects:
+                            raise FetchSecurityError(
+                                "source_redirect_limit_exceeded"
+                            )
+                        current_url = urljoin(current_url, location)
+                        self._validate_url(current_url)
+                        redirected = True
+                        break
+                    return self._non_redirect_response(raw, response_headers)
+                except FetchSecurityError as error:
+                    return _security_failure(error)
+                except Exception as error:
+                    diagnostic = _transport_diagnostic(error)
+                    if diagnostic is None:
+                        raise
+                    diagnostics.append(diagnostic)
+
+            if redirected:
+                continue
+            if diagnostics:
+                disposition, error_code = _aggregate_diagnostics(diagnostics)
                 return _failure(disposition, error_code)
+            return _failure(
+                FetchDisposition.RETRYABLE_FAILURE,
+                "source_dns_resolution_empty",
+            )
         return _failure(
             FetchDisposition.PERMANENT_FAILURE,
             "source_redirect_limit_exceeded",
+        )
+
+    def _address_targets(self, url: str) -> tuple[_AddressTarget, ...]:
+        parsed = self._validate_url(url)
+        host = parsed.hostname
+        if host is None:
+            raise FetchSecurityError("source_url_host_missing")
+        port = parsed.port or 443
+        addresses = self.resolver.resolve(host, port)
+        if not addresses:
+            raise FetchSecurityError("source_dns_resolution_empty")
+        ordered = sorted(addresses, key=lambda address: address.ip_address)
+        unique: list[ResolvedAddress] = []
+        seen: set[str] = set()
+        for address in ordered:
+            if address.host != host or address.port != port:
+                raise FetchSecurityError("source_resolver_binding_mismatch")
+            if address.ip_address in seen:
+                continue
+            seen.add(address.ip_address)
+            unique.append(address)
+            if len(unique) >= _MAXIMUM_ADDRESS_ATTEMPTS:
+                break
+        path_and_query = parsed.path or "/"
+        if parsed.query:
+            path_and_query = f"{path_and_query}?{parsed.query}"
+        return tuple(
+            _AddressTarget(
+                host=host,
+                port=port,
+                ip_address=address.ip_address,
+                path_and_query=path_and_query,
+            )
+            for address in unique
         )
 
 
@@ -103,14 +172,35 @@ def diagnostic_live_definitions(
 ) -> tuple[OfficialObservationDefinition, ...]:
     fetchers: dict[str, SourceFetcher] = {}
     for source in catalog.sources:
+        effective_timeout = max(
+            timeout_seconds,
+            _SOURCE_MINIMUM_TIMEOUT_SECONDS.get(
+                source.source_id,
+                timeout_seconds,
+            ),
+        )
         fetchers[source.source_id] = DiagnosticOfficialSourceHTTPFetcher(
             policy=OfficialFetchPolicy(
                 allowed_hosts=source.allowed_hosts,
-                timeout_seconds=timeout_seconds,
+                timeout_seconds=effective_timeout,
             ),
             transport=StdlibPinnedHTTPSFetchTransport(),
         )
     return definitions_from_catalog(catalog=catalog, fetchers=fetchers)
+
+
+def _aggregate_diagnostics(
+    diagnostics: list[tuple[FetchDisposition, str]],
+) -> tuple[FetchDisposition, str]:
+    retryable = next(
+        (
+            diagnostic
+            for diagnostic in diagnostics
+            if diagnostic[0] is FetchDisposition.RETRYABLE_FAILURE
+        ),
+        None,
+    )
+    return retryable or diagnostics[0]
 
 
 def _security_failure(error: FetchSecurityError) -> FetchResponse:

--- a/apps/tai/tests/test_official_source_address_failover.py
+++ b/apps/tai/tests/test_official_source_address_failover.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import ssl
+from datetime import UTC, datetime, timedelta
+
+from tai.managed_loader import FetchDisposition, FetchRequest
+from tai.official_source_diagnostics import (
+    DiagnosticOfficialSourceHTTPFetcher,
+    diagnostic_live_definitions,
+)
+from tai.official_source_fetcher import (
+    OfficialFetchPolicy,
+    ResolvedAddress,
+    TransportRequest,
+    TransportResponse,
+)
+from tai.source_coverage import (
+    CoverageRequirement,
+    CoverageTopic,
+    OfficialSourceCatalog,
+    OfficialSourceDefinition,
+    SourceFormat,
+)
+
+HOST = "data.example.gov"
+NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+
+
+class _Resolver:
+    def __init__(self, addresses: tuple[str, ...]) -> None:
+        self._addresses = addresses
+
+    def resolve(self, host: str, port: int) -> tuple[ResolvedAddress, ...]:
+        return tuple(
+            ResolvedAddress(host=host, port=port, ip_address=address)
+            for address in self._addresses
+        )
+
+
+class _BindingMismatchResolver:
+    def resolve(self, host: str, port: int) -> tuple[ResolvedAddress, ...]:
+        del host
+        return (
+            ResolvedAddress(
+                host="other.example.gov",
+                port=port,
+                ip_address="8.8.8.8",
+            ),
+        )
+
+
+class _AddressAwareTransport:
+    def __init__(self, outcomes: dict[str, Exception | TransportResponse]) -> None:
+        self._outcomes = outcomes
+        self.requests: list[TransportRequest] = []
+
+    def exchange(self, request: TransportRequest) -> TransportResponse:
+        self.requests.append(request)
+        outcome = self._outcomes[request.target_ip]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _response(status_code: int = 200) -> TransportResponse:
+    body = b"<html><body>official data 19.07.2026</body></html>"
+    return TransportResponse(
+        status_code=status_code,
+        headers={
+            "content-type": "text/html; charset=utf-8",
+            "content-length": str(len(body)),
+        },
+        body=body,
+        received_at=NOW,
+    )
+
+
+def _fetcher(
+    addresses: tuple[str, ...],
+    outcomes: dict[str, Exception | TransportResponse],
+) -> tuple[DiagnosticOfficialSourceHTTPFetcher, _AddressAwareTransport]:
+    transport = _AddressAwareTransport(outcomes)
+    return (
+        DiagnosticOfficialSourceHTTPFetcher(
+            policy=OfficialFetchPolicy(allowed_hosts=frozenset({HOST})),
+            resolver=_Resolver(addresses),
+            transport=transport,
+        ),
+        transport,
+    )
+
+
+def test_certificate_failure_on_one_public_address_fails_over_with_same_host() -> None:
+    fetcher, transport = _fetcher(
+        ("8.8.8.8", "8.8.4.4"),
+        {
+            "8.8.4.4": ssl.SSLCertVerificationError(1, "invalid chain"),
+            "8.8.8.8": _response(),
+        },
+    )
+
+    result = fetcher.fetch(
+        FetchRequest(source_id="official.example", source_uri=f"https://{HOST}/")
+    )
+
+    assert result.disposition is FetchDisposition.FETCHED
+    assert [request.target_ip for request in transport.requests] == [
+        "8.8.4.4",
+        "8.8.8.8",
+    ]
+    assert all(request.host == HOST for request in transport.requests)
+
+
+def test_timeout_on_one_public_address_fails_over_to_next_address() -> None:
+    fetcher, transport = _fetcher(
+        ("9.9.9.9", "8.8.8.8"),
+        {
+            "8.8.8.8": TimeoutError("slow edge"),
+            "9.9.9.9": _response(),
+        },
+    )
+
+    result = fetcher.fetch(
+        FetchRequest(source_id="official.example", source_uri=f"https://{HOST}/")
+    )
+
+    assert result.disposition is FetchDisposition.FETCHED
+    assert [request.target_ip for request in transport.requests] == [
+        "8.8.8.8",
+        "9.9.9.9",
+    ]
+
+
+def test_all_certificate_failures_remain_permanent_and_fail_closed() -> None:
+    fetcher, _ = _fetcher(
+        ("8.8.8.8", "9.9.9.9"),
+        {
+            "8.8.8.8": ssl.SSLCertVerificationError(1, "invalid chain one"),
+            "9.9.9.9": ssl.SSLCertVerificationError(1, "invalid chain two"),
+        },
+    )
+
+    result = fetcher.fetch(
+        FetchRequest(source_id="official.example", source_uri=f"https://{HOST}/")
+    )
+
+    assert result.disposition is FetchDisposition.PERMANENT_FAILURE
+    assert result.error_code == "source_tls_certificate_verification_failed"
+
+
+def test_address_attempts_are_bounded_to_four_verified_addresses() -> None:
+    addresses = ("1.1.1.1", "8.8.4.4", "8.8.8.8", "9.9.9.9", "93.184.216.34")
+    outcomes: dict[str, Exception | TransportResponse] = {
+        address: TimeoutError("slow edge") for address in addresses
+    }
+    outcomes["93.184.216.34"] = _response()
+    fetcher, transport = _fetcher(addresses, outcomes)
+
+    result = fetcher.fetch(
+        FetchRequest(source_id="official.example", source_uri=f"https://{HOST}/")
+    )
+
+    assert result.disposition is FetchDisposition.RETRYABLE_FAILURE
+    assert result.error_code == "source_transport_timeout"
+    assert len(transport.requests) == 4
+    assert "93.184.216.34" not in {
+        request.target_ip for request in transport.requests
+    }
+
+
+def test_resolver_binding_mismatch_fails_closed_before_transport() -> None:
+    transport = _AddressAwareTransport({"8.8.8.8": _response()})
+    fetcher = DiagnosticOfficialSourceHTTPFetcher(
+        policy=OfficialFetchPolicy(allowed_hosts=frozenset({HOST})),
+        resolver=_BindingMismatchResolver(),
+        transport=transport,
+    )
+
+    result = fetcher.fetch(
+        FetchRequest(source_id="official.example", source_uri=f"https://{HOST}/")
+    )
+
+    assert result.disposition is FetchDisposition.PERMANENT_FAILURE
+    assert result.error_code == "source_resolver_binding_mismatch"
+    assert transport.requests == []
+
+
+def test_http_response_is_not_hidden_by_address_failover() -> None:
+    fetcher, transport = _fetcher(
+        ("8.8.4.4", "8.8.8.8"),
+        {
+            "8.8.4.4": _response(503),
+            "8.8.8.8": _response(),
+        },
+    )
+
+    result = fetcher.fetch(
+        FetchRequest(source_id="official.example", source_uri=f"https://{HOST}/")
+    )
+
+    assert result.disposition is FetchDisposition.RETRYABLE_FAILURE
+    assert result.error_code == "source_http_503"
+    assert [request.target_ip for request in transport.requests] == ["8.8.4.4"]
+
+
+def test_mcx_live_definition_uses_bounded_slow_source_timeout() -> None:
+    source = OfficialSourceDefinition(
+        source_id="official.mcx.opendata",
+        owner="Министерство сельского хозяйства Российской Федерации",
+        entrypoint_uri="https://opendata.mcx.ru/",
+        allowed_hosts=frozenset({"opendata.mcx.ru"}),
+        topics=frozenset({CoverageTopic.GRAIN_TRACEABILITY}),
+        formats=frozenset({SourceFormat.HTML}),
+        expected_update_interval=timedelta(days=7),
+        maximum_publication_age=timedelta(days=31),
+        verified_at=NOW,
+    )
+    catalog = OfficialSourceCatalog(
+        sources=(source,),
+        requirements=(
+            CoverageRequirement(
+                topic=CoverageTopic.GRAIN_TRACEABILITY,
+                minimum_official_sources=1,
+                maximum_publication_age=timedelta(days=31),
+            ),
+        ),
+    )
+
+    definitions = diagnostic_live_definitions(
+        catalog=catalog,
+        timeout_seconds=20,
+    )
+
+    fetcher = definitions[0].fetcher
+    assert isinstance(fetcher, DiagnosticOfficialSourceHTTPFetcher)
+    assert fetcher.policy.timeout_seconds == 45


### PR DESCRIPTION
## Цель

Исправить подтверждённые exact-main причины `source_transport_timeout` для Минсельхоза и `source_tls_certificate_verification_failed` для Росстата без отключения TLS verification и без ослабления SSRF/DNS policy.

## Изменения

- diagnostic fetcher перебирает до четырёх уникальных `ResolvedAddress`, уже проверенных существующей public-DNS authority;
- exact host, port, TLS SNI и hostname verification сохраняются для каждой попытки;
- resolver binding mismatch остаётся permanent fail-closed;
- certificate failure или transport timeout на одном edge допускают bounded переход к следующему public edge;
- all-certificate failure остаётся permanent TLS failure;
- HTTP response, redirect, MIME, content limits и quarantine не маскируются address failover;
- для `official.mcx.opendata` минимальный timeout повышен с 20 до bounded 45 секунд;
- добавлены regression tests для TLS/timeout failover, all-certificate failure, четырёх попыток, resolver binding, HTTP non-failover и MCX timeout.

## Exact-head acceptance

Exact-head: `50ee822183a59e7abe7c4852a08553dbd89cb416`.
Base main: `3b137e530f44d6248bb9defa7fbdce64f6ff6709`.

PASS:

- TAI Foundation: Ruff, strict mypy, pytest/coverage;
- CI и Node CI;
- Security Scan;
- Security Quality Gate;
- Security Abuse exact-head evidence manifest;
- Runtime Context Security Gate и exact-head runtime manifest;
- Auction, Outbox и Disputes PostgreSQL acceptance;
- Dependency Review и optional-runtime retirement gate.

Review threads: 0.
Changed files: 2.

## Граница результата

Фактическое улучшение coverage принимается только после merge и нового controlled exact-main live artifact. Operational status остаётся `NOT_ATTESTED`.

Supersedes closed technical PR #2802. Part of #2789. Parent: #2726.