### PR TITLE
Вернуть последний идеальный вариант нижней плашки только на главную

### DIFF
--- a/apps/web/app/pc-public-entry/platform-v7/home-approved-contact-dock.css
+++ b/apps/web/app/pc-public-entry/platform-v7/home-approved-contact-dock.css
@@ -1,0 +1,147 @@
+[data-contact-dock-visual='approved'] {
+  display: contents;
+}
+
+/* Homepage-only restoration of the last approved contact dock composition. */
+[data-contact-dock-visual='approved'] .pc-public-contact-dock {
+  right: max(12px, env(safe-area-inset-right, 0px));
+  bottom: max(6px, calc(env(safe-area-inset-bottom, 0px) + 4px));
+  width: min(390px, calc(100vw - 24px - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px)));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid rgba(8, 122, 59, .42);
+  border-radius: 20px;
+  background: var(--pc-ppe-v5-surface, #ffffff);
+  background: color-mix(in srgb, var(--pc-ppe-v5-surface, #ffffff) 94%, transparent);
+  box-shadow:
+    0 18px 42px rgba(9, 33, 24, .16),
+    0 4px 12px rgba(8, 122, 59, .08),
+    inset 0 1px 0 rgba(255, 255, 255, .92);
+  backdrop-filter: blur(18px) saturate(135%);
+  -webkit-backdrop-filter: blur(18px) saturate(135%);
+}
+
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-action {
+  min-height: 54px;
+  border-radius: 15px;
+  gap: 7px;
+  padding: 6px 10px;
+}
+
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+  width: 30px;
+  height: 30px;
+  flex-basis: 30px;
+  border-radius: 10px;
+  color: var(--pc-ppe-v5-green, #087a3b);
+  background: linear-gradient(145deg, rgba(8, 122, 59, .13), rgba(8, 122, 59, .055));
+  box-shadow: inset 0 0 0 1px rgba(8, 122, 59, .12);
+}
+
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-action strong,
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+  color: inherit;
+  font-size: 12.5px;
+  font-weight: 720;
+}
+
+@media (hover: hover) {
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action:hover {
+    background: rgba(8, 122, 59, .07);
+    transform: translateY(-1px);
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action:hover .pc-public-contact-dock-icon {
+    color: #ffffff;
+    background: var(--pc-ppe-v5-green, #087a3b);
+    box-shadow: 0 5px 12px rgba(8, 122, 59, .20);
+    transform: scale(1.035);
+  }
+}
+
+[data-contact-dock-visual='approved'] .pc-public-contact-dock-action:active {
+  background: rgba(8, 122, 59, .11);
+  transform: translateY(0) scale(.985);
+}
+
+@media (max-width: 520px) {
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock {
+    right: max(8px, env(safe-area-inset-right, 0px));
+    left: max(8px, env(safe-area-inset-left, 0px));
+    bottom: max(2px, calc(env(safe-area-inset-bottom, 0px) + 2px));
+    width: auto;
+    border-radius: 18px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action {
+    min-height: 52px;
+    gap: 6px;
+    padding-inline: 6px;
+    border-radius: 13px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+    width: 28px;
+    height: 28px;
+    flex-basis: 28px;
+    border-radius: 9px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action strong,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+    font-size: 11.5px;
+  }
+}
+
+@media (max-width: 350px) {
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action {
+    gap: 4px;
+    padding-inline: 4px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+    width: 26px;
+    height: 26px;
+    flex-basis: 26px;
+    border-radius: 8px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon svg {
+    width: 17px;
+    height: 17px;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action strong,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+    font-size: 10.5px;
+  }
+}
+
+@media (forced-colors: active) {
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock {
+    border: 2px solid ButtonText;
+    background: Canvas;
+    box-shadow: none;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+    color: ButtonText;
+  }
+
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
+  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+    color: ButtonText;
+    background: Canvas;
+    box-shadow: inset 0 0 0 1px ButtonText;
+  }
+}

--- a/apps/web/app/pc-public-entry/platform-v7/page.tsx
+++ b/apps/web/app/pc-public-entry/platform-v7/page.tsx
@@ -1,4 +1,12 @@
+import './home-approved-contact-dock.css';
 import PlatformV7RootPage, { metadata } from '@/app/platform-v7/page';
 
 export { metadata };
-export default PlatformV7RootPage;
+
+export default function PublicEntryPlatformV7Page() {
+  return (
+    <div data-contact-dock-visual='approved'>
+      <PlatformV7RootPage />
+    </div>
+  );
+}

--- a/apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts
+++ b/apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts
@@ -11,6 +11,7 @@ const protectedRuntime = read('apps/web/components/platform-v7/PlatformV7Protect
 const protectedShell = read('apps/web/components/platform-v7/PlatformV7ProtectedShell.tsx');
 const nextConfig = read('apps/web/next.config.js');
 const isolatedLanding = read('apps/web/app/pc-public-entry/platform-v7/page.tsx');
+const approvedHomeDock = read('apps/web/app/pc-public-entry/platform-v7/home-approved-contact-dock.css');
 const isolatedLogin = read('apps/web/app/pc-public-entry/platform-v7/login/page.tsx');
 const isolatedRecovery = read('apps/web/app/pc-public-entry/platform-v7/forgot-password/page.tsx');
 const landing = read('apps/web/app/platform-v7/page.tsx');
@@ -60,9 +61,28 @@ describe('platform-v7 public/protected runtime split', () => {
     expect(nextConfig).toContain("{ source: '/platform-v7', destination: '/pc-public-entry/platform-v7' }");
     expect(nextConfig).toContain("{ source: '/platform-v7/login', destination: '/pc-public-entry/platform-v7/login' }");
     expect(nextConfig).toContain("{ source: '/platform-v7/forgot-password', destination: '/pc-public-entry/platform-v7/forgot-password' }");
+    expect(isolatedLanding).toContain("import './home-approved-contact-dock.css'");
     expect(isolatedLanding).toContain("from '@/app/platform-v7/page'");
+    expect(isolatedLanding).toContain("data-contact-dock-visual='approved'");
     expect(isolatedLogin).toContain("from '@/app/platform-v7/login/page'");
     expect(isolatedRecovery).toContain("from '@/app/platform-v7/forgot-password/page'");
+  });
+
+  it('restores only the last approved contact dock visual on the public homepage', () => {
+    expect(approvedHomeDock).toContain("[data-contact-dock-visual='approved']");
+    expect(approvedHomeDock).toContain('grid-template-columns: repeat(3, minmax(0, 1fr))');
+    expect(approvedHomeDock).toContain('width: min(390px');
+    expect(approvedHomeDock).toContain('border: 1px solid rgba(8, 122, 59, .42)');
+    expect(approvedHomeDock).toContain('border-radius: 20px');
+    expect(approvedHomeDock).toContain('min-height: 54px');
+    expect(approvedHomeDock).toContain('min-height: 52px');
+    expect(approvedHomeDock).toContain('width: 30px');
+    expect(approvedHomeDock).toContain('width: 28px');
+    expect(approvedHomeDock).toContain('font-size: 12.5px');
+    expect(approvedHomeDock).toContain('font-size: 11.5px');
+    expect(approvedHomeDock).toContain('bottom: max(2px, calc(env(safe-area-inset-bottom, 0px) + 2px))');
+    expect(approvedHomeDock).toContain('.pc-public-contact-dock-assistant strong');
+    expect(approvedHomeDock).toContain('color: inherit');
   });
 
   it('keeps the route template server-only and free of historical patching', () => {


### PR DESCRIPTION
## Что изменено
- на физически изолированную публичную главную возвращён последний согласованный вариант нижней плашки;
- сохранены три равных действия: `ИИ / Поддержка / Позвонить`;
- номер телефона не выводится в плашке, звонок остаётся только явным действием пользователя;
- восстановлены согласованные размеры, стеклянная поверхность, зелёная рамка, тень и положение над нижней safe-area;
- стили находятся внутри route-local CSS границы главной и не распространяются на вход, восстановление доступа, другие публичные страницы или кабинеты.

## Регрессия
- `platformV7PublicLayoutSplit.test.ts` фиксирует route-local подключение и ключевые параметры согласованного варианта;
- логика ИИ, поддержки, звонка, данных и прав доступа не менялась.