### PR TITLE
Вернуть последний согласованный вариант нижней плашки на главную

### DIFF
--- a/apps/web/app/pc-public-entry/platform-v7/page.tsx
+++ b/apps/web/app/pc-public-entry/platform-v7/page.tsx
@@ -1,4 +1,12 @@
+import '@/styles/platform-v7-home-approved-contact-dock.css';
 import PlatformV7RootPage, { metadata } from '@/app/platform-v7/page';
 
 export { metadata };
-export default PlatformV7RootPage;
+
+export default function PublicEntryPlatformV7Page() {
+  return (
+    <div data-contact-dock-visual='approved'>
+      <PlatformV7RootPage />
+    </div>
+  );
+}

--- a/apps/web/styles/platform-v7-home-approved-contact-dock.css
+++ b/apps/web/styles/platform-v7-home-approved-contact-dock.css
@@ -1,0 +1,151 @@
+[data-contact-dock-visual='approved'] {
+  display: contents;
+}
+
+/*
+ * Homepage-only restoration of the last approved contact dock composition.
+ * The shared component keeps all current assistant, support, call and
+ * accessibility behavior; this route scope restores only the accepted visual.
+ */
+[data-contact-dock-visual='approved'] .pc-public-contact-dock {
+  right: max(12px, env(safe-area-inset-right, 0px));
+  bottom: max(6px, calc(env(safe-area-inset-bottom, 0px) + 4px));
+  width: min(390px, calc(100vw - 24px - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px)));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid rgba(8, 122, 59, .42);
+  border-radius: 20px;
+  background: var(--pc-ppe-v5-surface, #ffffff);
+  background: color-mix(in srgb, var(--pc-ppe-v5-surface, #ffffff) 94%, transparent);
+  box-shadow:
+    0 18px 42px rgba(9, 33, 24, .16),
+    0 4px 12px rgba(8, 122, 59, .08),
+    inset 0 1px 0 rgba(255, 255, 255, .92);
+  backdrop-filter: blur(18px) saturate(135%);
+  -webkit-backdrop-filter: blur(18px) saturate(135%);
+}
+
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-action {
+  min-height: 54px;
+  border-radius: 15px;
+  gap: 7px;
+  padding: 6px 10px;
+}
+
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+  width: 30px;
+  height: 30px;
+  flex-basis: 30px;
+  border-radius: 10px;
+  color: var(--pc-ppe-v5-green, #087a3b);
+  background: linear-gradient(145deg, rgba(8, 122, 59, .13), rgba(8, 122, 59, .055));
+  box-shadow: inset 0 0 0 1px rgba(8, 122, 59, .12);
+}
+
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-action strong,
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+  color: inherit;
+  font-size: 12.5px;
+  font-weight: 720;
+}
+
+@media (hover: hover) {
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action:hover {
+    background: rgba(8, 122, 59, .07);
+    transform: translateY(-1px);
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action:hover .pc-public-contact-dock-icon {
+    color: #ffffff;
+    background: var(--pc-ppe-v5-green, #087a3b);
+    box-shadow: 0 5px 12px rgba(8, 122, 59, .20);
+    transform: scale(1.035);
+  }
+}
+
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-action:active {
+  background: rgba(8, 122, 59, .11);
+  transform: translateY(0) scale(.985);
+}
+
+@media (max-width: 520px) {
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock {
+    right: max(8px, env(safe-area-inset-right, 0px));
+    left: max(8px, env(safe-area-inset-left, 0px));
+    bottom: max(2px, calc(env(safe-area-inset-bottom, 0px) + 2px));
+    width: auto;
+    border-radius: 18px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action {
+    min-height: 52px;
+    gap: 6px;
+    padding-inline: 6px;
+    border-radius: 13px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+    width: 28px;
+    height: 28px;
+    flex-basis: 28px;
+    border-radius: 9px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action strong,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+    font-size: 11.5px;
+  }
+}
+
+@media (max-width: 350px) {
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action {
+    gap: 4px;
+    padding-inline: 4px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+    width: 26px;
+    height: 26px;
+    flex-basis: 26px;
+    border-radius: 8px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon svg {
+    width: 17px;
+    height: 17px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action strong,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+    font-size: 10.5px;
+  }
+}
+
+@media (forced-colors: active) {
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock {
+    border: 2px solid ButtonText;
+    background: Canvas;
+    box-shadow: none;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+    color: ButtonText;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+    color: ButtonText;
+    background: Canvas;
+    box-shadow: inset 0 0 0 1px ButtonText;
+  }
+}

--- a/apps/web/tests/unit/platformV7HomepageApprovedContactDock.test.ts
+++ b/apps/web/tests/unit/platformV7HomepageApprovedContactDock.test.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const read = (relative: string) => fs.readFileSync(path.join(root, relative), 'utf8');
+
+const publicEntryPage = read('apps/web/app/pc-public-entry/platform-v7/page.tsx');
+const approvedDock = read('apps/web/styles/platform-v7-home-approved-contact-dock.css');
+const sharedDock = read('apps/web/components/platform-v7/PublicContactDock.tsx');
+
+describe('platform-v7 homepage approved contact dock', () => {
+  it('scopes the approved visual to the rewritten public homepage', () => {
+    expect(publicEntryPage).toContain("import '@/styles/platform-v7-home-approved-contact-dock.css'");
+    expect(publicEntryPage).toContain("data-contact-dock-visual='approved'");
+    expect(publicEntryPage).toContain('<PlatformV7RootPage />');
+    expect(approvedDock).toContain("[data-contact-dock-visual='approved']");
+    expect(approvedDock).toContain('display: contents');
+  });
+
+  it('restores the last approved balanced glass composition', () => {
+    expect(approvedDock).toContain('width: min(390px');
+    expect(approvedDock).toContain('gap: 2px');
+    expect(approvedDock).toContain('padding: 3px');
+    expect(approvedDock).toContain('border: 1px solid rgba(8, 122, 59, .42)');
+    expect(approvedDock).toContain('border-radius: 20px');
+    expect(approvedDock).toContain('backdrop-filter: blur(18px) saturate(135%)');
+    expect(approvedDock).toContain('0 18px 42px rgba(9, 33, 24, .16)');
+  });
+
+  it('restores the approved mobile size and lower safe-area placement', () => {
+    expect(approvedDock).toContain('min-height: 54px');
+    expect(approvedDock).toContain('min-height: 52px');
+    expect(approvedDock).toContain('width: 30px');
+    expect(approvedDock).toContain('width: 28px');
+    expect(approvedDock).toContain('font-size: 12.5px');
+    expect(approvedDock).toContain('font-size: 11.5px');
+    expect(approvedDock).toContain('bottom: max(6px, calc(env(safe-area-inset-bottom, 0px) + 4px))');
+    expect(approvedDock).toContain('bottom: max(2px, calc(env(safe-area-inset-bottom, 0px) + 2px))');
+  });
+
+  it('keeps three equal actions and the phone number visually hidden', () => {
+    expect(approvedDock).toContain('grid-template-columns: repeat(3, minmax(0, 1fr))');
+    expect(approvedDock).toContain('.pc-public-contact-dock-assistant strong');
+    expect(approvedDock).toContain('color: inherit');
+    expect(approvedDock).toContain('font-weight: 720');
+    expect(sharedDock).toContain("assistant: 'ИИ'");
+    expect(sharedDock).toContain("support: 'Поддержка'");
+    expect(sharedDock).toContain("call: 'Позвонить'");
+    expect(sharedDock).not.toContain('<small>{SUPPORT_PHONE_DISPLAY}</small>');
+  });
+});


### PR DESCRIPTION
## Что изменено
- на переписанную главную страницу возвращён последний согласованный визуальный вариант нижней плашки;
- сохранены три равные действия: `ИИ / Поддержка / Позвонить`;
- номер телефона остаётся визуально скрытым, звонок работает через `tel:`;
- восстановлены согласованные размеры, стеклянная поверхность, мягкая зелёная рамка, тень и нижнее положение с учётом safe-area;
- изменение ограничено главной страницей и не меняет логику ИИ, поддержки или звонка.

## Регрессия
- добавлен статический unit-тест точных параметров последнего согласованного варианта;
- сохранён общий компонент и действующие accessibility-механизмы.