### PR TITLE
Не отдавать устаревшую главную после обновления нижней плашки

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -28,6 +28,14 @@ const securityHeaders = [
   },
 ];
 
+const publicEntryFreshHeaders = [
+  { key: 'Cache-Control', value: 'no-store, no-cache, max-age=0, must-revalidate' },
+  { key: 'CDN-Cache-Control', value: 'no-store' },
+  { key: 'Netlify-CDN-Cache-Control', value: 'no-store' },
+  { key: 'Pragma', value: 'no-cache' },
+  { key: 'Expires', value: '0' },
+];
+
 const nextConfig = {
   reactStrictMode: true,
   eslint: {
@@ -38,6 +46,18 @@ const nextConfig = {
   },
   async headers() {
     return [
+      {
+        source: '/',
+        headers: publicEntryFreshHeaders,
+      },
+      {
+        source: '/platform-v7',
+        headers: publicEntryFreshHeaders,
+      },
+      {
+        source: '/pc-public-entry/platform-v7',
+        headers: publicEntryFreshHeaders,
+      },
       {
         source: '/(.*)',
         headers: securityHeaders,

--- a/apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts
+++ b/apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts
@@ -72,6 +72,16 @@ describe('platform-v7 public/protected runtime split', () => {
     expect(isolatedLayout.indexOf('{children}')).toBeLessThan(isolatedLayout.indexOf('<HydrationSafeChatSupport />'));
   });
 
+  it('forces fresh HTML for the root and public homepage after contact dock releases', () => {
+    expect(nextConfig).toContain('const publicEntryFreshHeaders = [');
+    expect(nextConfig).toContain("{ key: 'Cache-Control', value: 'no-store, no-cache, max-age=0, must-revalidate' }");
+    expect(nextConfig).toContain("{ key: 'CDN-Cache-Control', value: 'no-store' }");
+    expect(nextConfig).toContain("{ key: 'Netlify-CDN-Cache-Control', value: 'no-store' }");
+    expect(nextConfig).toContain("source: '/'");
+    expect(nextConfig).toContain("source: '/platform-v7'");
+    expect(nextConfig).toContain("source: '/pc-public-entry/platform-v7'");
+  });
+
   it('restores only the last approved contact dock visual on the public homepage', () => {
     expect(approvedHomeDock).toContain("[data-contact-dock-visual='approved'] ~ .pc-public-contact-dock");
     expect(approvedHomeDock).not.toContain("[data-contact-dock-visual='approved'] .pc-public-contact-dock {");


### PR DESCRIPTION
## Причина

На мобильном браузере после production-деплоя остался старый HTML/JS: вместо объединённого dock отображалась прежняя одиночная кнопка поддержки. Текущий `main` уже содержит новый dock, поэтому такой экран возможен только при сохранённом клиентом старом entry-документе.

## Исправление

- для `/`, `/platform-v7` и внутреннего rewrite-route `/pc-public-entry/platform-v7` установлен `Cache-Control: no-store, no-cache, max-age=0, must-revalidate`;
- добавлены отдельные `CDN-Cache-Control` и `Netlify-CDN-Cache-Control: no-store`;
- сохранены security headers, rewrite-границы и все остальные маршруты;
- добавлена статическая регрессия на browser/CDN cache contract.

## Граница

Внешний вид и логика ИИ / поддержки / звонка не меняются. Изменяется только выдача свежего entry HTML после релизов.