### PR TITLE
Make the unified AI, support and call dock mandatory on public surfaces

### DIFF
--- a/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
+++ b/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
@@ -49,7 +49,7 @@ function normalize(pathname: string): string {
   const clean = pathname.split('?')[0].replace(/\/+$/u, '');
   const rewrittenHome = `${PUBLIC_ENTRY_REWRITE_PREFIX}${PUBLIC_HOME}`;
 
-  if (!clean) return PUBLIC_HOME;
+  if (!clean || clean === '/') return PUBLIC_HOME;
   if (clean === rewrittenHome || clean.startsWith(`${rewrittenHome}/`)) {
     return clean.slice(PUBLIC_ENTRY_REWRITE_PREFIX.length) || PUBLIC_HOME;
   }
@@ -108,21 +108,10 @@ function useVisualViewportMetrics() {
 export function ContextualSupportOrAssistant() {
   installPublicAssistantFetchResilience();
   useVisualViewportMetrics();
-  const pathname = usePathname() || PUBLIC_HOME;
-  const path = normalize(pathname);
+  const routerPathname = usePathname() || PUBLIC_HOME;
+  const browserPathname = typeof window === 'undefined' ? routerPathname : window.location.pathname;
+  const path = normalize(browserPathname || routerPathname);
   if (path === ASSISTANT_WORKSPACE) return null;
-
-  if (path === PUBLIC_HOME) {
-    return (
-      <>
-        <UnifiedModalSheetFullscreenController />
-        {/* Keep the separate no-account-data knowledge assistant and support workflows; unify only their public entry point. */}
-        <PublicPlatformAssistant />
-        <ChatSupportWidget />
-        <PublicContactDock />
-      </>
-    );
-  }
 
   if (isPrivateWorkspace(path)) {
     return (
@@ -133,10 +122,14 @@ export function ContextualSupportOrAssistant() {
     );
   }
 
+  // Every public platform surface uses one visible entry point. The standalone
+  // assistant and support launchers remain internal triggers for the shared dock.
   return (
     <>
       <UnifiedModalSheetFullscreenController />
+      <PublicPlatformAssistant />
       <ChatSupportWidget />
+      <PublicContactDock />
     </>
   );
 }

--- a/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
+++ b/apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts
@@ -6,6 +6,15 @@ test.describe('unified public modal sheet fullscreen control', () => {
     await page.goto('/platform-v7?lang=ru', { waitUntil: 'load' });
   });
 
+  test('every public home alias renders the unified dock instead of standalone support', async ({ page }) => {
+    for (const entry of ['/?lang=ru', '/pc-public-entry/platform-v7?lang=ru']) {
+      await page.goto(entry, { waitUntil: 'load' });
+      const dock = page.getByRole('navigation', { name: 'Связь и помощь' });
+      await expect(dock).toBeVisible();
+      await expect(page.locator('.p7-support-chat-button')).toBeHidden();
+    }
+  });
+
   test('rewritten public home keeps the unified AI, support and call dock visible', async ({ page }) => {
     const dock = page.getByRole('navigation', { name: 'Связь и помощь' });
 

--- a/apps/web/tests/unit/platformV7UnifiedPublicContactDock.test.ts
+++ b/apps/web/tests/unit/platformV7UnifiedPublicContactDock.test.ts
@@ -22,12 +22,23 @@ describe('platform-v7 unified public contact dock', () => {
     expect(dock).toContain("const SUPPORT_PHONE_DISPLAY = '8 916 277-89-89'");
   });
 
-  it('canonicalizes the Next.js public-entry rewrite before selecting the home surface', () => {
+  it('uses the browser-visible path and canonicalizes every public home alias', () => {
     expect(contextual).toContain("const PUBLIC_ENTRY_REWRITE_PREFIX = '/pc-public-entry'");
+    expect(contextual).toContain("if (!clean || clean === '/') return PUBLIC_HOME");
     expect(contextual).toContain('const rewrittenHome = `${PUBLIC_ENTRY_REWRITE_PREFIX}${PUBLIC_HOME}`');
     expect(contextual).toContain('if (clean === rewrittenHome || clean.startsWith(`${rewrittenHome}/`))');
     expect(contextual).toContain('return clean.slice(PUBLIC_ENTRY_REWRITE_PREFIX.length) || PUBLIC_HOME');
-    expect(contextual).toContain('if (path === PUBLIC_HOME)');
+    expect(contextual).toContain("const browserPathname = typeof window === 'undefined' ? routerPathname : window.location.pathname");
+    expect(contextual).toContain('const path = normalize(browserPathname || routerPathname)');
+  });
+
+  it('never falls back to a standalone support button on a public surface', () => {
+    const publicReturn = contextual.slice(contextual.lastIndexOf('return ('));
+    expect(publicReturn).toContain('<UnifiedModalSheetFullscreenController />');
+    expect(publicReturn).toContain('<PublicPlatformAssistant />');
+    expect(publicReturn).toContain('<ChatSupportWidget />');
+    expect(publicReturn).toContain('<PublicContactDock />');
+    expect(publicReturn).toContain('Every public platform surface uses one visible entry point');
   });
 
   it('keeps the call action but does not render the phone number in the dock', () => {


### PR DESCRIPTION
## Причина

Production продолжал показывать одиночную кнопку поддержки на части публичных входов. Корень проблемы — резервная ветка `ContextualSupportOrAssistant`, которая при любом нераспознанном публичном pathname рендерила только `ChatSupportWidget`.

## Исправление

- фактический browser pathname имеет приоритет над внутренним `usePathname()`;
- `/`, `/platform-v7` и `/pc-public-entry/platform-v7` приводятся к одному публичному контуру;
- удалён публичный fallback с одиночной кнопкой поддержки;
- на любом публичном surface обязательны `ИИ / Поддержка / Позвонить`;
- отдельные launcher-кнопки остаются только внутренними скрытыми триггерами;
- добавлены unit- и Playwright-регрессии для root и rewrite destination.

## Граница

Не меняются API, ответы ИИ, отправка обращений, телефон, роли, права, данные или бизнес-логика.

## Файлы

1. `apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx`
2. `apps/web/tests/unit/platformV7UnifiedPublicContactDock.test.ts`
3. `apps/web/tests/e2e/platform-v7-unified-modal-fullscreen.spec.ts`