### PR TITLE
Restore the unified AI, support and call dock on the public home

### DIFF
--- a/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
+++ b/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
@@ -16,6 +16,7 @@ import '@/styles/platform-v7-unified-modal-fullscreen.css';
 
 const ASSISTANT_WORKSPACE = '/platform-v7/assistant';
 const PUBLIC_HOME = '/platform-v7';
+const PUBLIC_ENTRY_REWRITE_PREFIX = '/pc-public-entry';
 
 const PUBLIC_EXACT = new Set([
   PUBLIC_HOME,
@@ -46,7 +47,13 @@ const PUBLIC_PREFIXES = [
 
 function normalize(pathname: string): string {
   const clean = pathname.split('?')[0].replace(/\/+$/u, '');
-  return clean || PUBLIC_HOME;
+  const rewrittenHome = `${PUBLIC_ENTRY_REWRITE_PREFIX}${PUBLIC_HOME}`;
+
+  if (!clean) return PUBLIC_HOME;
+  if (clean === rewrittenHome || clean.startsWith(`${rewrittenHome}/`)) {
+    return clean.slice(PUBLIC_ENTRY_REWRITE_PREFIX.length) || PUBLIC_HOME;
+  }
+  return clean;
 }
 
 function isPrivateWorkspace(pathname: string): boolean {

--- a/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
+++ b/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
@@ -6,14 +6,29 @@ test.describe('unified public modal sheet fullscreen control', () => {
     await page.goto('/platform-v7?lang=ru', { waitUntil: 'load' });
   });
 
+  test('rewritten public home keeps the unified AI, support and call dock visible', async ({ page }) => {
+    const dock = page.getByRole('navigation', { name: 'Связь и помощь' });
+
+    await expect(dock).toBeVisible();
+    await expect(dock.getByRole('button', { name: 'Открыть ИИ-помощника по платформе' })).toBeVisible();
+    await expect(dock.getByRole('button', { name: 'Открыть поддержку' })).toBeVisible();
+    await expect(dock.getByRole('link', { name: 'Позвонить по номеру 8 916 277-89-89' }))
+      .toHaveAttribute('href', 'tel:+79162778989');
+
+    await expect(page.locator('.pc-public-assistant-shortcut')).toBeHidden();
+    await expect(page.locator('.p7-support-chat-button')).toBeHidden();
+  });
+
   test('platform assistant opens as a compact intent-first sheet and preserves fullscreen', async ({ page }) => {
-    await page.locator('.pc-public-assistant-shortcut').click();
+    const dock = page.getByRole('navigation', { name: 'Связь и помощь' });
+    await dock.getByRole('button', { name: 'Открыть ИИ-помощника по платформе' }).click();
 
     const dialog = page.getByRole('dialog', { name: 'Помощник по платформе' });
     const expand = dialog.getByRole('button', { name: 'На весь экран' });
     await expect(dialog).toBeVisible();
     await expect(expand).toBeVisible();
     await expect(dialog).toHaveAttribute('data-pc-fullscreen', 'false');
+    await expect(dock).toBeHidden();
 
     const starters = dialog.locator('.pc-public-assistant-starters button');
     await expect(starters.first()).toBeVisible();
@@ -52,10 +67,12 @@ test.describe('unified public modal sheet fullscreen control', () => {
   });
 
   test('support is compact, has one focus ring and uses the same fullscreen control', async ({ page }) => {
-    await page.locator('.p7-support-chat-button').click();
+    const dock = page.getByRole('navigation', { name: 'Связь и помощь' });
+    await dock.getByRole('button', { name: 'Открыть поддержку' }).click();
 
     const dialog = page.getByRole('dialog', { name: 'Поддержка' });
     await expect(dialog).toBeVisible();
+    await expect(dock).toBeHidden();
     await expect(dialog.getByText('Поддержка', { exact: true })).toBeVisible();
     await expect(dialog.getByText('Поддержка Прозрачной Цены', { exact: true })).toHaveCount(0);
 

--- a/apps/web/tests/unit/platformV7UnifiedPublicContactDock.test.ts
+++ b/apps/web/tests/unit/platformV7UnifiedPublicContactDock.test.ts
@@ -22,6 +22,14 @@ describe('platform-v7 unified public contact dock', () => {
     expect(dock).toContain("const SUPPORT_PHONE_DISPLAY = '8 916 277-89-89'");
   });
 
+  it('canonicalizes the Next.js public-entry rewrite before selecting the home surface', () => {
+    expect(contextual).toContain("const PUBLIC_ENTRY_REWRITE_PREFIX = '/pc-public-entry'");
+    expect(contextual).toContain('const rewrittenHome = `${PUBLIC_ENTRY_REWRITE_PREFIX}${PUBLIC_HOME}`');
+    expect(contextual).toContain('if (clean === rewrittenHome || clean.startsWith(`${rewrittenHome}/`))');
+    expect(contextual).toContain('return clean.slice(PUBLIC_ENTRY_REWRITE_PREFIX.length) || PUBLIC_HOME');
+    expect(contextual).toContain('if (path === PUBLIC_HOME)');
+  });
+
   it('keeps the call action but does not render the phone number in the dock', () => {
     expect(dock).toContain('<strong>{ui.call}</strong>');
     expect(dock).not.toContain('<small>{SUPPORT_PHONE_DISPLAY}</small>');


### PR DESCRIPTION
## Причина

Публичная главная `/platform-v7` физически обслуживается Next.js rewrite-маршрутом `/pc-public-entry/platform-v7`. Клиентский `usePathname()` мог вернуть rewrite destination, поэтому `ContextualSupportOrAssistant` не распознавал страницу как главную и показывал старую одиночную кнопку поддержки вместо общей плашки.

## Исправление

- rewrite destination канонизируется обратно в `/platform-v7` до выбора публичного UI;
- на главной снова отображается единая нижняя плашка `ИИ / Поддержка / Позвонить`;
- старые отдельные launcher-кнопки остаются скрытыми и используются только как внутренние триггеры существующих окон;
- E2E теперь открывает ИИ и поддержку именно через общую плашку и проверяет `tel:+79162778989`;
- добавлена unit-регрессия на rewrite path.

## Граница

API, ответы ИИ, отправка обращений, номер телефона, роли, права, данные и бизнес-логика не меняются.

## Файлы

1. `apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx`
2. `apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts`
3. `apps/web/tests/unit/platformV7UnifiedPublicContactDock.test.ts`