### PR TITLE
Применить последний идеальный dock к реальному mount на главной

### DIFF
--- a/apps/web/app/pc-public-entry/platform-v7/home-approved-contact-dock.css
+++ b/apps/web/app/pc-public-entry/platform-v7/home-approved-contact-dock.css
@@ -2,8 +2,13 @@
   display: contents;
 }
 
-/* Homepage-only restoration of the last approved contact dock composition. */
-[data-contact-dock-visual='approved'] .pc-public-contact-dock {
+/*
+ * The public-home marker and hydration-safe dock are siblings because the dock
+ * mounts at the isolated route-layout boundary. The following-sibling scope
+ * keeps the approved composition on the homepage without leaking to login,
+ * recovery, supporting public routes or protected workspaces.
+ */
+[data-contact-dock-visual='approved'] ~ .pc-public-contact-dock {
   right: max(12px, env(safe-area-inset-right, 0px));
   bottom: max(6px, calc(env(safe-area-inset-bottom, 0px) + 4px));
   width: min(390px, calc(100vw - 24px - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px)));
@@ -22,15 +27,15 @@
   -webkit-backdrop-filter: blur(18px) saturate(135%);
 }
 
-[data-contact-dock-visual='approved'] .pc-public-contact-dock-action {
+[data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-action {
   min-height: 54px;
   border-radius: 15px;
   gap: 7px;
   padding: 6px 10px;
 }
 
-[data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
-[data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+[data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-icon,
+[data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
   width: 30px;
   height: 30px;
   flex-basis: 30px;
@@ -40,25 +45,25 @@
   box-shadow: inset 0 0 0 1px rgba(8, 122, 59, .12);
 }
 
-[data-contact-dock-visual='approved'] .pc-public-contact-dock-icon svg {
+[data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-icon svg {
   width: 18px;
   height: 18px;
 }
 
-[data-contact-dock-visual='approved'] .pc-public-contact-dock-action strong,
-[data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+[data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-action strong,
+[data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-assistant strong {
   color: inherit;
   font-size: 12.5px;
   font-weight: 720;
 }
 
 @media (hover: hover) {
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action:hover {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-action:hover {
     background: rgba(8, 122, 59, .07);
     transform: translateY(-1px);
   }
 
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action:hover .pc-public-contact-dock-icon {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-action:hover .pc-public-contact-dock-icon {
     color: #ffffff;
     background: var(--pc-ppe-v5-green, #087a3b);
     box-shadow: 0 5px 12px rgba(8, 122, 59, .20);
@@ -66,13 +71,13 @@
   }
 }
 
-[data-contact-dock-visual='approved'] .pc-public-contact-dock-action:active {
+[data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-action:active {
   background: rgba(8, 122, 59, .11);
   transform: translateY(0) scale(.985);
 }
 
 @media (max-width: 520px) {
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock {
     right: max(8px, env(safe-area-inset-right, 0px));
     left: max(8px, env(safe-area-inset-left, 0px));
     bottom: max(2px, calc(env(safe-area-inset-bottom, 0px) + 2px));
@@ -80,66 +85,66 @@
     border-radius: 18px;
   }
 
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-action {
     min-height: 52px;
     gap: 6px;
     padding-inline: 6px;
     border-radius: 13px;
   }
 
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-icon,
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
     width: 28px;
     height: 28px;
     flex-basis: 28px;
     border-radius: 9px;
   }
 
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action strong,
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-action strong,
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-assistant strong {
     font-size: 11.5px;
   }
 }
 
 @media (max-width: 350px) {
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-action {
     gap: 4px;
     padding-inline: 4px;
   }
 
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-icon,
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
     width: 26px;
     height: 26px;
     flex-basis: 26px;
     border-radius: 8px;
   }
 
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon svg {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-icon svg {
     width: 17px;
     height: 17px;
   }
 
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action strong,
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-action strong,
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-assistant strong {
     font-size: 10.5px;
   }
 }
 
 @media (forced-colors: active) {
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock {
     border: 2px solid ButtonText;
     background: Canvas;
     box-shadow: none;
   }
 
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-action,
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant strong {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-action,
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-assistant strong {
     color: ButtonText;
   }
 
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-icon,
-  [data-contact-dock-visual='approved'] .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-icon,
+  [data-contact-dock-visual='approved'] ~ .pc-public-contact-dock .pc-public-contact-dock-assistant .pc-public-contact-dock-icon {
     color: ButtonText;
     background: Canvas;
     box-shadow: inset 0 0 0 1px ButtonText;

--- a/apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts
+++ b/apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts
@@ -69,10 +69,12 @@ describe('platform-v7 public/protected runtime split', () => {
     expect(isolatedLogin).toContain("from '@/app/platform-v7/login/page'");
     expect(isolatedRecovery).toContain("from '@/app/platform-v7/forgot-password/page'");
     expect(isolatedLayout).toContain('<HydrationSafeChatSupport />');
+    expect(isolatedLayout.indexOf('{children}')).toBeLessThan(isolatedLayout.indexOf('<HydrationSafeChatSupport />'));
   });
 
   it('restores only the last approved contact dock visual on the public homepage', () => {
-    expect(approvedHomeDock).toContain("[data-contact-dock-visual='approved']");
+    expect(approvedHomeDock).toContain("[data-contact-dock-visual='approved'] ~ .pc-public-contact-dock");
+    expect(approvedHomeDock).not.toContain("[data-contact-dock-visual='approved'] .pc-public-contact-dock {");
     expect(approvedHomeDock).toContain('grid-template-columns: repeat(3, minmax(0, 1fr))');
     expect(approvedHomeDock).toContain('width: min(390px');
     expect(approvedHomeDock).toContain('border: 1px solid rgba(8, 122, 59, .42)');


### PR DESCRIPTION
## Что исправлено

- последний согласованный вариант нижней плашки теперь применяется к реальному hydration-safe dock на главной;
- учтена текущая DOM-композиция: маркер главной и dock являются соседними узлами, потому что dock монтируется на границе изолированного layout;
- route-local CSS не затрагивает вход, восстановление доступа, другие публичные страницы и кабинеты;
- добавлена регрессия, фиксирующая порядок `children → HydrationSafeChatSupport` и селектор соседнего dock.

## Причина

После последовательного слияния #2810 и #2814 CSS ожидал dock внутри маркера главной, но фактически dock рендерился следующим sibling-узлом. Поэтому согласованный внешний вид не применялся.

## Граница

Логика ИИ, поддержки, звонка, локализации и прав доступа не меняется. Изменены только homepage-local CSS и статическая регрессия.