### PR TITLE
TAI AP-13B.2b: add fail-closed verified build acceptance handoff

### DIFF
--- a/.github/workflows/tai-llama-toolchain-acceptance-handoff.yml
+++ b/.github/workflows/tai-llama-toolchain-acceptance-handoff.yml
@@ -1,0 +1,434 @@
+name: TAI llama.cpp Build Acceptance Handoff
+
+on:
+  workflow_run:
+    workflows:
+      - TAI llama.cpp Exact Source Build
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+jobs:
+  handoff:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.status == 'completed' &&
+      github.event.workflow_run.event == 'issue_comment' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.repository.full_name == github.repository
+    concurrency:
+      group: tai-llama-cpp-build-acceptance-handoff
+      cancel-in-progress: false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      SOURCE_WORKFLOW_NAME: TAI llama.cpp Exact Source Build
+      SOURCE_WORKFLOW_PATH: .github/workflows/tai-llama-toolchain-build.yml
+      ISSUE_NUMBER: '2832'
+      AUTHORITY_SHA256: 3064250e63baed7bdcfd20851e1d3ea2c86fc33f087b69a2a4fcff18c384374b
+      LLAMA_RELEASE: b9637
+      LLAMA_COMMIT: aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3
+      BUILD_PROFILE: linux-x86_64-cpu-release-static-v1
+
+    steps:
+      - name: Checkout exact triggering main
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate trusted source run and exact-main binding
+        id: source
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p handoff-work
+
+          gh api "repos/$REPOSITORY/actions/runs/$RUN_ID" \
+            > handoff-work/source-run.json
+          gh api "repos/$REPOSITORY/git/ref/heads/main" \
+            > handoff-work/main-ref.json
+          gh api --paginate --slurp \
+            "repos/$REPOSITORY/actions/runs/$RUN_ID/artifacts?per_page=100" \
+            > handoff-work/artifacts-pages.json
+
+          SOURCE_WORKFLOW_NAME="$SOURCE_WORKFLOW_NAME" \
+          SOURCE_WORKFLOW_PATH="$SOURCE_WORKFLOW_PATH" \
+          REPOSITORY="$REPOSITORY" \
+          RUN_ID="$RUN_ID" \
+          EVENT_HEAD_SHA="$EVENT_HEAD_SHA" \
+          AUTHORITY_SHA256="$AUTHORITY_SHA256" \
+          python - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          root = Path("handoff-work")
+          run = json.loads((root / "source-run.json").read_text())
+          main_ref = json.loads((root / "main-ref.json").read_text())
+          pages = json.loads((root / "artifacts-pages.json").read_text())
+          artifacts = [
+              artifact
+              for page in pages
+              for artifact in page.get("artifacts", [])
+          ]
+
+          expected_repo = os.environ["REPOSITORY"]
+          expected_run_id = int(os.environ["RUN_ID"])
+          expected_head_sha = os.environ["EVENT_HEAD_SHA"]
+          owner = expected_repo.split("/", 1)[0]
+
+          def require(condition: bool, reason: str) -> None:
+              if not condition:
+                  raise SystemExit(reason)
+
+          require(run.get("id") == expected_run_id, "SOURCE_RUN_ID_MISMATCH")
+          require(run.get("name") == os.environ["SOURCE_WORKFLOW_NAME"], "SOURCE_WORKFLOW_NAME_MISMATCH")
+          require(run.get("path") == os.environ["SOURCE_WORKFLOW_PATH"], "SOURCE_WORKFLOW_PATH_MISMATCH")
+          require(run.get("status") == "completed", "SOURCE_RUN_NOT_COMPLETED")
+          require(run.get("conclusion") == "success", "SOURCE_RUN_NOT_SUCCESSFUL")
+          require(run.get("event") == "issue_comment", "SOURCE_EVENT_NOT_ISSUE_COMMENT")
+          require(run.get("head_branch") == "main", "SOURCE_BRANCH_NOT_MAIN")
+          require(run.get("head_sha") == expected_head_sha, "SOURCE_HEAD_SHA_EVENT_MISMATCH")
+          require(re.fullmatch(r"[0-9a-f]{40}", expected_head_sha) is not None, "SOURCE_HEAD_SHA_INVALID")
+          require(run.get("repository", {}).get("full_name") == expected_repo, "SOURCE_REPOSITORY_MISMATCH")
+          require(run.get("head_repository", {}).get("full_name") == expected_repo, "SOURCE_HEAD_REPOSITORY_MISMATCH")
+          require(run.get("actor", {}).get("login") == owner, "SOURCE_ACTOR_NOT_OWNER")
+          require(run.get("triggering_actor", {}).get("login") == owner, "SOURCE_TRIGGERING_ACTOR_NOT_OWNER")
+          require(run.get("run_attempt", 0) >= 1, "SOURCE_RUN_ATTEMPT_INVALID")
+          require(main_ref.get("object", {}).get("sha") == expected_head_sha, "SOURCE_RUN_NOT_CURRENT_EXACT_MAIN")
+          require(os.popen("git rev-parse HEAD").read().strip() == expected_head_sha, "CHECKOUT_SHA_MISMATCH")
+          require(os.popen("git status --porcelain=v1 --untracked-files=all").read() == "", "CHECKOUT_NOT_CLEAN")
+
+          run_attempt = int(run["run_attempt"])
+          locator_name = f"tai-llama-toolchain-locator-{expected_head_sha}-{expected_run_id}-{run_attempt}"
+          package_name = f"tai-llama-toolchain-build-{expected_head_sha}-{expected_run_id}-{run_attempt}"
+          matching_locator = [
+              artifact for artifact in artifacts
+              if artifact.get("name") == locator_name and artifact.get("expired") is False
+          ]
+          matching_package = [
+              artifact for artifact in artifacts
+              if artifact.get("name") == package_name and artifact.get("expired") is False
+          ]
+          require(len(matching_locator) == 1, "LOCATOR_ARTIFACT_CARDINALITY_INVALID")
+          require(len(matching_package) == 1, "PACKAGE_ARTIFACT_CARDINALITY_INVALID")
+
+          locator = matching_locator[0]
+          package = matching_package[0]
+          for label, artifact in (("LOCATOR", locator), ("PACKAGE", package)):
+              require(isinstance(artifact.get("id"), int), f"{label}_ARTIFACT_ID_INVALID")
+              require(
+                  re.fullmatch(r"sha256:[0-9a-f]{64}", artifact.get("digest", "")) is not None,
+                  f"{label}_ARTIFACT_DIGEST_INVALID",
+              )
+              require(
+                  artifact.get("workflow_run", {}).get("id") == expected_run_id,
+                  f"{label}_ARTIFACT_RUN_ID_MISMATCH",
+              )
+              require(
+                  artifact.get("workflow_run", {}).get("head_branch") == "main",
+                  f"{label}_ARTIFACT_BRANCH_MISMATCH",
+              )
+              require(
+                  artifact.get("workflow_run", {}).get("head_sha") == expected_head_sha,
+                  f"{label}_ARTIFACT_HEAD_SHA_MISMATCH",
+              )
+
+          source = {
+              "run": run,
+              "locator_artifact": locator,
+              "package_artifact": package,
+          }
+          (root / "trusted-source.json").write_text(
+              json.dumps(source, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+          )
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as stream:
+              stream.write(f"locator_id={locator['id']}\n")
+              stream.write(f"locator_name={locator_name}\n")
+              stream.write(f"package_id={package['id']}\n")
+              stream.write(f"package_name={package_name}\n")
+              stream.write(f"head_sha={expected_head_sha}\n")
+              stream.write(f"run_attempt={run_attempt}\n")
+          PY
+
+      - name: Download only the locator artifact
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          LOCATOR_ID: ${{ steps.source.outputs.locator_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p handoff-work/locator
+          gh api "repos/$REPOSITORY/actions/artifacts/$LOCATOR_ID/zip" \
+            > handoff-work/locator.zip
+          test -s handoff-work/locator.zip
+          unzip -q handoff-work/locator.zip -d handoff-work/locator
+
+          find handoff-work/locator -type f -printf '%P\n' \
+            | LC_ALL=C sort > handoff-work/locator-files.txt
+          cat > handoff-work/expected-locator-files.txt <<'EOF'
+          llama-cpp-build-artifact-locator.v1.json
+          package-index.v1.json
+          restored-verification.v1.json
+          EOF
+          diff -u handoff-work/expected-locator-files.txt handoff-work/locator-files.txt
+
+      - name: Verify restored locator and create acceptance handoff
+        shell: bash
+        env:
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          SOURCE_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SOURCE_RUN_ATTEMPT: ${{ steps.source.outputs.run_attempt }}
+          LOCATOR_ARTIFACT_ID: ${{ steps.source.outputs.locator_id }}
+          LOCATOR_ARTIFACT_NAME: ${{ steps.source.outputs.locator_name }}
+          PACKAGE_ARTIFACT_ID: ${{ steps.source.outputs.package_id }}
+          PACKAGE_ARTIFACT_NAME: ${{ steps.source.outputs.package_name }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          root = Path("handoff-work")
+          locator_dir = root / "locator"
+          locator_path = locator_dir / "llama-cpp-build-artifact-locator.v1.json"
+          package_index_path = locator_dir / "package-index.v1.json"
+          restored_path = locator_dir / "restored-verification.v1.json"
+          trusted = json.loads((root / "trusted-source.json").read_text())
+          locator = json.loads(locator_path.read_text())
+          package_index = json.loads(package_index_path.read_text())
+          restored = json.loads(restored_path.read_text())
+
+          def digest(path: Path) -> str:
+              return hashlib.sha256(path.read_bytes()).hexdigest()
+
+          def require(condition: bool, reason: str) -> None:
+              if not condition:
+                  raise SystemExit(reason)
+
+          head_sha = os.environ["SOURCE_HEAD_SHA"]
+          run_id = int(os.environ["SOURCE_RUN_ID"])
+          run_attempt = int(os.environ["SOURCE_RUN_ATTEMPT"])
+          authority_sha = os.environ["AUTHORITY_SHA256"]
+          expected_targets = [
+              "llama-bench",
+              "llama-cli",
+              "llama-quantize",
+              "llama-server",
+          ]
+
+          require(locator.get("schema_version") == "tai.llama-cpp-build-artifact-locator.v1", "LOCATOR_SCHEMA_INVALID")
+          require(locator.get("status") == "VERIFIED_RESTORED", "LOCATOR_STATUS_INVALID")
+          require(locator.get("repository_sha") == head_sha, "LOCATOR_REPOSITORY_SHA_MISMATCH")
+          require(int(locator.get("workflow_run_id", -1)) == run_id, "LOCATOR_RUN_ID_MISMATCH")
+          require(int(locator.get("workflow_run_attempt", -1)) == run_attempt, "LOCATOR_RUN_ATTEMPT_MISMATCH")
+          require(str(locator.get("artifact", {}).get("id")) == os.environ["PACKAGE_ARTIFACT_ID"], "LOCATOR_PACKAGE_ID_MISMATCH")
+          require(locator.get("artifact", {}).get("name") == os.environ["PACKAGE_ARTIFACT_NAME"], "LOCATOR_PACKAGE_NAME_MISMATCH")
+          require(locator.get("artifact", {}).get("retention_days") == 90, "LOCATOR_RETENTION_INVALID")
+          require(
+              re.fullmatch(r"sha256:[0-9a-f]{64}", locator.get("artifact", {}).get("digest", "")) is not None,
+              "LOCATOR_PACKAGE_DIGEST_INVALID",
+          )
+          require(
+              locator["artifact"]["digest"] == trusted["package_artifact"]["digest"],
+              "LOCATOR_PACKAGE_API_DIGEST_MISMATCH",
+          )
+          require(locator.get("package_index", {}).get("sha256") == digest(package_index_path), "PACKAGE_INDEX_HASH_MISMATCH")
+          require(locator.get("package_index", {}).get("content") == package_index, "PACKAGE_INDEX_CONTENT_MISMATCH")
+          require(locator.get("restored_verification", {}).get("sha256") == digest(restored_path), "RESTORED_REPORT_HASH_MISMATCH")
+          require(locator.get("restored_verification", {}).get("content") == restored, "RESTORED_REPORT_CONTENT_MISMATCH")
+
+          require(package_index.get("schema_version") == "tai.llama-cpp-build-package-index.v1", "PACKAGE_INDEX_SCHEMA_INVALID")
+          require(package_index.get("status") == "PACKAGED", "PACKAGE_INDEX_STATUS_INVALID")
+          require(package_index.get("repository_sha") == head_sha, "PACKAGE_INDEX_REPOSITORY_SHA_MISMATCH")
+          require(int(package_index.get("workflow_run_id", -1)) == run_id, "PACKAGE_INDEX_RUN_ID_MISMATCH")
+          require(int(package_index.get("workflow_run_attempt", -1)) == run_attempt, "PACKAGE_INDEX_RUN_ATTEMPT_MISMATCH")
+          require(package_index.get("authority_sha256") == authority_sha, "PACKAGE_INDEX_AUTHORITY_MISMATCH")
+          require(package_index.get("retention_days") == 90, "PACKAGE_INDEX_RETENTION_INVALID")
+          for field in ("package", "build_evidence", "verification_report"):
+              record = package_index.get(field, {})
+              require(re.fullmatch(r"[0-9a-f]{64}", record.get("sha256", "")) is not None, f"{field.upper()}_HASH_INVALID")
+              require(isinstance(record.get("size_bytes"), int) and record["size_bytes"] > 0, f"{field.upper()}_SIZE_INVALID")
+
+          require(restored.get("status") == "VERIFIED", "RESTORED_STATUS_INVALID")
+          require(restored.get("reasons") == [], "RESTORED_REASONS_NOT_EMPTY")
+          require(restored.get("verified_targets") == expected_targets, "RESTORED_TARGETS_INVALID")
+
+          source_run = trusted["run"]
+          locator_artifact = trusted["locator_artifact"]
+          package_artifact = trusted["package_artifact"]
+          require(str(locator_artifact["id"]) == os.environ["LOCATOR_ARTIFACT_ID"], "LOCATOR_API_ID_MISMATCH")
+          require(locator_artifact["name"] == os.environ["LOCATOR_ARTIFACT_NAME"], "LOCATOR_API_NAME_MISMATCH")
+          require(str(package_artifact["id"]) == os.environ["PACKAGE_ARTIFACT_ID"], "PACKAGE_API_ID_MISMATCH")
+          require(package_artifact["name"] == os.environ["PACKAGE_ARTIFACT_NAME"], "PACKAGE_API_NAME_MISMATCH")
+
+          acceptance = {
+              "schema_version": "tai.llama-cpp-build-acceptance-handoff.v1",
+              "status": "VERIFIED_BUILD_READY_FOR_ACCEPTANCE_PR",
+              "issue": 2832,
+              "parent_issue": 2726,
+              "repository": os.environ["REPOSITORY"],
+              "repository_sha": head_sha,
+              "source_workflow": {
+                  "id": run_id,
+                  "run_number": source_run["run_number"],
+                  "run_attempt": run_attempt,
+                  "name": source_run["name"],
+                  "path": source_run["path"],
+                  "event": source_run["event"],
+                  "status": source_run["status"],
+                  "conclusion": source_run["conclusion"],
+                  "url": os.environ["SOURCE_RUN_URL"],
+                  "created_at": source_run["created_at"],
+                  "run_started_at": source_run["run_started_at"],
+                  "updated_at": source_run["updated_at"],
+              },
+              "authority": {
+                  "toolchain_name": "ggml-org/llama.cpp",
+                  "release": os.environ["LLAMA_RELEASE"],
+                  "commit": os.environ["LLAMA_COMMIT"],
+                  "profile_id": os.environ["BUILD_PROFILE"],
+                  "authority_sha256": authority_sha,
+              },
+              "locator_artifact": {
+                  "id": locator_artifact["id"],
+                  "name": locator_artifact["name"],
+                  "digest": locator_artifact["digest"],
+                  "size_bytes": locator_artifact["size_in_bytes"],
+                  "created_at": locator_artifact["created_at"],
+                  "expires_at": locator_artifact["expires_at"],
+              },
+              "package_artifact": {
+                  "id": package_artifact["id"],
+                  "name": package_artifact["name"],
+                  "digest": package_artifact["digest"],
+                  "size_bytes": package_artifact["size_in_bytes"],
+                  "created_at": package_artifact["created_at"],
+                  "expires_at": package_artifact["expires_at"],
+                  "retention_days": locator["artifact"]["retention_days"],
+              },
+              "locator": {
+                  "sha256": digest(locator_path),
+                  "content": locator,
+              },
+              "package": package_index["package"],
+              "build_evidence": package_index["build_evidence"],
+              "verification_report": package_index["verification_report"],
+              "restored_verification": {
+                  "sha256": digest(restored_path),
+                  "status": restored["status"],
+                  "reasons": restored["reasons"],
+                  "verified_targets": restored["verified_targets"],
+              },
+              "acceptance_requirements": {
+                  "separate_pull_request_required": True,
+                  "exact_head_and_exact_main_gates_required": True,
+                  "commit_only_locator_and_machine_readable_metadata": True,
+                  "close_issue_only_after_merge": True,
+              },
+              "model_acquisition_status": "PENDING_ACQUISITION",
+              "model_admission_status": "NOT_DONE",
+              "production_operational_status": "NOT_ATTESTED",
+          }
+          handoff_path = root / "llama-cpp-build-acceptance-handoff.v1.json"
+          handoff_path.write_text(
+              json.dumps(acceptance, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+          )
+
+          locator_text = locator_path.read_text()
+          handoff_text = handoff_path.read_text()
+          body = (
+              "<!-- tai-llama-cpp-build-acceptance-handoff:v1 -->\n"
+              f"## AP-13B.2b verified build handoff — run `{run_id}`\n\n"
+              f"- exact main: `{head_sha}`\n"
+              f"- restored status: `{restored['status']}`\n"
+              f"- package SHA-256: `{package_index['package']['sha256']}`\n"
+              f"- package bytes: `{package_index['package']['size_bytes']}`\n"
+              f"- operational status: `NOT_ATTESTED`\n"
+              f"- next authority step: separate exact-head/exact-main acceptance PR; do not close #2832 before merge.\n\n"
+              "<details><summary>Machine-readable acceptance handoff</summary>\n\n"
+              "```json\n" + handoff_text + "```\n"
+              "</details>\n\n"
+              "<details><summary>Exact restored locator</summary>\n\n"
+              "```json\n" + locator_text + "```\n"
+              "</details>\n"
+          )
+          require(len(body.encode("utf-8")) < 60000, "ISSUE_COMMENT_TOO_LARGE")
+          (root / "issue-comment.md").write_text(body)
+          request = {"body": body}
+          (root / "issue-comment-request.json").write_text(
+              json.dumps(request, ensure_ascii=False)
+          )
+          PY
+
+      - name: Publish immutable-metadata handoff to issue 2832
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          marker="tai-llama-cpp-build-acceptance-handoff:v1"
+          duplicate_count="$(
+            gh api --paginate "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" \
+              --jq "[.[] | select(.body | contains(\"$marker\")) | select(.body | contains(\"run \`$RUN_ID\`\"))] | length" \
+              | awk '{sum += $1} END {print sum + 0}'
+          )"
+          test "$duplicate_count" = '0'
+          gh api \
+            --method POST \
+            "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments" \
+            --input handoff-work/issue-comment-request.json \
+            > handoff-work/published-comment.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          published = json.loads(Path("handoff-work/published-comment.json").read_text())
+          body = published.get("body", "")
+          assert published.get("id")
+          assert "tai-llama-cpp-build-acceptance-handoff:v1" in body
+          assert "VERIFIED_BUILD_READY_FOR_ACCEPTANCE_PR" in body
+          assert "NOT_ATTESTED" in body
+          PY
+
+      - name: Publish handoff summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          handoff = json.loads(
+              Path("handoff-work/llama-cpp-build-acceptance-handoff.v1.json").read_text()
+          )
+          print("## TAI llama.cpp build acceptance handoff")
+          print(f"- repository SHA: `{handoff['repository_sha']}`")
+          print(f"- source run: `{handoff['source_workflow']['id']}`")
+          print(f"- status: `{handoff['status']}`")
+          print(f"- package SHA-256: `{handoff['package']['sha256']}`")
+          print(f"- locator artifact: `{handoff['locator_artifact']['id']}`")
+          print(f"- operational status: `{handoff['production_operational_status']}`")
+          PY

--- a/apps/tai/governance/scopes/ap-13b2b-acceptance-handoff-2832.json
+++ b/apps/tai/governance/scopes/ap-13b2b-acceptance-handoff-2832.json
@@ -1,0 +1,35 @@
+{
+  "acceptance": [
+    "workflow_run is bound to the accepted TAI llama.cpp Exact Source Build workflow",
+    "source run must be completed success, issue_comment-triggered, owner-operated, main-bound and current exact main",
+    "source workflow path, repository, head repository, SHA and run attempt are checked fail-closed",
+    "exactly one unexpired package artifact and one unexpired locator artifact are required",
+    "only the small locator artifact is downloaded; the build package is never downloaded",
+    "locator, package index and restored report hashes and embedded content are independently checked",
+    "authority digest, release, commit, profile, four targets and VERIFIED empty-reasons state are exact",
+    "handoff comment carries the exact locator and machine-readable acceptance metadata under 60000 bytes",
+    "handoff explicitly requires a separate exact-head and exact-main acceptance PR before issue closure",
+    "production_operational_status remains NOT_ATTESTED",
+    "Ruff, strict mypy, full pytest/coverage, workflow security and exact-head CI pass"
+  ],
+  "allowed_paths": [
+    ".github/workflows/tai-llama-toolchain-acceptance-handoff.yml",
+    "apps/tai/governance/scopes/ap-13b2b-acceptance-handoff-2832.json",
+    "apps/tai/tests/test_llama_toolchain_acceptance_handoff_workflow.py"
+  ],
+  "branch": "agent/tai-ap-13b2b-build-acceptance-handoff",
+  "forbidden_capabilities": [
+    "download, commit or expose the build package, source checkout, logs or compiled binaries",
+    "accept or close issue 2832 without a separate reviewed exact-head and exact-main pull request",
+    "run from pull_request, push, schedule, workflow_dispatch or an untrusted workflow",
+    "accept a source run that is not owner-triggered issue_comment success on current exact main",
+    "repository contents write, pull-request write, secret, package or OIDC access",
+    "model download, legal approval, conversion, quantization, benchmark or admission claim",
+    "production readiness or operational attestation claim"
+  ],
+  "issue": 2832,
+  "maturity_boundary": "verified-build-metadata-handoff-without-build-acceptance-or-operational-attestation",
+  "parent_issue": 2726,
+  "schema_version": "tai.concurrent-scope.v1",
+  "status": "active"
+}

--- a/apps/tai/tests/test_llama_toolchain_acceptance_handoff_workflow.py
+++ b/apps/tai/tests/test_llama_toolchain_acceptance_handoff_workflow.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).parents[3]
+WORKFLOW_PATH = (
+    ROOT / ".github" / "workflows" / "tai-llama-toolchain-acceptance-handoff.yml"
+)
+SCOPE_PATH = (
+    Path(__file__).parents[1]
+    / "governance"
+    / "scopes"
+    / "ap-13b2b-acceptance-handoff-2832.json"
+)
+
+EXPECTED_PATHS = {
+    ".github/workflows/tai-llama-toolchain-acceptance-handoff.yml",
+    "apps/tai/governance/scopes/ap-13b2b-acceptance-handoff-2832.json",
+    "apps/tai/tests/test_llama_toolchain_acceptance_handoff_workflow.py",
+}
+AUTHORITY_SHA256 = "3064250e63baed7bdcfd20851e1d3ea2c86fc33f087b69a2a4fcff18c384374b"
+LLAMA_COMMIT = "aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3"
+
+
+def workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def test_scope_is_exact_and_preserves_the_acceptance_boundary() -> None:
+    scope = json.loads(SCOPE_PATH.read_text(encoding="utf-8"))
+
+    assert scope["schema_version"] == "tai.concurrent-scope.v1"
+    assert scope["branch"] == "agent/tai-ap-13b2b-build-acceptance-handoff"
+    assert scope["status"] == "active"
+    assert scope["parent_issue"] == 2726
+    assert scope["issue"] == 2832
+    assert set(scope["allowed_paths"]) == EXPECTED_PATHS
+    assert len(scope["allowed_paths"]) == len(EXPECTED_PATHS)
+    assert any(
+        "separate exact-head and exact-main acceptance PR" in item
+        for item in scope["acceptance"]
+    )
+    assert "production readiness or operational attestation claim" in scope[
+        "forbidden_capabilities"
+    ]
+
+
+def test_handoff_is_bound_only_to_the_trusted_completed_build_workflow() -> None:
+    workflow = workflow_text()
+
+    assert "workflow_run:" in workflow
+    assert "TAI llama.cpp Exact Source Build" in workflow
+    assert "types:\n      - completed" in workflow
+    assert "pull_request:" not in workflow
+    assert "push:" not in workflow
+    assert "schedule:" not in workflow
+    assert "workflow_dispatch:" not in workflow
+    assert "issue_comment:" not in workflow.split("permissions:", 1)[0]
+    assert "github.event.workflow_run.conclusion == 'success'" in workflow
+    assert "github.event.workflow_run.status == 'completed'" in workflow
+    assert "github.event.workflow_run.event == 'issue_comment'" in workflow
+    assert "github.event.workflow_run.head_branch == 'main'" in workflow
+    assert "SOURCE_WORKFLOW_PATH: .github/workflows/tai-llama-toolchain-build.yml" in workflow
+
+
+def test_handoff_has_only_required_read_and_issue_comment_permissions() -> None:
+    workflow = workflow_text()
+
+    assert "permissions:\n  contents: read\n  actions: read\n  issues: write" in workflow
+    for forbidden in (
+        "contents: write",
+        "pull-requests: write",
+        "packages: write",
+        "id-token: write",
+        "secrets.",
+    ):
+        assert forbidden not in workflow
+    assert workflow.count("persist-credentials: false") == 1
+
+
+def test_source_run_and_artifact_identity_are_checked_fail_closed() -> None:
+    workflow = workflow_text()
+
+    required = (
+        "SOURCE_RUN_ID_MISMATCH",
+        "SOURCE_WORKFLOW_NAME_MISMATCH",
+        "SOURCE_WORKFLOW_PATH_MISMATCH",
+        "SOURCE_RUN_NOT_COMPLETED",
+        "SOURCE_RUN_NOT_SUCCESSFUL",
+        "SOURCE_EVENT_NOT_ISSUE_COMMENT",
+        "SOURCE_BRANCH_NOT_MAIN",
+        "SOURCE_HEAD_SHA_EVENT_MISMATCH",
+        "SOURCE_REPOSITORY_MISMATCH",
+        "SOURCE_HEAD_REPOSITORY_MISMATCH",
+        "SOURCE_ACTOR_NOT_OWNER",
+        "SOURCE_TRIGGERING_ACTOR_NOT_OWNER",
+        "SOURCE_RUN_NOT_CURRENT_EXACT_MAIN",
+        "CHECKOUT_SHA_MISMATCH",
+        "CHECKOUT_NOT_CLEAN",
+        "LOCATOR_ARTIFACT_CARDINALITY_INVALID",
+        "PACKAGE_ARTIFACT_CARDINALITY_INVALID",
+    )
+    for reason in required:
+        assert reason in workflow
+    assert 're.fullmatch(r"[0-9a-f]{40}", expected_head_sha)' in workflow
+    assert "repos/$REPOSITORY/git/ref/heads/main" in workflow
+    assert "actions/runs/$RUN_ID/artifacts?per_page=100" in workflow
+
+
+def test_handoff_downloads_only_the_small_locator_artifact() -> None:
+    workflow = workflow_text()
+    download_step = workflow[
+        workflow.index("      - name: Download only the locator artifact") :
+        workflow.index("      - name: Verify restored locator and create acceptance handoff")
+    ]
+
+    assert 'actions/artifacts/$LOCATOR_ID/zip' in download_step
+    assert "locator.zip" in download_step
+    assert "package-index.v1.json" in download_step
+    assert "restored-verification.v1.json" in download_step
+    assert "llama-cpp-build-artifact-locator.v1.json" in download_step
+    assert "PACKAGE_ARTIFACT_ID" not in download_step
+    assert "llama-cpp-b9637-evidence.tar.gz" not in download_step
+    assert "llama-cli" not in download_step
+    assert "llama-server" not in download_step
+    assert "llama-quantize" not in download_step
+    assert "llama-bench" not in download_step
+
+
+def test_locator_restore_and_exact_authority_are_independently_verified() -> None:
+    workflow = workflow_text()
+
+    assert "tai.llama-cpp-build-artifact-locator.v1" in workflow
+    assert "VERIFIED_RESTORED" in workflow
+    assert "tai.llama-cpp-build-package-index.v1" in workflow
+    assert "PACKAGED" in workflow
+    assert "RESTORED_STATUS_INVALID" in workflow
+    assert 'restored.get("reasons") == []' in workflow
+    assert AUTHORITY_SHA256 in workflow
+    assert "LLAMA_RELEASE: b9637" in workflow
+    assert f"LLAMA_COMMIT: {LLAMA_COMMIT}" in workflow
+    assert "BUILD_PROFILE: linux-x86_64-cpu-release-static-v1" in workflow
+    for target in ("llama-bench", "llama-cli", "llama-quantize", "llama-server"):
+        assert f'"{target}"' in workflow
+    assert "PACKAGE_INDEX_HASH_MISMATCH" in workflow
+    assert "RESTORED_REPORT_HASH_MISMATCH" in workflow
+    assert "LOCATOR_PACKAGE_API_DIGEST_MISMATCH" in workflow
+
+
+def test_handoff_is_machine_readable_duplicate_safe_and_not_an_acceptance_claim() -> None:
+    workflow = workflow_text()
+
+    assert "tai.llama-cpp-build-acceptance-handoff.v1" in workflow
+    assert "VERIFIED_BUILD_READY_FOR_ACCEPTANCE_PR" in workflow
+    assert "separate_pull_request_required" in workflow
+    assert "exact_head_and_exact_main_gates_required" in workflow
+    assert "close_issue_only_after_merge" in workflow
+    assert "tai-llama-cpp-build-acceptance-handoff:v1" in workflow
+    assert 'test "$duplicate_count" = \'0\'' in workflow
+    assert "len(body.encode(\"utf-8\")) < 60000" in workflow
+    assert '"production_operational_status": "NOT_ATTESTED"' in workflow
+    assert '"model_admission_status": "NOT_DONE"' in workflow
+    assert '"model_acquisition_status": "PENDING_ACQUISITION"' in workflow
+    assert "ADMITTED" not in workflow
+    assert "contents: write" not in workflow
+    assert "gh pr create" not in workflow
+    assert "git push" not in workflow


### PR DESCRIPTION
## Summary

Closes the missing transition between the real owner-triggered llama.cpp build and the separately reviewed acceptance PR for #2832.

- listens only to successful completed runs of `TAI llama.cpp Exact Source Build`;
- requires owner-triggered `issue_comment`, exact workflow path, same repository, `main` and current exact-main SHA;
- requires exactly one unexpired package artifact and one unexpired locator artifact for the exact run attempt;
- downloads only the small locator artifact, never the build package, source checkout, logs or binaries;
- independently validates locator/package-index/restored-report hashes, API artifact identities, authority digest, release, commit, profile and all four targets;
- publishes the exact locator and machine-readable `VERIFIED_BUILD_READY_FOR_ACCEPTANCE_PR` handoff to issue #2832;
- requires a separate exact-head/exact-main acceptance PR before issue closure.

## Security and maturity boundary

Permissions are limited to `contents: read`, `actions: read`, and `issues: write`. No contents write, PR write, packages, OIDC, secrets, model download, conversion, quantization, benchmark or admission is introduced.

This PR does not accept the real build and does not close #2832. `production_operational_status` remains `NOT_ATTESTED`; Qwen and Mistral remain `PENDING_ACQUISITION`.

## Exact scope

Exactly three new files:

- `.github/workflows/tai-llama-toolchain-acceptance-handoff.yml`;
- `apps/tai/governance/scopes/ap-13b2b-acceptance-handoff-2832.json`;
- `apps/tai/tests/test_llama_toolchain_acceptance_handoff_workflow.py`.

Part of #2832 and #2726.