### PR TITLE
Унифицировать вертикальный ритм текста в платформе

### DIFF
--- a/apps/web/components/platform-v7/ExecutionDesignSystem.module.css
+++ b/apps/web/components/platform-v7/ExecutionDesignSystem.module.css
@@ -54,16 +54,16 @@
   width: min(100%, 1440px);
   margin: 0 auto;
   display: grid;
-  gap: 16px;
-  padding: 0 0 24px;
+  gap: var(--ds-text-gap-action, 16px);
+  padding: 0 0 var(--ds-layout-gap-section, 24px);
 }
 
 .header {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 16px;
+  gap: var(--ds-text-gap-action, 16px);
   align-items: start;
-  padding: 20px;
+  padding: var(--ds-layout-gap-group, 20px);
   border: 1px solid var(--ged-border-soft);
   border-radius: 8px;
   background: linear-gradient(180deg, var(--ged-surface), var(--ged-bg-soft));
@@ -90,7 +90,7 @@
 }
 
 .title {
-  margin: 6px 0 0;
+  margin: var(--ds-text-gap-title, 8px) 0 0;
   max-width: 22ch;
   color: var(--ged-text);
   font-size: clamp(26px, 4vw, 42px);
@@ -101,7 +101,7 @@
 }
 
 .subtitle {
-  margin: 10px 0 0;
+  margin: var(--ds-text-gap-paragraph, 12px) 0 0;
   max-width: 74ch;
   color: var(--ged-text-soft);
   font-size: 14px;
@@ -112,14 +112,14 @@
 .headerMeta {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--ds-text-gap-title, 8px);
   justify-content: flex-end;
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--ged-grid-min, 240px)), 1fr));
-  gap: 12px;
+  gap: var(--ds-text-gap-paragraph, 12px);
   min-width: 0;
 }
 
@@ -182,12 +182,12 @@
 }
 
 .card {
-  padding: 16px;
+  padding: var(--ds-text-gap-action, 16px);
 }
 
 .kpiCard {
   display: grid;
-  gap: 9px;
+  gap: var(--ds-text-gap-title, 8px);
   padding: 15px;
 }
 
@@ -212,8 +212,8 @@
 .operationalCard {
   display: grid;
   grid-template-rows: auto 1fr auto;
-  gap: 14px;
-  padding: 16px;
+  gap: var(--ds-text-gap-paragraph, 12px);
+  padding: var(--ds-text-gap-action, 16px);
 }
 
 .cardTop {
@@ -221,7 +221,7 @@
   min-width: 0;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--ds-text-gap-paragraph, 12px);
 }
 
 .cardTitle {
@@ -236,12 +236,12 @@
 
 .cardBody {
   display: grid;
-  gap: 10px;
+  gap: var(--ds-text-gap-title, 8px);
 }
 
 .factBlock {
   display: grid;
-  gap: 3px;
+  gap: var(--ds-text-gap-label, 4px);
 }
 
 .factLabel {
@@ -281,7 +281,7 @@
 .actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--ds-text-gap-title, 8px);
   align-items: center;
 }
 
@@ -338,7 +338,7 @@
 
 @media (max-width: 720px) {
   .frame {
-    gap: 12px;
+    gap: var(--ds-text-gap-paragraph, 12px);
     padding-bottom: calc(18px + env(safe-area-inset-bottom));
   }
 

--- a/apps/web/components/platform-v7/RoleExecutionCockpit.module.css
+++ b/apps/web/components/platform-v7/RoleExecutionCockpit.module.css
@@ -1,0 +1,47 @@
+.contractGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: var(--ds-text-gap-title);
+  margin: 0 0 var(--ds-text-gap-paragraph);
+}
+
+.contractCard {
+  min-width: 0;
+  padding: var(--ds-space-2) var(--ds-space-3);
+  border: 1px solid var(--ds-color-border);
+  border-radius: var(--ds-radius-lg);
+  background: var(--ds-color-surface);
+  box-shadow: var(--ds-shadow-surface);
+}
+
+.contractCopy {
+  height: 100%;
+}
+
+.contractLabel {
+  color: var(--ds-color-text-muted);
+  font-size: 10px;
+  font-weight: 950;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.contractValue {
+  color: var(--ds-color-text-primary);
+  font-size: var(--ds-font-caption);
+  font-weight: 900;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 430px) {
+  .contractGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (forced-colors: active) {
+  .contractCard {
+    border-color: CanvasText;
+  }
+}

--- a/apps/web/components/platform-v7/RoleExecutionCockpit.tsx
+++ b/apps/web/components/platform-v7/RoleExecutionCockpit.tsx
@@ -1,3 +1,4 @@
+import { TextStack } from '@pc/design-system-v8';
 import {
   ExecutionCanvas,
   ExecutionCardGrid,
@@ -6,39 +7,8 @@ import {
   ExecutionStatusBadge,
 } from '@/components/platform-v7/ExecutionDesignSystem';
 import type { RoleExecutionCockpitModel } from '@/lib/platform-v7/role-execution-cockpit';
-import type { CSSProperties, ReactNode } from 'react';
-
-const contractGridStyle = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))',
-  gap: 8,
-  margin: '0 0 12px',
-} satisfies CSSProperties;
-
-const contractCardStyle = {
-  display: 'grid',
-  gap: 4,
-  padding: '10px 12px',
-  borderRadius: 16,
-  border: '1px solid var(--pc-border)',
-  background: 'var(--pc-bg-card)',
-  boxShadow: 'var(--pc-shadow-sm)',
-} satisfies CSSProperties;
-
-const contractLabelStyle = {
-  fontSize: 10,
-  fontWeight: 950,
-  textTransform: 'uppercase',
-  letterSpacing: '0.06em',
-  color: 'var(--pc-text-muted)',
-} satisfies CSSProperties;
-
-const contractValueStyle = {
-  fontSize: 12,
-  fontWeight: 900,
-  lineHeight: 1.35,
-  color: 'var(--pc-text-primary)',
-} satisfies CSSProperties;
+import type { ReactNode } from 'react';
+import styles from './RoleExecutionCockpit.module.css';
 
 function firstMoneyKpi(cockpit: RoleExecutionCockpitModel) {
   return cockpit.kpis.find((kpi) => kpi.tone === 'money' || /деньг|резерв|удерж|банк|₽/i.test(`${kpi.label} ${kpi.value} ${kpi.note}`));
@@ -64,11 +34,13 @@ function contractItems(cockpit: RoleExecutionCockpitModel) {
 
 export function RoleExecutionScreenContract({ cockpit }: { readonly cockpit: RoleExecutionCockpitModel }) {
   return (
-    <section data-testid={`platform-v7-${cockpit.role}-screen-contract`} aria-label='Контракт экрана роли' style={contractGridStyle}>
+    <section data-testid={`platform-v7-${cockpit.role}-screen-contract`} aria-label='Контракт экрана роли' className={styles.contractGrid}>
       {contractItems(cockpit).map((item) => (
-        <article key={item.label} style={contractCardStyle}>
-          <span style={contractLabelStyle}>{item.label}</span>
-          <strong style={contractValueStyle}>{item.value}</strong>
+        <article key={item.label} className={styles.contractCard}>
+          <TextStack className={styles.contractCopy} spacing='label'>
+            <span className={styles.contractLabel}>{item.label}</span>
+            <strong className={styles.contractValue}>{item.value}</strong>
+          </TextStack>
         </article>
       ))}
     </section>

--- a/apps/web/components/platform-v7/premium/CockpitHero.module.css
+++ b/apps/web/components/platform-v7/premium/CockpitHero.module.css
@@ -1,4 +1,8 @@
 .root {
+  --ds-text-gap-label: var(--ds-space-1, 4px);
+  --ds-text-gap-title: var(--ds-space-2, 8px);
+  --ds-text-gap-paragraph: var(--ds-space-3, 12px);
+  --ds-text-gap-action: var(--ds-space-4, 16px);
   min-width: 0;
   display: grid;
   gap: var(--ds-text-gap-action);

--- a/apps/web/components/platform-v7/premium/CockpitHero.module.css
+++ b/apps/web/components/platform-v7/premium/CockpitHero.module.css
@@ -1,0 +1,34 @@
+.root {
+  min-width: 0;
+  display: grid;
+  gap: var(--ds-text-gap-action);
+}
+
+.layout {
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--ds-text-gap-paragraph);
+  flex-wrap: wrap;
+}
+
+.copy {
+  min-width: 0;
+  flex: 1 1 28rem;
+}
+
+.aside {
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+@media (max-width: 720px) {
+  .layout {
+    display: grid;
+  }
+
+  .aside {
+    width: 100%;
+  }
+}

--- a/apps/web/components/platform-v7/premium/CockpitHero.tsx
+++ b/apps/web/components/platform-v7/premium/CockpitHero.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react';
+import { TextStack } from '@pc/design-system-v8';
+import styles from './CockpitHero.module.css';
 
 export function CockpitHero({
   eyebrow,
@@ -21,10 +23,12 @@ export function CockpitHero({
   /** extra class appended to the hero root (keeps page-specific responsive rules) */
   className?: string;
 }) {
+  const rootClassName = ['pc-prem-hero', styles.root, className].filter(Boolean).join(' ');
+
   return (
-    <section className={className ? `pc-prem-hero ${className}` : 'pc-prem-hero'}>
-      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 14, flexWrap: 'wrap' }}>
-        <div style={{ display: 'grid', gap: 9 }}>
+    <section className={rootClassName}>
+      <div className={styles.layout}>
+        <TextStack className={styles.copy} spacing='title'>
           {eyebrow ? <span className='pc-prem-hero__eyebrow'>{eyebrow}</span> : null}
           <h1 className='pc-prem-hero__title'>
             {title}
@@ -36,8 +40,8 @@ export function CockpitHero({
             ) : null}
           </h1>
           {lead ? <p className='pc-prem-hero__lead'>{lead}</p> : null}
-        </div>
-        {aside ? <div>{aside}</div> : null}
+        </TextStack>
+        {aside ? <div className={styles.aside}>{aside}</div> : null}
       </div>
       {children}
     </section>

--- a/apps/web/components/transaction-ux/MoneyObligationCockpit.module.css
+++ b/apps/web/components/transaction-ux/MoneyObligationCockpit.module.css
@@ -1,7 +1,7 @@
 .root {
   min-width: 0;
   display: grid;
-  gap: var(--ds-space-4);
+  gap: var(--ds-text-gap-action);
 }
 
 .header {
@@ -14,13 +14,13 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: start;
-  gap: var(--ds-space-4);
+  gap: var(--ds-text-gap-action);
 }
 
 .heading {
   min-width: 0;
   display: grid;
-  gap: var(--ds-space-2);
+  gap: var(--ds-text-gap-title);
 }
 
 .eyebrow {
@@ -57,7 +57,7 @@
   border-radius: var(--ds-radius-xl);
   background: var(--ds-color-warning-bg);
   display: grid;
-  gap: var(--ds-space-4);
+  gap: var(--ds-text-gap-action);
 }
 
 .priorityReady {
@@ -100,7 +100,7 @@
   margin: 0;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--ds-space-2);
+  gap: var(--ds-text-gap-title);
 }
 
 .metaItem,
@@ -111,7 +111,7 @@
   border-radius: var(--ds-radius-md);
   background: var(--ds-color-surface);
   display: grid;
-  gap: var(--ds-space-1);
+  gap: var(--ds-text-gap-label);
 }
 
 .metaItem dt,
@@ -143,7 +143,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--ds-space-2);
+  gap: var(--ds-text-gap-title);
 }
 
 .primaryLink,
@@ -180,7 +180,7 @@
 .toolGrid {
   min-width: 0;
   display: grid;
-  gap: var(--ds-space-3);
+  gap: var(--ds-text-gap-paragraph);
 }
 
 .sectionAnchor { scroll-margin-top: calc(98px + var(--ds-space-4)); }
@@ -195,7 +195,7 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--ds-space-3);
+  gap: var(--ds-text-gap-paragraph);
   text-align: left;
 }
 .queueLink:hover { border-color: var(--ds-color-action-primary); }
@@ -203,7 +203,7 @@
 .queueCopy {
   min-width: 0;
   display: grid;
-  gap: var(--ds-space-1);
+  gap: var(--ds-text-gap-label);
 }
 .queueCopy strong,
 .queueCopy span,

--- a/apps/web/components/transaction-ux/MoneyObligationCockpit.tsx
+++ b/apps/web/components/transaction-ux/MoneyObligationCockpit.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { StatusChip } from '@pc/design-system-v8';
+import { StatusChip, TextStack } from '@pc/design-system-v8';
 import styles from './MoneyObligationCockpit.module.css';
 
 export type MoneyStatusTone = 'neutral' | 'success' | 'warning' | 'critical' | 'information';
@@ -88,18 +88,20 @@ export function MoneyObligationCockpit({
     <main className={styles.root} data-testid={testId} data-money-obligation-cockpit='v8'>
       {liveStatus}
       <header className={styles.header}>
-        <div className={styles.heading}>
+        <TextStack className={styles.heading} spacing='title'>
           <span className={styles.eyebrow}>{eyebrow}</span>
           <h1 className={styles.title}>{title}</h1>
           <p className={styles.description}>{description}</p>
-        </div>
+        </TextStack>
         <div className={styles.status}><StatusChip tone={statusTone}>{statusLabel}</StatusChip></div>
       </header>
 
       <section className={`${styles.priority} ${priorityClass}`} aria-label={copy.prioritySection}>
-        <span className={styles.priorityEyebrow}>{priority.eyebrow ?? copy.nextAction}</span>
-        <h2 className={styles.priorityTitle}>{priority.title}</h2>
-        <p className={styles.priorityDescription}>{priority.description}</p>
+        <TextStack spacing='title'>
+          <span className={styles.priorityEyebrow}>{priority.eyebrow ?? copy.nextAction}</span>
+          <h2 className={styles.priorityTitle}>{priority.title}</h2>
+          <p className={styles.priorityDescription}>{priority.description}</p>
+        </TextStack>
         {meta.length > 0 ? (
           <dl className={styles.priorityMeta}>
             {meta.map((item) => (

--- a/apps/web/tests/unit/designSystemV8Foundation.test.ts
+++ b/apps/web/tests/unit/designSystemV8Foundation.test.ts
@@ -14,6 +14,11 @@ describe('Design System v8 foundation', () => {
     expect(tokens.component).toBeTruthy();
     expect(tokens.context).toBeTruthy();
     expect(tokens.semantic.action.primary.$value).toBe('{core.color.green.700}');
+    expect(tokens.semantic.spacing.text.label.$value).toBe('{core.space.1}');
+    expect(tokens.semantic.spacing.text.title.$value).toBe('{core.space.2}');
+    expect(tokens.semantic.spacing.text.paragraph.$value).toBe('{core.space.3}');
+    expect(tokens.semantic.spacing.text.action.$value).toBe('{core.space.4}');
+    expect(tokens.semantic.spacing.layout.section.$value).toBe('{core.space.6}');
   });
 
   it('loads generated tokens through the governed v8 runtime without a legacy style bundle', () => {
@@ -36,11 +41,30 @@ describe('Design System v8 foundation', () => {
     expect(css).not.toMatch(/#[0-9a-f]{3,8}\b/i);
     expect(css).not.toMatch(/\brgba?\s*\(/i);
     expect(css).not.toContain('!important');
+    expect(css).toContain('var(--ds-text-gap-paragraph)');
+    expect(css).toContain('var(--ds-layout-gap-section)');
+  });
+
+  it('uses governed text rhythm in shared cockpit layouts', () => {
+    const hero = read('apps/web/components/platform-v7/premium/CockpitHero.tsx');
+    const roleCockpit = read('apps/web/components/platform-v7/RoleExecutionCockpit.tsx');
+    const moneyCockpit = read('apps/web/components/transaction-ux/MoneyObligationCockpit.tsx');
+    const executionCss = read('apps/web/components/platform-v7/ExecutionDesignSystem.module.css');
+
+    expect(hero).toContain("TextStack");
+    expect(roleCockpit).toContain("TextStack");
+    expect(moneyCockpit).toContain("TextStack");
+    expect(hero).not.toMatch(/style\s*=\s*\{\{/);
+    expect(roleCockpit).not.toMatch(/style\s*=\s*\{\{/);
+    expect(executionCss).toContain('var(--ds-text-gap-title, 8px)');
+    expect(executionCss).toContain('var(--ds-text-gap-paragraph, 12px)');
   });
 
   it('registers automatic governance', () => {
     const governance = JSON.parse(read('design-governance-v8.json'));
     expect(governance.migratedFiles).toContain('apps/web/components/platform-v7/NextActionCard.tsx');
+    expect(governance.migratedFiles).toContain('apps/web/components/platform-v7/RoleExecutionCockpit.tsx');
+    expect(governance.migratedFiles).toContain('apps/web/components/platform-v7/premium/CockpitHero.tsx');
     expect(read('package.json')).toContain('design:v8:guard');
     expect(read('.github/workflows/design-system-v8.yml')).toContain('check-design-system-v8.mjs');
   });

--- a/apps/web/tests/unit/designSystemV8Foundation.test.ts
+++ b/apps/web/tests/unit/designSystemV8Foundation.test.ts
@@ -47,15 +47,19 @@ describe('Design System v8 foundation', () => {
 
   it('uses governed text rhythm in shared cockpit layouts', () => {
     const hero = read('apps/web/components/platform-v7/premium/CockpitHero.tsx');
+    const heroCss = read('apps/web/components/platform-v7/premium/CockpitHero.module.css');
     const roleCockpit = read('apps/web/components/platform-v7/RoleExecutionCockpit.tsx');
     const moneyCockpit = read('apps/web/components/transaction-ux/MoneyObligationCockpit.tsx');
+    const moneyCss = read('apps/web/components/transaction-ux/MoneyObligationCockpit.module.css');
     const executionCss = read('apps/web/components/platform-v7/ExecutionDesignSystem.module.css');
 
-    expect(hero).toContain("TextStack");
-    expect(roleCockpit).toContain("TextStack");
-    expect(moneyCockpit).toContain("TextStack");
+    expect(hero).toContain('TextStack');
+    expect(roleCockpit).toContain('TextStack');
+    expect(moneyCockpit).toContain('TextStack');
     expect(hero).not.toMatch(/style\s*=\s*\{\{/);
     expect(roleCockpit).not.toMatch(/style\s*=\s*\{\{/);
+    expect(heroCss).toContain('--ds-text-gap-title: var(--ds-space-2, 8px)');
+    expect(moneyCss).toContain('var(--ds-text-gap-action)');
     expect(executionCss).toContain('var(--ds-text-gap-title, 8px)');
     expect(executionCss).toContain('var(--ds-text-gap-paragraph, 12px)');
   });

--- a/apps/web/tests/unit/designSystemV8TextRhythm.test.tsx
+++ b/apps/web/tests/unit/designSystemV8TextRhythm.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Prose, TextStack } from '@pc/design-system-v8';
+
+describe('Design System v8 text rhythm', () => {
+  it('renders a semantic text stack with an explicit spacing contract', () => {
+    render(
+      <TextStack data-testid='text-stack' spacing='paragraph' align='center'>
+        <h2>Заголовок</h2>
+        <p>Первый абзац</p>
+        <p>Второй абзац</p>
+      </TextStack>,
+    );
+
+    const stack = screen.getByTestId('text-stack');
+    expect(stack).toHaveAttribute('data-text-stack', 'paragraph');
+    expect(screen.getByRole('heading', { level: 2, name: 'Заголовок' })).toBeInTheDocument();
+    expect(screen.getByText('Первый абзац')).toBeInTheDocument();
+    expect(screen.getByText('Второй абзац')).toBeInTheDocument();
+  });
+
+  it('keeps long-form content inside the governed prose boundary', () => {
+    render(
+      <Prose data-testid='prose'>
+        <h2>Условия сделки</h2>
+        <p>Первый смысловой блок.</p>
+        <p>Следующий смысловой блок.</p>
+        <ul><li>Пункт один</li><li>Пункт два</li></ul>
+      </Prose>,
+    );
+
+    expect(screen.getByTestId('prose')).toHaveAttribute('data-prose', 'true');
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+});

--- a/design-governance-v8.json
+++ b/design-governance-v8.json
@@ -1,5 +1,5 @@
 {
-  "version": 39,
+  "version": 40,
   "tokenSource": "packages/design-tokens/tokens.json",
   "tokenCss": "packages/design-tokens/tokens.css",
   "governedRoots": [
@@ -30,6 +30,8 @@
     "apps/web/components/v7r/AppShellV4.module.css",
     "apps/web/components/platform-v7/RoleIntentDashboard.tsx",
     "apps/web/components/platform-v7/RoleIntentDashboard.module.css",
+    "apps/web/components/platform-v7/RoleExecutionCockpit.module.css",
+    "apps/web/components/platform-v7/premium/CockpitHero.module.css",
     "apps/web/app/platform-v7/deals/page.tsx",
     "apps/web/app/platform-v7/deals/deals.module.css",
     "apps/web/components/platform-v7/CanonicalDealsList.tsx",
@@ -37,6 +39,8 @@
   ],
   "migratedFiles": [
     "apps/web/components/platform-v7/NextActionCard.tsx",
+    "apps/web/components/platform-v7/RoleExecutionCockpit.tsx",
+    "apps/web/components/platform-v7/premium/CockpitHero.tsx",
     "apps/web/app/platform-v7/driver/field/page.tsx",
     "apps/web/app/platform-v7/elevator/page.tsx",
     "apps/web/app/platform-v7/lab/page.tsx",

--- a/packages/design-system-v8/src/components.module.css
+++ b/packages/design-system-v8/src/components.module.css
@@ -11,6 +11,54 @@
 .surfaceSubtle { background: var(--ds-color-surface-subtle); box-shadow: none; }
 .surfacePadded { padding: var(--ds-space-4); }
 
+.textStack {
+  min-width: 0;
+  display: grid;
+}
+
+.textStack > * {
+  min-width: 0;
+  margin-block: 0;
+}
+
+.textStackLabel { gap: var(--ds-text-gap-label); }
+.textStackTitle { gap: var(--ds-text-gap-title); }
+.textStackParagraph { gap: var(--ds-text-gap-paragraph); }
+.textStackAction { gap: var(--ds-text-gap-action); }
+.textStackStart { justify-items: start; }
+.textStackCenter { justify-items: center; text-align: center; }
+.textStackStretch { justify-items: stretch; }
+
+.prose {
+  min-width: 0;
+  color: inherit;
+  line-height: 1.55;
+}
+
+.prose > :where(*) {
+  margin-block: 0;
+}
+
+.prose > :where(ul, ol) {
+  padding-inline-start: var(--ds-layout-gap-group);
+}
+
+.prose > :where(h1, h2, h3, h4, h5, h6) + :where(p, ul, ol, blockquote) {
+  margin-block-start: var(--ds-text-gap-title);
+}
+
+.prose > :where(p, ul, ol, blockquote) + :where(p, ul, ol, blockquote) {
+  margin-block-start: var(--ds-text-gap-paragraph);
+}
+
+.prose > :where(p, ul, ol, blockquote) + :where(h2, h3, h4, h5, h6) {
+  margin-block-start: var(--ds-layout-gap-section);
+}
+
+.prose :where(li + li) {
+  margin-block-start: var(--ds-text-gap-title);
+}
+
 .button {
   min-height: var(--ds-control-height);
   border: 1px solid transparent;
@@ -72,7 +120,7 @@
   line-height: 1.5;
 }
 .notice strong, .notice p { margin: 0; }
-.noticeCopy { min-width: 0; display: grid; gap: var(--ds-space-1); }
+.noticeCopy { min-width: 0; display: grid; gap: var(--ds-text-gap-label); }
 .noticeNeutral { color: var(--ds-color-text-secondary); background: var(--ds-color-surface-subtle); }
 .noticeSuccess { color: var(--ds-color-success); background: var(--ds-color-success-bg); }
 .noticeWarning { color: var(--ds-color-warning); background: var(--ds-color-warning-bg); }
@@ -87,19 +135,19 @@
   color: var(--ds-color-text-primary);
   padding: var(--ds-space-5);
   display: grid;
-  gap: var(--ds-space-4);
+  gap: var(--ds-text-gap-action);
 }
 
 .nextActionBlocked { border-color: var(--ds-color-critical); background: var(--ds-color-critical-bg); }
 .nextActionHeader { display: grid; grid-template-columns: var(--ds-control-height) minmax(0, 1fr); gap: var(--ds-space-3); align-items: start; }
 .nextActionIcon { width: var(--ds-control-height); height: var(--ds-control-height); border-radius: var(--ds-radius-lg); background: var(--ds-color-surface); display: grid; place-items: center; color: var(--ds-color-action-primary); }
 .nextActionBlocked .nextActionIcon { color: var(--ds-color-critical); }
-.nextActionCopy { min-width: 0; display: grid; gap: var(--ds-space-1); }
+.nextActionCopy { min-width: 0; display: grid; gap: var(--ds-text-gap-label); }
 .nextActionLabel { color: var(--ds-color-text-muted); font-size: var(--ds-font-caption); font-weight: 900; letter-spacing: 0.04em; text-transform: uppercase; }
 .nextActionTitle { margin: 0; font-size: clamp(var(--ds-font-title), 4vw, var(--ds-font-display)); line-height: 1.15; overflow-wrap: anywhere; }
 .nextActionReason { margin: 0; max-width: 68ch; color: var(--ds-color-text-secondary); font-size: var(--ds-font-body); line-height: 1.55; }
 .nextActionMeta { margin: 0; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--ds-space-2); }
-.nextActionMetaItem { min-width: 0; border: 1px solid var(--ds-color-border); border-radius: var(--ds-radius-md); background: var(--ds-color-surface); padding: var(--ds-space-3); display: grid; gap: var(--ds-space-1); }
+.nextActionMetaItem { min-width: 0; border: 1px solid var(--ds-color-border); border-radius: var(--ds-radius-md); background: var(--ds-color-surface); padding: var(--ds-space-3); display: grid; gap: var(--ds-text-gap-label); }
 .nextActionMetaItem dt { color: var(--ds-color-text-muted); font-size: var(--ds-font-caption); }
 .nextActionMetaItem dd { margin: 0; color: var(--ds-color-text-primary); font-weight: 800; overflow-wrap: anywhere; }
 .nextActionActions { display: flex; flex-wrap: wrap; gap: var(--ds-space-2); align-items: center; }

--- a/packages/design-system-v8/src/components.tsx
+++ b/packages/design-system-v8/src/components.tsx
@@ -4,6 +4,8 @@ import styles from './components.module.css';
 type Tone = 'neutral' | 'success' | 'warning' | 'critical' | 'information';
 type ButtonVariant = 'primary' | 'secondary' | 'danger';
 type SurfaceVariant = 'default' | 'plain' | 'subtle';
+type TextStackSpacing = 'label' | 'title' | 'paragraph' | 'action';
+type TextStackAlign = 'start' | 'center' | 'stretch';
 
 function cx(...values: Array<string | false | null | undefined>): string {
   return values.filter(Boolean).join(' ');
@@ -27,6 +29,40 @@ export function Surface({ variant = 'default', padded = true, className, ...prop
       )}
     />
   );
+}
+
+const textStackSpacingClasses: Record<TextStackSpacing, string> = {
+  label: styles.textStackLabel,
+  title: styles.textStackTitle,
+  paragraph: styles.textStackParagraph,
+  action: styles.textStackAction,
+};
+
+const textStackAlignClasses: Record<TextStackAlign, string> = {
+  start: styles.textStackStart,
+  center: styles.textStackCenter,
+  stretch: styles.textStackStretch,
+};
+
+export type TextStackProps = React.HTMLAttributes<HTMLDivElement> & {
+  spacing?: TextStackSpacing;
+  align?: TextStackAlign;
+};
+
+export function TextStack({ spacing = 'title', align = 'stretch', className, ...props }: TextStackProps) {
+  return (
+    <div
+      {...props}
+      data-text-stack={spacing}
+      className={cx(styles.textStack, textStackSpacingClasses[spacing], textStackAlignClasses[align], className)}
+    />
+  );
+}
+
+export type ProseProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function Prose({ className, ...props }: ProseProps) {
+  return <div {...props} data-prose='true' className={cx(styles.prose, className)} />;
 }
 
 export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {

--- a/packages/design-system-v8/src/index.ts
+++ b/packages/design-system-v8/src/index.ts
@@ -2,16 +2,20 @@ export {
   Button,
   InlineNotice,
   NextActionCard,
+  Prose,
   StatusChip,
   Surface,
+  TextStack,
 } from './components';
 
 export type {
   ButtonProps,
   InlineNoticeProps,
   NextActionCardProps,
+  ProseProps,
   StatusChipProps,
   SurfaceProps,
+  TextStackProps,
 } from './components';
 
 export { EmptyState } from './EmptyState';

--- a/packages/design-tokens/tokens.css
+++ b/packages/design-tokens/tokens.css
@@ -30,6 +30,14 @@
   --ds-space-8: 32px;
   --ds-space-10: 40px;
 
+  --ds-text-gap-label: var(--ds-space-1);
+  --ds-text-gap-title: var(--ds-space-2);
+  --ds-text-gap-paragraph: var(--ds-space-3);
+  --ds-text-gap-action: var(--ds-space-4);
+  --ds-layout-gap-group: var(--ds-space-5);
+  --ds-layout-gap-section: var(--ds-space-6);
+  --ds-layout-gap-section-wide: var(--ds-space-8);
+
   --ds-radius-sm: 6px;
   --ds-radius-md: 10px;
   --ds-radius-lg: 16px;

--- a/packages/design-tokens/tokens.json
+++ b/packages/design-tokens/tokens.json
@@ -102,6 +102,19 @@
       "criticalBackground": { "$type": "color", "$value": "{core.color.red.50}" },
       "information": { "$type": "color", "$value": "{core.color.blue.700}" },
       "informationBackground": { "$type": "color", "$value": "{core.color.blue.50}" }
+    },
+    "spacing": {
+      "text": {
+        "label": { "$type": "dimension", "$value": "{core.space.1}" },
+        "title": { "$type": "dimension", "$value": "{core.space.2}" },
+        "paragraph": { "$type": "dimension", "$value": "{core.space.3}" },
+        "action": { "$type": "dimension", "$value": "{core.space.4}" }
+      },
+      "layout": {
+        "group": { "$type": "dimension", "$value": "{core.space.5}" },
+        "section": { "$type": "dimension", "$value": "{core.space.6}" },
+        "sectionWide": { "$type": "dimension", "$value": "{core.space.8}" }
+      }
     }
   },
   "component": {


### PR DESCRIPTION
## Что изменено

- добавлены семантические токены вертикального ритма для связей `label → value`, `title → description`, `paragraph → paragraph`, `text → action` и межсекционных интервалов;
- в Design System v8 добавлены примитивы `TextStack` и `Prose`;
- удалены локальные inline-отступы из `CockpitHero` и контракта ролевого cockpit;
- нормализованы отступы в KPI, операционных карточках и заголовках `ExecutionDesignSystem`;
- применён единый текстовый ритм к `MoneyObligationCockpit`, используемому покупателем, продавцом, банком и другими денежными контурами;
- расширен design governance: новые cockpit-компоненты больше не могут возвращать inline-стили, literal colors или обход дизайн-системы;
- добавлены unit-проверки токенов, компонентов и мигрированных шаблонов.

## Почему

На экранах одинаковые смысловые связи использовали разные значения `gap` и локальные `margin`. Это создавало неодинаковый вертикальный ритм между заголовками, пояснениями, значениями KPI и действиями. Исправление вынесено в общий контракт, а не разложено по локальным CSS-патчам.

## Контракт интервалов

- label → value: 4 px;
- title → description: 8 px;
- paragraph → paragraph: 12 px;
- text → action: 16 px;
- группа → группа: 20 px;
- раздел → раздел: 24 px;
- широкий desktop-раздел: 32 px.

## Проверки

- `designSystemV8Foundation.test.ts` расширен проверками semantic spacing;
- добавлен `designSystemV8TextRhythm.test.tsx`;
- governance version повышена до 40;
- Netlify deploy-preview собран и опубликован без ошибок;
- GitHub Actions и browser/accessibility matrix ещё выполняются или находятся в очереди, поэтому PR остаётся draft.

## Preview

- https://deploy-preview-2838--gleaming-mandazi-bb9856.netlify.app

## Риски и границы

- изменение не затрагивает RBAC, данные сделки, банковскую логику, интеграции или state machine;
- `Prose` предназначен только для длинного текста; UI-компоненты используют `TextStack`;
- промышленная готовность не заявляется до успешного CI и визуальной проверки на 360/390/430/1280/1440 px для RU/EN/ZH.