### PR TITLE
TAI AP-15A: add fail-closed semantic and hybrid retrieval authority

### DIFF
--- a/apps/tai/governance/scopes/ap-15a-2823.json
+++ b/apps/tai/governance/scopes/ap-15a-2823.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "tai.concurrent-scope.v1",
+  "branch": "agent/tai-ap-15a-hybrid-retrieval-authority",
+  "status": "active",
+  "parent_issue": 2726,
+  "issue": 2823,
+  "maturity_boundary": "semantic-hybrid-retrieval-structural-authority-only",
+  "allowed_paths": [
+    "apps/tai/governance/scopes/ap-15a-2823.json",
+    "apps/tai/tai/retrieval_index.py",
+    "apps/tai/tai/semantic_retrieval.py",
+    "apps/tai/tai/hybrid_retrieval.py",
+    "apps/tai/tai/retrieval_benchmark.py",
+    "apps/tai/tests/test_ap15a_scope.py",
+    "apps/tai/tests/test_semantic_retrieval.py",
+    "apps/tai/tests/test_hybrid_retrieval.py",
+    "apps/tai/tests/test_retrieval_benchmark.py"
+  ],
+  "forbidden_capabilities": [
+    "production default switch from lexical to hybrid retrieval",
+    "unadmitted embedding or reranker component",
+    "external mandatory AI API",
+    "pgvector or ANN production storage claim",
+    "synthetic benchmark promoted to operational evidence",
+    "cross-tenant, revoked, expired or low-trust candidate scoring",
+    "autonomous privileged write",
+    "production acceptance claim"
+  ],
+  "acceptance": [
+    "authority filtering is shared and executes before lexical or semantic scoring",
+    "embedding identity, dimension and finite vector contracts fail closed",
+    "HYBRID_REQUIRED rejects unavailable or unadmitted semantic authority",
+    "reciprocal-rank fusion and tie-breaking are deterministic",
+    "reranker cannot add, remove or cross-bind candidates",
+    "retrieval evidence is component-, mode-, candidate- and digest-bound",
+    "benchmark authority reports Recall@K, MRR, nDCG and prohibited hits",
+    "STRUCTURAL_ONLY evidence cannot produce operational acceptance",
+    "Ruff, strict mypy and focused pytest checks pass"
+  ]
+}

--- a/apps/tai/tai/hybrid_retrieval.py
+++ b/apps/tai/tai/hybrid_retrieval.py
@@ -1,0 +1,547 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Protocol
+
+from tai.retrieval_index import RetrievalHit, RetrievalQuery
+from tai.retrieval_service import RetrievalBudget
+from tai.semantic_retrieval import (
+    EmbeddingIdentity,
+    RetrievalComponentStatus,
+    SemanticRetrievalError,
+    SemanticSearchResult,
+)
+
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+
+
+class HybridRetrievalMode(StrEnum):
+    LEXICAL_ONLY = "LEXICAL_ONLY"
+    HYBRID_OPTIONAL = "HYBRID_OPTIONAL"
+    HYBRID_REQUIRED = "HYBRID_REQUIRED"
+
+
+class EffectiveRetrievalMode(StrEnum):
+    LEXICAL = "LEXICAL"
+    HYBRID = "HYBRID"
+
+
+class RetrievalExecutionClass(StrEnum):
+    STRUCTURAL_ONLY = "STRUCTURAL_ONLY"
+    MEASURED = "MEASURED"
+
+
+class LexicalSearch(Protocol):
+    @property
+    def identity_sha256(self) -> str: ...
+
+    def search(self, query: RetrievalQuery) -> tuple[RetrievalHit, ...]: ...
+
+
+class SemanticSearch(Protocol):
+    @property
+    def identity(self) -> EmbeddingIdentity: ...
+
+    @property
+    def identity_sha256(self) -> str: ...
+
+    @property
+    def components_admitted(self) -> bool: ...
+
+    def search(self, query: RetrievalQuery) -> SemanticSearchResult: ...
+
+
+@dataclass(frozen=True, slots=True)
+class RerankerIdentity:
+    reranker_id: str
+    revision: str
+    status: RetrievalComponentStatus
+
+    def __post_init__(self) -> None:
+        _portable(self.reranker_id, "reranker_id")
+        _portable(self.revision, "reranker revision")
+
+    @property
+    def sha256(self) -> str:
+        return _sha256_json(
+            {
+                "reranker_id": self.reranker_id,
+                "revision": self.revision,
+                "status": self.status.value,
+            }
+        )
+
+
+class Reranker(Protocol):
+    @property
+    def identity(self) -> RerankerIdentity: ...
+
+    def rerank(
+        self,
+        query: RetrievalQuery,
+        candidates: tuple[RetrievalHit, ...],
+    ) -> tuple[str, ...]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class FusionPolicy:
+    reciprocal_rank_constant: int = 60
+    lexical_weight: float = 1.0
+    semantic_weight: float = 1.0
+    candidate_multiplier: int = 4
+    require_admitted_components: bool = True
+
+    def __post_init__(self) -> None:
+        if self.reciprocal_rank_constant < 1 or self.reciprocal_rank_constant > 10_000:
+            raise ValueError("reciprocal_rank_constant must be between 1 and 10000")
+        if self.lexical_weight <= 0.0 or self.semantic_weight <= 0.0:
+            raise ValueError("fusion weights must be positive")
+        if self.candidate_multiplier < 1 or self.candidate_multiplier > 10:
+            raise ValueError("candidate_multiplier must be between 1 and 10")
+
+    @property
+    def sha256(self) -> str:
+        return _sha256_json(
+            {
+                "candidate_multiplier": self.candidate_multiplier,
+                "lexical_weight": self.lexical_weight,
+                "reciprocal_rank_constant": self.reciprocal_rank_constant,
+                "require_admitted_components": self.require_admitted_components,
+                "semantic_weight": self.semantic_weight,
+                "strategy": "RECIPROCAL_RANK_FUSION",
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HybridCandidateTrace:
+    chunk_id: str
+    lexical_rank: int | None
+    semantic_rank: int | None
+    fused_score: float
+    final_rank: int
+
+
+@dataclass(frozen=True, slots=True)
+class HybridSearchTrace:
+    requested_mode: HybridRetrievalMode
+    effective_mode: EffectiveRetrievalMode
+    execution_class: RetrievalExecutionClass
+    lexical_identity_sha256: str
+    lexical_candidate_count: int
+    semantic_candidate_count: int
+    fused_candidate_count: int
+    fusion_policy_sha256: str
+    semantic_identity_sha256: str | None
+    embedding_identity_sha256: str | None
+    semantic_trace_sha256: str | None
+    reranker_identity_sha256: str | None
+    fallback_reason: str | None
+    candidates: tuple[HybridCandidateTrace, ...]
+    selected_chunk_ids: tuple[str, ...]
+
+    @property
+    def sha256(self) -> str:
+        return _sha256_json(
+            {
+                "candidates": [
+                    {
+                        "chunk_id": candidate.chunk_id,
+                        "final_rank": candidate.final_rank,
+                        "fused_score": candidate.fused_score,
+                        "lexical_rank": candidate.lexical_rank,
+                        "semantic_rank": candidate.semantic_rank,
+                    }
+                    for candidate in self.candidates
+                ],
+                "effective_mode": self.effective_mode.value,
+                "execution_class": self.execution_class.value,
+                "embedding_identity_sha256": self.embedding_identity_sha256,
+                "fallback_reason": self.fallback_reason,
+                "fused_candidate_count": self.fused_candidate_count,
+                "fusion_policy_sha256": self.fusion_policy_sha256,
+                "lexical_candidate_count": self.lexical_candidate_count,
+                "lexical_identity_sha256": self.lexical_identity_sha256,
+                "requested_mode": self.requested_mode.value,
+                "reranker_identity_sha256": self.reranker_identity_sha256,
+                "selected_chunk_ids": list(self.selected_chunk_ids),
+                "semantic_candidate_count": self.semantic_candidate_count,
+                "semantic_identity_sha256": self.semantic_identity_sha256,
+                "semantic_trace_sha256": self.semantic_trace_sha256,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HybridSearchResult:
+    hits: tuple[RetrievalHit, ...]
+    trace: HybridSearchTrace
+
+
+class HybridRetrievalError(RuntimeError):
+    pass
+
+
+class HybridRequiredUnavailable(HybridRetrievalError):
+    pass
+
+
+class CandidateIdentityConflict(HybridRetrievalError):
+    pass
+
+
+class RerankerContractViolation(HybridRetrievalError):
+    pass
+
+
+class HybridRetriever:
+    """Deterministic lexical/semantic fusion that cannot expand retrieval authority."""
+
+    def __init__(
+        self,
+        *,
+        lexical: LexicalSearch,
+        semantic: SemanticSearch | None,
+        mode: HybridRetrievalMode,
+        fusion_policy: FusionPolicy | None = None,
+        reranker: Reranker | None = None,
+    ) -> None:
+        self._lexical = lexical
+        self._semantic = semantic
+        self._mode = mode
+        self._fusion_policy = fusion_policy or FusionPolicy()
+        self._reranker = reranker
+
+    @property
+    def identity_sha256(self) -> str:
+        return _sha256_json(
+            {
+                "lexical_identity_sha256": self._lexical.identity_sha256,
+                "semantic_identity_sha256": (
+                    None if self._semantic is None else self._semantic.identity_sha256
+                ),
+                "fusion_policy_sha256": self._fusion_policy.sha256,
+                "mode": self._mode.value,
+                "reranker_identity_sha256": (
+                    None if self._reranker is None else self._reranker.identity.sha256
+                ),
+            }
+        )
+
+    @property
+    def components_admitted(self) -> bool:
+        if self._mode is HybridRetrievalMode.LEXICAL_ONLY or self._semantic is None:
+            return False
+        if not self._semantic.components_admitted:
+            return False
+        return self._reranker is None or (
+            self._reranker.identity.status is RetrievalComponentStatus.ADMITTED
+        )
+
+    @property
+    def execution_class(self) -> RetrievalExecutionClass:
+        return (
+            RetrievalExecutionClass.MEASURED
+            if self.components_admitted
+            else RetrievalExecutionClass.STRUCTURAL_ONLY
+        )
+
+    def search(self, query: RetrievalQuery) -> HybridSearchResult:
+        candidate_limit = min(
+            100,
+            max(query.limit, query.limit * self._fusion_policy.candidate_multiplier),
+        )
+        candidate_query = replace(query, limit=candidate_limit)
+        lexical_hits = self._lexical.search(candidate_query)
+        semantic_result: SemanticSearchResult | None = None
+        semantic_identity_sha256 = (
+            None if self._semantic is None else self._semantic.identity_sha256
+        )
+        fallback_reason: str | None = None
+
+        if self._mode is not HybridRetrievalMode.LEXICAL_ONLY:
+            if self._semantic is None:
+                if self._mode is HybridRetrievalMode.HYBRID_REQUIRED:
+                    raise HybridRequiredUnavailable("semantic retrieval is not configured")
+                fallback_reason = "SEMANTIC_NOT_CONFIGURED"
+            else:
+                try:
+                    semantic_result = self._semantic.search(candidate_query)
+                except SemanticRetrievalError as error:
+                    if self._mode is HybridRetrievalMode.HYBRID_REQUIRED:
+                        raise HybridRequiredUnavailable(
+                            "semantic retrieval is unavailable"
+                        ) from error
+                    fallback_reason = "SEMANTIC_UNAVAILABLE"
+
+        if semantic_result is None:
+            effective_mode = EffectiveRetrievalMode.LEXICAL
+            ordered = lexical_hits
+            lexical_ranks = _ranks(lexical_hits)
+            semantic_ranks: dict[str, int] = {}
+            embedding_identity_sha256 = None
+            semantic_trace_sha256 = None
+        else:
+            if (
+                self._fusion_policy.require_admitted_components
+                and self._semantic is not None
+                and not self._semantic.components_admitted
+            ):
+                raise HybridRequiredUnavailable("semantic component is not admitted")
+            effective_mode = EffectiveRetrievalMode.HYBRID
+            lexical_ranks = _ranks(lexical_hits)
+            semantic_ranks = _ranks(semantic_result.hits)
+            ordered = self._fuse(lexical_hits, semantic_result.hits)
+            embedding_identity_sha256 = semantic_result.trace.embedding_identity_sha256
+            semantic_trace_sha256 = semantic_result.trace.sha256
+
+        if self._reranker is not None:
+            if (
+                self._fusion_policy.require_admitted_components
+                and self._reranker.identity.status is not RetrievalComponentStatus.ADMITTED
+            ):
+                raise HybridRequiredUnavailable("reranker component is not admitted")
+            ordered = self._apply_reranker(query, ordered)
+
+        selected = tuple(ordered[: query.limit])
+        final_ranks = {hit.chunk_id: rank for rank, hit in enumerate(ordered, start=1)}
+        candidate_traces = tuple(
+            HybridCandidateTrace(
+                chunk_id=hit.chunk_id,
+                lexical_rank=lexical_ranks.get(hit.chunk_id),
+                semantic_rank=semantic_ranks.get(hit.chunk_id),
+                fused_score=hit.score,
+                final_rank=final_ranks[hit.chunk_id],
+            )
+            for hit in ordered
+        )
+        return HybridSearchResult(
+            hits=selected,
+            trace=HybridSearchTrace(
+                requested_mode=self._mode,
+                effective_mode=effective_mode,
+                execution_class=self.execution_class,
+                lexical_identity_sha256=self._lexical.identity_sha256,
+                lexical_candidate_count=len(lexical_hits),
+                semantic_candidate_count=(
+                    0 if semantic_result is None else len(semantic_result.hits)
+                ),
+                fused_candidate_count=len(ordered),
+                fusion_policy_sha256=self._fusion_policy.sha256,
+                semantic_identity_sha256=semantic_identity_sha256,
+                embedding_identity_sha256=embedding_identity_sha256,
+                semantic_trace_sha256=semantic_trace_sha256,
+                reranker_identity_sha256=(
+                    None if self._reranker is None else self._reranker.identity.sha256
+                ),
+                fallback_reason=fallback_reason,
+                candidates=candidate_traces,
+                selected_chunk_ids=tuple(hit.chunk_id for hit in selected),
+            ),
+        )
+
+    def _fuse(
+        self,
+        lexical_hits: tuple[RetrievalHit, ...],
+        semantic_hits: tuple[RetrievalHit, ...],
+    ) -> tuple[RetrievalHit, ...]:
+        candidates: dict[str, RetrievalHit] = {}
+        for hit in (*lexical_hits, *semantic_hits):
+            existing = candidates.get(hit.chunk_id)
+            if existing is not None and not _same_candidate(existing, hit):
+                raise CandidateIdentityConflict("retrieval components disagree on chunk identity")
+            candidates[hit.chunk_id] = hit
+
+        lexical_ranks = _ranks(lexical_hits)
+        semantic_ranks = _ranks(semantic_hits)
+        fused: list[RetrievalHit] = []
+        for chunk_id, hit in candidates.items():
+            score = 0.0
+            lexical_rank = lexical_ranks.get(chunk_id)
+            semantic_rank = semantic_ranks.get(chunk_id)
+            if lexical_rank is not None:
+                score += self._fusion_policy.lexical_weight / (
+                    self._fusion_policy.reciprocal_rank_constant + lexical_rank
+                )
+            if semantic_rank is not None:
+                score += self._fusion_policy.semantic_weight / (
+                    self._fusion_policy.reciprocal_rank_constant + semantic_rank
+                )
+            fused.append(replace(hit, score=score))
+        fused.sort(key=lambda item: (-item.score, item.chunk_id))
+        return tuple(fused)
+
+    def _apply_reranker(
+        self,
+        query: RetrievalQuery,
+        candidates: tuple[RetrievalHit, ...],
+    ) -> tuple[RetrievalHit, ...]:
+        reranker = self._reranker
+        if reranker is None:
+            raise RuntimeError("reranker is not configured")
+        ordered_ids = reranker.rerank(query, candidates)
+        candidate_ids = tuple(hit.chunk_id for hit in candidates)
+        if len(ordered_ids) != len(candidate_ids) or len(set(ordered_ids)) != len(ordered_ids):
+            raise RerankerContractViolation("reranker must return one unique ID per candidate")
+        if set(ordered_ids) != set(candidate_ids):
+            raise RerankerContractViolation("reranker cannot add or remove candidates")
+        by_id = {hit.chunk_id: hit for hit in candidates}
+        return tuple(by_id[chunk_id] for chunk_id in ordered_ids)
+
+
+@dataclass(frozen=True, slots=True)
+class HybridRetrievalEvidence:
+    request_id: str
+    query_sha256: str
+    tenant_id: str | None
+    retrieved_at: datetime
+    minimum_trust_score: float
+    generation: int | None
+    result_count: int
+    total_chars: int
+    chunk_ids: tuple[str, ...]
+    source_ids: tuple[str, ...]
+    effective_mode: EffectiveRetrievalMode
+    execution_class: RetrievalExecutionClass
+    engine_identity_sha256: str
+    search_trace_sha256: str
+
+    @property
+    def sha256(self) -> str:
+        return _sha256_json(
+            {
+                "chunk_ids": list(self.chunk_ids),
+                "effective_mode": self.effective_mode.value,
+                "execution_class": self.execution_class.value,
+                "engine_identity_sha256": self.engine_identity_sha256,
+                "generation": self.generation,
+                "minimum_trust_score": self.minimum_trust_score,
+                "query_sha256": self.query_sha256,
+                "request_id": self.request_id,
+                "result_count": self.result_count,
+                "retrieved_at": self.retrieved_at.isoformat(),
+                "search_trace_sha256": self.search_trace_sha256,
+                "source_ids": list(self.source_ids),
+                "tenant_id": self.tenant_id,
+                "total_chars": self.total_chars,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HybridRetrievalResponse:
+    hits: tuple[RetrievalHit, ...]
+    evidence: HybridRetrievalEvidence
+    trace: HybridSearchTrace
+
+
+class HybridRetrievalAuditSink(Protocol):
+    def record(self, evidence: HybridRetrievalEvidence) -> None: ...
+
+
+class NullHybridRetrievalAuditSink:
+    def record(self, evidence: HybridRetrievalEvidence) -> None:
+        del evidence
+
+
+class HybridRetrievalService:
+    def __init__(
+        self,
+        engine: HybridRetriever,
+        *,
+        budget: RetrievalBudget | None = None,
+        audit_sink: HybridRetrievalAuditSink | None = None,
+    ) -> None:
+        self._engine = engine
+        self._budget = budget or RetrievalBudget()
+        self._audit_sink = audit_sink or NullHybridRetrievalAuditSink()
+
+    def retrieve(
+        self,
+        *,
+        request_id: str,
+        text: str,
+        tenant_id: str | None,
+        now: datetime,
+        minimum_trust_score: float = 0.5,
+    ) -> HybridRetrievalResponse:
+        normalized_request_id = request_id.strip()
+        if not normalized_request_id:
+            raise ValueError("request_id must not be blank")
+        query = RetrievalQuery(
+            text=text,
+            tenant_id=tenant_id,
+            now=now,
+            minimum_trust_score=minimum_trust_score,
+            limit=self._budget.max_results,
+        )
+        search_result = self._engine.search(query)
+        selected: list[RetrievalHit] = []
+        total_chars = 0
+        for hit in search_result.hits:
+            projected = total_chars + len(hit.text)
+            if projected > self._budget.max_total_chars:
+                continue
+            selected.append(hit)
+            total_chars = projected
+        hits = tuple(selected)
+        generations = {hit.generation for hit in hits}
+        evidence = HybridRetrievalEvidence(
+            request_id=normalized_request_id,
+            query_sha256=hashlib.sha256(text.strip().encode()).hexdigest(),
+            tenant_id=None if tenant_id is None else tenant_id.strip(),
+            retrieved_at=now,
+            minimum_trust_score=minimum_trust_score,
+            generation=(next(iter(generations)) if len(generations) == 1 else None),
+            result_count=len(hits),
+            total_chars=total_chars,
+            chunk_ids=tuple(hit.chunk_id for hit in hits),
+            source_ids=tuple(hit.source_id for hit in hits),
+            effective_mode=search_result.trace.effective_mode,
+            execution_class=search_result.trace.execution_class,
+            engine_identity_sha256=self._engine.identity_sha256,
+            search_trace_sha256=search_result.trace.sha256,
+        )
+        self._audit_sink.record(evidence)
+        return HybridRetrievalResponse(hits=hits, evidence=evidence, trace=search_result.trace)
+
+
+def _ranks(hits: Sequence[RetrievalHit]) -> dict[str, int]:
+    ranks: dict[str, int] = {}
+    for rank, hit in enumerate(hits, start=1):
+        if hit.chunk_id in ranks:
+            raise CandidateIdentityConflict("retrieval component returned duplicate chunk IDs")
+        ranks[hit.chunk_id] = rank
+    return ranks
+
+
+def _same_candidate(left: RetrievalHit, right: RetrievalHit) -> bool:
+    return (
+        left.chunk_id == right.chunk_id
+        and left.source_id == right.source_id
+        and left.generation == right.generation
+        and left.text == right.text
+        and left.trust_score == right.trust_score
+    )
+
+
+def _portable(value: str, name: str) -> None:
+    if _IDENTIFIER.fullmatch(value.strip()) is None:
+        raise ValueError(f"{name} must use a bounded portable identifier")
+
+
+def _sha256_json(value: Any) -> str:
+    canonical = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()

--- a/apps/tai/tai/retrieval_benchmark.py
+++ b/apps/tai/tai/retrieval_benchmark.py
@@ -1,0 +1,484 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Protocol
+
+from tai.git_oid import validate_git_oid
+from tai.hybrid_retrieval import (
+    EffectiveRetrievalMode,
+    HybridSearchResult,
+    RetrievalExecutionClass,
+)
+from tai.retrieval_index import RetrievalQuery
+
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+BenchmarkEvidenceClass = RetrievalExecutionClass
+
+
+class BenchmarkOutcome(StrEnum):
+    PASS = "PASS"  # noqa: S105
+    FAIL = "FAIL"
+    ERROR = "ERROR"
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalBenchmarkCase:
+    case_id: str
+    query: str
+    expected_chunk_ids: tuple[str, ...]
+    prohibited_chunk_ids: tuple[str, ...]
+    tenant_id: str | None
+    now: datetime
+    limit: int = 10
+    minimum_trust_score: float = 0.5
+    critical: bool = False
+
+    def __post_init__(self) -> None:
+        _portable(self.case_id, "case_id")
+        if not self.query.strip():
+            raise ValueError("benchmark query must not be blank")
+        if not self.expected_chunk_ids:
+            raise ValueError("benchmark case must define expected chunks")
+        _unique_portable(self.expected_chunk_ids, "expected_chunk_ids")
+        _unique_portable(self.prohibited_chunk_ids, "prohibited_chunk_ids")
+        if set(self.expected_chunk_ids).intersection(self.prohibited_chunk_ids):
+            raise ValueError("expected and prohibited chunks must not overlap")
+        if self.tenant_id is not None and not self.tenant_id.strip():
+            raise ValueError("tenant_id must be null or non-blank")
+        if self.now.utcoffset() is None:
+            raise ValueError("benchmark time must be timezone-aware")
+        if self.limit < 1 or self.limit > 100:
+            raise ValueError("benchmark limit must be between 1 and 100")
+        if not 0.0 <= self.minimum_trust_score <= 1.0:
+            raise ValueError("minimum_trust_score must be between 0 and 1")
+
+    @property
+    def sha256(self) -> str:
+        return _sha256_json(
+            {
+                "case_id": self.case_id,
+                "critical": self.critical,
+                "expected_chunk_ids": list(self.expected_chunk_ids),
+                "limit": self.limit,
+                "minimum_trust_score": self.minimum_trust_score,
+                "now": self.now.isoformat(),
+                "prohibited_chunk_ids": list(self.prohibited_chunk_ids),
+                "query_sha256": hashlib.sha256(self.query.encode()).hexdigest(),
+                "tenant_id": self.tenant_id,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalBenchmarkSuite:
+    suite_id: str
+    version: str
+    cases: tuple[RetrievalBenchmarkCase, ...]
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        _portable(self.suite_id, "suite_id")
+        _portable(self.version, "suite version")
+        if self.created_at.utcoffset() is None:
+            raise ValueError("suite created_at must be timezone-aware")
+        if not self.cases:
+            raise ValueError("benchmark suite must contain cases")
+        case_ids = [case.case_id for case in self.cases]
+        if len(case_ids) != len(set(case_ids)):
+            raise ValueError("benchmark case IDs must be unique")
+
+    @property
+    def sha256(self) -> str:
+        return _sha256_json(
+            {
+                "cases": [
+                    case.sha256
+                    for case in sorted(self.cases, key=lambda item: item.case_id)
+                ],
+                "created_at": self.created_at.isoformat(),
+                "suite_id": self.suite_id,
+                "version": self.version,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalBenchmarkPolicy:
+    minimum_case_count: int = 20
+    minimum_recall_at_k: float = 0.90
+    minimum_mrr: float = 0.85
+    minimum_ndcg_at_k: float = 0.85
+    required_critical_recall: float = 1.0
+    maximum_errors: int = 0
+    maximum_prohibited_hits: int = 0
+    require_measured_evidence: bool = True
+    require_hybrid_mode: bool = True
+    require_admitted_components: bool = True
+
+    def __post_init__(self) -> None:
+        if self.minimum_case_count < 1:
+            raise ValueError("minimum_case_count must be positive")
+        for value, name in (
+            (self.minimum_recall_at_k, "minimum_recall_at_k"),
+            (self.minimum_mrr, "minimum_mrr"),
+            (self.minimum_ndcg_at_k, "minimum_ndcg_at_k"),
+            (self.required_critical_recall, "required_critical_recall"),
+        ):
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be between 0 and 1")
+        if self.maximum_errors < 0 or self.maximum_prohibited_hits < 0:
+            raise ValueError("benchmark budgets must not be negative")
+
+    @property
+    def sha256(self) -> str:
+        return _sha256_json(
+            {
+                "maximum_errors": self.maximum_errors,
+                "maximum_prohibited_hits": self.maximum_prohibited_hits,
+                "minimum_case_count": self.minimum_case_count,
+                "minimum_mrr": self.minimum_mrr,
+                "minimum_ndcg_at_k": self.minimum_ndcg_at_k,
+                "minimum_recall_at_k": self.minimum_recall_at_k,
+                "require_admitted_components": self.require_admitted_components,
+                "require_hybrid_mode": self.require_hybrid_mode,
+                "require_measured_evidence": self.require_measured_evidence,
+                "required_critical_recall": self.required_critical_recall,
+            }
+        )
+
+
+class BenchmarkEngine(Protocol):
+    @property
+    def identity_sha256(self) -> str: ...
+
+    @property
+    def components_admitted(self) -> bool: ...
+
+    @property
+    def execution_class(self) -> RetrievalExecutionClass: ...
+
+    def search(self, query: RetrievalQuery) -> HybridSearchResult: ...
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalBenchmarkCaseResult:
+    case_id: str
+    outcome: BenchmarkOutcome
+    returned_chunk_ids: tuple[str, ...]
+    recall_at_k: float
+    reciprocal_rank: float
+    ndcg_at_k: float
+    prohibited_hits: tuple[str, ...]
+    effective_mode: EffectiveRetrievalMode | None
+    trace_sha256: str | None
+    violations: tuple[str, ...]
+    result_sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalBenchmarkSummary:
+    total_cases: int
+    passed_cases: int
+    failed_cases: int
+    error_cases: int
+    mean_recall_at_k: float
+    mean_reciprocal_rank: float
+    mean_ndcg_at_k: float
+    critical_recall: float
+    prohibited_hit_count: int
+    lexical_fallback_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalBenchmarkReport:
+    suite_id: str
+    suite_version: str
+    suite_sha256: str
+    exact_head_sha: str
+    engine_identity_sha256: str
+    policy_sha256: str
+    evidence_class: BenchmarkEvidenceClass
+    results: tuple[RetrievalBenchmarkCaseResult, ...]
+    summary: RetrievalBenchmarkSummary
+    accepted: bool
+    rejection_reasons: tuple[str, ...]
+    report_sha256: str
+
+
+class RetrievalBenchmarkAuthority:
+    def __init__(self, policy: RetrievalBenchmarkPolicy | None = None) -> None:
+        self._policy = policy or RetrievalBenchmarkPolicy()
+
+    def evaluate(
+        self,
+        *,
+        engine: BenchmarkEngine,
+        suite: RetrievalBenchmarkSuite,
+        exact_head_sha: str,
+    ) -> RetrievalBenchmarkReport:
+        validate_git_oid(exact_head_sha, "exact_head_sha")
+        _digest(engine.identity_sha256, "engine identity")
+        evidence_class = engine.execution_class
+        results = tuple(
+            self._evaluate_case(engine, case)
+            for case in sorted(suite.cases, key=lambda item: item.case_id)
+        )
+        summary = _summary(results, suite)
+        reasons = self._rejection_reasons(
+            suite=suite,
+            summary=summary,
+            evidence_class=evidence_class,
+            components_admitted=engine.components_admitted,
+        )
+        accepted = not reasons
+        payload = {
+            "accepted": accepted,
+            "engine_identity_sha256": engine.identity_sha256,
+            "evidence_class": evidence_class.value,
+            "exact_head_sha": exact_head_sha,
+            "policy_sha256": self._policy.sha256,
+            "rejection_reasons": list(reasons),
+            "results": [result.result_sha256 for result in results],
+            "suite_sha256": suite.sha256,
+            "summary": _summary_payload(summary),
+        }
+        return RetrievalBenchmarkReport(
+            suite_id=suite.suite_id,
+            suite_version=suite.version,
+            suite_sha256=suite.sha256,
+            exact_head_sha=exact_head_sha,
+            engine_identity_sha256=engine.identity_sha256,
+            policy_sha256=self._policy.sha256,
+            evidence_class=evidence_class,
+            results=results,
+            summary=summary,
+            accepted=accepted,
+            rejection_reasons=reasons,
+            report_sha256=_sha256_json(payload),
+        )
+
+    def _evaluate_case(
+        self,
+        engine: BenchmarkEngine,
+        case: RetrievalBenchmarkCase,
+    ) -> RetrievalBenchmarkCaseResult:
+        try:
+            response = engine.search(
+                RetrievalQuery(
+                    text=case.query,
+                    tenant_id=case.tenant_id,
+                    now=case.now,
+                    minimum_trust_score=case.minimum_trust_score,
+                    limit=case.limit,
+                )
+            )
+        except Exception:
+            return _case_result(
+                case=case,
+                outcome=BenchmarkOutcome.ERROR,
+                returned=(),
+                recall=0.0,
+                reciprocal_rank=0.0,
+                ndcg=0.0,
+                prohibited=(),
+                effective_mode=None,
+                trace_sha256=None,
+                violations=("ENGINE_ERROR",),
+            )
+
+        returned = tuple(hit.chunk_id for hit in response.hits)
+        expected = set(case.expected_chunk_ids)
+        recall = len(expected.intersection(returned)) / len(expected)
+        reciprocal_rank = _reciprocal_rank(returned, expected)
+        ndcg = _ndcg(returned, expected, case.limit)
+        prohibited = tuple(sorted(set(returned).intersection(case.prohibited_chunk_ids)))
+        violations: list[str] = []
+        if prohibited:
+            violations.append("PROHIBITED_CHUNK_RETRIEVED")
+        if case.critical and recall < 1.0:
+            violations.append("CRITICAL_EXPECTED_CHUNK_MISSING")
+        outcome = BenchmarkOutcome.PASS if not violations else BenchmarkOutcome.FAIL
+        return _case_result(
+            case=case,
+            outcome=outcome,
+            returned=returned,
+            recall=recall,
+            reciprocal_rank=reciprocal_rank,
+            ndcg=ndcg,
+            prohibited=prohibited,
+            effective_mode=response.trace.effective_mode,
+            trace_sha256=response.trace.sha256,
+            violations=tuple(violations),
+        )
+
+    def _rejection_reasons(
+        self,
+        *,
+        suite: RetrievalBenchmarkSuite,
+        summary: RetrievalBenchmarkSummary,
+        evidence_class: RetrievalExecutionClass,
+        components_admitted: bool,
+    ) -> tuple[str, ...]:
+        reasons: list[str] = []
+        if len(suite.cases) < self._policy.minimum_case_count:
+            reasons.append("INSUFFICIENT_CASE_COUNT")
+        if summary.mean_recall_at_k < self._policy.minimum_recall_at_k:
+            reasons.append("RECALL_AT_K_BELOW_THRESHOLD")
+        if summary.mean_reciprocal_rank < self._policy.minimum_mrr:
+            reasons.append("MRR_BELOW_THRESHOLD")
+        if summary.mean_ndcg_at_k < self._policy.minimum_ndcg_at_k:
+            reasons.append("NDCG_AT_K_BELOW_THRESHOLD")
+        if summary.critical_recall < self._policy.required_critical_recall:
+            reasons.append("CRITICAL_RECALL_BELOW_THRESHOLD")
+        if summary.error_cases > self._policy.maximum_errors:
+            reasons.append("ERROR_BUDGET_EXCEEDED")
+        if summary.prohibited_hit_count > self._policy.maximum_prohibited_hits:
+            reasons.append("PROHIBITED_HIT_BUDGET_EXCEEDED")
+        if self._policy.require_hybrid_mode and summary.lexical_fallback_count > 0:
+            reasons.append("HYBRID_MODE_NOT_SATISFIED")
+        if self._policy.require_admitted_components and not components_admitted:
+            reasons.append("RETRIEVAL_COMPONENTS_NOT_ADMITTED")
+        if (
+            self._policy.require_measured_evidence
+            and evidence_class is not RetrievalExecutionClass.MEASURED
+        ):
+            reasons.append("STRUCTURAL_FIXTURES_NOT_OPERATIONAL_EVIDENCE")
+        return tuple(reasons)
+
+
+def _case_result(
+    *,
+    case: RetrievalBenchmarkCase,
+    outcome: BenchmarkOutcome,
+    returned: tuple[str, ...],
+    recall: float,
+    reciprocal_rank: float,
+    ndcg: float,
+    prohibited: tuple[str, ...],
+    effective_mode: EffectiveRetrievalMode | None,
+    trace_sha256: str | None,
+    violations: tuple[str, ...],
+) -> RetrievalBenchmarkCaseResult:
+    result_sha256 = _sha256_json(
+        {
+            "case_sha256": case.sha256,
+            "effective_mode": None if effective_mode is None else effective_mode.value,
+            "ndcg_at_k": ndcg,
+            "outcome": outcome.value,
+            "prohibited_hits": list(prohibited),
+            "recall_at_k": recall,
+            "reciprocal_rank": reciprocal_rank,
+            "returned_chunk_ids": list(returned),
+            "trace_sha256": trace_sha256,
+            "violations": list(violations),
+        }
+    )
+    return RetrievalBenchmarkCaseResult(
+        case_id=case.case_id,
+        outcome=outcome,
+        returned_chunk_ids=returned,
+        recall_at_k=recall,
+        reciprocal_rank=reciprocal_rank,
+        ndcg_at_k=ndcg,
+        prohibited_hits=prohibited,
+        effective_mode=effective_mode,
+        trace_sha256=trace_sha256,
+        violations=violations,
+        result_sha256=result_sha256,
+    )
+
+
+def _summary(
+    results: tuple[RetrievalBenchmarkCaseResult, ...],
+    suite: RetrievalBenchmarkSuite,
+) -> RetrievalBenchmarkSummary:
+    total = len(results)
+    critical_ids = {case.case_id for case in suite.cases if case.critical}
+    critical_results = [result for result in results if result.case_id in critical_ids]
+    critical_expected = len(critical_results)
+    critical_recall = (
+        1.0
+        if critical_expected == 0
+        else sum(result.recall_at_k for result in critical_results) / critical_expected
+    )
+    return RetrievalBenchmarkSummary(
+        total_cases=total,
+        passed_cases=sum(result.outcome is BenchmarkOutcome.PASS for result in results),
+        failed_cases=sum(result.outcome is BenchmarkOutcome.FAIL for result in results),
+        error_cases=sum(result.outcome is BenchmarkOutcome.ERROR for result in results),
+        mean_recall_at_k=sum(result.recall_at_k for result in results) / total,
+        mean_reciprocal_rank=sum(result.reciprocal_rank for result in results) / total,
+        mean_ndcg_at_k=sum(result.ndcg_at_k for result in results) / total,
+        critical_recall=critical_recall,
+        prohibited_hit_count=sum(len(result.prohibited_hits) for result in results),
+        lexical_fallback_count=sum(
+            result.effective_mode is not EffectiveRetrievalMode.HYBRID for result in results
+        ),
+    )
+
+
+def _reciprocal_rank(returned: tuple[str, ...], expected: set[str]) -> float:
+    for rank, chunk_id in enumerate(returned, start=1):
+        if chunk_id in expected:
+            return 1.0 / rank
+    return 0.0
+
+
+def _ndcg(returned: tuple[str, ...], expected: set[str], limit: int) -> float:
+    relevance = [1.0 if chunk_id in expected else 0.0 for chunk_id in returned[:limit]]
+    dcg = sum(value / math.log2(rank + 1) for rank, value in enumerate(relevance, start=1))
+    ideal_count = min(len(expected), limit)
+    ideal = sum(1.0 / math.log2(rank + 1) for rank in range(1, ideal_count + 1))
+    return 0.0 if ideal == 0.0 else dcg / ideal
+
+
+def _summary_payload(summary: RetrievalBenchmarkSummary) -> dict[str, int | float]:
+    return {
+        "critical_recall": summary.critical_recall,
+        "error_cases": summary.error_cases,
+        "failed_cases": summary.failed_cases,
+        "lexical_fallback_count": summary.lexical_fallback_count,
+        "mean_ndcg_at_k": summary.mean_ndcg_at_k,
+        "mean_recall_at_k": summary.mean_recall_at_k,
+        "mean_reciprocal_rank": summary.mean_reciprocal_rank,
+        "passed_cases": summary.passed_cases,
+        "prohibited_hit_count": summary.prohibited_hit_count,
+        "total_cases": summary.total_cases,
+    }
+
+
+def _unique_portable(values: tuple[str, ...], name: str) -> None:
+    if len(values) != len(set(values)):
+        raise ValueError(f"{name} must be unique")
+    for value in values:
+        _portable(value, name)
+
+
+def _portable(value: str, name: str) -> None:
+    if _IDENTIFIER.fullmatch(value.strip()) is None:
+        raise ValueError(f"{name} must use a bounded portable identifier")
+
+
+def _digest(value: str, name: str) -> None:
+    if _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+def _sha256_json(value: Any) -> str:
+    canonical = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()

--- a/apps/tai/tai/retrieval_index.py
+++ b/apps/tai/tai/retrieval_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import math
 import re
 from collections import Counter
@@ -11,6 +12,9 @@ from typing import Protocol
 from tai.knowledge_chunking import KnowledgeChunk
 
 _TOKEN = re.compile(r"[0-9A-Za-zА-Яа-яЁё]+", re.UNICODE)
+_LEXICAL_IDENTITY_SHA256 = hashlib.sha256(
+    b"tai.lexical.bm25.v1|k1=1.2|b=0.75|numerator=2.2|trust=0.5+0.5x"
+).hexdigest()
 
 
 class IndexGenerationStatus(StrEnum):
@@ -135,15 +139,15 @@ class LexicalRetriever:
     def __init__(self, repository: RetrievalIndexRepository) -> None:
         self._repository = repository
 
+    @property
+    def identity_sha256(self) -> str:
+        return _LEXICAL_IDENTITY_SHA256
+
     def search(self, query: RetrievalQuery) -> tuple[RetrievalHit, ...]:
         query_terms = _tokens(query.text)
         if not query_terms:
             return ()
-        eligible = tuple(
-            item
-            for item in self._repository.active_documents()
-            if _eligible(item.document, query)
-        )
+        eligible = active_eligible_documents(self._repository, query)
         if not eligible:
             return ()
 
@@ -190,11 +194,20 @@ class LexicalRetriever:
         return tuple(hits[: query.limit])
 
 
-def _tokens(text: str) -> tuple[str, ...]:
-    return tuple(match.group(0).casefold() for match in _TOKEN.finditer(text))
+def active_eligible_documents(
+    repository: RetrievalIndexRepository,
+    query: RetrievalQuery,
+) -> tuple[IndexedChunk, ...]:
+    """Return one active generation after applying authority filters before scoring."""
+
+    active = repository.active_documents()
+    generations = {item.generation for item in active}
+    if len(generations) > 1:
+        raise RuntimeError("active retrieval documents span multiple generations")
+    return tuple(item for item in active if is_document_eligible(item.document, query))
 
 
-def _eligible(document: RetrievalDocument, query: RetrievalQuery) -> bool:
+def is_document_eligible(document: RetrievalDocument, query: RetrievalQuery) -> bool:
     if document.revoked or document.trust_score < query.minimum_trust_score:
         return False
     if document.valid_until is not None and document.valid_until <= query.now:
@@ -202,3 +215,7 @@ def _eligible(document: RetrievalDocument, query: RetrievalQuery) -> bool:
     if document.tenant_id is None:
         return True
     return query.tenant_id is not None and document.tenant_id == query.tenant_id
+
+
+def _tokens(text: str) -> tuple[str, ...]:
+    return tuple(match.group(0).casefold() for match in _TOKEN.finditer(text))

--- a/apps/tai/tai/semantic_retrieval.py
+++ b/apps/tai/tai/semantic_retrieval.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+
+from tai.retrieval_index import (
+    RetrievalHit,
+    RetrievalIndexRepository,
+    RetrievalQuery,
+    active_eligible_documents,
+)
+
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9._:-]{1,160}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class RetrievalComponentStatus(StrEnum):
+    TEST_ONLY = "TEST_ONLY"
+    PENDING = "PENDING"
+    ADMITTED = "ADMITTED"
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingIdentity:
+    provider_id: str
+    model_id: str
+    revision: str
+    dimensions: int
+    status: RetrievalComponentStatus
+
+    def __post_init__(self) -> None:
+        _portable(self.provider_id, "provider_id")
+        _portable(self.model_id, "model_id")
+        _portable(self.revision, "revision")
+        if self.dimensions < 1 or self.dimensions > 32_768:
+            raise ValueError("embedding dimensions must be between 1 and 32768")
+
+    @property
+    def sha256(self) -> str:
+        return _sha256_json(
+            {
+                "dimensions": self.dimensions,
+                "model_id": self.model_id,
+                "provider_id": self.provider_id,
+                "revision": self.revision,
+                "status": self.status.value,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingVector:
+    identity: EmbeddingIdentity
+    values: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.values) != self.identity.dimensions:
+            raise ValueError("embedding vector dimension does not match identity")
+        if any(not math.isfinite(value) for value in self.values):
+            raise ValueError("embedding vector values must be finite")
+        if math.fsum(value * value for value in self.values) <= 0.0:
+            raise ValueError("embedding vector norm must be positive")
+
+    @property
+    def normalized_values(self) -> tuple[float, ...]:
+        norm = math.sqrt(math.fsum(value * value for value in self.values))
+        return tuple(value / norm for value in self.values)
+
+    @property
+    def sha256(self) -> str:
+        return _sha256_json(
+            {
+                "identity_sha256": self.identity.sha256,
+                "values": list(self.values),
+            }
+        )
+
+
+class EmbeddingProvider(Protocol):
+    @property
+    def identity(self) -> EmbeddingIdentity: ...
+
+    def embed(self, text: str) -> EmbeddingVector: ...
+
+
+class SemanticVectorRepository(Protocol):
+    @property
+    def identity(self) -> EmbeddingIdentity: ...
+
+    @property
+    def authority_status(self) -> RetrievalComponentStatus: ...
+
+    @property
+    def authority_sha256(self) -> str: ...
+
+    def vectors_for_generation(self, generation: int) -> Mapping[str, EmbeddingVector]: ...
+
+
+class InMemorySemanticVectorRepository:
+    """Deterministic local/test vector store. It is not a production ANN authority."""
+
+    def __init__(self, identity: EmbeddingIdentity) -> None:
+        self._identity = identity
+        self._generations: dict[int, dict[str, EmbeddingVector]] = {}
+
+    @property
+    def identity(self) -> EmbeddingIdentity:
+        return self._identity
+
+    @property
+    def authority_status(self) -> RetrievalComponentStatus:
+        return RetrievalComponentStatus.TEST_ONLY
+
+    @property
+    def authority_sha256(self) -> str:
+        return _sha256_json(
+            {
+                "embedding_identity_sha256": self._identity.sha256,
+                "repository_kind": "IN_MEMORY_EXACT_MAP",
+                "status": self.authority_status.value,
+            }
+        )
+
+    def add_generation(
+        self,
+        generation: int,
+        vectors: Mapping[str, EmbeddingVector],
+    ) -> None:
+        if generation < 1:
+            raise ValueError("generation must be positive")
+        normalized: dict[str, EmbeddingVector] = {}
+        for chunk_id, vector in vectors.items():
+            _portable(chunk_id, "chunk_id")
+            if vector.identity != self._identity:
+                raise ValueError("semantic vector identity does not match repository")
+            normalized[chunk_id] = vector
+        self._generations[generation] = normalized
+
+    def vectors_for_generation(self, generation: int) -> Mapping[str, EmbeddingVector]:
+        return dict(self._generations.get(generation, {}))
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticRetrievalPolicy:
+    require_admitted_model: bool = True
+    require_admitted_index: bool = True
+    require_complete_generation: bool = True
+    minimum_similarity: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.minimum_similarity <= 1.0:
+            raise ValueError("minimum_similarity must be between 0 and 1")
+
+    @property
+    def sha256(self) -> str:
+        return _sha256_json(
+            {
+                "minimum_similarity": self.minimum_similarity,
+                "require_admitted_index": self.require_admitted_index,
+                "require_admitted_model": self.require_admitted_model,
+                "require_complete_generation": self.require_complete_generation,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticSearchTrace:
+    generation: int | None
+    embedding_identity_sha256: str
+    vector_authority_sha256: str
+    query_vector_sha256: str | None
+    eligible_count: int
+    indexed_count: int
+    scored_count: int
+    missing_chunk_ids: tuple[str, ...]
+    policy_sha256: str
+
+    @property
+    def sha256(self) -> str:
+        return _sha256_json(
+            {
+                "eligible_count": self.eligible_count,
+                "embedding_identity_sha256": self.embedding_identity_sha256,
+                "generation": self.generation,
+                "vector_authority_sha256": self.vector_authority_sha256,
+                "indexed_count": self.indexed_count,
+                "missing_chunk_ids": list(self.missing_chunk_ids),
+                "policy_sha256": self.policy_sha256,
+                "query_vector_sha256": self.query_vector_sha256,
+                "scored_count": self.scored_count,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticSearchResult:
+    hits: tuple[RetrievalHit, ...]
+    trace: SemanticSearchTrace
+
+
+class SemanticRetrievalError(RuntimeError):
+    pass
+
+
+class SemanticAuthorityUnavailable(SemanticRetrievalError):
+    pass
+
+
+class SemanticIndexIncomplete(SemanticRetrievalError):
+    pass
+
+
+class SemanticRetriever:
+    """Cosine semantic retrieval after tenant, trust, revocation and freshness filters."""
+
+    def __init__(
+        self,
+        *,
+        retrieval_repository: RetrievalIndexRepository,
+        vector_repository: SemanticVectorRepository,
+        provider: EmbeddingProvider,
+        policy: SemanticRetrievalPolicy | None = None,
+    ) -> None:
+        if vector_repository.identity != provider.identity:
+            raise ValueError("semantic provider and vector repository identities differ")
+        self._retrieval_repository = retrieval_repository
+        self._vector_repository = vector_repository
+        self._provider = provider
+        self._policy = policy or SemanticRetrievalPolicy()
+
+    @property
+    def identity(self) -> EmbeddingIdentity:
+        return self._provider.identity
+
+    @property
+    def identity_sha256(self) -> str:
+        return _sha256_json(
+            {
+                "embedding_identity_sha256": self.identity.sha256,
+                "policy_sha256": self._policy.sha256,
+                "vector_authority_sha256": self._vector_repository.authority_sha256,
+            }
+        )
+
+    @property
+    def components_admitted(self) -> bool:
+        return (
+            self.identity.status is RetrievalComponentStatus.ADMITTED
+            and self._vector_repository.authority_status
+            is RetrievalComponentStatus.ADMITTED
+        )
+
+    @property
+    def policy(self) -> SemanticRetrievalPolicy:
+        return self._policy
+
+    def search(self, query: RetrievalQuery) -> SemanticSearchResult:
+        identity = self.identity
+        if (
+            self._policy.require_admitted_model
+            and identity.status is not RetrievalComponentStatus.ADMITTED
+        ):
+            raise SemanticAuthorityUnavailable("semantic model is not admitted")
+        if (
+            self._policy.require_admitted_index
+            and self._vector_repository.authority_status
+            is not RetrievalComponentStatus.ADMITTED
+        ):
+            raise SemanticAuthorityUnavailable("semantic vector authority is not admitted")
+
+        eligible = active_eligible_documents(self._retrieval_repository, query)
+        if not eligible:
+            return SemanticSearchResult(
+                hits=(),
+                trace=SemanticSearchTrace(
+                    generation=None,
+                    embedding_identity_sha256=identity.sha256,
+                    vector_authority_sha256=self._vector_repository.authority_sha256,
+                    query_vector_sha256=None,
+                    eligible_count=0,
+                    indexed_count=0,
+                    scored_count=0,
+                    missing_chunk_ids=(),
+                    policy_sha256=self._policy.sha256,
+                ),
+            )
+
+        generation = eligible[0].generation
+        vectors = self._vector_repository.vectors_for_generation(generation)
+        missing = tuple(
+            sorted(
+                item.document.chunk.chunk_id
+                for item in eligible
+                if item.document.chunk.chunk_id not in vectors
+            )
+        )
+        if missing and self._policy.require_complete_generation:
+            raise SemanticIndexIncomplete("semantic generation is incomplete")
+
+        try:
+            query_vector = self._provider.embed(query.text)
+        except SemanticRetrievalError:
+            raise
+        except Exception as error:
+            raise SemanticAuthorityUnavailable("semantic provider failed") from error
+        if query_vector.identity != identity:
+            raise SemanticAuthorityUnavailable("semantic provider returned a different identity")
+
+        query_values = query_vector.normalized_values
+        hits: list[RetrievalHit] = []
+        indexed_count = 0
+        for item in eligible:
+            chunk = item.document.chunk
+            vector = vectors.get(chunk.chunk_id)
+            if vector is None:
+                continue
+            indexed_count += 1
+            if vector.identity != identity:
+                raise SemanticAuthorityUnavailable("semantic index contains a different identity")
+            cosine = math.fsum(
+                left * right
+                for left, right in zip(query_values, vector.normalized_values, strict=True)
+            )
+            cosine = min(1.0, max(-1.0, cosine))
+            if cosine < self._policy.minimum_similarity:
+                continue
+            normalized_similarity = (cosine + 1.0) / 2.0
+            score = normalized_similarity * (0.5 + 0.5 * item.document.trust_score)
+            hits.append(
+                RetrievalHit(
+                    chunk_id=chunk.chunk_id,
+                    source_id=chunk.source_id,
+                    generation=item.generation,
+                    score=score,
+                    text=chunk.text,
+                    trust_score=item.document.trust_score,
+                )
+            )
+        hits.sort(key=lambda hit: (-hit.score, hit.chunk_id))
+        selected = tuple(hits[: query.limit])
+        return SemanticSearchResult(
+            hits=selected,
+            trace=SemanticSearchTrace(
+                generation=generation,
+                embedding_identity_sha256=identity.sha256,
+                vector_authority_sha256=self._vector_repository.authority_sha256,
+                query_vector_sha256=query_vector.sha256,
+                eligible_count=len(eligible),
+                indexed_count=indexed_count,
+                scored_count=len(hits),
+                missing_chunk_ids=missing,
+                policy_sha256=self._policy.sha256,
+            ),
+        )
+
+
+def _portable(value: str, name: str) -> None:
+    if _IDENTIFIER.fullmatch(value.strip()) is None:
+        raise ValueError(f"{name} must use a bounded portable identifier")
+
+
+def _sha256_json(value: Any) -> str:
+    canonical = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def validate_sha256(value: str, name: str) -> None:
+    if _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")

--- a/apps/tai/tests/test_ap15a_scope.py
+++ b/apps/tai/tests/test_ap15a_scope.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+SCOPE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "governance"
+    / "scopes"
+    / "ap-15a-2823.json"
+)
+
+EXPECTED_PATHS = {
+    "apps/tai/governance/scopes/ap-15a-2823.json",
+    "apps/tai/tai/retrieval_index.py",
+    "apps/tai/tai/semantic_retrieval.py",
+    "apps/tai/tai/hybrid_retrieval.py",
+    "apps/tai/tai/retrieval_benchmark.py",
+    "apps/tai/tests/test_ap15a_scope.py",
+    "apps/tai/tests/test_semantic_retrieval.py",
+    "apps/tai/tests/test_hybrid_retrieval.py",
+    "apps/tai/tests/test_retrieval_benchmark.py",
+}
+
+
+def test_ap15a_scope_is_exact_and_fail_closed() -> None:
+    scope = json.loads(SCOPE_PATH.read_text(encoding="utf-8"))
+
+    assert scope["schema_version"] == "tai.concurrent-scope.v1"
+    assert scope["branch"] == "agent/tai-ap-15a-hybrid-retrieval-authority"
+    assert scope["status"] == "active"
+    assert scope["parent_issue"] == 2726
+    assert scope["issue"] == 2823
+    assert set(scope["allowed_paths"]) == EXPECTED_PATHS
+    assert len(scope["allowed_paths"]) == len(EXPECTED_PATHS)
+    assert "synthetic benchmark promoted to operational evidence" in scope[
+        "forbidden_capabilities"
+    ]
+    assert "production default switch from lexical to hybrid retrieval" in scope[
+        "forbidden_capabilities"
+    ]

--- a/apps/tai/tests/test_hybrid_retrieval.py
+++ b/apps/tai/tests/test_hybrid_retrieval.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from tai.hybrid_retrieval import (
+    EffectiveRetrievalMode,
+    FusionPolicy,
+    HybridRequiredUnavailable,
+    HybridRetrievalMode,
+    HybridRetrievalService,
+    HybridRetriever,
+    RerankerContractViolation,
+    RerankerIdentity,
+    RetrievalExecutionClass,
+)
+from tai.retrieval_index import RetrievalHit, RetrievalQuery
+from tai.retrieval_service import RetrievalBudget
+from tai.semantic_retrieval import (
+    EmbeddingIdentity,
+    RetrievalComponentStatus,
+    SemanticAuthorityUnavailable,
+    SemanticSearchResult,
+    SemanticSearchTrace,
+)
+
+NOW = datetime(2026, 7, 19, tzinfo=UTC)
+
+
+def _hit(chunk_id: str, score: float, *, source_id: str | None = None) -> RetrievalHit:
+    return RetrievalHit(
+        chunk_id=chunk_id,
+        source_id=source_id or f"source-{chunk_id}",
+        generation=1,
+        score=score,
+        text=f"text {chunk_id}",
+        trust_score=1.0,
+    )
+
+
+class _Lexical:
+    def __init__(self, hits: tuple[RetrievalHit, ...]) -> None:
+        self._hits = hits
+
+    @property
+    def identity_sha256(self) -> str:
+        return "d" * 64
+
+    def search(self, query: RetrievalQuery) -> tuple[RetrievalHit, ...]:
+        return self._hits[: query.limit]
+
+
+class _Semantic:
+    def __init__(
+        self,
+        hits: tuple[RetrievalHit, ...],
+        *,
+        status: RetrievalComponentStatus = RetrievalComponentStatus.ADMITTED,
+        fail: bool = False,
+    ) -> None:
+        self._hits = hits
+        self._fail = fail
+        self._identity = EmbeddingIdentity(
+            provider_id="local",
+            model_id="embed",
+            revision="r1",
+            dimensions=2,
+            status=status,
+        )
+
+    @property
+    def identity(self) -> EmbeddingIdentity:
+        return self._identity
+
+    @property
+    def identity_sha256(self) -> str:
+        return "e" * 64 if self.components_admitted else "f" * 64
+
+    @property
+    def components_admitted(self) -> bool:
+        return self._identity.status is RetrievalComponentStatus.ADMITTED
+
+    def search(self, query: RetrievalQuery) -> SemanticSearchResult:
+        if self._fail:
+            raise SemanticAuthorityUnavailable("unavailable")
+        hits = self._hits[: query.limit]
+        return SemanticSearchResult(
+            hits=hits,
+            trace=SemanticSearchTrace(
+                generation=1,
+                embedding_identity_sha256=self.identity.sha256,
+                vector_authority_sha256="c" * 64,
+                query_vector_sha256="a" * 64,
+                eligible_count=len(hits),
+                indexed_count=len(hits),
+                scored_count=len(hits),
+                missing_chunk_ids=(),
+                policy_sha256="b" * 64,
+            ),
+        )
+
+
+class _Reranker:
+    def __init__(self, order: tuple[str, ...]) -> None:
+        self._order = order
+        self._identity = RerankerIdentity(
+            reranker_id="reranker",
+            revision="r1",
+            status=RetrievalComponentStatus.ADMITTED,
+        )
+
+    @property
+    def identity(self) -> RerankerIdentity:
+        return self._identity
+
+    def rerank(
+        self,
+        query: RetrievalQuery,
+        candidates: tuple[RetrievalHit, ...],
+    ) -> tuple[str, ...]:
+        del query, candidates
+        return self._order
+
+
+def _query(limit: int = 10) -> RetrievalQuery:
+    return RetrievalQuery(text="query", tenant_id=None, now=NOW, limit=limit)
+
+
+def test_rrf_is_stable_and_preserves_candidate_identity() -> None:
+    engine = HybridRetriever(
+        lexical=_Lexical((_hit("a", 9.0), _hit("b", 8.0))),
+        semantic=_Semantic((_hit("b", 0.9), _hit("c", 0.8))),
+        mode=HybridRetrievalMode.HYBRID_REQUIRED,
+        fusion_policy=FusionPolicy(reciprocal_rank_constant=10),
+    )
+
+    first = engine.search(_query())
+    second = engine.search(_query())
+
+    assert [hit.chunk_id for hit in first.hits] == ["b", "a", "c"]
+    assert first == second
+    assert first.trace.effective_mode is EffectiveRetrievalMode.HYBRID
+    assert first.trace.lexical_candidate_count == 2
+    assert first.trace.semantic_candidate_count == 2
+    assert len(first.trace.sha256) == 64
+
+
+def test_optional_mode_records_lexical_fallback() -> None:
+    engine = HybridRetriever(
+        lexical=_Lexical((_hit("a", 1.0),)),
+        semantic=_Semantic((), fail=True),
+        mode=HybridRetrievalMode.HYBRID_OPTIONAL,
+    )
+    result = engine.search(_query())
+
+    assert [hit.chunk_id for hit in result.hits] == ["a"]
+    assert result.trace.effective_mode is EffectiveRetrievalMode.LEXICAL
+    assert result.trace.fallback_reason == "SEMANTIC_UNAVAILABLE"
+
+
+def test_required_mode_rejects_missing_or_failed_semantic_authority() -> None:
+    with pytest.raises(HybridRequiredUnavailable, match="not configured"):
+        HybridRetriever(
+            lexical=_Lexical((_hit("a", 1.0),)),
+            semantic=None,
+            mode=HybridRetrievalMode.HYBRID_REQUIRED,
+        ).search(_query())
+
+    with pytest.raises(HybridRequiredUnavailable, match="unavailable"):
+        HybridRetriever(
+            lexical=_Lexical((_hit("a", 1.0),)),
+            semantic=_Semantic((), fail=True),
+            mode=HybridRetrievalMode.HYBRID_REQUIRED,
+        ).search(_query())
+
+
+def test_structural_semantic_component_cannot_be_measured() -> None:
+    engine = HybridRetriever(
+        lexical=_Lexical((_hit("a", 1.0),)),
+        semantic=_Semantic(
+            (_hit("b", 1.0),),
+            status=RetrievalComponentStatus.TEST_ONLY,
+        ),
+        mode=HybridRetrievalMode.HYBRID_REQUIRED,
+        fusion_policy=FusionPolicy(require_admitted_components=False),
+    )
+
+    result = engine.search(_query())
+
+    assert engine.components_admitted is False
+    assert result.trace.execution_class is RetrievalExecutionClass.STRUCTURAL_ONLY
+
+
+def test_reranker_cannot_inject_or_remove_candidates() -> None:
+    engine = HybridRetriever(
+        lexical=_Lexical((_hit("a", 1.0),)),
+        semantic=_Semantic((_hit("b", 1.0),)),
+        mode=HybridRetrievalMode.HYBRID_REQUIRED,
+        reranker=_Reranker(("a", "injected")),
+    )
+
+    with pytest.raises(RerankerContractViolation, match="add or remove"):
+        engine.search(_query())
+
+
+def test_hybrid_service_emits_digest_bound_evidence_and_budget() -> None:
+    engine = HybridRetriever(
+        lexical=_Lexical((_hit("a", 1.0), _hit("b", 0.9))),
+        semantic=_Semantic((_hit("b", 1.0), _hit("a", 0.9))),
+        mode=HybridRetrievalMode.HYBRID_REQUIRED,
+    )
+    response = HybridRetrievalService(
+        engine,
+        budget=RetrievalBudget(max_results=2, max_total_chars=256),
+    ).retrieve(
+        request_id="request-1",
+        text="query",
+        tenant_id=None,
+        now=NOW,
+    )
+
+    assert response.evidence.effective_mode is EffectiveRetrievalMode.HYBRID
+    assert response.evidence.chunk_ids == tuple(hit.chunk_id for hit in response.hits)
+    assert response.evidence.search_trace_sha256 == response.trace.sha256
+    assert len(response.evidence.sha256) == 64
+    assert response.evidence.total_chars <= 256

--- a/apps/tai/tests/test_retrieval_benchmark.py
+++ b/apps/tai/tests/test_retrieval_benchmark.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from tai.hybrid_retrieval import (
+    EffectiveRetrievalMode,
+    FusionPolicy,
+    HybridRetrievalMode,
+    HybridSearchResult,
+    HybridSearchTrace,
+)
+from tai.retrieval_benchmark import (
+    BenchmarkEvidenceClass,
+    RetrievalBenchmarkAuthority,
+    RetrievalBenchmarkCase,
+    RetrievalBenchmarkPolicy,
+    RetrievalBenchmarkSuite,
+)
+from tai.retrieval_index import RetrievalHit, RetrievalQuery
+
+NOW = datetime(2026, 7, 19, tzinfo=UTC)
+
+
+def _hit(chunk_id: str) -> RetrievalHit:
+    return RetrievalHit(
+        chunk_id=chunk_id,
+        source_id=f"source-{chunk_id}",
+        generation=1,
+        score=1.0,
+        text=chunk_id,
+        trust_score=1.0,
+    )
+
+
+class _Engine:
+    def __init__(
+        self,
+        answers: dict[str, tuple[str, ...]],
+        *,
+        admitted: bool = True,
+        mode: EffectiveRetrievalMode = EffectiveRetrievalMode.HYBRID,
+        evidence_class: BenchmarkEvidenceClass = BenchmarkEvidenceClass.STRUCTURAL_ONLY,
+    ) -> None:
+        self._answers = answers
+        self._admitted = admitted
+        self._mode = mode
+        self._identity = "c" * 64
+        self._evidence_class = evidence_class
+
+    @property
+    def identity_sha256(self) -> str:
+        return self._identity
+
+    @property
+    def components_admitted(self) -> bool:
+        return self._admitted
+
+    @property
+    def execution_class(self) -> BenchmarkEvidenceClass:
+        return self._evidence_class
+
+    def search(self, query: RetrievalQuery) -> HybridSearchResult:
+        ids = self._answers[query.text][: query.limit]
+        hits = tuple(_hit(chunk_id) for chunk_id in ids)
+        return HybridSearchResult(
+            hits=hits,
+            trace=HybridSearchTrace(
+                requested_mode=HybridRetrievalMode.HYBRID_REQUIRED,
+                effective_mode=self._mode,
+                execution_class=self._evidence_class,
+                lexical_identity_sha256="d" * 64,
+                lexical_candidate_count=len(hits),
+                semantic_candidate_count=len(hits),
+                fused_candidate_count=len(hits),
+                fusion_policy_sha256=FusionPolicy().sha256,
+                semantic_identity_sha256="e" * 64,
+                embedding_identity_sha256="a" * 64,
+                semantic_trace_sha256="b" * 64,
+                reranker_identity_sha256=None,
+                fallback_reason=None,
+                candidates=(),
+                selected_chunk_ids=ids,
+            ),
+        )
+
+
+def _case(
+    case_id: str,
+    query: str,
+    expected: tuple[str, ...],
+    *,
+    prohibited: tuple[str, ...] = (),
+    critical: bool = False,
+) -> RetrievalBenchmarkCase:
+    return RetrievalBenchmarkCase(
+        case_id=case_id,
+        query=query,
+        expected_chunk_ids=expected,
+        prohibited_chunk_ids=prohibited,
+        tenant_id=None,
+        now=NOW,
+        limit=3,
+        critical=critical,
+    )
+
+
+def _suite(*cases: RetrievalBenchmarkCase) -> RetrievalBenchmarkSuite:
+    return RetrievalBenchmarkSuite(
+        suite_id="tai.ap15a.test",
+        version="2026.07.19.1",
+        cases=tuple(cases),
+        created_at=NOW,
+    )
+
+
+def _policy() -> RetrievalBenchmarkPolicy:
+    return RetrievalBenchmarkPolicy(
+        minimum_case_count=2,
+        minimum_recall_at_k=1.0,
+        minimum_mrr=1.0,
+        minimum_ndcg_at_k=1.0,
+        required_critical_recall=1.0,
+    )
+
+
+def test_structural_fixture_never_becomes_operational_acceptance() -> None:
+    suite = _suite(
+        _case("case-a", "q1", ("a",), critical=True),
+        _case("case-b", "q2", ("b",)),
+    )
+    report = RetrievalBenchmarkAuthority(_policy()).evaluate(
+        engine=_Engine({"q1": ("a",), "q2": ("b",)}),
+        suite=suite,
+        exact_head_sha="d" * 40,
+    )
+
+    assert report.accepted is False
+    assert "STRUCTURAL_FIXTURES_NOT_OPERATIONAL_EVIDENCE" in report.rejection_reasons
+    assert report.summary.mean_recall_at_k == 1.0
+    assert len(report.report_sha256) == 64
+
+
+def test_measured_admitted_hybrid_report_can_pass() -> None:
+    suite = _suite(
+        _case("case-a", "q1", ("a",), critical=True),
+        _case("case-b", "q2", ("b",)),
+    )
+    report = RetrievalBenchmarkAuthority(_policy()).evaluate(
+        engine=_Engine(
+            {"q1": ("a",), "q2": ("b",)},
+            evidence_class=BenchmarkEvidenceClass.MEASURED,
+        ),
+        suite=suite,
+        exact_head_sha="e" * 40,
+    )
+
+    assert report.accepted is True
+    assert report.rejection_reasons == ()
+
+
+def test_prohibited_leak_and_lexical_fallback_block_acceptance() -> None:
+    suite = _suite(
+        _case("case-a", "q1", ("a",), prohibited=("secret",), critical=True),
+        _case("case-b", "q2", ("b",)),
+    )
+    report = RetrievalBenchmarkAuthority(_policy()).evaluate(
+        engine=_Engine(
+            {"q1": ("secret", "a"), "q2": ("b",)},
+            mode=EffectiveRetrievalMode.LEXICAL,
+            evidence_class=BenchmarkEvidenceClass.MEASURED,
+        ),
+        suite=suite,
+        exact_head_sha="f" * 40,
+    )
+
+    assert report.accepted is False
+    assert "PROHIBITED_HIT_BUDGET_EXCEEDED" in report.rejection_reasons
+    assert "HYBRID_MODE_NOT_SATISFIED" in report.rejection_reasons
+    assert report.summary.prohibited_hit_count == 1
+
+
+def test_report_is_deterministic_across_suite_case_order() -> None:
+    first_suite = _suite(
+        _case("case-b", "q2", ("b",)),
+        _case("case-a", "q1", ("a",), critical=True),
+    )
+    second_suite = _suite(
+        _case("case-a", "q1", ("a",), critical=True),
+        _case("case-b", "q2", ("b",)),
+    )
+    engine = _Engine(
+        {"q1": ("a",), "q2": ("b",)},
+        evidence_class=BenchmarkEvidenceClass.MEASURED,
+    )
+    authority = RetrievalBenchmarkAuthority(_policy())
+
+    first = authority.evaluate(
+        engine=engine,
+        suite=first_suite,
+        exact_head_sha="2" * 40,
+    )
+    second = authority.evaluate(
+        engine=engine,
+        suite=second_suite,
+        exact_head_sha="2" * 40,
+    )
+
+    assert first.suite_sha256 == second.suite_sha256
+    assert first.report_sha256 == second.report_sha256
+    assert [result.case_id for result in first.results] == ["case-a", "case-b"]
+
+
+def test_unadmitted_components_block_measured_report() -> None:
+    suite = _suite(
+        _case("case-a", "q1", ("a",)),
+        _case("case-b", "q2", ("b",)),
+    )
+    report = RetrievalBenchmarkAuthority(_policy()).evaluate(
+        engine=_Engine(
+            {"q1": ("a",), "q2": ("b",)},
+            admitted=False,
+            evidence_class=BenchmarkEvidenceClass.MEASURED,
+        ),
+        suite=suite,
+        exact_head_sha="1" * 40,
+    )
+
+    assert report.accepted is False
+    assert "RETRIEVAL_COMPONENTS_NOT_ADMITTED" in report.rejection_reasons

--- a/apps/tai/tests/test_semantic_retrieval.py
+++ b/apps/tai/tests/test_semantic_retrieval.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tai.knowledge_chunking import KnowledgeChunk
+from tai.retrieval_index import (
+    InMemoryRetrievalIndexRepository,
+    RetrievalDocument,
+    RetrievalQuery,
+)
+from tai.semantic_retrieval import (
+    EmbeddingIdentity,
+    EmbeddingVector,
+    InMemorySemanticVectorRepository,
+    RetrievalComponentStatus,
+    SemanticAuthorityUnavailable,
+    SemanticIndexIncomplete,
+    SemanticRetrievalPolicy,
+    SemanticRetriever,
+)
+
+NOW = datetime(2026, 7, 19, tzinfo=UTC)
+STRUCTURAL_POLICY = SemanticRetrievalPolicy(require_admitted_index=False)
+
+
+def _identity(status: RetrievalComponentStatus = RetrievalComponentStatus.ADMITTED):
+    return EmbeddingIdentity(
+        provider_id="local-embedding",
+        model_id="embedding-model",
+        revision="rev-1",
+        dimensions=2,
+        status=status,
+    )
+
+
+def _vector(identity: EmbeddingIdentity, left: float, right: float) -> EmbeddingVector:
+    return EmbeddingVector(identity=identity, values=(left, right))
+
+
+def _document(
+    chunk_id: str,
+    text: str,
+    *,
+    source_id: str,
+    tenant_id: str | None = None,
+    trust_score: float = 1.0,
+    valid_until: datetime | None = None,
+    revoked: bool = False,
+) -> RetrievalDocument:
+    return RetrievalDocument(
+        chunk=KnowledgeChunk(
+            chunk_id=chunk_id,
+            source_id=source_id,
+            document_checksum_sha256="a" * 64,
+            ordinal=0,
+            text=text,
+            token_estimate=1,
+        ),
+        tenant_id=tenant_id,
+        trust_score=trust_score,
+        valid_until=valid_until,
+        revoked=revoked,
+    )
+
+
+class _Provider:
+    def __init__(
+        self,
+        identity: EmbeddingIdentity,
+        vectors: dict[str, EmbeddingVector],
+    ) -> None:
+        self._identity = identity
+        self._vectors = vectors
+
+    @property
+    def identity(self) -> EmbeddingIdentity:
+        return self._identity
+
+    def embed(self, text: str) -> EmbeddingVector:
+        return self._vectors[text]
+
+
+class _FailingProvider(_Provider):
+    def embed(self, text: str) -> EmbeddingVector:
+        del text
+        raise RuntimeError("private provider failure")
+
+
+def _repository(*documents: RetrievalDocument):
+    repository = InMemoryRetrievalIndexRepository()
+    generation = repository.begin_generation()
+    repository.add(generation, tuple(documents))
+    repository.activate(generation)
+    return repository, generation
+
+
+def test_semantic_filters_authority_before_scoring() -> None:
+    identity = _identity()
+    public = _document("public", "public grain", source_id="public")
+    other_tenant = _document(
+        "private-other",
+        "private exact match",
+        source_id="private",
+        tenant_id="tenant-b",
+    )
+    expired = _document(
+        "expired",
+        "expired exact match",
+        source_id="expired",
+        valid_until=NOW - timedelta(seconds=1),
+    )
+    revoked = _document(
+        "revoked",
+        "revoked exact match",
+        source_id="revoked",
+        revoked=True,
+    )
+    repository, generation = _repository(public, other_tenant, expired, revoked)
+    vectors = InMemorySemanticVectorRepository(identity)
+    vectors.add_generation(
+        generation,
+        {
+            "public": _vector(identity, 0.8, 0.2),
+            "private-other": _vector(identity, 1.0, 0.0),
+            "expired": _vector(identity, 1.0, 0.0),
+            "revoked": _vector(identity, 1.0, 0.0),
+        },
+    )
+    provider = _Provider(identity, {"grain query": _vector(identity, 1.0, 0.0)})
+    result = SemanticRetriever(
+        retrieval_repository=repository,
+        vector_repository=vectors,
+        provider=provider,
+        policy=STRUCTURAL_POLICY,
+    ).search(
+        RetrievalQuery(
+            text="grain query",
+            tenant_id="tenant-a",
+            now=NOW,
+            limit=10,
+        )
+    )
+
+    assert [hit.chunk_id for hit in result.hits] == ["public"]
+    assert result.trace.eligible_count == 1
+    assert result.trace.indexed_count == 1
+    assert result.trace.missing_chunk_ids == ()
+
+
+def test_semantic_requires_complete_generation() -> None:
+    identity = _identity()
+    repository, generation = _repository(
+        _document("a", "a", source_id="a"),
+        _document("b", "b", source_id="b"),
+    )
+    vectors = InMemorySemanticVectorRepository(identity)
+    vectors.add_generation(generation, {"a": _vector(identity, 1.0, 0.0)})
+    provider = _Provider(identity, {"query": _vector(identity, 1.0, 0.0)})
+
+    with pytest.raises(SemanticIndexIncomplete, match="incomplete"):
+        SemanticRetriever(
+            retrieval_repository=repository,
+            vector_repository=vectors,
+            provider=provider,
+            policy=STRUCTURAL_POLICY,
+        ).search(RetrievalQuery(text="query", tenant_id=None, now=NOW))
+
+
+def test_test_only_embedding_is_rejected_by_admission_policy() -> None:
+    identity = _identity(RetrievalComponentStatus.TEST_ONLY)
+    repository, generation = _repository(_document("a", "a", source_id="a"))
+    vectors = InMemorySemanticVectorRepository(identity)
+    vectors.add_generation(generation, {"a": _vector(identity, 1.0, 0.0)})
+    provider = _Provider(identity, {"query": _vector(identity, 1.0, 0.0)})
+
+    with pytest.raises(SemanticAuthorityUnavailable, match="not admitted"):
+        SemanticRetriever(
+            retrieval_repository=repository,
+            vector_repository=vectors,
+            provider=provider,
+        ).search(RetrievalQuery(text="query", tenant_id=None, now=NOW))
+
+    structural = SemanticRetriever(
+        retrieval_repository=repository,
+        vector_repository=vectors,
+        provider=provider,
+        policy=SemanticRetrievalPolicy(
+            require_admitted_model=False,
+            require_admitted_index=False,
+        ),
+    ).search(RetrievalQuery(text="query", tenant_id=None, now=NOW))
+    assert structural.hits[0].chunk_id == "a"
+
+
+def test_in_memory_vector_authority_never_counts_as_admitted() -> None:
+    identity = _identity()
+    repository, generation = _repository(_document("a", "a", source_id="a"))
+    vectors = InMemorySemanticVectorRepository(identity)
+    vectors.add_generation(generation, {"a": _vector(identity, 1.0, 0.0)})
+    provider = _Provider(identity, {"query": _vector(identity, 1.0, 0.0)})
+    retriever = SemanticRetriever(
+        retrieval_repository=repository,
+        vector_repository=vectors,
+        provider=provider,
+    )
+
+    assert retriever.components_admitted is False
+    with pytest.raises(SemanticAuthorityUnavailable, match="vector authority"):
+        retriever.search(RetrievalQuery(text="query", tenant_id=None, now=NOW))
+
+    structural = SemanticRetriever(
+        retrieval_repository=repository,
+        vector_repository=vectors,
+        provider=provider,
+        policy=STRUCTURAL_POLICY,
+    ).search(RetrievalQuery(text="query", tenant_id=None, now=NOW))
+    assert structural.trace.vector_authority_sha256 == vectors.authority_sha256
+
+
+def test_provider_failure_is_bounded() -> None:
+    identity = _identity()
+    repository, generation = _repository(_document("a", "a", source_id="a"))
+    vectors = InMemorySemanticVectorRepository(identity)
+    vectors.add_generation(generation, {"a": _vector(identity, 1.0, 0.0)})
+
+    with pytest.raises(SemanticAuthorityUnavailable, match="provider failed"):
+        SemanticRetriever(
+            retrieval_repository=repository,
+            vector_repository=vectors,
+            provider=_FailingProvider(identity, {}),
+            policy=STRUCTURAL_POLICY,
+        ).search(RetrievalQuery(text="query", tenant_id=None, now=NOW))
+
+
+def test_embedding_vector_validation_fails_closed() -> None:
+    identity = _identity()
+    with pytest.raises(ValueError, match="dimension"):
+        EmbeddingVector(identity=identity, values=(1.0,))
+    with pytest.raises(ValueError, match="finite"):
+        EmbeddingVector(identity=identity, values=(float("nan"), 1.0))
+    with pytest.raises(ValueError, match="norm"):
+        EmbeddingVector(identity=identity, values=(0.0, 0.0))


### PR DESCRIPTION
## Scope

Implements the structural AP-15A semantic/hybrid retrieval authority for #2823 on current `main`, without switching production retrieval away from the accepted lexical default and without claiming a real embedding model, ANN store, measured quality, or operational acceptance.

Parent: #2726.

## Changed

- centralizes tenant, trust, revocation and freshness eligibility so lexical and semantic ranking share the same pre-scoring authority boundary;
- adds immutable embedding provider/model/revision/dimension/status identity;
- rejects dimension mismatch, NaN/Inf vectors, zero-norm vectors, provider/index identity mismatch and incomplete semantic generations;
- adds cosine semantic retrieval only after authority filtering;
- adds explicit `LEXICAL_ONLY`, `HYBRID_OPTIONAL` and `HYBRID_REQUIRED` modes;
- adds deterministic reciprocal-rank fusion with stable chunk-ID tie-breaking;
- allows bounded reranking only as an exact permutation of already-authorized candidates;
- records requested/effective mode, component identities, fallback reason, candidate ranks and SHA-256 search evidence;
- adds immutable benchmark suite/case digests and deterministic Recall@K, MRR, nDCG, critical recall, prohibited-hit and lexical-fallback metrics;
- makes `STRUCTURAL_ONLY` fixtures incapable of producing operational acceptance;
- declares an exact nine-file AP-15A source-controlled scope.

## Changed files

- `apps/tai/governance/scopes/ap-15a-2823.json`
- `apps/tai/tai/retrieval_index.py`
- `apps/tai/tai/semantic_retrieval.py`
- `apps/tai/tai/hybrid_retrieval.py`
- `apps/tai/tai/retrieval_benchmark.py`
- `apps/tai/tests/test_ap15a_scope.py`
- `apps/tai/tests/test_semantic_retrieval.py`
- `apps/tai/tests/test_hybrid_retrieval.py`
- `apps/tai/tests/test_retrieval_benchmark.py`

## Guards

- production composition and `RetrievalService(LexicalRetriever(...))` are unchanged;
- `InMemorySemanticVectorRepository` is explicitly local/test-only and is not a production ANN authority;
- `HYBRID_REQUIRED` fails closed when semantic authority is absent, failed, incomplete, or unadmitted;
- optional fallback is explicitly recorded as lexical and cannot be reported as hybrid;
- rerankers cannot introduce, remove, duplicate or cross-bind candidates;
- no external AI API, package, lockfile, database migration, pgvector, runtime default, UI, tool authority, or autonomous write change;
- operational status remains `NOT_ATTESTED`.

## Checks

Executed against the exact contents published to this branch:

```text
ruff check \
  tai/retrieval_index.py \
  tai/semantic_retrieval.py \
  tai/hybrid_retrieval.py \
  tai/retrieval_benchmark.py \
  tests/test_ap15a_scope.py \
  tests/test_semantic_retrieval.py \
  tests/test_hybrid_retrieval.py \
  tests/test_retrieval_benchmark.py
PASS

MYPYPATH=. mypy --strict --explicit-package-bases \
  tai/retrieval_index.py \
  tai/semantic_retrieval.py \
  tai/hybrid_retrieval.py \
  tai/retrieval_benchmark.py
Success: no issues found in 4 source files

pytest focused AP-15A + existing lexical regression matrix
20 passed
```

All nine remote Git blob SHA values were compared with the locally tested files and matched exactly.

Branch head: `35065b7585ced2fed9c0db644617fa42c283b066`.
Base: `723cea58592b69c0c8a0a5cea6d88d969024ef09`.
The branch is one commit ahead and zero commits behind `main`.

## Known limitations

- No real embedding or reranker artifact is selected, downloaded, licensed, benchmarked, or admitted.
- No PostgreSQL vector/ANN persistence is implemented.
- The benchmark layer is an authority and metrics contour; measured multilingual retrieval quality against real AP-14C evidence remains pending.
- Production remains lexical-only until a separate exact-head admission and benchmark slice proves real components and explicitly changes composition.
- This PR does not close #2823 or change the TAI maturity status.
