### PR TITLE
Добавить маркетинговый контекст будущего ИИ на главную

### DIFF
--- a/apps/web/app/platform-v7/page.tsx
+++ b/apps/web/app/platform-v7/page.tsx
@@ -8,6 +8,7 @@ import '@/styles/platform-v7-public-product-entry-variants.css';
 import '@/styles/platform-v7-public-product-experience-v5.css';
 import type { Metadata } from 'next';
 import { getLocale, getTranslations } from 'next-intl/server';
+import { PublicAiMarketingBlock } from '@/components/platform-v7/PublicAiMarketingBlock';
 import { PublicSiteHeader } from '@/components/platform-v7/PublicSiteHeader';
 import { PublicLocaleLink } from '@/components/platform-v7/PublicLocaleLink';
 import { PublicDealPreview } from '@/components/platform-v7/PublicDealPreview';
@@ -109,9 +110,12 @@ export default async function PlatformV7RootPage() {
   const contourStages = TOUR_STAGES;
   const start = firstStageCopy[locale === 'en' || locale === 'zh' ? locale : 'ru'];
   const startDealHref = `/platform-v7/how-it-works?lang=${encodeURIComponent(locale)}&entry=deal&stage=terms&lens=execution&perspective=buyer`;
+  const roleEntryHref = `/platform-v7/how-it-works?lang=${encodeURIComponent(locale)}&entry=role`;
+  const aiNavLabel = locale === 'ru' ? 'ИИ' : 'AI';
   const nav = (
     <>
       <a href='#deal-example'>{ui.header.howItWorks}</a>
+      <a href='#ai-copilot'>{aiNavLabel}</a>
       <a href='#participants'>{ui.header.participants}</a>
       <a href='#reliability'>{ui.header.reliability}</a>
     </>
@@ -204,6 +208,8 @@ export default async function PlatformV7RootPage() {
         <section id='deal-example' className='pc-ppe-section' aria-label={ui.home.preview.demoLabel}>
           <PublicDealPreview copy={copy} locale={locale} />
         </section>
+
+        <PublicAiMarketingBlock locale={locale} roleEntryHref={roleEntryHref} />
 
         <section id='participants' className='pc-ppe-section' aria-labelledby='pc-ppe-perspectives-title'>
           <div className='pc-ppe-section-header'>

--- a/apps/web/components/platform-v7/PublicAiMarketingBlock.module.css
+++ b/apps/web/components/platform-v7/PublicAiMarketingBlock.module.css
@@ -1,0 +1,337 @@
+.section {
+  position: relative;
+}
+
+.panel {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(340px, .92fr);
+  align-items: stretch;
+  gap: clamp(30px, 5vw, 58px);
+  overflow: hidden;
+  padding: clamp(26px, 4.2vw, 48px);
+  border: 1px solid var(--pc-ppe-v5-line, #cfdcd4);
+  border-radius: var(--pc-ppe-v5-radius, 14px);
+  background: linear-gradient(135deg, #f4faf6 0%, #ffffff 52%, #edf6f0 100%);
+  box-shadow: 0 14px 36px rgba(9, 33, 24, .06);
+}
+
+.panel::before {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  inset: -140px auto auto -120px;
+  width: 320px;
+  height: 320px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(8, 122, 59, .12), rgba(8, 122, 59, 0) 70%);
+  pointer-events: none;
+}
+
+.copy {
+  min-width: 0;
+}
+
+.copy h2 {
+  max-width: 760px;
+  margin: 14px 0 12px;
+  color: var(--pc-ppe-v5-ink, #092118);
+  font-size: clamp(34px, 4vw, 50px);
+  line-height: 1.06;
+  letter-spacing: -.035em;
+  text-wrap: balance;
+}
+
+.lead {
+  max-width: 760px;
+  margin: 0;
+  color: var(--pc-ppe-v5-muted, #52635b);
+  font-size: 17px;
+  line-height: 1.58;
+}
+
+.capabilities {
+  display: grid;
+  gap: 0;
+  margin: 26px 0 0;
+  padding: 0;
+  border-top: 1px solid #d5e1d9;
+  list-style: none;
+}
+
+.capabilities li {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 14px;
+  padding: 17px 0;
+  border-bottom: 1px solid #d5e1d9;
+}
+
+.capabilityIcon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid #b8d2c1;
+  border-radius: 10px;
+  background: #ffffff;
+  color: var(--pc-ppe-v5-green-dark, #07572e);
+}
+
+.capabilities strong {
+  display: block;
+  color: var(--pc-ppe-v5-ink, #092118);
+  font-size: 16px;
+  line-height: 1.3;
+}
+
+.capabilities p {
+  margin: 5px 0 0;
+  color: var(--pc-ppe-v5-muted, #52635b);
+  font-size: 14px;
+  line-height: 1.52;
+}
+
+.maturity {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 10px;
+  margin: 20px 0 0;
+  padding: 13px 14px;
+  border-left: 4px solid #3d8b5d;
+  background: rgba(255, 255, 255, .72);
+  color: #29443a;
+  font-size: 13px;
+  line-height: 1.5;
+  font-weight: 650;
+}
+
+.maturity > span:first-child {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 7px;
+  background: #e8f5ec;
+  color: var(--pc-ppe-v5-green-dark, #07572e);
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  width: fit-content;
+  min-height: 52px;
+  margin-top: 22px;
+  padding: 12px 18px;
+  border-radius: 10px;
+  background: var(--pc-ppe-v5-green, #087a3b);
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.cta:hover,
+.cta:focus-visible {
+  background: #066832;
+}
+
+.cta:focus-visible {
+  outline: 3px solid rgba(8, 122, 59, .28);
+  outline-offset: 3px;
+}
+
+.scenario {
+  align-self: stretch;
+  min-width: 0;
+  padding: clamp(22px, 3vw, 30px);
+  border: 1px solid rgba(255, 255, 255, .14);
+  border-radius: 12px;
+  background: #0d2e21;
+  color: #ffffff;
+  box-shadow: 0 18px 42px rgba(9, 33, 24, .16);
+}
+
+.scenarioTopline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  color: #bce1c9;
+}
+
+.scenarioBadge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 5px 9px;
+  border: 1px solid rgba(255, 255, 255, .24);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, .08);
+  color: #d9f1e2;
+  font-size: 12px;
+  line-height: 1.2;
+  font-weight: 820;
+  letter-spacing: .035em;
+  text-transform: uppercase;
+}
+
+.scenarioContext {
+  margin: 24px 0 0;
+  color: #bcd2c5;
+  font-size: 13px;
+  line-height: 1.45;
+  font-weight: 720;
+}
+
+.scenario h3 {
+  margin: 9px 0 0;
+  color: #ffffff;
+  font-size: clamp(28px, 3.1vw, 40px);
+  line-height: 1.08;
+  letter-spacing: -.03em;
+  text-wrap: balance;
+}
+
+.scenarioFacts {
+  display: grid;
+  gap: 0;
+  margin: 24px 0 0;
+}
+
+.scenarioFacts > div {
+  padding: 16px 0;
+  border-top: 1px solid rgba(255, 255, 255, .14);
+}
+
+.scenarioFacts dt {
+  color: #9fc7ad;
+  font-size: 11px;
+  line-height: 1.2;
+  font-weight: 820;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.scenarioFacts dd {
+  margin: 7px 0 0;
+  color: #eef6f1;
+  font-size: 15px;
+  line-height: 1.52;
+  font-weight: 650;
+}
+
+.control {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 10px;
+  margin: 8px 0 0;
+  padding: 14px;
+  border-left: 4px solid #7bc796;
+  background: rgba(255, 255, 255, .07);
+  color: #e7f2eb;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.control > span:first-child {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid rgba(255, 255, 255, .22);
+  border-radius: 7px;
+  color: #bce1c9;
+}
+
+@media (max-width: 900px) {
+  .panel {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .scenario {
+    max-width: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .panel {
+    gap: 24px;
+    padding: 20px 18px;
+  }
+
+  .copy h2 {
+    font-size: 33px;
+    line-height: 1.08;
+  }
+
+  .lead {
+    font-size: 16px;
+  }
+
+  .capabilities {
+    margin-top: 22px;
+  }
+
+  .capabilities li {
+    grid-template-columns: 40px minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  .capabilityIcon {
+    width: 40px;
+    height: 40px;
+  }
+
+  .cta {
+    width: 100%;
+  }
+
+  .scenario {
+    padding: 20px 17px;
+  }
+
+  .scenario h3 {
+    font-size: 30px;
+  }
+}
+
+@media (max-width: 380px) {
+  .copy h2 {
+    font-size: 30px;
+  }
+
+  .scenario h3 {
+    font-size: 27px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cta {
+    transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .panel,
+  .capabilityIcon,
+  .scenario,
+  .maturity,
+  .control,
+  .cta {
+    border: 2px solid CanvasText;
+    background: Canvas;
+    color: CanvasText;
+    box-shadow: none;
+  }
+
+  .scenario h3,
+  .scenarioFacts dd,
+  .scenarioBadge,
+  .cta {
+    color: CanvasText;
+  }
+}

--- a/apps/web/components/platform-v7/PublicAiMarketingBlock.tsx
+++ b/apps/web/components/platform-v7/PublicAiMarketingBlock.tsx
@@ -1,0 +1,238 @@
+import { PublicExperienceLink } from './PublicExperienceAnalytics';
+import { PublicExperienceIcon, type PublicExperienceIconName } from './PublicExperienceIcon';
+import styles from './PublicAiMarketingBlock.module.css';
+
+type Locale = 'ru' | 'en' | 'zh';
+
+type Capability = {
+  icon: PublicExperienceIconName;
+  title: string;
+  body: string;
+};
+
+type MarketingCopy = {
+  eyebrow: string;
+  title: string;
+  lead: string;
+  capabilities: Capability[];
+  maturity: string;
+  cta: string;
+  scenario: {
+    aria: string;
+    badge: string;
+    context: string;
+    title: string;
+    reasonLabel: string;
+    reason: string;
+    impactLabel: string;
+    impact: string;
+    actionLabel: string;
+    action: string;
+    control: string;
+  };
+};
+
+const COPY: Record<Locale, MarketingCopy> = {
+  ru: {
+    eyebrow: 'ИИ в целевой версии платформы',
+    title: 'Раньше увидеть риск. Понять причину. Быстрее перейти к действию.',
+    lead: 'После запуска полноценного ИИ «Прозрачная Цена» будет анализировать ход сделки, документы, логистику, качество и денежные основания. Система заранее покажет блокер, объяснит его влияние и подготовит следующий шаг для ответственного участника.',
+    capabilities: [
+      {
+        icon: 'risk',
+        title: 'Увидит риск до срыва',
+        body: 'Отметит, когда срок, документ, качество, маршрут или основание расчёта начинают отклоняться от сценария.',
+      },
+      {
+        icon: 'documents',
+        title: 'Объяснит на фактах',
+        body: 'Свяжет сигнал с событием, документом, источником, ответственным, дедлайном и суммой влияния.',
+      },
+      {
+        icon: 'intelligence',
+        title: 'Подготовит следующий шаг',
+        body: 'Соберёт запрос, чек-лист, уведомление, пакет оснований или сценарий эскалации — по роли и контексту сделки.',
+      },
+    ],
+    maturity: 'Целевой контур будет вводиться поэтапно. ИИ не заменит полномочия участников: критические действия останутся под подтверждением человека.',
+    cta: 'Посмотреть ценность для своей роли',
+    scenario: {
+      aria: 'Пример будущего сигнала ИИ по демонстрационной сделке',
+      badge: 'Пример будущего сигнала',
+      context: 'Покупатель · Пшеница 3 класса · 500 т',
+      title: 'Расчёт может задержаться',
+      reasonLabel: 'Причина',
+      reason: 'Не подтверждён лабораторный протокол. До контрольного срока — 6 часов.',
+      impactLabel: 'Влияние',
+      impact: '6,9 млн ₽ остаются под риском задержки; следующая отгрузка может не попасть в окно.',
+      actionLabel: 'Следующий шаг',
+      action: 'ИИ подготовит запрос протокола и пакет оснований для проверки.',
+      control: 'Отправка и любые критические действия — только после подтверждения пользователя.',
+    },
+  },
+  en: {
+    eyebrow: 'AI in the target platform experience',
+    title: 'See risk earlier. Understand the cause. Move to action faster.',
+    lead: 'Once the full AI layer is launched, Transparent Price will analyse deal progress, documents, logistics, quality and payment grounds. It will surface blockers early, explain their impact and prepare the next step for the responsible participant.',
+    capabilities: [
+      {
+        icon: 'risk',
+        title: 'Sees risk before disruption',
+        body: 'Flags when a deadline, document, quality result, route or settlement ground starts to diverge from the agreed flow.',
+      },
+      {
+        icon: 'documents',
+        title: 'Explains with evidence',
+        body: 'Connects each signal to the event, document, source, owner, deadline and financial impact.',
+      },
+      {
+        icon: 'intelligence',
+        title: 'Prepares the next step',
+        body: 'Builds a request, checklist, notice, evidence pack or escalation path for the role and deal context.',
+      },
+    ],
+    maturity: 'The target experience will be introduced in stages. AI will not replace participant authority: consequential actions will remain subject to human confirmation.',
+    cta: 'See the value for your role',
+    scenario: {
+      aria: 'Example of a future AI signal for the demonstration deal',
+      badge: 'Example future signal',
+      context: 'Buyer · Class 3 wheat · 500 t',
+      title: 'Settlement may be delayed',
+      reasonLabel: 'Reason',
+      reason: 'The laboratory protocol has not been confirmed. Six hours remain before the control deadline.',
+      impactLabel: 'Impact',
+      impact: 'RUB 6.9m remains exposed to delay, and the next shipment may miss its window.',
+      actionLabel: 'Next step',
+      action: 'AI will prepare a protocol request and an evidence pack for review.',
+      control: 'Sending and any consequential action will require user confirmation.',
+    },
+  },
+  zh: {
+    eyebrow: '平台目标版本中的 AI',
+    title: '更早发现风险，理解原因，更快进入下一步。',
+    lead: '完整 AI 上线后，“透明价格”将分析交易进度、文件、物流、质量和付款依据，提前提示阻塞点，解释其影响，并为责任方准备下一步。',
+    capabilities: [
+      {
+        icon: 'risk',
+        title: '在中断前发现风险',
+        body: '当期限、文件、质量结果、路线或结算依据开始偏离约定流程时，系统会提前提示。',
+      },
+      {
+        icon: 'documents',
+        title: '基于事实进行解释',
+        body: '每个信号都会关联事件、文件、来源、责任方、期限和资金影响。',
+      },
+      {
+        icon: 'intelligence',
+        title: '准备下一步行动',
+        body: '根据角色和交易上下文，生成请求、检查清单、通知、依据包或升级路径。',
+      },
+    ],
+    maturity: '目标形态将分阶段上线。AI 不会取代交易参与方的权限；重要操作仍需人工确认。',
+    cta: '查看对您角色的价值',
+    scenario: {
+      aria: '演示交易中的未来 AI 信号示例',
+      badge: '未来信号示例',
+      context: '买方 · 三等小麦 · 500 吨',
+      title: '结算可能延迟',
+      reasonLabel: '原因',
+      reason: '实验室报告尚未确认，距离控制期限还有 6 小时。',
+      impactLabel: '影响',
+      impact: '690 万卢布仍面临延迟风险，下一批发运可能错过时间窗口。',
+      actionLabel: '下一步',
+      action: 'AI 将准备报告请求和供审核的依据包。',
+      control: '发送和任何重要操作都必须经过用户确认。',
+    },
+  },
+};
+
+function resolveLocale(locale: string): Locale {
+  if (locale === 'en' || locale === 'zh') return locale;
+  return 'ru';
+}
+
+export function PublicAiMarketingBlock({
+  locale,
+  roleEntryHref,
+}: {
+  locale: string;
+  roleEntryHref: string;
+}) {
+  const ui = COPY[resolveLocale(locale)];
+
+  return (
+    <section
+      id='ai-copilot'
+      className={`pc-ppe-section ${styles.section}`}
+      aria-labelledby='pc-ppe-ai-title'
+      data-testid='platform-v7-ai-future-value'
+    >
+      <div className={styles.panel}>
+        <div className={styles.copy}>
+          <span className='pc-ppe-section-eyebrow'>{ui.eyebrow}</span>
+          <h2 id='pc-ppe-ai-title'>{ui.title}</h2>
+          <p className={styles.lead}>{ui.lead}</p>
+
+          <ul className={styles.capabilities}>
+            {ui.capabilities.map((capability) => (
+              <li key={capability.title}>
+                <span className={styles.capabilityIcon} aria-hidden='true'>
+                  <PublicExperienceIcon name={capability.icon} size={22} />
+                </span>
+                <div>
+                  <strong>{capability.title}</strong>
+                  <p>{capability.body}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <p className={styles.maturity} role='note'>
+            <span aria-hidden='true'><PublicExperienceIcon name='check' size={18} /></span>
+            <span>{ui.maturity}</span>
+          </p>
+
+          <PublicExperienceLink
+            href={roleEntryHref}
+            className={styles.cta}
+            eventName='ai_future_value_role_cta'
+            locale={locale}
+            params={{ source: 'home_ai_future_value' }}
+          >
+            <span>{ui.cta}</span>
+            <PublicExperienceIcon name='arrow' size={20} />
+          </PublicExperienceLink>
+        </div>
+
+        <article className={styles.scenario} aria-label={ui.scenario.aria}>
+          <div className={styles.scenarioTopline}>
+            <span className={styles.scenarioBadge}>{ui.scenario.badge}</span>
+            <PublicExperienceIcon name='intelligence' size={24} />
+          </div>
+          <p className={styles.scenarioContext}>{ui.scenario.context}</p>
+          <h3>{ui.scenario.title}</h3>
+
+          <dl className={styles.scenarioFacts}>
+            <div>
+              <dt>{ui.scenario.reasonLabel}</dt>
+              <dd>{ui.scenario.reason}</dd>
+            </div>
+            <div>
+              <dt>{ui.scenario.impactLabel}</dt>
+              <dd>{ui.scenario.impact}</dd>
+            </div>
+            <div>
+              <dt>{ui.scenario.actionLabel}</dt>
+              <dd>{ui.scenario.action}</dd>
+            </div>
+          </dl>
+
+          <p className={styles.control}>
+            <span aria-hidden='true'><PublicExperienceIcon name='check' size={18} /></span>
+            <span>{ui.scenario.control}</span>
+          </p>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/tests/unit/platformV7PublicAiMarketingBlock.test.ts
+++ b/apps/web/tests/unit/platformV7PublicAiMarketingBlock.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const read = (relativePath: string) => readFileSync(join(process.cwd(), relativePath), 'utf8');
+
+describe('platform-v7 public AI marketing context', () => {
+  const page = read('app/platform-v7/page.tsx');
+  const block = read('components/platform-v7/PublicAiMarketingBlock.tsx');
+  const styles = read('components/platform-v7/PublicAiMarketingBlock.module.css');
+
+  it('places the future AI value between the deal example and role workspaces', () => {
+    expect(page).toContain("import { PublicAiMarketingBlock } from '@/components/platform-v7/PublicAiMarketingBlock';");
+    expect(page).toContain("<a href='#ai-copilot'>{aiNavLabel}</a>");
+    expect(page).toContain('<PublicAiMarketingBlock locale={locale} roleEntryHref={roleEntryHref} />');
+
+    const dealIndex = page.indexOf("id='deal-example'");
+    const aiIndex = page.indexOf('<PublicAiMarketingBlock');
+    const participantsIndex = page.indexOf("id='participants'");
+
+    expect(dealIndex).toBeGreaterThan(-1);
+    expect(aiIndex).toBeGreaterThan(dealIndex);
+    expect(participantsIndex).toBeGreaterThan(aiIndex);
+  });
+
+  it('markets the target outcome without claiming the capability is already live', () => {
+    expect(block).toContain("eyebrow: 'ИИ в целевой версии платформы'");
+    expect(block).toContain("После запуска полноценного ИИ");
+    expect(block).toContain("Увидит риск до срыва");
+    expect(block).toContain("Объяснит на фактах");
+    expect(block).toContain("Подготовит следующий шаг");
+    expect(block).toContain("Целевой контур будет вводиться поэтапно");
+    expect(block).toContain("Пример будущего сигнала");
+    expect(block).toContain("только после подтверждения пользователя");
+    expect(block).not.toContain('ИИ уже анализирует');
+    expect(block).not.toContain('самостоятельно выполняет');
+  });
+
+  it('uses a semantic evidence-led structure with one measurable next step', () => {
+    expect(block).toContain("id='ai-copilot'");
+    expect(block).toContain("aria-labelledby='pc-ppe-ai-title'");
+    expect(block).toContain("data-testid='platform-v7-ai-future-value'");
+    expect(block).toContain('<ul className={styles.capabilities}>');
+    expect(block).toContain('<dl className={styles.scenarioFacts}>');
+    expect(block).toContain("role='note'");
+    expect(block).toContain("eventName='ai_future_value_role_cta'");
+    expect(block).toContain("params={{ source: 'home_ai_future_value' }}");
+  });
+
+  it('covers RU, EN and ZH and remains responsive and accessible', () => {
+    expect(block).toContain("en: {");
+    expect(block).toContain("zh: {");
+    expect(block).toContain('See risk earlier. Understand the cause. Move to action faster.');
+    expect(block).toContain('更早发现风险，理解原因，更快进入下一步。');
+    expect(styles).toContain('grid-template-columns: minmax(0, 1.08fr) minmax(340px, .92fr)');
+    expect(styles).toContain('@media (max-width: 900px)');
+    expect(styles).toContain('@media (max-width: 720px)');
+    expect(styles).toContain('@media (max-width: 380px)');
+    expect(styles).toContain('@media (forced-colors: active)');
+    expect(styles).toContain('min-height: 52px');
+  });
+});


### PR DESCRIPTION
## Что изменено

- Добавлен самостоятельный маркетинговый блок о целевом ИИ-контуре на публичную главную.
- Блок расположен после демонстрационной сделки и до выбора ролей, поэтому продолжает уже показанный сценарий, а не конкурирует с hero.
- Ценность сформулирована через результат: раннее обнаружение риска, объяснение на фактах и подготовку следующего шага.
- Добавлен пример будущего сигнала по той же демонстрационной сделке: причина → влияние → следующий шаг → пользовательское подтверждение.
- Добавлены RU / EN / ZH версии, адаптивные стили, forced-colors и семантическая разметка.
- В навигацию главной добавлен якорь «ИИ» / «AI».

## Почему

Текущий публичный помощник воспринимается как справочный чат. Новый блок позиционирует будущий полноценный ИИ как встроенный слой исполнения сделки, сохраняя честную границу зрелости: целевой контур внедряется поэтапно, а критические действия подтверждает человек.

## Проверки

- Локальная TSX-проверка: ошибок парсинга нет.
- Локальные регрессионные проверки: порядок секций, будущая формулировка, human-in-the-loop, RU/EN/ZH, responsive/forced-colors — пройдены.
- Добавлен `platformV7PublicAiMarketingBlock.test.ts` для CI.
