### PR TITLE
Гарантировать нижнюю плашку в initial HTML и удалить старый service worker

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -93,6 +93,7 @@ const LEAN_PUBLIC_ENTRY_PATHS = new Set([
   '/pc-public-entry/platform-v7/login',
   '/pc-public-entry/platform-v7/forgot-password',
 ]);
+const serviceWorkerRecoveryScript = `(function(){var version='2026-07-19-contact-dock-v3';var parameter='pc-sw-recovery';var controlled=false;try{controlled=!!('serviceWorker'in navigator&&navigator.serviceWorker.controller);}catch(e){}var tasks=[];try{if('serviceWorker'in navigator){tasks.push(navigator.serviceWorker.getRegistrations().then(function(items){return Promise.all(items.map(function(item){return item.unregister();}));}));}}catch(e){}try{if('caches'in window){tasks.push(caches.keys().then(function(keys){return Promise.all(keys.map(function(key){return caches.delete(key);}));}));}}catch(e){}Promise.all(tasks).catch(function(){}).then(function(){try{var url=new URL(window.location.href);var recovered=url.searchParams.get(parameter)===version;if(controlled&&!recovered){url.searchParams.set(parameter,version);window.location.replace(url.toString());return;}if(recovered){url.searchParams.delete(parameter);window.history.replaceState(window.history.state,'',url.pathname+(url.search||'')+url.hash);}}catch(e){}});})();`;
 const themeScript = `(function(){try{var t=localStorage.getItem('pc-theme');if(t==='dark'||t==='light'||t==='high-contrast'){document.documentElement.setAttribute('data-theme',t);}else{document.documentElement.setAttribute('data-theme','light');}}catch(e){}})();`;
 
 function normalizePath(value: string | null) {
@@ -120,6 +121,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
       className={`notranslate${fontVariables ? ` ${fontVariables}` : ''}`}
     >
       <head>
+        <script dangerouslySetInnerHTML={{ __html: serviceWorkerRecoveryScript }} />
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
         <meta name='google' content='notranslate' />
         <meta name='googlebot' content='notranslate' />

--- a/apps/web/app/pc-public-entry/platform-v7/layout.tsx
+++ b/apps/web/app/pc-public-entry/platform-v7/layout.tsx
@@ -1,15 +1,19 @@
 import type { ReactNode } from 'react';
 import { HydrationSafeChatSupport } from '@/components/platform-v7/HydrationSafeChatSupport';
+import { PublicContactDock } from '@/components/platform-v7/PublicContactDock';
 
 /**
  * The landing, login and recovery URLs are rewritten into this physically
- * isolated tree. Keep the unified contact dock at the tree boundary so all
- * three entry surfaces get exactly one hydration-safe mount.
+ * isolated tree. Render the contact dock as its own client boundary so the
+ * three-action surface is present in the initial HTML, while the assistant and
+ * support panels may continue loading through the hydration-safe runtime.
  */
 export default function PublicEntryLayout({ children }: { children: ReactNode }) {
   return (
     <>
       {children}
+      <span data-public-entry-contact-dock-mounted='true' hidden />
+      <PublicContactDock />
       <HydrationSafeChatSupport />
     </>
   );

--- a/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
+++ b/apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx
@@ -117,6 +117,8 @@ export function ContextualSupportOrAssistant() {
   const routerPathname = usePathname() || PUBLIC_HOME;
   const browserPathname = typeof window === 'undefined' ? routerPathname : window.location.pathname;
   const path = normalize(browserPathname || routerPathname);
+  const externalPublicDock = typeof document !== 'undefined'
+    && Boolean(document.querySelector('[data-public-entry-contact-dock-mounted="true"]'));
 
   // The full-page assistant already renders its own workspace panel. Keep the
   // shared dock for human support and phone access, while the AI action focuses
@@ -142,14 +144,15 @@ export function ContextualSupportOrAssistant() {
     );
   }
 
-  // Every public platform surface uses one visible entry point. The standalone
-  // assistant and support launchers remain internal triggers for the shared dock.
+  // Every public platform surface uses one visible entry point. The physically
+  // isolated entry tree renders that dock in initial HTML; other public routes
+  // retain the hydration-safe internal mount.
   return (
     <>
       <UnifiedModalSheetFullscreenController />
       <PublicPlatformAssistant />
       <ChatSupportWidget />
-      <PublicContactDock />
+      {externalPublicDock ? null : <PublicContactDock />}
     </>
   );
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -36,6 +36,11 @@ const publicEntryFreshHeaders = [
   { key: 'Expires', value: '0' },
 ];
 
+const serviceWorkerRecoveryHeaders = [
+  ...publicEntryFreshHeaders,
+  { key: 'Service-Worker-Allowed', value: '/' },
+];
+
 const nextConfig = {
   reactStrictMode: true,
   eslint: {
@@ -57,6 +62,10 @@ const nextConfig = {
       {
         source: '/pc-public-entry/platform-v7',
         headers: publicEntryFreshHeaders,
+      },
+      {
+        source: '/sw.js',
+        headers: serviceWorkerRecoveryHeaders,
       },
       {
         source: '/(.*)',

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,19 +1,41 @@
-// Platform v7 pilot: do not cache pages or app chunks.
-// This worker exists only to clear old CacheStorage once. It must not navigate
-// clients on activation; otherwise mobile browsers can fall into a reload loop
-// when the app registers /sw.js again on the next load.
+// Platform v7 recovery worker: never cache pages or app chunks.
+// Older pilot workers could retain a stale public entry document. This worker
+// takes control once, clears legacy storage, moves affected entry clients to a
+// cache-busted URL, and unregisters itself so the recovery cannot loop.
+const RECOVERY_VERSION = '2026-07-19-contact-dock-v3';
+const RECOVERY_PARAMETER = 'pc-sw-recovery';
+const ENTRY_PATHS = new Set(['/', '/platform-v7', '/pc-public-entry/platform-v7']);
+
+async function clearLegacyCaches() {
+  const keys = await caches.keys();
+  await Promise.all(keys.map((key) => caches.delete(key)));
+}
+
 self.addEventListener('install', (event) => {
   self.skipWaiting();
-  event.waitUntil(caches.keys().then((keys) => Promise.all(keys.map((key) => caches.delete(key)))));
+  event.waitUntil(clearLegacyCaches());
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil((async () => {
-    const keys = await caches.keys();
-    await Promise.all(keys.map((key) => caches.delete(key)));
-    if (self.registration && self.registration.unregister) {
-      await self.registration.unregister();
-    }
+    await clearLegacyCaches();
+    await self.clients.claim();
+
+    const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    await self.registration.unregister();
+
+    await Promise.all(clients.map(async (client) => {
+      try {
+        const url = new URL(client.url);
+        const normalizedPath = url.pathname.replace(/\/+$/u, '') || '/';
+        if (url.origin !== self.location.origin || !ENTRY_PATHS.has(normalizedPath)) return;
+        if (url.searchParams.get(RECOVERY_PARAMETER) === RECOVERY_VERSION) return;
+        url.searchParams.set(RECOVERY_PARAMETER, RECOVERY_VERSION);
+        await client.navigate(url.toString());
+      } catch {
+        // A closed or non-navigable client requires no recovery action.
+      }
+    }));
   })());
 });
 

--- a/apps/web/tests/unit/platformV7PublicEntryContactDockMount.test.ts
+++ b/apps/web/tests/unit/platformV7PublicEntryContactDockMount.test.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const read = (relative: string) => fs.readFileSync(path.join(root, relative), 'utf8');
+const entryLayout = read('apps/web/app/pc-public-entry/platform-v7/layout.tsx');
+const contextual = read('apps/web/components/platform-v7/ContextualSupportOrAssistant.tsx');
+const dock = read('apps/web/components/platform-v7/PublicContactDock.tsx');
+
+describe('platform-v7 public entry contact dock mount', () => {
+  it('renders the three-action dock in initial entry HTML before the deferred support runtime', () => {
+    expect(entryLayout).toContain("import { PublicContactDock } from '@/components/platform-v7/PublicContactDock'");
+    expect(entryLayout).toContain("data-public-entry-contact-dock-mounted='true'");
+    expect(entryLayout).toContain('<PublicContactDock />');
+    expect(entryLayout).toContain('<HydrationSafeChatSupport />');
+    expect(entryLayout.indexOf('<PublicContactDock />'))
+      .toBeLessThan(entryLayout.indexOf('<HydrationSafeChatSupport />'));
+  });
+
+  it('keeps the deferred assistant and support panels without mounting a duplicate public dock', () => {
+    expect(contextual).toContain('const externalPublicDock =');
+    expect(contextual).toContain("document.querySelector('[data-public-entry-contact-dock-mounted=\"true\"]')");
+    expect(contextual).toContain('{externalPublicDock ? null : <PublicContactDock />}');
+    expect(contextual).toContain('<PublicPlatformAssistant />');
+    expect(contextual).toContain('<ChatSupportWidget />');
+  });
+
+  it('ships the launcher-hiding CSS with the server-rendered dock boundary', () => {
+    expect(dock).toContain('.p7-support-chat-button {');
+    expect(dock).toContain('width: 1px !important');
+    expect(dock).toContain('opacity: 0 !important');
+    expect(dock).toContain('pointer-events: none !important');
+  });
+});

--- a/apps/web/tests/unit/platformV7ServiceWorkerNoReloadLoop.test.ts
+++ b/apps/web/tests/unit/platformV7ServiceWorkerNoReloadLoop.test.ts
@@ -2,13 +2,33 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const source = fs.readFileSync(path.join(process.cwd(), 'apps/web/public/sw.js'), 'utf8');
+const root = process.cwd();
+const serviceWorker = fs.readFileSync(path.join(root, 'apps/web/public/sw.js'), 'utf8');
+const rootLayout = fs.readFileSync(path.join(root, 'apps/web/app/layout.tsx'), 'utf8');
+const nextConfig = fs.readFileSync(path.join(root, 'apps/web/next.config.js'), 'utf8');
 
-describe('platform-v7 service worker stability', () => {
-  it('does not navigate clients during activate and does not intercept fetches', () => {
-    expect(source).not.toContain('client.navigate');
-    expect(source).not.toContain('clients.matchAll');
-    expect(source).not.toContain('event.respondWith(fetch(event.request))');
-    expect(source).toContain('self.registration.unregister');
+describe('platform-v7 service worker recovery', () => {
+  it('navigates stale entry clients once, unregisters, and never intercepts fetches', () => {
+    expect(serviceWorker).toContain("const RECOVERY_VERSION = '2026-07-19-contact-dock-v3'");
+    expect(serviceWorker).toContain("const RECOVERY_PARAMETER = 'pc-sw-recovery'");
+    expect(serviceWorker).toContain("new Set(['/', '/platform-v7', '/pc-public-entry/platform-v7'])");
+    expect(serviceWorker).toContain('self.clients.claim()');
+    expect(serviceWorker).toContain("self.clients.matchAll({ type: 'window', includeUncontrolled: true })");
+    expect(serviceWorker).toContain('url.searchParams.get(RECOVERY_PARAMETER) === RECOVERY_VERSION');
+    expect(serviceWorker).toContain('client.navigate(url.toString())');
+    expect(serviceWorker).toContain('self.registration.unregister');
+    expect(serviceWorker).not.toContain('event.respondWith');
+  });
+
+  it('clears legacy registrations from every document and serves the recovery worker uncached', () => {
+    expect(rootLayout).toContain('const serviceWorkerRecoveryScript =');
+    expect(rootLayout).toContain('navigator.serviceWorker.getRegistrations()');
+    expect(rootLayout).toContain('navigator.serviceWorker.controller');
+    expect(rootLayout).toContain('caches.keys()');
+    expect(rootLayout).toContain('window.location.replace(url.toString())');
+    expect(rootLayout).toContain("url.searchParams.delete(parameter)");
+    expect(nextConfig).toContain("source: '/sw.js'");
+    expect(nextConfig).toContain("{ key: 'Service-Worker-Allowed', value: '/' }");
+    expect(nextConfig).toContain("{ key: 'Netlify-CDN-Cache-Control', value: 'no-store' }");
   });
 });


### PR DESCRIPTION
## Наблюдаемая проблема

На фактическом мобильном production после повторного открытия продолжает отображаться одиночная зелёная кнопка поддержки. Это доказывает две независимые границы:

1. returning-клиент всё ещё может оставаться под управлением старого PWA service worker;
2. объединённый dock сейчас появляется только после `ssr:false` dynamic runtime, поэтому initial HTML не содержит требуемую плашку.

## Исправление

- `PublicContactDock` вынесен в отдельную client boundary внутри физически изолированного public-entry layout и теперь присутствует в initial HTML;
- deferred runtime продолжает загружать ИИ и поддержку, но обнаруживает внешний dock и не создаёт второй;
- текущий `sw.js` превращён в одноразовый recovery worker: очищает старые CacheStorage, захватывает старые entry-клиенты, переводит их на versioned URL ровно один раз и сам удаляет регистрацию;
- root layout дополнительно снимает оставшиеся регистрации и повторяет один controlled reload при необходимости;
- `/sw.js` выдаётся без browser/CDN cache и с явным root scope;
- добавлены регрессии на initial-HTML mount, отсутствие duplicate dock и одноразовое восстановление service worker.

## Граница

Логика ИИ, формы поддержки, звонка, локализации, авторизации и кабинетов не меняется. Изменяется только надёжность видимого contact dock и очистка устаревшего PWA runtime.

## Scope

7 файлов приложения/тестов; требуется отдельная source-controlled authority для точной ветки и путей перед merge.