### PR TITLE
Перезапустить canonical web-сборку для страницы ИИ

### DIFF
--- a/apps/web/.canonical-rebuild-ai-page
+++ b/apps/web/.canonical-rebuild-ai-page
@@ -1,0 +1,3 @@
+Canonical web rebuild trigger for the public AI-in-action page.
+Source feature commit: 676d5d452aaa4551facb1cd819d98a40a86cb323
+Triggered: 2026-07-20


### PR DESCRIPTION
## Цель

Принудительно запустить canonical `Build & Publish Canonical Docker Images` после объединения страницы `/platform-v7/demo/ai`.

## Изменение

Добавлен безопасный release-trigger внутри `apps/web/**`. Он не меняет поведение, интерфейс или runtime, но создаёт новый exact-main SHA и запускает canonical web image build/publish в GHCR.

## Production

После публикации нового `grainflow-web:latest` Watchtower должен обновить VPS. Если автоматическое обновление не произойдёт, потребуется только целевой `pull/up` сервиса `web` с проверкой OCI revision.