### PR TITLE
TAI AP-14D.6: owner-only exact-main trigger

### DIFF
--- a/.github/workflows/tai-live-source-evidence.yml
+++ b/.github/workflows/tai-live-source-evidence.yml
@@ -2,6 +2,8 @@ name: TAI Live Official Source Evidence
 
 on:
   workflow_dispatch:
+  issue_comment:
+    types: [created]
   schedule:
     - cron: '23 4 * * 2'
 
@@ -9,13 +11,27 @@ permissions:
   contents: read
   actions: read
 
-concurrency:
-  group: tai-live-official-source-evidence
-  cancel-in-progress: false
-
 jobs:
   collect:
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.action == 'created' &&
+          github.event.issue.pull_request == null &&
+          github.event.comment.body == '/tai run exact-main' &&
+          github.event.comment.author_association == 'OWNER' &&
+          github.event.comment.user.login == github.repository_owner &&
+          github.actor == github.repository_owner &&
+          github.triggering_actor == github.repository_owner
+        )
+      )
+    concurrency:
+      group: tai-live-official-source-evidence
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
@@ -112,7 +128,8 @@ jobs:
             )
           fi
           acceptance_args=()
-          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ]; then
+          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] \
+            || [ "$GITHUB_EVENT_NAME" = 'issue_comment' ]; then
             acceptance_args+=(--require-complete-coverage)
           fi
           python -m tai.live_source_evidence_cli \

--- a/apps/tai/knowledge-sources/AP-14D-NEXT-LIVE-RUN.md
+++ b/apps/tai/knowledge-sources/AP-14D-NEXT-LIVE-RUN.md
@@ -13,4 +13,6 @@ Acceptance for the diagnostic rerun:
 7. controlled `workflow_dispatch` acceptance requires `6/6` observed sources, `8/8` covered topics, `10000/10000` critical coverage, no history gap and `HEALTHY` dashboard status;
 8. scheduled refresh fails after artifact upload on critical, stale, expired or history-gap alerts.
 
+The repository owner can invoke the same complete exact-main acceptance through the exact issue command `/tai run exact-main`; all other issue comments are skipped and the workflow retains read-only permissions.
+
 This rerun identifies the next source-specific repair. It is not production attestation.

--- a/apps/tai/tai/live_source_evidence_cli.py
+++ b/apps/tai/tai/live_source_evidence_cli.py
@@ -65,7 +65,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--run-attempt", type=int, default=1)
     parser.add_argument(
         "--trigger",
-        choices=("schedule", "workflow_dispatch"),
+        choices=("issue_comment", "schedule", "workflow_dispatch"),
         default="workflow_dispatch",
     )
     parser.add_argument("--previous-history", type=Path)

--- a/apps/tai/tai/source_health.py
+++ b/apps/tai/tai/source_health.py
@@ -149,7 +149,7 @@ class SourceRefreshCycle:
         _git_oid(self.repository_sha)
         if self.run_id < 1 or self.run_attempt < 1:
             raise ValueError("refresh cycle run identity must be positive")
-        if self.trigger not in {"schedule", "workflow_dispatch"}:
+        if self.trigger not in {"issue_comment", "schedule", "workflow_dispatch"}:
             raise ValueError("refresh cycle trigger is not governed")
         _aware(self.started_at, "started_at")
         _aware(self.completed_at, "completed_at")

--- a/apps/tai/tests/test_live_source_evidence_workflow.py
+++ b/apps/tai/tests/test_live_source_evidence_workflow.py
@@ -12,6 +12,8 @@ def test_live_evidence_workflow_is_read_only_exact_main_and_non_merge_blocking()
     ).read_text(encoding="utf-8")
 
     assert "workflow_dispatch:" in workflow
+    assert "issue_comment:" in workflow
+    assert "types: [created]" in workflow
     assert "schedule:" in workflow
     assert "pull_request:" not in workflow
     assert "push:" not in workflow
@@ -22,6 +24,16 @@ def test_live_evidence_workflow_is_read_only_exact_main_and_non_merge_blocking()
     assert "id-token: write" not in workflow
     assert "secrets." not in workflow
     assert "github.ref == 'refs/heads/main'" in workflow
+    assert "github.event.comment.body == '/tai run exact-main'" in workflow
+    assert "github.event.action == 'created'" in workflow
+    assert "github.event_name == 'schedule'" in workflow
+    assert "github.event_name == 'workflow_dispatch'" in workflow
+    assert "github.event.comment.author_association == 'OWNER'" in workflow
+    assert "github.event.issue.pull_request == null" in workflow
+    assert "github.event.comment.user.login == github.repository_owner" in workflow
+    assert "github.actor == github.repository_owner" in workflow
+    assert "github.triggering_actor == github.repository_owner" in workflow
+    assert workflow.index("    concurrency:") > workflow.index("  collect:")
     assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in workflow
     assert 'test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"' in workflow
     assert "select(.workflow_run.head_branch == \"main\")" in workflow
@@ -42,5 +54,6 @@ def test_live_evidence_workflow_is_read_only_exact_main_and_non_merge_blocking()
     assert "knowledge-acceptance.v1.json" in workflow
     assert "evidence-bundle-index.v1.json" in workflow
     assert "--require-complete-coverage" in workflow
+    assert "[ \"$GITHUB_EVENT_NAME\" = 'issue_comment' ]" in workflow
     assert "github.token" in workflow
     assert "continue-on-error" not in workflow

--- a/apps/tai/tests/test_source_health.py
+++ b/apps/tai/tests/test_source_health.py
@@ -144,6 +144,12 @@ def _observation(
     )
 
 
+def test_owner_command_trigger_is_governed() -> None:
+    cycle = replace(_cycle(1, _success()), trigger="issue_comment")
+
+    assert cycle.trigger == "issue_comment"
+
+
 def _coverage(
     catalog: OfficialSourceCatalog,
     observation: SourceObservation | None,

--- a/docs/platform-v7/autopilot/scopes/tai-ap-14d-2789.json
+++ b/docs/platform-v7/autopilot/scopes/tai-ap-14d-2789.json
@@ -6,7 +6,7 @@
   "status": "active",
   "maturityBoundary": "official-source-health-and-exact-main-knowledge-evidence-only",
   "globalProgramStateUnchanged": "This isolated TAI scope does not advance platform-v7 Industrial Integration-Ready or TAI operational attestation.",
-  "branchBaseExactMain": "7279b5d850994bfab92cc8afb0573ea279b63447",
+  "branchBaseExactMain": "27a45cc95c730aeedfbdc6ad23e8cbc89b6cf527",
   "taiKnowledgeBaselineExactMain": "d19dfdd9556ee9c771b121c66849f459bc267625",
   "remediatesReviewThreads": [
     "PR #2803 discussion_r3610703119",
@@ -43,6 +43,7 @@
     "immutable bounded refresh-history chain with rerun deduplication",
     "machine-readable stale, expiry and consecutive-failure alerts",
     "exact-SHA read-only workflow with artifact upload before enforcement",
+    "owner-only exact issue command for connector-driven acceptance",
     "controlled exact-main 6/6 sources and 8/8 critical topics",
     "Ruff, strict mypy, pytest coverage and exact-head security gates",
     "zero unresolved review threads before merge"


### PR DESCRIPTION
Follow-up to #2807 and part of #2789.

Adds a permanent connector-driven trigger for the read-only live-source acceptance:

- only an exact `/tai run exact-main` issue comment is accepted;
- only the repository owner may author and trigger it, including re-runs;
- PR comments and all untrusted comments are skipped;
- concurrency is job-scoped so skipped comments cannot block a legitimate run;
- the exact-main SHA check, read-only permissions, artifact-first enforcement and 6/6 + 8/8 gate remain unchanged.

Local verification: scope guard passed; Ruff and strict mypy passed; targeted workflow/source-health/CLI tests passed; independent security review found no blockers.