### PR TITLE
Restore unified contact dock across platform routes

### DIFF
--- a/apps/web/app/pc-public-entry/platform-v7/layout.tsx
+++ b/apps/web/app/pc-public-entry/platform-v7/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+import { HydrationSafeChatSupport } from '@/components/platform-v7/HydrationSafeChatSupport';
+
+/**
+ * The landing, login and recovery URLs are rewritten into this physically
+ * isolated tree. Keep the unified contact dock at the tree boundary so all
+ * three entry surfaces get exactly one hydration-safe mount.
+ */
+export default function PublicEntryLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      {children}
+      <HydrationSafeChatSupport />
+    </>
+  );
+}

--- a/apps/web/app/platform-v7/layout.tsx
+++ b/apps/web/app/platform-v7/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { cookies, headers } from 'next/headers';
 import { notFound, redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
+import { HydrationSafeChatSupport } from '@/components/platform-v7/HydrationSafeChatSupport';
 import { ACCESS_COOKIE } from '@/lib/auth-cookies';
 import { canRoleAccessCabinet } from '@/lib/platform-v7/cabinet-access-policy';
 import { isDesignSystemV8Route } from '@/lib/platform-v7/design-system-v8-route-policy';
@@ -223,7 +224,16 @@ export default async function PlatformV7Layout({ children }: { children: ReactNo
   const pathname = normalizePath((await headers()).get('x-pc-pathname'));
 
   // Every public route owns its static route-level shell, locale copy and CSS.
-  if (isPublicPath(pathname)) return children;
+  // The contact dock is mounted at the route boundary so supporting pages that
+  // do not render PublicSiteHeader still expose the same AI/support/call entry.
+  if (isPublicPath(pathname)) {
+    return (
+      <>
+        {children}
+        <HydrationSafeChatSupport />
+      </>
+    );
+  }
 
   // Staff remains a separate privileged authority plane and authenticates through
   // its own server-issued staff session rather than a business cabinet role.

--- a/apps/web/components/platform-v7/AiAssistantPanel.tsx
+++ b/apps/web/components/platform-v7/AiAssistantPanel.tsx
@@ -603,6 +603,8 @@ export function AiAssistantPanel({ variant = 'floating' }: { variant?: Variant }
   const panel = (
     <section
       ref={panelRef}
+      id={variant === 'floating' ? 'p7-private-ai-assistant-panel' : 'p7-private-ai-assistant-workspace'}
+      tabIndex={variant === 'workspace' ? -1 : undefined}
       className={`p7-ai-panel ${variant === 'workspace' ? 'p7-ai-panel-workspace' : ''}`}
       role={variant === 'floating' ? 'dialog' : 'region'}
       aria-modal={variant === 'floating' ? 'true' : undefined}

--- a/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
+++ b/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
@@ -4,7 +4,6 @@ import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
 import { AiAssistantPanel } from './AiAssistantPanel';
 import { ChatSupportWidget } from './ChatSupportWidget';
-import { PrivateAssistantShortcutLabel } from './PrivateAssistantShortcutLabel';
 import { PublicContactDock } from './PublicContactDock';
 import { PublicPlatformAssistant } from './PublicPlatformAssistant';
 import { UnifiedModalSheetFullscreenController } from './UnifiedModalSheetFullscreenController';
@@ -34,15 +33,22 @@ const PUBLIC_EXACT = new Set([
   '/platform-v7/contacts',
   '/platform-v7/request',
   '/platform-v7/docs',
+  '/platform-v7/about',
+  '/platform-v7/oferta',
+  '/platform-v7/roles',
   '/platform-v7/secure-grain-deal',
+  '/platform-v7/grain-logistics',
+  '/platform-v7/grain-quality',
+  '/platform-v7/grain-documents',
+  '/platform-v7/grain-payment',
   '/platform-v7/fgis-zerno',
   '/platform-v7/privacy',
   '/platform-v7/terms',
 ]);
 
 const PUBLIC_PREFIXES = [
-  '/platform-v7/demo/',
-  '/platform-v7/role-preview/',
+  '/platform-v7/demo',
+  '/platform-v7/role-preview',
 ] as const;
 
 function normalize(pathname: string): string {
@@ -60,7 +66,7 @@ function isPrivateWorkspace(pathname: string): boolean {
   const path = normalize(pathname);
   if (!path.startsWith('/platform-v7')) return false;
   if (PUBLIC_EXACT.has(path)) return false;
-  if (PUBLIC_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
+  if (PUBLIC_PREFIXES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))) return false;
   return true;
 }
 
@@ -111,13 +117,27 @@ export function ContextualSupportOrAssistant() {
   const routerPathname = usePathname() || PUBLIC_HOME;
   const browserPathname = typeof window === 'undefined' ? routerPathname : window.location.pathname;
   const path = normalize(browserPathname || routerPathname);
-  if (path === ASSISTANT_WORKSPACE) return null;
+
+  // The full-page assistant already renders its own workspace panel. Keep the
+  // shared dock for human support and phone access, while the AI action focuses
+  // that existing panel instead of creating a duplicate floating assistant.
+  if (path === ASSISTANT_WORKSPACE) {
+    return (
+      <>
+        <UnifiedModalSheetFullscreenController />
+        <ChatSupportWidget />
+        <PublicContactDock assistantContext='workspace' />
+      </>
+    );
+  }
 
   if (isPrivateWorkspace(path)) {
     return (
       <>
-        <PrivateAssistantShortcutLabel />
+        <UnifiedModalSheetFullscreenController />
         <AiAssistantPanel variant='floating' />
+        <ChatSupportWidget />
+        <PublicContactDock assistantContext='private' />
       </>
     );
   }

--- a/apps/web/components/platform-v7/PlatformV7DesignSystemV8Runtime.tsx
+++ b/apps/web/components/platform-v7/PlatformV7DesignSystemV8Runtime.tsx
@@ -2,7 +2,6 @@
 
 import type { ReactNode } from 'react';
 import '../../../../packages/design-tokens/tokens.css';
-import { HydrationSafeChatSupport } from '@/components/platform-v7/HydrationSafeChatSupport';
 
 /**
  * Minimal runtime for routes accepted into Design System v8.
@@ -13,10 +12,5 @@ import { HydrationSafeChatSupport } from '@/components/platform-v7/HydrationSafe
  * presentation through tokens and CSS Modules.
  */
 export function PlatformV7DesignSystemV8Runtime({ children }: { children: ReactNode }) {
-  return (
-    <>
-      {children}
-      <HydrationSafeChatSupport />
-    </>
-  );
+  return children;
 }

--- a/apps/web/components/platform-v7/PlatformV7ProtectedRuntime.tsx
+++ b/apps/web/components/platform-v7/PlatformV7ProtectedRuntime.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 import { ToastProvider } from '@/components/v7r/Toast';
 import { PlatformThemeSync } from '@/components/v7r/PlatformThemeSync';
+import { HydrationSafeChatSupport } from '@/components/platform-v7/HydrationSafeChatSupport';
 import { PlatformV7ProtectedShell } from '@/components/platform-v7/PlatformV7ProtectedShell';
 import type { PlatformRole } from '@/stores/usePlatformV7RStore';
 
@@ -19,6 +20,7 @@ export function PlatformV7ProtectedRuntime({
     <ToastProvider>
       <PlatformThemeSync />
       <PlatformV7ProtectedShell pathname={pathname} verifiedRole={verifiedRole}>{children}</PlatformV7ProtectedShell>
+      <HydrationSafeChatSupport />
     </ToastProvider>
   );
 }

--- a/apps/web/components/platform-v7/PublicContactDock.tsx
+++ b/apps/web/components/platform-v7/PublicContactDock.tsx
@@ -6,6 +6,7 @@ import { trackEvent } from '@/lib/analytics/track';
 
 type Locale = 'ru' | 'en' | 'zh';
 type Surface = 'assistant' | 'support';
+type AssistantContext = 'public' | 'private' | 'workspace';
 
 const SUPPORT_PHONE_DISPLAY = '8 916 277-89-89';
 const SUPPORT_PHONE_HREF = 'tel:+79162778989';
@@ -55,7 +56,7 @@ function restoreAttribute(node: HTMLElement, name: string, value: string | null)
   else node.setAttribute(name, value);
 }
 
-export function PublicContactDock() {
+export function PublicContactDock({ assistantContext = 'public' }: { assistantContext?: AssistantContext }) {
   const [locale, setLocale] = React.useState<Locale>('ru');
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const assistantButtonRef = React.useRef<HTMLButtonElement>(null);
@@ -63,11 +64,23 @@ export function PublicContactDock() {
   const returnFocusRef = React.useRef<Surface | null>(null);
   const openStateRef = React.useRef({ assistant: false, support: false });
   const ui = COPY[locale];
+  const assistantTriggerSelector = assistantContext === 'workspace'
+    ? null
+    : assistantContext === 'private'
+      ? '.p7-ai-trigger'
+      : '.pc-public-assistant-shortcut';
+  const assistantPanelSelector = assistantContext === 'workspace'
+    ? '#p7-private-ai-assistant-workspace'
+    : assistantContext === 'private'
+      ? '#p7-private-ai-assistant-panel'
+      : '#pc-public-assistant-panel';
 
   React.useEffect(() => setLocale(resolveLocale()), []);
 
   React.useEffect(() => {
-    const assistantTrigger = document.querySelector<HTMLButtonElement>('.pc-public-assistant-shortcut');
+    const assistantTrigger = assistantTriggerSelector
+      ? document.querySelector<HTMLButtonElement>(assistantTriggerSelector)
+      : null;
     const supportTrigger = document.querySelector<HTMLButtonElement>('.p7-support-chat-button');
     const triggers = [assistantTrigger, supportTrigger].filter((node): node is HTMLButtonElement => Boolean(node));
     const previous = triggers.map((node) => ({
@@ -82,12 +95,13 @@ export function PublicContactDock() {
     }
 
     const syncOpenState = () => {
-      const assistantOpen = Boolean(document.querySelector('#pc-public-assistant-panel'));
+      const assistantOpen = assistantContext !== 'workspace' && Boolean(document.querySelector(assistantPanelSelector));
       const supportOpen = Boolean(document.querySelector('.p7-support-chat-panel'));
+      const blockingModalOpen = Boolean(document.querySelector('[role="dialog"][aria-modal="true"]'));
       const previousOpen = openStateRef.current;
       const focusTarget = returnFocusRef.current;
 
-      setDialogOpen(assistantOpen || supportOpen);
+      setDialogOpen(assistantOpen || supportOpen || blockingModalOpen);
 
       if (previousOpen.assistant && !assistantOpen && focusTarget === 'assistant') {
         returnFocusRef.current = null;
@@ -112,10 +126,18 @@ export function PublicContactDock() {
         restoreAttribute(entry.node, 'aria-hidden', entry.ariaHidden);
       }
     };
-  }, []);
+  }, [assistantContext, assistantPanelSelector, assistantTriggerSelector]);
 
   const openSurface = (surface: Surface) => {
-    const selector = surface === 'assistant' ? '.pc-public-assistant-shortcut' : '.p7-support-chat-button';
+    if (surface === 'assistant' && assistantContext === 'workspace') {
+      const workspace = document.querySelector<HTMLElement>(assistantPanelSelector);
+      if (!workspace) return;
+      workspace.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      window.requestAnimationFrame(() => workspace.focus({ preventScroll: true }));
+      return;
+    }
+    const selector = surface === 'assistant' ? assistantTriggerSelector : '.p7-support-chat-button';
+    if (!selector) return;
     const trigger = document.querySelector<HTMLButtonElement>(selector);
     if (!trigger) return;
     returnFocusRef.current = surface;
@@ -128,14 +150,15 @@ export function PublicContactDock() {
       aria-label={ui.group}
       aria-hidden={dialogOpen}
       data-dialog-open={dialogOpen ? 'true' : 'false'}
+      data-assistant-context={assistantContext}
     >
       <button
         ref={assistantButtonRef}
         type='button'
         className='pc-public-contact-dock-action pc-public-contact-dock-assistant'
         aria-label={ui.assistantAria}
-        aria-haspopup='dialog'
-        aria-controls='pc-public-assistant-panel'
+        aria-haspopup={assistantContext === 'workspace' ? undefined : 'dialog'}
+        aria-controls={assistantPanelSelector.slice(1)}
         onClick={() => openSurface('assistant')}
       >
         <span className='pc-public-contact-dock-icon' aria-hidden='true'>
@@ -162,7 +185,10 @@ export function PublicContactDock() {
         className='pc-public-contact-dock-action pc-public-contact-dock-call'
         href={SUPPORT_PHONE_HREF}
         aria-label={ui.callAria}
-        onClick={() => trackEvent('public_support_phone_clicked', { source: 'unified_contact_dock' })}
+        onClick={() => trackEvent('public_support_phone_clicked', {
+          source: 'unified_contact_dock',
+          assistantContext,
+        })}
       >
         <span className='pc-public-contact-dock-icon' aria-hidden='true'>
           <Phone size={17} strokeWidth={2.1} />
@@ -177,6 +203,7 @@ export function PublicContactDock() {
 
 const css = `
 .pc-public-assistant-shortcut,
+.p7-ai-trigger,
 .p7-support-chat-button {
   position: fixed !important;
   width: 1px !important;
@@ -223,6 +250,14 @@ const css = `
   visibility: hidden;
   opacity: 0;
   pointer-events: none;
+}
+.pc-public-contact-dock[data-assistant-context='private'],
+.pc-public-contact-dock[data-assistant-context='workspace'] {
+  bottom: max(92px, calc(env(safe-area-inset-bottom, 0px) + 88px));
+  z-index: 97;
+}
+.pc-shell-root-v4 .pc-v4-main {
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 156px);
 }
 .pc-public-contact-dock,
 .pc-public-contact-dock * { box-sizing: border-box; min-width: 0; }

--- a/apps/web/components/platform-v7/PublicSiteHeader.tsx
+++ b/apps/web/components/platform-v7/PublicSiteHeader.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
 import { BrandMark } from '@/components/v7r/BrandMark';
-import { HydrationSafeChatSupport } from '@/components/platform-v7/HydrationSafeChatSupport';
 import { PublicLocaleSwitch } from '@/components/platform-v7/PublicLocaleSwitch';
 
 export const PUBLIC_SITE_HEADER_HEIGHT = 64;
@@ -339,7 +338,6 @@ export function PublicSiteHeader({
           {actions}
         </div>
       </header>
-      <HydrationSafeChatSupport />
     </>
   );
 }

--- a/apps/web/tests/unit/platformV7BrowserAcceptanceRepairs.test.ts
+++ b/apps/web/tests/unit/platformV7BrowserAcceptanceRepairs.test.ts
@@ -12,6 +12,7 @@ const protectedShell = read('apps/web/components/platform-v7/PlatformV7Protected
 const protectedShellCss = read('apps/web/components/platform-v7/PlatformV7ProtectedShell.module.css');
 const designSystemRuntime = read('apps/web/components/platform-v7/PlatformV7DesignSystemV8Runtime.tsx');
 const publicHeader = read('apps/web/components/platform-v7/PublicSiteHeader.tsx');
+const publicEntryLayout = read('apps/web/app/pc-public-entry/platform-v7/layout.tsx');
 const supportMount = read('apps/web/components/platform-v7/HydrationSafeChatSupport.tsx');
 const quietLayer = read('apps/web/components/platform-v7/UxFinalQuietLayer.tsx');
 const workStepGuide = read('apps/web/components/platform-v7/WorkStepGuide.tsx');
@@ -48,13 +49,16 @@ describe('platform-v7 browser acceptance repairs', () => {
     expect(protectedShell).not.toContain('Открываем интерфейс кабинета');
   });
 
-  it('keeps support entirely outside the server and initial hydration tree', () => {
-    expect(publicHeader).toContain('<HydrationSafeChatSupport />');
+  it('keeps support outside server rendering and mounts it once per public or protected tree', () => {
+    expect(serverLayout).toContain('<HydrationSafeChatSupport />');
+    expect(publicEntryLayout).toContain('<HydrationSafeChatSupport />');
+    expect(publicHeader).not.toContain('<HydrationSafeChatSupport />');
     expect(publicHeader).not.toContain('<ChatSupportWidget />');
-    expect(designSystemRuntime).toContain('<HydrationSafeChatSupport />');
+    expect(protectedRuntime).toContain('<HydrationSafeChatSupport />');
+    expect(designSystemRuntime).not.toContain('<HydrationSafeChatSupport />');
     expect(designSystemRuntime).not.toContain('<ChatSupportWidget />');
     expect(supportMount).toContain("import dynamic from 'next/dynamic'");
-    expect(supportMount).toContain("import('@/components/platform-v7/ChatSupportWidget')");
+    expect(supportMount).toContain("import('@/components/platform-v7/ContextualSupportOrAssistant')");
     expect(supportMount).toContain('ssr: false');
     expect(supportMount).toContain('loading: () => null');
     expect(supportMount).not.toContain('setMounted');

--- a/apps/web/tests/unit/platformV7DesignSystemV8RuntimeIsolation.test.ts
+++ b/apps/web/tests/unit/platformV7DesignSystemV8RuntimeIsolation.test.ts
@@ -170,7 +170,7 @@ describe('platform-v7 Design System v8 runtime isolation', () => {
 
   it('keeps the governed runtime token-only, hydration-safe and free of DOM/style repair code', () => {
     expect(v8Runtime).toContain('packages/design-tokens/tokens.css');
-    expect(v8Runtime).toContain('<HydrationSafeChatSupport />');
+    expect(v8Runtime).not.toContain('<HydrationSafeChatSupport />');
     expect(v8Runtime).not.toContain('<ChatSupportWidget />');
     expect(v8Runtime).not.toContain('PlatformV7FullStyleRuntime');
     expect(v8Runtime).not.toContain('PlatformV7TemplateGuards');

--- a/apps/web/tests/unit/platformV7IndustrialAssistantShortcuts.test.ts
+++ b/apps/web/tests/unit/platformV7IndustrialAssistantShortcuts.test.ts
@@ -7,33 +7,33 @@ const read = (relative: string) => fs.readFileSync(path.join(root, relative), 'u
 
 const contextual = read('apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx');
 const publicAssistant = read('apps/web/components/platform-v7/PublicPlatformAssistant.tsx');
-const privateShortcut = read('apps/web/components/platform-v7/PrivateAssistantShortcutLabel.tsx');
+const privateAssistant = read('apps/web/components/platform-v7/AiAssistantPanel.tsx');
+const dock = read('apps/web/components/platform-v7/PublicContactDock.tsx');
 const publicRoute = read('apps/web/app/api/public-platform-assistant/route.ts');
 const knowledge = read('apps/web/lib/platform-v7/public-assistant-knowledge.ts');
 const publicStyles = read('apps/web/styles/platform-v7-public-assistant.css');
-const privateStyles = read('apps/web/components/platform-v7/PrivateAssistantShortcutLabel.module.css');
 
 describe('platform-v7 industrial assistant shortcuts', () => {
-  it('keeps public knowledge and private Deal assistance as separate surfaces', () => {
-    expect(contextual).toContain("if (path === PUBLIC_HOME)");
+  it('keeps public knowledge and private Deal assistance separate behind one shared dock', () => {
+    expect(contextual).toContain('if (isPrivateWorkspace(path))');
     expect(contextual).toContain('<PublicPlatformAssistant />');
     expect(contextual).toContain('<ChatSupportWidget />');
-    expect(contextual).toContain('<PrivateAssistantShortcutLabel />');
+    expect(contextual).not.toContain('<PrivateAssistantShortcutLabel />');
     expect(contextual).toContain("<AiAssistantPanel variant='floating' />");
-    expect(contextual).toContain('separate no-account-data knowledge assistant');
+    expect(contextual).toContain("<PublicContactDock assistantContext='private' />");
     expect(publicAssistant).not.toContain('/api/proxy/ai-assistant');
-    expect(privateShortcut).toContain("href='/platform-v7/assistant'");
+    expect(privateAssistant).toContain("href='/platform-v7/assistant'");
   });
 
-  it('exposes a visible RU EN ZH private shortcut without claiming unverified Deal context', () => {
-    expect(privateShortcut).toContain('Помощник сделки');
-    expect(privateShortcut).toContain('Deal assistant');
-    expect(privateShortcut).toContain('交易助手');
-    expect(privateShortcut).toContain('Ролевой контекст ЛК');
-    expect(privateShortcut).not.toContain('?deal=');
-    expect(privateStyles).toContain('min-height: 54px');
-    expect(privateStyles).toContain('env(safe-area-inset-bottom)');
-    expect(privateStyles).toContain('@media (forced-colors: active)');
+  it('exposes localized private AI, human support and phone actions without showing the number', () => {
+    expect(dock).toContain("assistant: 'ИИ'");
+    expect(dock).toContain("assistant: 'AI'");
+    expect(dock).toContain("assistant: 'AI 助手'");
+    expect(dock).toContain("support: 'Поддержка'");
+    expect(dock).toContain("call: 'Позвонить'");
+    expect(contextual).toContain("<PublicContactDock assistantContext='private' />");
+    expect(dock).not.toContain('<small>{SUPPORT_PHONE_DISPLAY}</small>');
+    expect(privateAssistant).not.toContain('?deal=');
   });
 
   it('uses a stateless public knowledge API with bounded input and no external model call', () => {

--- a/apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts
+++ b/apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts
@@ -10,6 +10,7 @@ const template = read('apps/web/app/platform-v7/template.tsx');
 const protectedRuntime = read('apps/web/components/platform-v7/PlatformV7ProtectedRuntime.tsx');
 const protectedShell = read('apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx');
 const nextConfig = read('apps/web/next.config.js');
+const isolatedLayout = read('apps/web/app/pc-public-entry/platform-v7/layout.tsx');
 const isolatedLanding = read('apps/web/app/pc-public-entry/platform-v7/page.tsx');
 const isolatedLogin = read('apps/web/app/pc-public-entry/platform-v7/login/page.tsx');
 const isolatedRecovery = read('apps/web/app/pc-public-entry/platform-v7/forgot-password/page.tsx');
@@ -31,16 +32,17 @@ const removedRuntimes = [
   'apps/web/components/platform-v7/PlatformV7PublicRuntime.tsx',
 ];
 
-const removedPublicShellCss = 'apps/web/app/platform-v7/_styles/public-supporting-shell.css';
+const publicSupportingShellCss = 'apps/web/app/platform-v7/_styles/public-supporting-shell.css';
 
 describe('platform-v7 public/protected runtime split', () => {
   it('returns public route content without creating a universal client or supporting shell', () => {
     expect(layout).toContain("from 'next/headers'");
-    expect(layout).toContain("headers().get('x-pc-pathname')");
-    expect(layout).toContain('if (isPublicPath(pathname)) return children');
+    expect(layout).toContain("(await headers()).get('x-pc-pathname')");
+    expect(layout).toContain('if (isPublicPath(pathname)) {');
+    expect(layout).toContain('<HydrationSafeChatSupport />');
     expect(layout).toContain("await import('@/components/platform-v7/PlatformV7ProtectedRuntime')");
     expect(layout).not.toContain('PlatformV7PublicPageShell');
-    expect(layout).not.toContain('PublicSiteHeader');
+    expect(layout).not.toContain("from '@/components/platform-v7/PublicSiteHeader'");
     expect(layout).not.toContain('PlatformV7FullStyleRuntime');
     expect(layout).not.toContain('PlatformV7ShellSwitch');
   });
@@ -63,6 +65,7 @@ describe('platform-v7 public/protected runtime split', () => {
     expect(isolatedLanding).toContain("from '@/app/platform-v7/page'");
     expect(isolatedLogin).toContain("from '@/app/platform-v7/login/page'");
     expect(isolatedRecovery).toContain("from '@/app/platform-v7/forgot-password/page'");
+    expect(isolatedLayout).toContain('<HydrationSafeChatSupport />');
   });
 
   it('keeps the route template server-only and free of historical patching', () => {
@@ -82,7 +85,7 @@ describe('platform-v7 public/protected runtime split', () => {
     expect(protectedRuntime).toContain('<ToastProvider>');
     expect(protectedRuntime).toContain('<PlatformThemeSync />');
     expect(protectedRuntime).toContain('<PlatformV7ProtectedShell pathname={pathname} verifiedRole={verifiedRole}>');
-    expect(protectedShell).toContain('<AppShellV4 initialRole={initialRole}>');
+    expect(protectedShell).toContain('<AppShellV4 initialRole={verifiedRole}>');
     expect(protectedShell).toContain('<PlatformV7SingleEntryGuard />');
     expect(protectedShell).toContain('<RbacCabinetGuard />');
   });
@@ -97,19 +100,19 @@ describe('platform-v7 public/protected runtime split', () => {
     expect(publicHeader).toContain("<a href='/platform-v7' className='pc-site-brand'");
   });
 
-  it('loads public CSS from concrete routes and removes the obsolete supporting shell stylesheet', () => {
+  it('loads entry CSS from concrete routes and keeps the shared supporting-page contract explicit', () => {
     expect(rootLayout).not.toContain('platform-v7-dark-role-fixes.css');
-    expect(rootLayout).not.toContain('public-supporting-shell.css');
+    expect(rootLayout).toContain("import './platform-v7/_styles/public-supporting-shell.css'");
     expect(layout).not.toContain("import '@/styles/");
     expect(template).not.toContain("import '@/styles/");
     expect(landing).toContain("import '@/styles/platform-v7-public-header.css'");
-    expect(landing).toContain("import '@/styles/platform-v7-public-landing.css'");
+    expect(landing).toContain("import '@/styles/platform-v7-public-product-experience-v5.css'");
     expect(loginLayout).toContain("import '@/styles/platform-v7-public-auth.css'");
     expect(recovery).toContain("import '@/styles/platform-v7-public-auth.css'");
     expect(publicHeaderCss).toContain('.pc-site-header');
     expect(publicAuthCss).toContain('.pc-auth-page');
     expect(publicLandingCss).toContain('.pc-v7-public-entry');
-    expect(fs.existsSync(absolute(removedPublicShellCss))).toBe(false);
+    expect(fs.existsSync(absolute(publicSupportingShellCss))).toBe(true);
     for (const runtime of removedRuntimes) expect(fs.existsSync(absolute(runtime))).toBe(false);
   });
 

--- a/apps/web/tests/unit/platformV7RoleScopedAiAssistant.test.ts
+++ b/apps/web/tests/unit/platformV7RoleScopedAiAssistant.test.ts
@@ -16,14 +16,16 @@ const apiController = read('apps/api/src/modules/ai-insights/ai-assistant.contro
 const legacyInsights = read('apps/api/src/modules/ai-insights/ai-insights.service.ts');
 
 describe('platform-v7 role-scoped AI assistant', () => {
-  it('mounts one persistent assistant only in private workspaces and preserves public human support', () => {
+  it('mounts one role-scoped assistant inside the shared contact dock in private workspaces', () => {
     expect(hydration).toContain('ContextualSupportOrAssistant');
-    expect(hydration).toContain('structured decision cards');
+    expect(hydration).toContain('structured');
+    expect(hydration).toContain('decision cards');
     expect(contextual).toContain("<AiAssistantPanel variant='floating' />");
     expect(contextual).toContain('<ChatSupportWidget />');
     expect(contextual).toContain("'/platform-v7/login'");
     expect(contextual).toContain("'/platform-v7/how-it-works'");
-    expect(contextual).toContain('One persistent conversational assistant');
+    expect(contextual).toContain("<PublicContactDock assistantContext='private' />");
+    expect(contextual).toContain("<PublicContactDock assistantContext='workspace' />");
   });
 
   it('uses the real backend for real sessions and an explicitly labelled role-scoped synthetic mode only for demo tokens', () => {

--- a/apps/web/tests/unit/platformV7UnifiedPublicContactDock.test.ts
+++ b/apps/web/tests/unit/platformV7UnifiedPublicContactDock.test.ts
@@ -7,6 +7,12 @@ const read = (relative: string) => fs.readFileSync(path.join(root, relative), 'u
 
 const contextual = read('apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx');
 const dock = read('apps/web/components/platform-v7/PublicContactDock.tsx');
+const privateAssistant = read('apps/web/components/platform-v7/AiAssistantPanel.tsx');
+const protectedRuntime = read('apps/web/components/platform-v7/PlatformV7ProtectedRuntime.tsx');
+const designSystemRuntime = read('apps/web/components/platform-v7/PlatformV7DesignSystemV8Runtime.tsx');
+const publicLayout = read('apps/web/app/platform-v7/layout.tsx');
+const publicEntryLayout = read('apps/web/app/pc-public-entry/platform-v7/layout.tsx');
+const publicHeader = read('apps/web/components/platform-v7/PublicSiteHeader.tsx');
 
 describe('platform-v7 unified public contact dock', () => {
   it('replaces the two public launchers with one three-action surface', () => {
@@ -32,13 +38,77 @@ describe('platform-v7 unified public contact dock', () => {
     expect(contextual).toContain('const path = normalize(browserPathname || routerPathname)');
   });
 
+  it('keeps every server-public supporting route on the public assistant contract', () => {
+    for (const path of [
+      '/platform-v7/about',
+      '/platform-v7/oferta',
+      '/platform-v7/roles',
+      '/platform-v7/grain-logistics',
+      '/platform-v7/grain-quality',
+      '/platform-v7/grain-documents',
+      '/platform-v7/grain-payment',
+    ]) expect(contextual).toContain(`'${path}'`);
+    expect(contextual).toContain("path === prefix || path.startsWith(`${prefix}/`)");
+  });
+
   it('never falls back to a standalone support button on a public surface', () => {
     const publicReturn = contextual.slice(contextual.lastIndexOf('return ('));
     expect(publicReturn).toContain('<UnifiedModalSheetFullscreenController />');
     expect(publicReturn).toContain('<PublicPlatformAssistant />');
     expect(publicReturn).toContain('<ChatSupportWidget />');
     expect(publicReturn).toContain('<PublicContactDock />');
-    expect(publicReturn).toContain('Every public platform surface uses one visible entry point');
+    expect(contextual).toContain('Every public platform surface uses one visible entry point');
+  });
+
+  it('mounts the same three-action dock once across every protected workspace', () => {
+    const privateBranch = contextual.slice(
+      contextual.indexOf('if (isPrivateWorkspace(path))'),
+      contextual.indexOf('// Every public platform surface'),
+    );
+    expect(privateBranch).toContain("<AiAssistantPanel variant='floating' />");
+    expect(privateBranch).toContain('<ChatSupportWidget />');
+    expect(privateBranch).toContain("<PublicContactDock assistantContext='private' />");
+    expect(privateBranch).not.toContain('<PrivateAssistantShortcutLabel />');
+    expect(protectedRuntime).toContain('<HydrationSafeChatSupport />');
+    expect(designSystemRuntime).not.toContain('<HydrationSafeChatSupport />');
+  });
+
+  it('mounts once at both public route boundaries instead of individual headers', () => {
+    expect(publicLayout).toContain('if (isPublicPath(pathname)) {');
+    expect(publicLayout).toContain('<HydrationSafeChatSupport />');
+    expect(publicEntryLayout).toContain('<HydrationSafeChatSupport />');
+    expect(publicHeader).not.toContain('<HydrationSafeChatSupport />');
+  });
+
+  it('routes the dock AI action to the correct public or private assistant', () => {
+    expect(dock).toContain("type AssistantContext = 'public' | 'private' | 'workspace'");
+    expect(dock).toContain("assistantContext === 'workspace'");
+    expect(dock).toContain("? '#p7-private-ai-assistant-workspace'");
+    expect(dock).toContain("? '#p7-private-ai-assistant-panel'");
+    expect(dock).toContain("data-assistant-context={assistantContext}");
+    expect(dock).toContain('.p7-ai-trigger,');
+    expect(privateAssistant).toContain("id={variant === 'floating' ? 'p7-private-ai-assistant-panel' : 'p7-private-ai-assistant-workspace'}");
+    expect(privateAssistant).toContain("tabIndex={variant === 'workspace' ? -1 : undefined}");
+  });
+
+  it('keeps the dock on the full-page assistant without duplicating its AI panel', () => {
+    const workspaceBranch = contextual.slice(
+      contextual.indexOf('if (path === ASSISTANT_WORKSPACE)'),
+      contextual.indexOf('if (isPrivateWorkspace(path))'),
+    );
+    expect(workspaceBranch).toContain('<ChatSupportWidget />');
+    expect(workspaceBranch).toContain("<PublicContactDock assistantContext='workspace' />");
+    expect(workspaceBranch).not.toContain("<AiAssistantPanel variant='floating' />");
+    expect(dock).toContain("workspace.scrollIntoView({ block: 'start', behavior: 'smooth' })");
+  });
+
+  it('stays above the persistent cabinet navigation instead of covering it', () => {
+    expect(dock).toContain(".pc-public-contact-dock[data-assistant-context='private'],");
+    expect(dock).toContain(".pc-public-contact-dock[data-assistant-context='workspace']");
+    expect(dock).toContain('bottom: max(92px, calc(env(safe-area-inset-bottom, 0px) + 88px))');
+    expect(dock).toContain('z-index: 97');
+    expect(dock).toContain('.pc-shell-root-v4 .pc-v4-main');
+    expect(dock).toContain('padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 156px)');
   });
 
   it('keeps the call action but does not render the phone number in the dock', () => {
@@ -59,7 +129,8 @@ describe('platform-v7 unified public contact dock', () => {
   });
 
   it('does not overlay or intercept either open dialog', () => {
-    expect(dock).toContain('setDialogOpen(assistantOpen || supportOpen)');
+    expect(dock).toContain("document.querySelector('[role=\"dialog\"][aria-modal=\"true\"]')");
+    expect(dock).toContain('setDialogOpen(assistantOpen || supportOpen || blockingModalOpen)');
     expect(dock).toContain("data-dialog-open={dialogOpen ? 'true' : 'false'}");
     expect(dock).toContain('aria-hidden={dialogOpen}');
     expect(dock).toContain(".pc-public-contact-dock[data-dialog-open='true']");

--- a/apps/web/tests/unit/publicContactDockRuntime.test.tsx
+++ b/apps/web/tests/unit/publicContactDockRuntime.test.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PublicContactDock } from '../../components/platform-v7/PublicContactDock';
+
+vi.mock('@/lib/analytics/track', () => ({ trackEvent: vi.fn() }));
+
+function nativeButton(className: string, onClick = vi.fn()): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.className = className;
+  button.addEventListener('click', onClick);
+  document.body.append(button);
+  return button;
+}
+
+describe('PublicContactDock runtime', () => {
+  beforeEach(() => {
+    document.documentElement.lang = 'ru';
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => window.setTimeout(() => callback(0), 0),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it('delegates the public AI and support actions to their internal workflows', () => {
+    const assistantClick = vi.fn();
+    const supportClick = vi.fn();
+    const assistant = nativeButton('pc-public-assistant-shortcut', assistantClick);
+    const support = nativeButton('p7-support-chat-button', supportClick);
+
+    render(<PublicContactDock />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Открыть ИИ-помощника по платформе' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Открыть поддержку' }));
+
+    expect(assistantClick).toHaveBeenCalledOnce();
+    expect(supportClick).toHaveBeenCalledOnce();
+    expect(assistant).toHaveAttribute('aria-hidden', 'true');
+    expect(support).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByRole('link', { name: 'Позвонить по номеру 8 916 277-89-89' }))
+      .toHaveAttribute('href', 'tel:+79162778989');
+  });
+
+  it('delegates the private AI action and stays above the cabinet navigation', () => {
+    const assistantClick = vi.fn();
+    nativeButton('p7-ai-trigger', assistantClick);
+    nativeButton('p7-support-chat-button');
+
+    render(<PublicContactDock assistantContext='private' />);
+    const dock = screen.getByRole('navigation', { name: 'Связь и помощь' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Открыть ИИ-помощника по платформе' }));
+
+    expect(assistantClick).toHaveBeenCalledOnce();
+    expect(dock).toHaveAttribute('data-assistant-context', 'private');
+  });
+
+  it('focuses the existing full-page assistant instead of mounting a second one', async () => {
+    nativeButton('p7-support-chat-button');
+    const workspace = document.createElement('section');
+    workspace.id = 'p7-private-ai-assistant-workspace';
+    workspace.tabIndex = -1;
+    const scrollIntoView = vi.fn();
+    workspace.scrollIntoView = scrollIntoView;
+    document.body.append(workspace);
+
+    render(<PublicContactDock assistantContext='workspace' />);
+    fireEvent.click(screen.getByRole('button', { name: 'Открыть ИИ-помощника по платформе' }));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start', behavior: 'smooth' });
+    await waitFor(() => expect(document.activeElement).toBe(workspace));
+  });
+
+  it('gets out of the way while any aria-modal dialog is open', async () => {
+    nativeButton('p7-ai-trigger');
+    nativeButton('p7-support-chat-button');
+    render(<PublicContactDock assistantContext='private' />);
+    const dock = screen.getByRole('navigation', { name: 'Связь и помощь' });
+
+    const dialog = document.createElement('section');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    document.body.append(dialog);
+
+    await waitFor(() => expect(dock).toHaveAttribute('data-dialog-open', 'true'));
+    expect(dock).toHaveAttribute('aria-hidden', 'true');
+
+    dialog.remove();
+    await waitFor(() => expect(dock).toHaveAttribute('data-dialog-open', 'false'));
+  });
+});


### PR DESCRIPTION
## Scope
Restore one unified AI / support / call dock across rewritten public routes, supporting public routes, protected cabinets, and the assistant workspace without duplicate launchers or modal/nav overlap.

## Changed files
- centralize hydration-safe mounts in the public-entry, public, and protected layout trees
- make the dock context-aware for public, private, and workspace assistants
- reserve mobile space and hide the dock while any aria-modal dialog is open
- defer the public assistant catalog request until the user explicitly opens the assistant
- add static and DOM runtime regression coverage

## Guards
- remote diff is 16 intended `apps/web/**` files; commit tree matches the locally validated tree
- `platform-v7 autopilot guard` is blocked because the current IR-10.4 source-of-truth scope excludes all `apps/web` work
- repository policy requires a separate independent authority PR for this exact branch/path scope before merge; this PR must remain unmerged until that is recorded

## Checks
- 74 focused unit/static/runtime tests passed
- TypeScript `tsc --noEmit` passed
- initial Next.js production build passed (233 static pages)
- two deploy previews passed; browser verification confirms the visible fixed dock, all three actions, and `tel:+79162778989`
- exact-head CI rerunning after the lazy-catalog fix

## Known limitations
- local Playwright was unavailable because the Chromium executable is not installed; GitHub's browser matrix is the acceptance authority
- production at `процент-агро.рф` is a separately operated Caddy/Docker server and will require a targeted `web` service rebuild after an authorized merge