### PR TITLE
Показать нижнюю плашку в initial HTML и принудительно снять старый PWA runtime

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -93,6 +93,7 @@ const LEAN_PUBLIC_ENTRY_PATHS = new Set([
   '/pc-public-entry/platform-v7/login',
   '/pc-public-entry/platform-v7/forgot-password',
 ]);
+const serviceWorkerRecoveryScript = `(function(){var version='2026-07-19-contact-dock-v3';var parameter='pc-sw-recovery';var controlled=false;try{controlled=!!('serviceWorker'in navigator&&navigator.serviceWorker.controller);}catch(e){}var tasks=[];try{if('serviceWorker'in navigator){tasks.push(navigator.serviceWorker.getRegistrations().then(function(items){return Promise.all(items.map(function(item){return item.unregister();}));}));}}catch(e){}try{if('caches'in window){tasks.push(caches.keys().then(function(keys){return Promise.all(keys.map(function(key){return caches.delete(key);}));}));}}catch(e){}Promise.all(tasks).catch(function(){}).then(function(){try{var url=new URL(window.location.href);var recovered=url.searchParams.get(parameter)===version;if(controlled&&!recovered){url.searchParams.set(parameter,version);window.location.replace(url.toString());return;}if(recovered){url.searchParams.delete(parameter);window.history.replaceState(window.history.state,'',url.pathname+(url.search||'')+url.hash);}}catch(e){}});})();`;
 const themeScript = `(function(){try{var t=localStorage.getItem('pc-theme');if(t==='dark'||t==='light'||t==='high-contrast'){document.documentElement.setAttribute('data-theme',t);}else{document.documentElement.setAttribute('data-theme','light');}}catch(e){}})();`;
 
 function normalizePath(value: string | null) {
@@ -120,6 +121,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
       className={`notranslate${fontVariables ? ` ${fontVariables}` : ''}`}
     >
       <head>
+        <script dangerouslySetInnerHTML={{ __html: serviceWorkerRecoveryScript }} />
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
         <meta name='google' content='notranslate' />
         <meta name='googlebot' content='notranslate' />

--- a/apps/web/app/pc-public-entry/platform-v7/layout.tsx
+++ b/apps/web/app/pc-public-entry/platform-v7/layout.tsx
@@ -1,15 +1,21 @@
+import './public-entry-contact-dock-mount.css';
 import type { ReactNode } from 'react';
 import { HydrationSafeChatSupport } from '@/components/platform-v7/HydrationSafeChatSupport';
+import { PublicContactDock } from '@/components/platform-v7/PublicContactDock';
 
 /**
  * The landing, login and recovery URLs are rewritten into this physically
- * isolated tree. Keep the unified contact dock at the tree boundary so all
- * three entry surfaces get exactly one hydration-safe mount.
+ * isolated tree. Render the visible three-action dock in initial HTML; the
+ * hydration-safe runtime then supplies the deferred assistant and support
+ * panels while its later duplicate dock is suppressed by the route boundary.
  */
 export default function PublicEntryLayout({ children }: { children: ReactNode }) {
   return (
     <>
       {children}
+      <span data-public-entry-contact-dock-mounted='true' hidden />
+      <PublicContactDock />
+      <span data-public-entry-contact-dock-end='true' hidden />
       <HydrationSafeChatSupport />
     </>
   );

--- a/apps/web/app/pc-public-entry/platform-v7/public-entry-contact-dock-mount.css
+++ b/apps/web/app/pc-public-entry/platform-v7/public-entry-contact-dock-mount.css
@@ -1,0 +1,8 @@
+/*
+ * Public entry renders one contact dock in initial HTML. The deferred
+ * assistant/support runtime still creates its historical dock node after this
+ * boundary; keep that later duplicate out of layout and accessibility trees.
+ */
+[data-public-entry-contact-dock-end='true'] ~ .pc-public-contact-dock {
+  display: none !important;
+}

--- a/apps/web/app/pc-public-entry/sw-recovery/route.ts
+++ b/apps/web/app/pc-public-entry/sw-recovery/route.ts
@@ -1,0 +1,59 @@
+const RECOVERY_WORKER = String.raw`// Platform v7 recovery worker: never cache pages or app chunks.
+const RECOVERY_VERSION = '2026-07-19-contact-dock-v3';
+const RECOVERY_PARAMETER = 'pc-sw-recovery';
+const ENTRY_PATHS = new Set(['/', '/platform-v7', '/pc-public-entry/platform-v7']);
+
+async function clearLegacyCaches() {
+  const keys = await caches.keys();
+  await Promise.all(keys.map((key) => caches.delete(key)));
+}
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(clearLegacyCaches());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    await clearLegacyCaches();
+    await self.clients.claim();
+    const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    await self.registration.unregister();
+
+    await Promise.all(clients.map(async (client) => {
+      try {
+        const url = new URL(client.url);
+        const normalizedPath = url.pathname.replace(/\/+$/u, '') || '/';
+        if (url.origin !== self.location.origin || !ENTRY_PATHS.has(normalizedPath)) return;
+        if (url.searchParams.get(RECOVERY_PARAMETER) === RECOVERY_VERSION) return;
+        url.searchParams.set(RECOVERY_PARAMETER, RECOVERY_VERSION);
+        await client.navigate(url.toString());
+      } catch {
+        // A closed or non-navigable client requires no recovery action.
+      }
+    }));
+  })());
+});
+
+self.addEventListener('fetch', () => {
+  return;
+});
+`;
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export function GET() {
+  return new Response(RECOVERY_WORKER, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/javascript; charset=utf-8',
+      'Cache-Control': 'no-store, no-cache, max-age=0, must-revalidate',
+      'CDN-Cache-Control': 'no-store',
+      'Netlify-CDN-Cache-Control': 'no-store',
+      'Service-Worker-Allowed': '/',
+      Pragma: 'no-cache',
+      Expires: '0',
+    },
+  });
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -36,6 +36,11 @@ const publicEntryFreshHeaders = [
   { key: 'Expires', value: '0' },
 ];
 
+const serviceWorkerRecoveryHeaders = [
+  ...publicEntryFreshHeaders,
+  { key: 'Service-Worker-Allowed', value: '/' },
+];
+
 const nextConfig = {
   reactStrictMode: true,
   eslint: {
@@ -59,6 +64,10 @@ const nextConfig = {
         headers: publicEntryFreshHeaders,
       },
       {
+        source: '/sw.js',
+        headers: serviceWorkerRecoveryHeaders,
+      },
+      {
         source: '/(.*)',
         headers: securityHeaders,
       },
@@ -67,6 +76,7 @@ const nextConfig = {
   async rewrites() {
     return {
       beforeFiles: [
+        { source: '/sw.js', destination: '/pc-public-entry/sw-recovery' },
         { source: '/platform-v7', destination: '/pc-public-entry/platform-v7' },
         { source: '/platform-v7/login', destination: '/pc-public-entry/platform-v7/login' },
         { source: '/platform-v7/forgot-password', destination: '/pc-public-entry/platform-v7/forgot-password' },

--- a/apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts
+++ b/apps/web/tests/unit/platformV7PublicLayoutSplit.test.ts
@@ -13,6 +13,8 @@ const nextConfig = read('apps/web/next.config.js');
 const isolatedLayout = read('apps/web/app/pc-public-entry/platform-v7/layout.tsx');
 const isolatedLanding = read('apps/web/app/pc-public-entry/platform-v7/page.tsx');
 const approvedHomeDock = read('apps/web/app/pc-public-entry/platform-v7/home-approved-contact-dock.css');
+const entryDockMountCss = read('apps/web/app/pc-public-entry/platform-v7/public-entry-contact-dock-mount.css');
+const serviceWorkerRecovery = read('apps/web/app/pc-public-entry/sw-recovery/route.ts');
 const isolatedLogin = read('apps/web/app/pc-public-entry/platform-v7/login/page.tsx');
 const isolatedRecovery = read('apps/web/app/pc-public-entry/platform-v7/forgot-password/page.tsx');
 const landing = read('apps/web/app/platform-v7/page.tsx');
@@ -72,7 +74,19 @@ describe('platform-v7 public/protected runtime split', () => {
     expect(isolatedLayout.indexOf('{children}')).toBeLessThan(isolatedLayout.indexOf('<HydrationSafeChatSupport />'));
   });
 
-  it('forces fresh HTML for the root and public homepage after contact dock releases', () => {
+  it('renders one contact dock in initial entry HTML and suppresses the deferred duplicate', () => {
+    expect(isolatedLayout).toContain("import './public-entry-contact-dock-mount.css'");
+    expect(isolatedLayout).toContain("import { PublicContactDock } from '@/components/platform-v7/PublicContactDock'");
+    expect(isolatedLayout).toContain("data-public-entry-contact-dock-mounted='true'");
+    expect(isolatedLayout).toContain("data-public-entry-contact-dock-end='true'");
+    expect(isolatedLayout).toContain('<PublicContactDock />');
+    expect(isolatedLayout.indexOf('<PublicContactDock />'))
+      .toBeLessThan(isolatedLayout.indexOf('<HydrationSafeChatSupport />'));
+    expect(entryDockMountCss).toContain("[data-public-entry-contact-dock-end='true'] ~ .pc-public-contact-dock");
+    expect(entryDockMountCss).toContain('display: none !important');
+  });
+
+  it('forces fresh HTML and actively recovers clients controlled by the legacy service worker', () => {
     expect(nextConfig).toContain('const publicEntryFreshHeaders = [');
     expect(nextConfig).toContain("{ key: 'Cache-Control', value: 'no-store, no-cache, max-age=0, must-revalidate' }");
     expect(nextConfig).toContain("{ key: 'CDN-Cache-Control', value: 'no-store' }");
@@ -80,6 +94,19 @@ describe('platform-v7 public/protected runtime split', () => {
     expect(nextConfig).toContain("source: '/'");
     expect(nextConfig).toContain("source: '/platform-v7'");
     expect(nextConfig).toContain("source: '/pc-public-entry/platform-v7'");
+    expect(nextConfig).toContain("source: '/sw.js'");
+    expect(nextConfig).toContain("{ source: '/sw.js', destination: '/pc-public-entry/sw-recovery' }");
+    expect(nextConfig).toContain("{ key: 'Service-Worker-Allowed', value: '/' }");
+    expect(rootLayout).toContain('const serviceWorkerRecoveryScript =');
+    expect(rootLayout).toContain('navigator.serviceWorker.getRegistrations()');
+    expect(rootLayout).toContain('navigator.serviceWorker.controller');
+    expect(rootLayout).toContain('window.location.replace(url.toString())');
+    expect(serviceWorkerRecovery).toContain("const RECOVERY_VERSION = '2026-07-19-contact-dock-v3'");
+    expect(serviceWorkerRecovery).toContain('self.clients.claim()');
+    expect(serviceWorkerRecovery).toContain("self.clients.matchAll({ type: 'window', includeUncontrolled: true })");
+    expect(serviceWorkerRecovery).toContain('client.navigate(url.toString())');
+    expect(serviceWorkerRecovery).toContain('self.registration.unregister()');
+    expect(serviceWorkerRecovery).not.toContain('event.respondWith');
   });
 
   it('restores only the last approved contact dock visual on the public homepage', () => {


### PR DESCRIPTION
## Подтверждённая причина

После production-деплоя и повторного открытия на мобильном устройстве остаётся одиночная кнопка поддержки. Исправление кэширующих HTTP-заголовков недостаточно: старый PWA worker может продолжать контролировать вкладку, а требуемый dock до сих пор создаётся только после `ssr:false` dynamic runtime.

## Исправление

- единый `PublicContactDock` теперь рендерится отдельной client boundary прямо в initial HTML физически изолированного public-entry layout;
- deferred runtime ИИ/поддержки сохраняется, а его исторический второй dock скрывается строго после route-boundary marker;
- запросы старых регистраций к `/sw.js` переписываются на одноразовый recovery worker внутри public-entry дерева;
- recovery worker очищает CacheStorage, захватывает entry-клиенты, переводит их на versioned URL ровно один раз и удаляет регистрацию;
- root layout дополнительно снимает оставшиеся регистрации и делает один controlled reload, после чего убирает технический query-параметр;
- entry HTML и recovery worker отдаются без browser/CDN cache;
- статическая регрессия фиксирует initial-HTML dock, отсутствие второго видимого dock и service-worker recovery contract.

## Граница

ИИ, форма поддержки, `tel:`-звонок, локализация, auth/RBAC и кабинеты не меняются. Изменение ограничено существующим `fix/public-entry-lcp-css-boundary` scope.