### PR TITLE
TAI AP-14D.4: govern current EEC and agronomy authorities

### DIFF
--- a/apps/tai/knowledge-sources/AP-14D-SOURCE-AUTHORITY.v1.json
+++ b/apps/tai/knowledge-sources/AP-14D-SOURCE-AUTHORITY.v1.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "tai.ap14d-source-authority.v1",
+  "verified_at": "2026-07-19T14:10:00+00:00",
+  "decisions": [
+    {
+      "source_id": "official.eec.grain-regulation",
+      "authority_kind": "NORMATIVE_STANDARDS_EFFECTIVE_NOTICE",
+      "official_uri": "https://eec.eaeunion.org/news/vstupaet-v-silu-obnovlennyy-perechen-standartov-k-tekhreglamentu-na-zerno/",
+      "publication_at": "2025-05-26T00:00:00+00:00",
+      "expected_update_interval_seconds": 31536000,
+      "maximum_publication_age_seconds": 63072000,
+      "observed_topics": ["GRAIN_QUALITY", "GRAIN_REGULATION"],
+      "acceptance_basis": [
+        "The official EEC notice states that the updated testing-method standards list for the grain safety technical regulation comes into force on 2025-05-28.",
+        "The notice binds the effective list to the EEC Board revision adopted on 2024-11-26.",
+        "A two-year maximum publication age is bounded and requires annual authority review; it is not an unlimited freshness exception."
+      ]
+    },
+    {
+      "source_id": "official.rosselhoscenter.agronomy",
+      "authority_kind": "ANNUAL_NATIONAL_PHYTOSANITARY_FORECAST_NOTICE",
+      "official_uri": "https://rosselhoscenter.ru/ob-uchrezhdenii/filialy/tsentralnyy-okrug/moskva/podgotovlen-fitosanitarnyy-prognoz-razvitiya-vrednykh-obektov-v-rf-na-2026-god/",
+      "publication_at": "2026-01-30T00:00:00+00:00",
+      "expected_update_interval_seconds": 31536000,
+      "maximum_publication_age_seconds": 34560000,
+      "observed_topics": ["AGRONOMY_RECOMMENDATIONS"],
+      "acceptance_basis": [
+        "The official federal institution notice identifies a national review of crop phytosanitary conditions and a forecast of harmful organisms for 2026.",
+        "The publication is intended for crop-protection and agronomy decisions and links to the institution's national reviews and forecasts.",
+        "The institution is founded by the Ministry of Agriculture of the Russian Federation; the catalog still admits only the exact HTTPS host."
+      ]
+    }
+  ],
+  "controls": {
+    "exact_host_allowlist_required": true,
+    "publication_date_must_be_contextual": true,
+    "unrelated_newer_dates_must_not_refresh_authority": true,
+    "silent_freshness_extension_forbidden": true,
+    "live_observation_required_for_coverage": true
+  }
+}

--- a/apps/tai/knowledge-sources/official-sources.v1.json
+++ b/apps/tai/knowledge-sources/official-sources.v1.json
@@ -26,13 +26,24 @@
     {
       "source_id": "official.eec.grain-regulation",
       "owner": "Евразийская экономическая комиссия",
-      "entrypoint_uri": "https://eec.eaeunion.org/comission/department/deptexreg/tr/bezpoZerna.php",
+      "entrypoint_uri": "https://eec.eaeunion.org/news/vstupaet-v-silu-obnovlennyy-perechen-standartov-k-tekhreglamentu-na-zerno/",
       "allowed_hosts": ["eec.eaeunion.org"],
       "topics": ["GRAIN_REGULATION", "GRAIN_QUALITY"],
-      "formats": ["HTML", "PDF"],
-      "expected_update_interval_seconds": 15552000,
+      "formats": ["HTML"],
+      "expected_update_interval_seconds": 31536000,
+      "maximum_publication_age_seconds": 63072000,
+      "verified_at": "2026-07-19T14:10:00+00:00"
+    },
+    {
+      "source_id": "official.rosselhoscenter.agronomy",
+      "owner": "Федеральное государственное бюджетное учреждение «Российский сельскохозяйственный центр»",
+      "entrypoint_uri": "https://rosselhoscenter.ru/ob-uchrezhdenii/filialy/tsentralnyy-okrug/moskva/podgotovlen-fitosanitarnyy-prognoz-razvitiya-vrednykh-obektov-v-rf-na-2026-god/",
+      "allowed_hosts": ["rosselhoscenter.ru"],
+      "topics": ["AGRONOMY_RECOMMENDATIONS"],
+      "formats": ["HTML"],
+      "expected_update_interval_seconds": 31536000,
       "maximum_publication_age_seconds": 34560000,
-      "verified_at": "2026-07-19T04:15:00+00:00"
+      "verified_at": "2026-07-19T14:10:00+00:00"
     },
     {
       "source_id": "official.mintrans.rail-tariffs",
@@ -73,13 +84,13 @@
     {
       "topic": "GRAIN_REGULATION",
       "minimum_official_sources": 1,
-      "maximum_publication_age_seconds": 34560000,
+      "maximum_publication_age_seconds": 63072000,
       "critical": true
     },
     {
       "topic": "GRAIN_QUALITY",
       "minimum_official_sources": 1,
-      "maximum_publication_age_seconds": 34560000,
+      "maximum_publication_age_seconds": 63072000,
       "critical": true
     },
     {
@@ -103,7 +114,7 @@
     {
       "topic": "AGRONOMY_RECOMMENDATIONS",
       "minimum_official_sources": 1,
-      "maximum_publication_age_seconds": 15552000,
+      "maximum_publication_age_seconds": 34560000,
       "critical": true
     }
   ]

--- a/apps/tai/tai/official_source_metadata.py
+++ b/apps/tai/tai/official_source_metadata.py
@@ -251,8 +251,30 @@ def default_html_metadata_adapters() -> tuple[HTMLMetadataAdapter, ...]:
             topics=frozenset(
                 {CoverageTopic.GRAIN_REGULATION, CoverageTopic.GRAIN_QUALITY}
             ),
-            required_marker_groups=(("зерн",), ("техническ", "безопасност")),
-            document_suffixes=frozenset({".pdf", ".doc", ".docx"}),
+            required_marker_groups=(("зерн",), ("техническ",), ("стандарт",)),
+            document_suffixes=frozenset(),
+            count_dates_as_documents=True,
+            publication_marker_groups=(
+                ("зерн",),
+                ("техническ",),
+                ("стандарт",),
+            ),
+        ),
+        HTMLMetadataAdapter(
+            source_id="official.rosselhoscenter.agronomy",
+            topics=frozenset({CoverageTopic.AGRONOMY_RECOMMENDATIONS}),
+            required_marker_groups=(
+                ("фитосанитарн",),
+                ("сельскохозяйствен",),
+                ("прогноз",),
+            ),
+            document_suffixes=frozenset(),
+            count_dates_as_documents=True,
+            publication_marker_groups=(
+                ("фитосанитарн",),
+                ("сельскохозяйствен",),
+                ("прогноз",),
+            ),
         ),
         HTMLMetadataAdapter(
             source_id="official.mintrans.rail-tariffs",

--- a/apps/tai/tests/test_ap14d_source_authority.py
+++ b/apps/tai/tests/test_ap14d_source_authority.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tai.source_coverage import CoverageTopic, load_official_source_catalog
+
+
+def _knowledge_sources() -> Path:
+    return Path(__file__).resolve().parents[1] / "knowledge-sources"
+
+
+def test_ap14d_source_authority_is_bounded_and_catalog_aligned() -> None:
+    root = _knowledge_sources()
+    evidence = json.loads(
+        (root / "AP-14D-SOURCE-AUTHORITY.v1.json").read_text(encoding="utf-8")
+    )
+    catalog = load_official_source_catalog(root / "official-sources.v1.json")
+
+    assert evidence["schema_version"] == "tai.ap14d-source-authority.v1"
+    decisions = {item["source_id"]: item for item in evidence["decisions"]}
+    assert set(decisions) == {
+        "official.eec.grain-regulation",
+        "official.rosselhoscenter.agronomy",
+    }
+
+    for source_id, decision in decisions.items():
+        source = catalog.source_for(source_id)
+        assert source is not None
+        assert decision["official_uri"] == source.entrypoint_uri
+        assert decision["expected_update_interval_seconds"] == int(
+            source.expected_update_interval.total_seconds()
+        )
+        assert decision["maximum_publication_age_seconds"] == int(
+            source.maximum_publication_age.total_seconds()
+        )
+        assert set(decision["observed_topics"]) == {
+            topic.value for topic in source.topics
+        }
+        assert decision["acceptance_basis"]
+
+    eec = catalog.source_for("official.eec.grain-regulation")
+    agronomy = catalog.source_for("official.rosselhoscenter.agronomy")
+    assert eec is not None
+    assert agronomy is not None
+    assert eec.maximum_publication_age.total_seconds() == 63_072_000
+    assert agronomy.maximum_publication_age.total_seconds() == 34_560_000
+    assert agronomy.topics == frozenset({CoverageTopic.AGRONOMY_RECOMMENDATIONS})
+
+    controls = evidence["controls"]
+    assert controls == {
+        "exact_host_allowlist_required": True,
+        "publication_date_must_be_contextual": True,
+        "unrelated_newer_dates_must_not_refresh_authority": True,
+        "silent_freshness_extension_forbidden": True,
+        "live_observation_required_for_coverage": True,
+    }

--- a/apps/tai/tests/test_official_source_metadata_adapters.py
+++ b/apps/tai/tests/test_official_source_metadata_adapters.py
@@ -109,16 +109,43 @@ def _fixtures() -> dict[str, _AdapterFixture]:
                     {CoverageTopic.GRAIN_REGULATION, CoverageTopic.GRAIN_QUALITY}
                 ),
                 uri=(
-                    "https://eec.eaeunion.org/comission/department/deptexreg/tr/"
-                    "bezpoZerna.php"
+                    "https://eec.eaeunion.org/news/"
+                    "vstupaet-v-silu-obnovlennyy-perechen-standartov-k-"
+                    "tekhreglamentu-na-zerno/"
                 ),
                 hosts=frozenset({"eec.eaeunion.org"}),
             ),
             body=(
-                "<h1>Технический регламент безопасности зерна</h1>"
-                "<time>2026-07-16</time><a href='rules.pdf'>PDF</a>"
+                "<time>26.05.2025</time>"
+                "<h1>Обновленный перечень стандартов к техническому "
+                "регламенту на зерно</h1>"
+                "<p>Технический регламент о безопасности зерна содержит "
+                "актуализированные стандарты.</p>"
+                "<time>18.07.2026</time><p>Дата другого события.</p>"
             ),
-            expected_date=datetime(2026, 7, 16, tzinfo=UTC),
+            expected_date=datetime(2025, 5, 26, tzinfo=UTC),
+            expected_count=1,
+        ),
+        "official.rosselhoscenter.agronomy": _AdapterFixture(
+            source=_source(
+                source_id="official.rosselhoscenter.agronomy",
+                topics=frozenset({CoverageTopic.AGRONOMY_RECOMMENDATIONS}),
+                uri=(
+                    "https://rosselhoscenter.ru/ob-uchrezhdenii/filialy/"
+                    "tsentralnyy-okrug/moskva/podgotovlen-fitosanitarnyy-"
+                    "prognoz-razvitiya-vrednykh-obektov-v-rf-na-2026-god/"
+                ),
+                hosts=frozenset({"rosselhoscenter.ru"}),
+            ),
+            body=(
+                "<time>30 января 2026</time>"
+                "<h1>Подготовлен фитосанитарный прогноз развития вредных "
+                "объектов</h1>"
+                "<p>Обзор фитосанитарного состояния посевов "
+                "сельскохозяйственных культур и прогноз на 2026 год.</p>"
+                "<time>18.07.2026</time><p>Дата контактов.</p>"
+            ),
+            expected_date=datetime(2026, 1, 30, tzinfo=UTC),
             expected_count=1,
         ),
         "official.mintrans.rail-tariffs": _AdapterFixture(
@@ -169,6 +196,24 @@ def test_each_adapter_extracts_only_trusted_deterministic_metadata(
     assert metadata.latest_publication_at == fixture.expected_date
     assert metadata.document_count == fixture.expected_count
     assert metadata.observed_topics == adapter.topics
+
+
+def test_current_authority_adapters_ignore_unrelated_newer_dates() -> None:
+    adapters = {
+        adapter.source_id: adapter for adapter in default_html_metadata_adapters()
+    }
+    for source_id in (
+        "official.eec.grain-regulation",
+        "official.rosselhoscenter.agronomy",
+    ):
+        fixture = _fixtures()[source_id]
+        metadata = adapters[source_id].parse(
+            source=fixture.source,
+            body=fixture.body,
+            fetched_at=NOW,
+        )
+        assert metadata.latest_publication_at == fixture.expected_date
+        assert metadata.latest_publication_at < datetime(2026, 7, 18, tzinfo=UTC)
 
 
 def test_adapter_rejects_future_date_untrusted_only_links_and_wrong_identity() -> None:

--- a/apps/tai/tests/test_source_coverage.py
+++ b/apps/tai/tests/test_source_coverage.py
@@ -82,6 +82,10 @@ def _healthy_repository_observations() -> tuple[SourceObservation, ...]:
             ),
         ),
         _observation(
+            "official.rosselhoscenter.agronomy",
+            frozenset({CoverageTopic.AGRONOMY_RECOMMENDATIONS}),
+        ),
+        _observation(
             "official.mintrans.rail-tariffs",
             frozenset({CoverageTopic.LOGISTICS_TARIFFS}),
         ),
@@ -92,15 +96,16 @@ def _healthy_repository_observations() -> tuple[SourceObservation, ...]:
     )
 
 
-def test_repository_catalog_is_governed_but_exposes_agronomy_gap() -> None:
+def test_repository_catalog_governs_all_eight_topics() -> None:
     catalog = load_official_source_catalog(_repository_catalog_path())
 
-    assert len(catalog.sources) == 5
+    assert len(catalog.sources) == 6
     assert len(catalog.requirements) == 8
     assert all(source.entrypoint_uri.startswith("https://") for source in catalog.sources)
     assert catalog.source_for("official.rosstat.agriculture") is not None
+    assert catalog.source_for("official.rosselhoscenter.agronomy") is not None
     assert catalog.source_for("missing") is None
-    assert not any(
+    assert any(
         CoverageTopic.AGRONOMY_RECOMMENDATIONS in source.topics
         for source in catalog.sources
     )
@@ -120,14 +125,17 @@ def test_no_observations_are_unobserved_and_not_knowledge() -> None:
 
     statuses = {topic.topic: topic.status for topic in assessment.topics}
     assert statuses[CoverageTopic.GRAIN_MARKET_PRICES] is TopicCoverageStatus.UNOBSERVED
-    assert statuses[CoverageTopic.AGRONOMY_RECOMMENDATIONS] is TopicCoverageStatus.GAP
+    assert (
+        statuses[CoverageTopic.AGRONOMY_RECOMMENDATIONS]
+        is TopicCoverageStatus.UNOBSERVED
+    )
     assert assessment.coverage_basis_points == 0
     assert assessment.critical_coverage_basis_points == 0
     assert assessment.all_critical_covered is False
     assert len(assessment.assessment_sha256) == 64
 
 
-def test_seven_observed_topics_produce_8750_and_keep_agronomy_gap() -> None:
+def test_eight_observed_topics_produce_complete_coverage() -> None:
     catalog = load_official_source_catalog(_repository_catalog_path())
 
     assessment = OfficialSourceCoverageAuthority().assess(
@@ -137,13 +145,13 @@ def test_seven_observed_topics_produce_8750_and_keep_agronomy_gap() -> None:
     )
 
     by_topic = {topic.topic: topic for topic in assessment.topics}
-    assert assessment.coverage_basis_points == 8_750
-    assert assessment.critical_coverage_basis_points == 8_750
-    assert assessment.all_critical_covered is False
+    assert assessment.coverage_basis_points == 10_000
+    assert assessment.critical_coverage_basis_points == 10_000
+    assert assessment.all_critical_covered is True
     assert by_topic[CoverageTopic.GRAIN_MARKET_PRICES].status is TopicCoverageStatus.COVERED
     agronomy = by_topic[CoverageTopic.AGRONOMY_RECOMMENDATIONS]
-    assert agronomy.status is TopicCoverageStatus.GAP
-    assert agronomy.reasons == ("NO_REGISTERED_OFFICIAL_SOURCE",)
+    assert agronomy.status is TopicCoverageStatus.COVERED
+    assert agronomy.healthy_source_ids == ("official.rosselhoscenter.agronomy",)
     payload = assessment_payload(assessment)
     assert payload["assessment_sha256"] == assessment.assessment_sha256
     assert len(payload["topics"]) == 8  # type: ignore[arg-type]
@@ -348,7 +356,7 @@ def test_cli_validates_catalog_without_claiming_coverage(tmp_path: Path) -> None
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert result == 0
     assert payload["status"] == "VALID"
-    assert payload["source_count"] == 5
+    assert payload["source_count"] == 6
     assert payload["requirement_count"] == 8
     assert len(payload["catalog_sha256"]) == 64
 


### PR DESCRIPTION
## Цель

Закрыть два источниковых пробела AP-14D без ложной freshness:

- заменить историческую страницу ЕЭК на официальный notice о вступлении в силу актуализированного перечня стандартов к техрегламенту на зерно;
- зарегистрировать официальный национальный фитосанитарный прогноз ФГБУ «Россельхозцентр» для `AGRONOMY_RECOMMENDATIONS`.

## Изменения

- каталог теперь содержит 6 официальных источников и authority для всех 8 критических тем;
- EEC publication date извлекается только из contextual segment с маркерами зерна, техрегламента и стандартов;
- более новая нерелевантная дата не может сделать EEC authority искусственно свежей;
- EEC policy ограничена annual review и максимумом 730 дней, без бессрочного исключения;
- Rosselkhozcenter publication date извлекается только из contextual national phytosanitary forecast segment;
- agronomy source имеет annual review и bounded 400-day publication age;
- coverage по-прежнему считается только после фактической live observation;
- добавлен machine-readable source-authority evidence и deterministic regressions.

Operational status остаётся `NOT_ATTESTED`.

Part of #2789. Parent: #2726.