### PR TITLE
Опубликовать exact web-образ исправленной AI-страницы

### DIFF
--- a/.github/workflows/publish-ai-route-d6fe86.yml
+++ b/.github/workflows/publish-ai-route-d6fe86.yml
@@ -1,0 +1,87 @@
+name: Publish corrected animated AI web route d6fe86
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/publish-ai-route-d6fe86.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  TARGET_SHA: d6fe86b0d385adbca30a0039c5d9de2e771af4cb
+  IMAGE: ghcr.io/pachaninm-lab/grainflow-web
+
+jobs:
+  publish:
+    name: Build, publish and verify corrected AI route image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout exact accepted source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_SHA }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve immutable metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          echo "tag=sha-${TARGET_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and publish exact linux/amd64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile.web
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.meta.outputs.tag }}
+          build-args: |
+            BUILD_DATE=${{ steps.meta.outputs.build_date }}
+            GIT_COMMIT=${{ env.TARGET_SHA }}
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=max,scope=web
+
+      - name: Verify exact revision and architecture
+        shell: bash
+        run: |
+          set -euo pipefail
+          ref="${IMAGE}:${{ steps.meta.outputs.tag }}"
+          docker pull --platform linux/amd64 "$ref"
+          revision="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$ref")"
+          architecture="$(docker image inspect --format '{{ .Architecture }}' "$ref")"
+          echo "IMAGE_REF=$ref"
+          echo "REVISION=$revision"
+          echo "ARCHITECTURE=$architecture"
+          test "$revision" = "$TARGET_SHA"
+          test "$architecture" = amd64
+
+      - name: Verify corrected route contract in accepted source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f apps/web/app/platform-v7/ai-in-action/page.tsx
+          grep -Fq "data-ai-experience-route='/platform-v7/ai-in-action'" apps/web/app/platform-v7/ai-in-action/page.tsx
+          grep -Fq 'interactive-animated-ai-explainer' apps/web/app/platform-v7/ai-in-action/page.tsx
+          grep -Fq "source: '/platform-v7/demo/ai'" apps/web/next.config.js
+          grep -Fq "destination: '/platform-v7/ai-in-action'" apps/web/next.config.js
+          grep -Fq '@keyframes corePulse' apps/web/components/platform-v7/PublicAiInActionExperience.module.css
+          grep -Fq '@keyframes scanOrbit' apps/web/components/platform-v7/PublicAiInActionExperience.module.css
+          grep -Fq 'window.setInterval' apps/web/components/platform-v7/PublicAiInActionExperience.tsx


### PR DESCRIPTION
Одноразовый release workflow успешно собрал и опубликовал linux/amd64 web-образ строго из принятого main-коммита `d6fe86b0d385adbca30a0039c5d9de2e771af4cb` под immutable-тегом `sha-d6fe86b`. OCI revision, архитектура и контракт отдельного маршрута `/platform-v7/ai-in-action` проверены. Workflow-файл намеренно не объединяется в main.