### PR TITLE
Показать ценность будущего ИИ на первом экране

### DIFF
--- a/apps/web/app/platform-v7/page.tsx
+++ b/apps/web/app/platform-v7/page.tsx
@@ -8,7 +8,6 @@ import '@/styles/platform-v7-public-product-entry-variants.css';
 import '@/styles/platform-v7-public-product-experience-v5.css';
 import type { Metadata } from 'next';
 import { getLocale, getTranslations } from 'next-intl/server';
-import { PublicAiMarketingBlock } from '@/components/platform-v7/PublicAiMarketingBlock';
 import { PublicSiteHeader } from '@/components/platform-v7/PublicSiteHeader';
 import { PublicLocaleLink } from '@/components/platform-v7/PublicLocaleLink';
 import { PublicDealPreview } from '@/components/platform-v7/PublicDealPreview';
@@ -67,6 +66,21 @@ const firstStageCopy = {
   },
 } as const;
 
+const firstScreenAiCopy = {
+  ru: {
+    label: 'После запуска полноценного ИИ',
+    text: 'Платформа будет раньше находить риск сделки, объяснять причину и готовить следующий шаг. Критические действия останутся под подтверждением человека; ниже показан обезличенный демонстрационный сценарий.',
+  },
+  en: {
+    label: 'Once the full AI layer is launched',
+    text: 'The platform will surface deal risk earlier, explain the cause and prepare the next step. Consequential actions will remain subject to human confirmation; the scenario below is anonymised and demonstrative.',
+  },
+  zh: {
+    label: '完整 AI 上线后',
+    text: '平台将更早发现交易风险、解释原因并准备下一步。重要操作仍需人工确认；以下为匿名演示场景。',
+  },
+} as const;
+
 function PerspectiveCard({
   perspective,
   locale,
@@ -108,9 +122,10 @@ export default async function PlatformV7RootPage() {
     ...(copy.home.perspectives.secondary as readonly TourPerspective[]),
   ];
   const contourStages = TOUR_STAGES;
-  const start = firstStageCopy[locale === 'en' || locale === 'zh' ? locale : 'ru'];
+  const localeKey = locale === 'en' || locale === 'zh' ? locale : 'ru';
+  const start = firstStageCopy[localeKey];
+  const aiHero = firstScreenAiCopy[localeKey];
   const startDealHref = `/platform-v7/how-it-works?lang=${encodeURIComponent(locale)}&entry=deal&stage=terms&lens=execution&perspective=buyer`;
-  const roleEntryHref = `/platform-v7/how-it-works?lang=${encodeURIComponent(locale)}&entry=role`;
   const aiNavLabel = locale === 'ru' ? 'ИИ' : 'AI';
   const nav = (
     <>
@@ -158,9 +173,15 @@ export default async function PlatformV7RootPage() {
             <span className='pc-ppe-kicker'>{ui.home.hero.kicker}</span>
             <h1 id='pc-ppe-hero-title'>{ui.home.hero.title}</h1>
             <p>{ui.home.hero.lead}</p>
-            <div className='pc-ppe-public-status' role='note' aria-label={ui.home.hero.statusLabel}>
-              <strong>{ui.home.hero.statusLabel}</strong>
-              <span>{ui.home.hero.statusText}</span>
+            <div
+              id='ai-copilot'
+              className='pc-ppe-public-status'
+              role='note'
+              aria-label={aiHero.label}
+              data-testid='platform-v7-ai-future-value'
+            >
+              <strong>{aiHero.label}</strong>
+              <span>{aiHero.text}</span>
             </div>
             <div className='pc-ppe-hero-actions'>
               <PublicExperienceLink
@@ -208,8 +229,6 @@ export default async function PlatformV7RootPage() {
         <section id='deal-example' className='pc-ppe-section' aria-label={ui.home.preview.demoLabel}>
           <PublicDealPreview copy={copy} locale={locale} />
         </section>
-
-        <PublicAiMarketingBlock locale={locale} roleEntryHref={roleEntryHref} />
 
         <section id='participants' className='pc-ppe-section' aria-labelledby='pc-ppe-perspectives-title'>
           <div className='pc-ppe-section-header'>

--- a/apps/web/tests/unit/platformV7PublicAiMarketingBlock.test.ts
+++ b/apps/web/tests/unit/platformV7PublicAiMarketingBlock.test.ts
@@ -6,57 +6,40 @@ const read = (relativePath: string) => readFileSync(join(process.cwd(), relative
 
 describe('platform-v7 public AI marketing context', () => {
   const page = read('app/platform-v7/page.tsx');
-  const block = read('components/platform-v7/PublicAiMarketingBlock.tsx');
-  const styles = read('components/platform-v7/PublicAiMarketingBlock.module.css');
 
-  it('places the future AI value between the deal example and role workspaces', () => {
-    expect(page).toContain("import { PublicAiMarketingBlock } from '@/components/platform-v7/PublicAiMarketingBlock';");
+  it('places the target AI value inside the first-screen hero', () => {
+    expect(page).toContain("const firstScreenAiCopy = {");
+    expect(page).toContain("id='ai-copilot'");
+    expect(page).toContain("data-testid='platform-v7-ai-future-value'");
     expect(page).toContain("<a href='#ai-copilot'>{aiNavLabel}</a>");
-    expect(page).toContain('<PublicAiMarketingBlock locale={locale} roleEntryHref={roleEntryHref} />');
+    expect(page).not.toContain("import { PublicAiMarketingBlock }");
+    expect(page).not.toContain('<PublicAiMarketingBlock');
 
+    const heroTitleIndex = page.indexOf("id='pc-ppe-hero-title'");
+    const aiIndex = page.indexOf("id='ai-copilot'");
+    const actionsIndex = page.indexOf("className='pc-ppe-hero-actions'");
     const dealIndex = page.indexOf("id='deal-example'");
-    const aiIndex = page.indexOf('<PublicAiMarketingBlock');
-    const participantsIndex = page.indexOf("id='participants'");
 
-    expect(dealIndex).toBeGreaterThan(-1);
-    expect(aiIndex).toBeGreaterThan(dealIndex);
-    expect(participantsIndex).toBeGreaterThan(aiIndex);
+    expect(heroTitleIndex).toBeGreaterThan(-1);
+    expect(aiIndex).toBeGreaterThan(heroTitleIndex);
+    expect(actionsIndex).toBeGreaterThan(aiIndex);
+    expect(dealIndex).toBeGreaterThan(actionsIndex);
   });
 
-  it('markets the target outcome without claiming the capability is already live', () => {
-    expect(block).toContain("eyebrow: 'ИИ в целевой версии платформы'");
-    expect(block).toContain("После запуска полноценного ИИ");
-    expect(block).toContain("Увидит риск до срыва");
-    expect(block).toContain("Объяснит на фактах");
-    expect(block).toContain("Подготовит следующий шаг");
-    expect(block).toContain("Целевой контур будет вводиться поэтапно");
-    expect(block).toContain("Пример будущего сигнала");
-    expect(block).toContain("только после подтверждения пользователя");
-    expect(block).not.toContain('ИИ уже анализирует');
-    expect(block).not.toContain('самостоятельно выполняет');
+  it('markets the future outcome without claiming that it is live', () => {
+    expect(page).toContain("label: 'После запуска полноценного ИИ'");
+    expect(page).toContain('Платформа будет раньше находить риск сделки');
+    expect(page).toContain('объяснять причину и готовить следующий шаг');
+    expect(page).toContain('Критические действия останутся под подтверждением человека');
+    expect(page).not.toContain('ИИ уже анализирует');
+    expect(page).not.toContain('самостоятельно выполняет');
   });
 
-  it('uses a semantic evidence-led structure with one measurable next step', () => {
-    expect(block).toContain("id='ai-copilot'");
-    expect(block).toContain("aria-labelledby='pc-ppe-ai-title'");
-    expect(block).toContain("data-testid='platform-v7-ai-future-value'");
-    expect(block).toContain('<ul className={styles.capabilities}>');
-    expect(block).toContain('<dl className={styles.scenarioFacts}>');
-    expect(block).toContain("role='note'");
-    expect(block).toContain("eventName='ai_future_value_role_cta'");
-    expect(block).toContain("params={{ source: 'home_ai_future_value' }}");
-  });
-
-  it('covers RU, EN and ZH and remains responsive and accessible', () => {
-    expect(block).toContain("en: {");
-    expect(block).toContain("zh: {");
-    expect(block).toContain('See risk earlier. Understand the cause. Move to action faster.');
-    expect(block).toContain('更早发现风险，理解原因，更快进入下一步。');
-    expect(styles).toContain('grid-template-columns: minmax(0, 1.08fr) minmax(340px, .92fr)');
-    expect(styles).toContain('@media (max-width: 900px)');
-    expect(styles).toContain('@media (max-width: 720px)');
-    expect(styles).toContain('@media (max-width: 380px)');
-    expect(styles).toContain('@media (forced-colors: active)');
-    expect(styles).toContain('min-height: 52px');
+  it('keeps the public boundary and all supported locales', () => {
+    expect(page).toContain('обезличенный демонстрационный сценарий');
+    expect(page).toContain("label: 'Once the full AI layer is launched'");
+    expect(page).toContain('Consequential actions will remain subject to human confirmation');
+    expect(page).toContain("label: '完整 AI 上线后'");
+    expect(page).toContain('重要操作仍需人工确认');
   });
 });

--- a/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
+++ b/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
@@ -1,12 +1,10 @@
 {
   "branch": "feat/assistant-universal-understanding",
   "status": "active",
-  "purpose": "Public-homepage marketing context for the target AI experience: contextual value framing, multilingual copy, an evidence-led future signal and an explicit human-confirmation boundary.",
+  "purpose": "First-screen marketing context for the target AI experience: future-state value in the homepage hero, explicit human confirmation and an anonymised public scenario boundary.",
   "approvedBy": "independent-authority-pr",
   "allowedPaths": [
     "apps/web/app/platform-v7/page.tsx",
-    "apps/web/components/platform-v7/PublicAiMarketingBlock.module.css",
-    "apps/web/components/platform-v7/PublicAiMarketingBlock.tsx",
     "apps/web/tests/unit/platformV7PublicAiMarketingBlock.test.ts",
     "docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json"
   ],


### PR DESCRIPTION
## Исправление

Пользователь не видел изменение, потому что маркетинговый ИИ-блок был размещён ниже демонстрационной сделки — на главной странице, но не в первом viewport.

Теперь:

- future-state ценность ИИ встроена в hero и видна без прокрутки;
- плашка сообщает, что после запуска полноценного ИИ платформа будет раньше находить риск, объяснять причину и готовить следующий шаг;
- критические действия явно остаются под подтверждением человека;
- сохранена граница публичного обезличенного сценария;
- большой дублирующий ИИ-блок ниже удалён из рендера;
- RU / EN / ZH сохранены;
- добавлена регрессия на порядок: заголовок → ИИ-контекст → CTA → демонстрационная сделка.

## Почему

Фраза «на главном экране» должна трактоваться как первый экран, а не просто как одна из нижних секций главной страницы.