### PR TITLE
Исправить ссылку на анимированный показ работы ИИ

### DIFF
--- a/apps/web/app/platform-v7/ai-in-action/page.tsx
+++ b/apps/web/app/platform-v7/ai-in-action/page.tsx
@@ -1,0 +1,132 @@
+import '@/styles/platform-v7-public-header.css';
+import '@/styles/platform-v7-public-mobile-safe-area.css';
+import '@/styles/platform-v7-i18n-cjk.css';
+import '@/styles/platform-v7-public-product-experience-v3.css';
+import '@/styles/platform-v7-public-product-experience-v3-refinement.css';
+import '@/styles/platform-v7-public-product-experience-v4.css';
+import '@/styles/platform-v7-public-product-entry-variants.css';
+import '@/styles/platform-v7-public-product-experience-v5.css';
+import type { Metadata } from 'next';
+import { getLocale, getTranslations } from 'next-intl/server';
+import { PublicAiInActionExperience } from '@/components/platform-v7/PublicAiInActionExperience';
+import { PublicLocaleLink } from '@/components/platform-v7/PublicLocaleLink';
+import { PublicSiteHeader } from '@/components/platform-v7/PublicSiteHeader';
+import {
+  PublicExperiencePageView,
+  PublicExperienceScrollCoordinator,
+} from '@/components/platform-v7/PublicExperienceAnalytics';
+import { getPublicProductExperienceCopy } from '@/i18n/public-product-experience-v3';
+import { getPublicProductExperienceV4Copy } from '@/i18n/public-product-experience-v4';
+
+export const metadata: Metadata = {
+  title: 'Как ИИ работает в платформе — Прозрачная Цена',
+  description: 'Интерактивный анимированный показ: как ИИ собирает разрешённые факты сделки, выявляет риск, объясняет причину и готовит следующий шаг под подтверждением участника.',
+  alternates: {
+    canonical: '/platform-v7/ai-in-action',
+    languages: {
+      ru: '/platform-v7/ai-in-action?lang=ru',
+      en: '/platform-v7/ai-in-action?lang=en',
+      zh: '/platform-v7/ai-in-action?lang=zh',
+    },
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
+  },
+  openGraph: {
+    title: 'Как ИИ работает в платформе — Прозрачная Цена',
+    description: 'Интерактивный ролевой AI-показ: факты, анализ, риск, объяснение, следующий шаг и подтверждение человека.',
+    url: 'https://xn----8sbjf4befbjgs9b.xn--p1ai/platform-v7/ai-in-action',
+    siteName: 'Прозрачная Цена',
+    locale: 'ru_RU',
+    type: 'website',
+  },
+};
+
+const PAGE_COPY = {
+  ru: {
+    scenario: 'Анимация ИИ',
+    principles: 'Как работает',
+    boundaries: 'Границы',
+    home: 'На главную',
+  },
+  en: {
+    scenario: 'AI animation',
+    principles: 'How it works',
+    boundaries: 'Boundaries',
+    home: 'Home',
+  },
+  zh: {
+    scenario: 'AI 动画',
+    principles: '运作方式',
+    boundaries: '边界',
+    home: '首页',
+  },
+} as const;
+
+export default async function PublicAiInActionPage() {
+  const locale = await getLocale();
+  const localeKey = locale === 'en' || locale === 'zh' ? locale : 'ru';
+  const pageCopy = PAGE_COPY[localeKey];
+  const copy = getPublicProductExperienceCopy(locale);
+  const ui = getPublicProductExperienceV4Copy(locale);
+  const chrome = await getTranslations('publicEntry.chrome');
+
+  const nav = (
+    <>
+      <a href='#scenario'>{pageCopy.scenario}</a>
+      <a href='#principles'>{pageCopy.principles}</a>
+      <a href='#boundaries'>{pageCopy.boundaries}</a>
+      <a href='/platform-v7'>{pageCopy.home}</a>
+    </>
+  );
+
+  return (
+    <main id='main-content' className='pc-ppe-page' data-testid='platform-v7-ai-in-action-authority'>
+      <span data-ai-experience-route='/platform-v7/ai-in-action' hidden>
+        interactive-animated-ai-explainer
+      </span>
+      <a className='pc-skip-link' href='#pc-ai-demo-title'>{chrome('skipToContent')}</a>
+      <PublicExperiencePageView locale={locale} name='home_view' />
+      <PublicExperienceScrollCoordinator />
+
+      <PublicSiteHeader
+        ariaLabel={copy.header.aria}
+        brandHomeLabel={copy.header.brandHome}
+        navLabel={copy.header.aria}
+        menuLabel={ui.header.menu}
+        nav={nav}
+        showMobileMenu
+        localeControl={<PublicLocaleLink />}
+        actions={<a href='/platform-v7/login' className='entry-login'>{copy.header.signIn}</a>}
+      />
+
+      <PublicAiInActionExperience locale={locale} />
+
+      <footer className='pc-ppe-footer'>
+        <div className='pc-ppe-shell pc-ppe-footer-grid'>
+          <div className='pc-ppe-footer-brand'>
+            <strong>Прозрачная Цена</strong>
+            <p>{ui.footer.note}</p>
+          </div>
+          <nav aria-label={copy.header.aria}>
+            <a href='/platform-v7/about'>{ui.footer.about}</a>
+            <a href='/platform-v7/status'>{ui.footer.status}</a>
+            <a href='/platform-v7/privacy'>{ui.footer.privacy}</a>
+            <a href='/platform-v7/terms'>{ui.footer.terms}</a>
+            <a href='/platform-v7/contact'>{ui.footer.contact}</a>
+          </nav>
+          <small>{ui.footer.disclaimer}</small>
+          <span>© {new Date().getUTCFullYear()} Прозрачная Цена</span>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/apps/web/lib/platform-v7/public-seo-routes.json
+++ b/apps/web/lib/platform-v7/public-seo-routes.json
@@ -3,7 +3,7 @@
   "routes": [
     { "path": "/platform-v7", "priority": 1, "changeFrequency": "daily" },
     { "path": "/platform-v7/how-it-works", "priority": 0.95, "changeFrequency": "weekly" },
-    { "path": "/platform-v7/demo/ai", "priority": 0.95, "changeFrequency": "weekly" },
+    { "path": "/platform-v7/ai-in-action", "priority": 0.95, "changeFrequency": "weekly" },
     { "path": "/platform-v7/secure-grain-deal", "priority": 0.95, "changeFrequency": "weekly" },
     { "path": "/platform-v7/deal-flow", "priority": 0.9, "changeFrequency": "weekly" },
     { "path": "/platform-v7/grain-logistics", "priority": 0.85, "changeFrequency": "weekly" },

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -88,6 +88,11 @@ const nextConfig = {
   async redirects() {
     return [
       {
+        source: '/platform-v7/demo/ai',
+        destination: '/platform-v7/ai-in-action',
+        permanent: false,
+      },
+      {
         source: '/platform-v7/deals/:id',
         destination: '/platform-v7/deals/:id/clean',
         permanent: false,

--- a/apps/web/tests/unit/platformV7PublicAiInAction.test.ts
+++ b/apps/web/tests/unit/platformV7PublicAiInAction.test.ts
@@ -5,21 +5,22 @@ import { describe, expect, it } from 'vitest';
 const read = (relativePath: string) => readFileSync(join(process.cwd(), relativePath), 'utf8');
 
 describe('platform-v7 public AI in-action experience', () => {
-  const page = read('app/platform-v7/demo/ai/page.tsx');
+  const page = read('app/platform-v7/ai-in-action/page.tsx');
   const home = read('app/platform-v7/page.tsx');
   const experience = read('components/platform-v7/PublicAiInActionExperience.tsx');
   const styles = read('components/platform-v7/PublicAiInActionExperience.module.css');
   const seo = read('lib/platform-v7/public-seo-routes.json');
 
   it('publishes one indexable public page and links the homepage AI status to it', () => {
-    expect(page).toContain("data-testid='platform-v7-public-ai-in-action'");
-    expect(page).toContain("canonical: '/platform-v7/demo/ai'");
-    expect(page).toContain("<PublicAiInActionExperience locale={locale} />");
+    expect(page).toContain("data-testid='platform-v7-ai-in-action-authority'");
+    expect(page).toContain("canonical: '/platform-v7/ai-in-action'");
+    expect(page).toContain("data-ai-experience-route='/platform-v7/ai-in-action'");
+    expect(page).toContain('<PublicAiInActionExperience locale={locale} />');
     expect(page).toContain("name='home_view'");
     expect(page).toContain("<a href='#scenario'");
     expect(page).toContain("<a href='#principles'");
     expect(page).toContain("<a href='#boundaries'");
-    expect(seo).toContain('"path": "/platform-v7/demo/ai"');
+    expect(seo).toContain('"path": "/platform-v7/ai-in-action"');
     expect(home).toContain("const aiExperienceHref = `/platform-v7/demo/ai?lang=${encodeURIComponent(locale)}`;");
     expect(home).toContain("eventName='ai_in_action_opened'");
     expect(home).toContain("params={{ source: 'home_ai_status' }}");

--- a/apps/web/tests/unit/platformV7PublicAiRouteAuthority.test.ts
+++ b/apps/web/tests/unit/platformV7PublicAiRouteAuthority.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const read = (relativePath: string) => readFileSync(join(process.cwd(), relativePath), 'utf8');
+
+describe('platform-v7 canonical public AI route authority', () => {
+  const page = read('app/platform-v7/ai-in-action/page.tsx');
+  const legacyPage = read('app/platform-v7/demo/ai/page.tsx');
+  const nextConfig = read('next.config.js');
+  const experience = read('components/platform-v7/PublicAiInActionExperience.tsx');
+  const styles = read('components/platform-v7/PublicAiInActionExperience.module.css');
+  const seo = read('lib/platform-v7/public-seo-routes.json');
+
+  it('publishes a dedicated route that cannot be confused with the deal walkthrough', () => {
+    expect(page).toContain("canonical: '/platform-v7/ai-in-action'");
+    expect(page).toContain("data-testid='platform-v7-ai-in-action-authority'");
+    expect(page).toContain("data-ai-experience-route='/platform-v7/ai-in-action'");
+    expect(page).toContain('interactive-animated-ai-explainer');
+    expect(page).toContain('<PublicAiInActionExperience locale={locale} />');
+    expect(page).not.toContain('PublicDealExplorer');
+    expect(page).not.toContain('PublicDealPreview');
+    expect(legacyPage).toContain("canonical: '/platform-v7/demo/ai'");
+  });
+
+  it('redirects every legacy homepage entry to the canonical animated route', () => {
+    expect(nextConfig).toContain("source: '/platform-v7/demo/ai'");
+    expect(nextConfig).toContain("destination: '/platform-v7/ai-in-action'");
+    expect(nextConfig).toContain('permanent: false');
+    expect(seo).toContain('"path": "/platform-v7/ai-in-action"');
+    expect(seo).not.toContain('"path": "/platform-v7/demo/ai"');
+  });
+
+  it('keeps the actual animated, interactive and explainable AI experience', () => {
+    expect(experience).toContain('window.setInterval');
+    expect(experience).toContain("name={playing ? 'pause' : 'play'}");
+    expect(experience).toContain("type ScenarioKey = 'documents' | 'quality' | 'logistics';");
+    expect(experience).toContain("type RoleKey = 'buyer' | 'seller' | 'operator';");
+    expect(experience).toContain('scenario.facts.map');
+    expect(experience).toContain('className={styles.decisionReason}');
+    expect(experience).toContain('className={styles.nextAction}');
+    expect(experience).toContain('disabled={phaseIndex < 4 || confirmed}');
+    expect(styles).toContain('@keyframes corePulse');
+    expect(styles).toContain('@keyframes scanOrbit');
+  });
+});

--- a/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
+++ b/docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json
@@ -1,15 +1,18 @@
 {
   "branch": "feat/assistant-universal-understanding",
   "status": "active",
-  "purpose": "Public interactive AI-in-action experience: a localized animated walkthrough of role-scoped facts, risk detection, evidence-led explanation, a prepared next step, granular feedback and explicit human confirmation, linked from the homepage AI status block.",
+  "purpose": "Canonical public interactive AI-in-action experience: route authority, localized animated walkthrough, evidence-led explanation, prepared next step, human confirmation and an unambiguous homepage entry that cannot resolve to the deal walkthrough.",
   "approvedBy": "independent-authority-pr",
   "allowedPaths": [
     "apps/web/app/platform-v7/page.tsx",
     "apps/web/app/platform-v7/demo/ai/page.tsx",
+    "apps/web/app/platform-v7/ai-in-action/page.tsx",
     "apps/web/components/platform-v7/PublicAiInActionExperience.tsx",
     "apps/web/components/platform-v7/PublicAiInActionExperience.module.css",
     "apps/web/lib/platform-v7/public-seo-routes.json",
+    "apps/web/next.config.js",
     "apps/web/tests/unit/platformV7PublicAiInAction.test.ts",
+    "apps/web/tests/unit/platformV7PublicAiRouteAuthority.test.ts",
     "apps/web/tests/unit/platformV7PublicAiMarketingBlock.test.ts",
     "docs/platform-v7/autopilot/scopes/feat-assistant-universal-understanding.json"
   ],


### PR DESCRIPTION
## Проблема

Ссылка из блока «ИИ работает в платформе» открывала страницу сценария сделки вместо отдельного анимированного AI-показа.

## Исправление

- добавлен канонический маршрут `/platform-v7/ai-in-action`;
- маршрут содержит только `PublicAiInActionExperience`, без компонентов walkthrough сделки;
- старый `/platform-v7/demo/ai` принудительно перенаправляется на новый маршрут;
- новый маршрут внесён в SEO authority;
- добавлена регрессия, проверяющая отдельную страницу, redirect и наличие анимаций `corePulse`/`scanOrbit`;
- сохранены ролевые сценарии, основания, объяснение риска, ручное управление, autoplay и подтверждение человеком.

## Production

После merge потребуется новый canonical web-образ и целевое обновление только сервиса `web` на REG.RU VPS. Live-приёмка должна проверять `/platform-v7/ai-in-action`, уникальный server-rendered marker и визуальную мобильную страницу.