### PR TITLE
Authorize restore-global-contact-dock scope for PR #2810

### DIFF
--- a/docs/platform-v7/autopilot/scopes/restore-global-contact-dock-2810.json
+++ b/docs/platform-v7/autopilot/scopes/restore-global-contact-dock-2810.json
@@ -1,0 +1,34 @@
+{
+  "branch": "agent/restore-global-contact-dock",
+  "status": "active",
+  "purpose": "Narrowly restore one unified AI, human support and explicit user-initiated call dock across public and protected platform-v7 surfaces, including the assistant workspace, without changing account, role, data, command or model authority.",
+  "approvedBy": "independent-authority-pr",
+  "implementationPullRequest": 2810,
+  "authorityBaseExactMain": "3ff82ac89ca166fcfc0139204d551d9489731e46",
+  "allowedPaths": [
+    "apps/web/app/pc-public-entry/platform-v7/layout.tsx",
+    "apps/web/app/platform-v7/layout.tsx",
+    "apps/web/components/platform-v7/AiAssistantPanel.tsx",
+    "apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx",
+    "apps/web/components/platform-v7/PlatformV7DesignSystemV8Runtime.tsx",
+    "apps/web/components/platform-v7/PlatformV7ProtectedRuntime.tsx",
+    "apps/web/components/platform-v7/PublicContactDock.tsx",
+    "apps/web/components/platform-v7/PublicPlatformAssistant.tsx",
+    "apps/web/components/platform-v7/PublicSiteHeader.tsx",
+    "apps/web/tests/unit/platformV7BrowserAcceptanceRepairs.test.ts",
+    "apps/web/tests/unit/platformV7DesignSystemV8RuntimeIsolation.test.ts",
+    "apps/web/tests/unit/platformV7IndustrialAssistantShortcuts.test.ts",
+    "apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts",
+    "apps/web/tests/unit/platformV7RoleScopedAiAssistant.test.ts",
+    "apps/web/tests/unit/platformV7UnifiedPublicContactDock.test.ts",
+    "apps/web/tests/unit/publicContactDockRuntime.test.tsx"
+  ],
+  "forbiddenCapabilities": [
+    "account data access from public mode",
+    "cross-role or cross-tenant access",
+    "autonomous commands",
+    "automatic or background phone calls without an explicit user action",
+    "external public model calls",
+    "full public question text persistence"
+  ]
+}

--- a/scripts/p7-autopilot-guard.sh
+++ b/scripts/p7-autopilot-guard.sh
@@ -310,6 +310,7 @@ SOURCE_CONTROLLED_SCOPE=$(GITHUB_HEAD_REF="${GITHUB_HEAD_REF:-}" node - <<'JS'
 const fs = require('fs');
 const branch = String(process.env.GITHUB_HEAD_REF || '').trim();
 const manifests = {
+  'agent/restore-global-contact-dock': 'docs/platform-v7/autopilot/scopes/restore-global-contact-dock-2810.json',
   'ir/k8s-production-like-2659': 'docs/platform-v7/autopilot/scopes/ir-k8s-production-like-2659.json',
   'feat/assistant-universal-understanding': 'docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json',
 };


### PR DESCRIPTION
## Authority decision

Independently authorizes the narrow implementation scope for PR #2810 on the exact branch `agent/restore-global-contact-dock`.

The source-controlled manifest permits exactly the 16 implementation paths currently changed by PR #2810 and no others. Its purpose is limited to restoring one unified AI / human support / explicit user-initiated call dock across public and protected platform-v7 surfaces, including the assistant workspace.

## Authority changes

- add `docs/platform-v7/autopilot/scopes/restore-global-contact-dock-2810.json`;
- add one exact branch-to-manifest mapping in `scripts/p7-autopilot-guard.sh`;
- leave `autopilot-state.json` and all runtime files unchanged.

## Retained prohibitions

This authority does not permit:

- account data access from public mode;
- cross-role or cross-tenant access;
- autonomous commands;
- automatic or background calls without an explicit user action;
- external public model calls;
- persistence of full public question text.

## Validation

- authority branch base and merge base: `3ff82ac89ca166fcfc0139204d551d9489731e46`;
- remote authority diff: exactly 2 files, both governance-only;
- manifest parses as JSON;
- manifest branch/status/approval/PR metadata verified;
- 16 unique allowed paths exactly equal the 16 changed filenames in PR #2810;
- guard mapping appears exactly once.

PR #2810 remains subject to exact-head CI, review, and all non-scope gates. This authority PR does not merge or otherwise approve the implementation itself.