### PR TITLE
TAI AP-13B.2b: accept verified restored llama.cpp build

### DIFF
--- a/apps/tai/governance/scopes/ap-13b2b-build-acceptance-2832.json
+++ b/apps/tai/governance/scopes/ap-13b2b-build-acceptance-2832.json
@@ -1,0 +1,32 @@
+{
+  "acceptance": [
+    "owner-triggered build run 29727061145 completed successfully on exact-main 637d36f7e9bb152ee3c7b22545a9a83eca3e4388",
+    "all four governed build, package, restore and independent verification steps passed",
+    "package artifact 8454821423 and locator artifact 8454825634 are immutable, SHA-256-bound, unexpired and retained for 90 days",
+    "committed locator has status VERIFIED_RESTORED and restored report has status VERIFIED with no reasons",
+    "all four binary target sizes and SHA-256 values are recorded as metadata without committing binaries",
+    "changes after the build through acceptance base b411a960cc259919e701704bfa652bd06d33c7d8 do not touch TAI or llama.cpp authority paths",
+    "Qwen and Mistral remain PENDING_ACQUISITION; legal review and benchmarks remain NOT_DONE",
+    "production_operational_status remains NOT_ATTESTED",
+    "Ruff, strict mypy, full pytest/coverage, security/runtime and exact-head/exact-main gates pass"
+  ],
+  "allowed_paths": [
+    "apps/tai/governance/scopes/ap-13b2b-build-acceptance-2832.json",
+    "apps/tai/model-artifacts/llama-cpp-build-acceptance.v1.json",
+    "apps/tai/model-artifacts/llama-cpp-build-artifact-locator.accepted.v1.json",
+    "apps/tai/tests/test_llama_toolchain_build_acceptance.py"
+  ],
+  "branch": "agent/tai-ap-13b2b-build-acceptance",
+  "forbidden_capabilities": [
+    "committed source archive, build package, log or compiled binary",
+    "model download, conversion, quantization or GGUF claim",
+    "automated legal approval",
+    "benchmark or model admission claim",
+    "production readiness or operational attestation claim"
+  ],
+  "issue": 2832,
+  "maturity_boundary": "verified-restored-llama-toolchain-build-without-model-or-operational-admission",
+  "parent_issue": 2726,
+  "schema_version": "tai.concurrent-scope.v1",
+  "status": "active"
+}

--- a/apps/tai/model-artifacts/llama-cpp-build-acceptance.v1.json
+++ b/apps/tai/model-artifacts/llama-cpp-build-acceptance.v1.json
@@ -1,0 +1,242 @@
+{
+  "authority": {
+    "authority_sha256": "3064250e63baed7bdcfd20851e1d3ea2c86fc33f087b69a2a4fcff18c384374b",
+    "commit": "aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3",
+    "profile_id": "linux-x86_64-cpu-release-static-v1",
+    "release": "b9637",
+    "repository_uri": "https://github.com/ggml-org/llama.cpp",
+    "toolchain_name": "ggml-org/llama.cpp"
+  },
+  "authority_continuity": {
+    "acceptance_base_sha": "b411a960cc259919e701704bfa652bd06d33c7d8",
+    "authority_changed": false,
+    "build_repository_sha": "637d36f7e9bb152ee3c7b22545a9a83eca3e4388",
+    "changed_paths": [
+      "apps/web/app/platform-v7/layout.tsx",
+      "apps/web/app/platform-v7/page.tsx",
+      "apps/web/tests/unit/platformV7PublicAiRouteAuthority.test.ts",
+      "docs/platform-v7/autopilot/scopes/fix-public-ai-layout-authority.json",
+      "scripts/p7-autopilot-guard.sh"
+    ],
+    "commits_after_build": 7,
+    "compare_status": "ahead"
+  },
+  "build_run": {
+    "actor": "pachaninm-lab",
+    "command": "/tai build llama-cpp exact-main",
+    "completed_at": "2026-07-20T08:18:51Z",
+    "event": "issue_comment",
+    "repository_sha": "637d36f7e9bb152ee3c7b22545a9a83eca3e4388",
+    "run_attempt": 1,
+    "run_id": 29727061145,
+    "started_at": "2026-07-20T08:12:01Z",
+    "triggering_actor": "pachaninm-lab",
+    "workflow_name": "TAI llama.cpp Exact Source Build",
+    "workflow_path": ".github/workflows/tai-llama-toolchain-build.yml"
+  },
+  "evidence": {
+    "binaries": [
+      {
+        "path": "build/llama.cpp-b9637/bin/llama-cli",
+        "sha256": "1f97b492e7739ec9e10b9a7da5317a27b70845873d060b7ede2c2d2f3e92f849",
+        "size_bytes": 12399720,
+        "target": "llama-cli"
+      },
+      {
+        "path": "build/llama.cpp-b9637/bin/llama-server",
+        "sha256": "1b26384ad90d9ae8fe65b2a3e2dfd08c70d92663b2127d5f479f34774b4a6dbf",
+        "size_bytes": 12940416,
+        "target": "llama-server"
+      },
+      {
+        "path": "build/llama.cpp-b9637/bin/llama-quantize",
+        "sha256": "77ae93aca41abd98f6b1e63478c09de77ab558d11d6cea6f1f53949310920e20",
+        "size_bytes": 5616560,
+        "target": "llama-quantize"
+      },
+      {
+        "path": "build/llama.cpp-b9637/bin/llama-bench",
+        "sha256": "eac9d7ee5e75a84668755caf44a09d3e1c5907d2b88fab205c27ad1e57bef335",
+        "size_bytes": 10023592,
+        "target": "llama-bench"
+      }
+    ],
+    "build_manifest": {
+      "path": "llama-evidence/evidence/llama-cpp-build.v1.json",
+      "sha256": "44f8aaefa9ba250cd2f523d07de9e084d9d8cc2a8bd0f17430e4a299aa35e1a1",
+      "size_bytes": 4531
+    },
+    "commands": {
+      "build": [
+        "cmake",
+        "--build",
+        "build/llama.cpp-b9637",
+        "--config",
+        "Release",
+        "--target",
+        "llama-cli",
+        "llama-server",
+        "llama-quantize",
+        "llama-bench",
+        "--parallel",
+        "2"
+      ],
+      "configure": [
+        "cmake",
+        "-S",
+        "source/llama.cpp",
+        "-B",
+        "build/llama.cpp-b9637",
+        "-G",
+        "Ninja",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DLLAMA_BUILD_COMMON=ON",
+        "-DLLAMA_BUILD_TESTS=OFF",
+        "-DLLAMA_BUILD_EXAMPLES=OFF",
+        "-DLLAMA_BUILD_TOOLS=ON",
+        "-DLLAMA_BUILD_SERVER=ON",
+        "-DLLAMA_BUILD_APP=OFF",
+        "-DLLAMA_BUILD_UI=OFF",
+        "-DLLAMA_USE_PREBUILT_UI=OFF",
+        "-DLLAMA_TOOLS_INSTALL=OFF",
+        "-DLLAMA_OPENSSL=OFF",
+        "-DLLAMA_LLGUIDANCE=OFF",
+        "-DGGML_NATIVE=OFF"
+      ]
+    },
+    "environment": {
+      "architecture": "x86_64",
+      "c_compiler": {
+        "executable": "/usr/bin/cc",
+        "output": {
+          "path": "evidence/cc-version.txt",
+          "sha256": "3e8cc208c40f60832f67377aa1b03c3e7e858f20cd5d365464944700c0bd7ad1",
+          "size_bytes": 245
+        },
+        "version": "cc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0"
+      },
+      "cmake": {
+        "executable": "/usr/local/bin/cmake",
+        "output": {
+          "path": "evidence/cmake-version.txt",
+          "sha256": "f6e81c2559f3ce00c5fdad01d7b226c301f5d6b07ee04f65db6dbfdc1cc5970b",
+          "size_bytes": 91
+        },
+        "version": "cmake version 3.31.6"
+      },
+      "cxx_compiler": {
+        "executable": "/usr/bin/c++",
+        "output": {
+          "path": "evidence/cxx-version.txt",
+          "sha256": "88b7c4b67564a146863224148116065fee418539f0a408f3636a68f3bde51805",
+          "size_bytes": 246
+        },
+        "version": "c++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0"
+      },
+      "generator": "Ninja",
+      "operating_system": "linux"
+    },
+    "logs": {
+      "build_log": {
+        "path": "evidence/build.log",
+        "sha256": "8b376133956adeb36f911a07dff91e2f10826f2dbf586751f177bca2c78999e0",
+        "size_bytes": 23869
+      },
+      "cmake_cache": {
+        "path": "build/llama.cpp-b9637/CMakeCache.txt",
+        "sha256": "b86f6f42a7ad5e049cfa2c10ebc7e89f716a55cb454105e9a3e246e71224a4bf",
+        "size_bytes": 31648
+      },
+      "configure_log": {
+        "path": "evidence/configure.log",
+        "sha256": "fab4d0c10fd974122c32619038accfc8ad82930d8d617cac3d5462096332029e",
+        "size_bytes": 1506
+      }
+    },
+    "source": {
+      "checkout_path": "source/llama.cpp",
+      "checkout_tree_sha256": "529bad4b20bf533b7f19c35513cc61103b8277f0c33ceb8ccff43171fd336ea9",
+      "git_head_output": {
+        "path": "evidence/git-head.txt",
+        "sha256": "c12f8a2d5dc09d4f84fccd5c20f948c93693f9d9916b0437b47946ccf99ef479",
+        "size_bytes": 41
+      },
+      "git_status_output": {
+        "path": "evidence/git-status.txt",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size_bytes": 0
+      },
+      "source_archive": {
+        "path": "source/llama.cpp-aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3.tar.gz",
+        "sha256": "3857876e4a2461f7041166bd74b5d39e3db51b8639353d55f87d6f904b3b75bd",
+        "size_bytes": 34876966
+      }
+    },
+    "verification_report": {
+      "evidence_sha256": "a1d58c34ca8e6184156abc12c310eb144cbac8996a7b0a0552e89fce468e0cac",
+      "path": "llama-evidence/evidence/llama-cpp-verification.v1.json",
+      "reasons": [],
+      "report_sha256": "d3284b22f4f2e64d79db3c4bad58877731cd04e02d082826aa6a72967aa04b51",
+      "sha256": "b8140f52ef9da5c3c1a6a7340107076a307665b50695ec2b6bd1a2a5f7e37040",
+      "size_bytes": 1023,
+      "status": "VERIFIED"
+    },
+    "verified_targets": [
+      "llama-bench",
+      "llama-cli",
+      "llama-quantize",
+      "llama-server"
+    ]
+  },
+  "external_artifacts": {
+    "locator_artifact": {
+      "api_digest": "sha256:db5f9213178f3bdd3e24c2e28fa979df705ebd78e03d4f9217f3fea5412e6227",
+      "committed_locator_path": "apps/tai/model-artifacts/llama-cpp-build-artifact-locator.accepted.v1.json",
+      "committed_locator_sha256": "64cc5bbd6d310491b21d8e24244ca6219b7caa91a8051b38b0d9e6efe234c159",
+      "expires_at": "2026-10-18T08:12:02Z",
+      "id": 8454825634,
+      "name": "tai-llama-toolchain-locator-637d36f7e9bb152ee3c7b22545a9a83eca3e4388-29727061145-1",
+      "retention_days": 90,
+      "zip_size_bytes": 5389
+    },
+    "package_artifact": {
+      "api_digest": "sha256:807f815e0265096150d87b4ff289d02e26fcd1d83cca891957c66a4e39054e52",
+      "expires_at": "2026-10-18T08:12:02Z",
+      "id": 8454821423,
+      "name": "tai-llama-toolchain-build-637d36f7e9bb152ee3c7b22545a9a83eca3e4388-29727061145-1",
+      "payload_sha256": "b742781c628fb1ab5ef1341e9937bb1d7a76cd96afaaf904d71d20554fa6a450",
+      "payload_size_bytes": 135198377,
+      "retention_days": 90,
+      "zip_size_bytes": 135199864
+    }
+  },
+  "issue": 2832,
+  "maturity_boundary": {
+    "accepted_use": [
+      "AP-13B.3 exact-source conversion evidence",
+      "AP-13B.3 governed quantization evidence",
+      "AP-13C benchmark execution"
+    ],
+    "benchmarks": "NOT_DONE",
+    "forbidden_claims": [
+      "model weights acquired",
+      "license approved",
+      "model admitted",
+      "production ready",
+      "operationally attested"
+    ],
+    "legal_review": "NOT_DONE",
+    "model_acquisition": "PENDING_ACQUISITION",
+    "model_admission": "NOT_DONE",
+    "production_operational_status": "NOT_ATTESTED"
+  },
+  "restore": {
+    "independent_reverification": true,
+    "package_index_sha256": "6a70beb3d653e9cad578f18a2dcf7b5df8761e26c309edd83255dff6db711c4a",
+    "restored_verification_sha256": "b8140f52ef9da5c3c1a6a7340107076a307665b50695ec2b6bd1a2a5f7e37040",
+    "status": "VERIFIED_RESTORED"
+  },
+  "schema_version": "tai.llama-cpp-build-acceptance.v1",
+  "status": "VERIFIED_RESTORED"
+}

--- a/apps/tai/model-artifacts/llama-cpp-build-artifact-locator.accepted.v1.json
+++ b/apps/tai/model-artifacts/llama-cpp-build-artifact-locator.accepted.v1.json
@@ -1,0 +1,73 @@
+{
+  "artifact": {
+    "digest": "807f815e0265096150d87b4ff289d02e26fcd1d83cca891957c66a4e39054e52",
+    "id": "8454821423",
+    "name": "tai-llama-toolchain-build-637d36f7e9bb152ee3c7b22545a9a83eca3e4388-29727061145-1",
+    "retention_days": 90,
+    "url": "https://github.com/pachaninm-lab/pachanin-demo/actions/runs/29727061145/artifacts/8454821423"
+  },
+  "package_index": {
+    "content": {
+      "authority_sha256": "3064250e63baed7bdcfd20851e1d3ea2c86fc33f087b69a2a4fcff18c384374b",
+      "build_evidence": {
+        "path": "llama-evidence/evidence/llama-cpp-build.v1.json",
+        "sha256": "44f8aaefa9ba250cd2f523d07de9e084d9d8cc2a8bd0f17430e4a299aa35e1a1",
+        "size_bytes": 4531
+      },
+      "package": {
+        "path": "llama-cpp-b9637-evidence.tar.gz",
+        "sha256": "b742781c628fb1ab5ef1341e9937bb1d7a76cd96afaaf904d71d20554fa6a450",
+        "size_bytes": 135198377
+      },
+      "repository_sha": "637d36f7e9bb152ee3c7b22545a9a83eca3e4388",
+      "retention_days": 90,
+      "schema_version": "tai.llama-cpp-build-package-index.v1",
+      "status": "PACKAGED",
+      "verification_report": {
+        "path": "llama-evidence/evidence/llama-cpp-verification.v1.json",
+        "sha256": "b8140f52ef9da5c3c1a6a7340107076a307665b50695ec2b6bd1a2a5f7e37040",
+        "size_bytes": 1023
+      },
+      "workflow_run_attempt": "1",
+      "workflow_run_id": "29727061145"
+    },
+    "sha256": "6a70beb3d653e9cad578f18a2dcf7b5df8761e26c309edd83255dff6db711c4a"
+  },
+  "repository_sha": "637d36f7e9bb152ee3c7b22545a9a83eca3e4388",
+  "restored_verification": {
+    "content": {
+      "authority_sha256": "3064250e63baed7bdcfd20851e1d3ea2c86fc33f087b69a2a4fcff18c384374b",
+      "evidence_sha256": "a1d58c34ca8e6184156abc12c310eb144cbac8996a7b0a0552e89fce468e0cac",
+      "reasons": [],
+      "report_sha256": "d3284b22f4f2e64d79db3c4bad58877731cd04e02d082826aa6a72967aa04b51",
+      "schema_version": "tai.llama-cpp-toolchain-verification-report.v1",
+      "status": "VERIFIED",
+      "verified_files": [
+        "build/llama.cpp-b9637/CMakeCache.txt",
+        "build/llama.cpp-b9637/bin/llama-bench",
+        "build/llama.cpp-b9637/bin/llama-cli",
+        "build/llama.cpp-b9637/bin/llama-quantize",
+        "build/llama.cpp-b9637/bin/llama-server",
+        "evidence/build.log",
+        "evidence/cc-version.txt",
+        "evidence/cmake-version.txt",
+        "evidence/configure.log",
+        "evidence/cxx-version.txt",
+        "evidence/git-head.txt",
+        "evidence/git-status.txt",
+        "source/llama.cpp-aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3.tar.gz"
+      ],
+      "verified_targets": [
+        "llama-bench",
+        "llama-cli",
+        "llama-quantize",
+        "llama-server"
+      ]
+    },
+    "sha256": "b8140f52ef9da5c3c1a6a7340107076a307665b50695ec2b6bd1a2a5f7e37040"
+  },
+  "schema_version": "tai.llama-cpp-build-artifact-locator.v1",
+  "status": "VERIFIED_RESTORED",
+  "workflow_run_attempt": "1",
+  "workflow_run_id": "29727061145"
+}

--- a/apps/tai/tests/test_llama_toolchain_build_acceptance.py
+++ b/apps/tai/tests/test_llama_toolchain_build_acceptance.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).parents[1]
 ACCEPTANCE_PATH = ROOT / "model-artifacts" / "llama-cpp-build-acceptance.v1.json"
@@ -42,7 +43,7 @@ EXPECTED_PATHS = {
 }
 
 
-def _load(path: Path) -> dict[str, object]:
+def _load(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 

--- a/apps/tai/tests/test_llama_toolchain_build_acceptance.py
+++ b/apps/tai/tests/test_llama_toolchain_build_acceptance.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+ACCEPTANCE_PATH = ROOT / "model-artifacts" / "llama-cpp-build-acceptance.v1.json"
+LOCATOR_PATH = (
+    ROOT / "model-artifacts" / "llama-cpp-build-artifact-locator.accepted.v1.json"
+)
+SCOPE_PATH = (
+    ROOT / "governance" / "scopes" / "ap-13b2b-build-acceptance-2832.json"
+)
+
+AUTHORITY_SHA256 = "3064250e63baed7bdcfd20851e1d3ea2c86fc33f087b69a2a4fcff18c384374b"
+BUILD_SHA = "637d36f7e9bb152ee3c7b22545a9a83eca3e4388"
+ACCEPTANCE_BASE_SHA = "b411a960cc259919e701704bfa652bd06d33c7d8"
+EXPECTED_TARGETS = {
+    "llama-cli": (
+        12_399_720,
+        "1f97b492e7739ec9e10b9a7da5317a27b70845873d060b7ede2c2d2f3e92f849",
+    ),
+    "llama-server": (
+        12_940_416,
+        "1b26384ad90d9ae8fe65b2a3e2dfd08c70d92663b2127d5f479f34774b4a6dbf",
+    ),
+    "llama-quantize": (
+        5_616_560,
+        "77ae93aca41abd98f6b1e63478c09de77ab558d11d6cea6f1f53949310920e20",
+    ),
+    "llama-bench": (
+        10_023_592,
+        "eac9d7ee5e75a84668755caf44a09d3e1c5907d2b88fab205c27ad1e57bef335",
+    ),
+}
+EXPECTED_PATHS = {
+    "apps/tai/governance/scopes/ap-13b2b-build-acceptance-2832.json",
+    "apps/tai/model-artifacts/llama-cpp-build-acceptance.v1.json",
+    "apps/tai/model-artifacts/llama-cpp-build-artifact-locator.accepted.v1.json",
+    "apps/tai/tests/test_llama_toolchain_build_acceptance.py",
+}
+
+
+def _load(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_acceptance_binds_the_successful_exact_main_build() -> None:
+    acceptance = _load(ACCEPTANCE_PATH)
+
+    assert acceptance["schema_version"] == "tai.llama-cpp-build-acceptance.v1"
+    assert acceptance["status"] == "VERIFIED_RESTORED"
+    assert acceptance["issue"] == 2832
+    assert acceptance["authority"]["authority_sha256"] == AUTHORITY_SHA256
+    assert acceptance["authority"]["commit"] == (
+        "aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3"
+    )
+    assert acceptance["build_run"] == {
+        "actor": "pachaninm-lab",
+        "command": "/tai build llama-cpp exact-main",
+        "completed_at": "2026-07-20T08:18:51Z",
+        "event": "issue_comment",
+        "repository_sha": BUILD_SHA,
+        "run_attempt": 1,
+        "run_id": 29727061145,
+        "started_at": "2026-07-20T08:12:01Z",
+        "triggering_actor": "pachaninm-lab",
+        "workflow_name": "TAI llama.cpp Exact Source Build",
+        "workflow_path": ".github/workflows/tai-llama-toolchain-build.yml",
+    }
+
+
+def test_acceptance_records_only_metadata_for_all_four_binaries() -> None:
+    acceptance = _load(ACCEPTANCE_PATH)
+    binaries = acceptance["evidence"]["binaries"]
+
+    observed = {
+        entry["target"]: (entry["size_bytes"], entry["sha256"])
+        for entry in binaries
+    }
+    assert observed == EXPECTED_TARGETS
+    assert acceptance["evidence"]["verified_targets"] == [
+        "llama-bench",
+        "llama-cli",
+        "llama-quantize",
+        "llama-server",
+    ]
+    for entry in binaries:
+        assert entry["path"].startswith("build/llama.cpp-b9637/bin/")
+        assert not (ROOT / entry["path"]).exists()
+
+
+def test_locator_and_external_artifact_identities_are_exact() -> None:
+    acceptance = _load(ACCEPTANCE_PATH)
+    locator = _load(LOCATOR_PATH)
+    artifacts = acceptance["external_artifacts"]
+
+    assert _sha256(LOCATOR_PATH) == (
+        artifacts["locator_artifact"]["committed_locator_sha256"]
+    )
+    assert locator["status"] == "VERIFIED_RESTORED"
+    assert locator["repository_sha"] == BUILD_SHA
+    assert locator["workflow_run_id"] == "29727061145"
+    assert locator["workflow_run_attempt"] == "1"
+    assert locator["artifact"]["id"] == "8454821423"
+    assert locator["artifact"]["digest"] == (
+        "807f815e0265096150d87b4ff289d02e26fcd1d83cca891957c66a4e39054e52"
+    )
+    assert artifacts["package_artifact"]["api_digest"] == (
+        "sha256:807f815e0265096150d87b4ff289d02e26fcd1d83cca891957c66a4e39054e52"
+    )
+    assert artifacts["locator_artifact"]["api_digest"] == (
+        "sha256:db5f9213178f3bdd3e24c2e28fa979df705ebd78e03d4f9217f3fea5412e6227"
+    )
+    assert artifacts["package_artifact"]["expires_at"] == "2026-10-18T08:12:02Z"
+    assert artifacts["locator_artifact"]["expires_at"] == "2026-10-18T08:12:02Z"
+
+
+def test_restored_verification_and_authority_continuity_fail_closed() -> None:
+    acceptance = _load(ACCEPTANCE_PATH)
+    locator = _load(LOCATOR_PATH)
+
+    restored = locator["restored_verification"]["content"]
+    assert restored["status"] == "VERIFIED"
+    assert restored["reasons"] == []
+    assert restored["authority_sha256"] == AUTHORITY_SHA256
+    assert acceptance["restore"]["independent_reverification"] is True
+    assert acceptance["authority_continuity"] == {
+        "acceptance_base_sha": ACCEPTANCE_BASE_SHA,
+        "authority_changed": False,
+        "build_repository_sha": BUILD_SHA,
+        "changed_paths": [
+            "apps/web/app/platform-v7/layout.tsx",
+            "apps/web/app/platform-v7/page.tsx",
+            "apps/web/tests/unit/platformV7PublicAiRouteAuthority.test.ts",
+            "docs/platform-v7/autopilot/scopes/fix-public-ai-layout-authority.json",
+            "scripts/p7-autopilot-guard.sh",
+        ],
+        "commits_after_build": 7,
+        "compare_status": "ahead",
+    }
+
+
+def test_maturity_boundary_does_not_admit_models_or_production() -> None:
+    acceptance = _load(ACCEPTANCE_PATH)
+    maturity = acceptance["maturity_boundary"]
+
+    assert maturity["model_acquisition"] == "PENDING_ACQUISITION"
+    assert maturity["legal_review"] == "NOT_DONE"
+    assert maturity["benchmarks"] == "NOT_DONE"
+    assert maturity["model_admission"] == "NOT_DONE"
+    assert maturity["production_operational_status"] == "NOT_ATTESTED"
+    assert "model admitted" in maturity["forbidden_claims"]
+    assert "operationally attested" in maturity["forbidden_claims"]
+
+
+def test_scope_is_exact_and_forbids_large_or_privileged_artifacts() -> None:
+    scope = _load(SCOPE_PATH)
+
+    assert scope["schema_version"] == "tai.concurrent-scope.v1"
+    assert scope["branch"] == "agent/tai-ap-13b2b-build-acceptance"
+    assert scope["issue"] == 2832
+    assert set(scope["allowed_paths"]) == EXPECTED_PATHS
+    assert len(scope["allowed_paths"]) == len(EXPECTED_PATHS)
+    assert "committed source archive, build package, log or compiled binary" in scope[
+        "forbidden_capabilities"
+    ]
+    assert "production readiness or operational attestation claim" in scope[
+        "forbidden_capabilities"
+    ]


### PR DESCRIPTION
## Result

Records the real owner-triggered llama.cpp source build as a separately reviewed acceptance slice.

- controlled build run `29727061145` completed successfully on exact-main `637d36f7e9bb152ee3c7b22545a9a83eca3e4388`;
- exact upstream release `b9637` / commit `aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3` was built under authority `3064250e63baed7bdcfd20851e1d3ea2c86fc33f087b69a2a4fcff18c384374b`;
- package artifact `8454821423` and locator artifact `8454825634` are immutable, digest-bound and retained for 90 days;
- the uploaded package was restored and independently reverified with `status=VERIFIED`, no rejection reasons and all four governed targets;
- sizes and SHA-256 values for `llama-cli`, `llama-server`, `llama-quantize` and `llama-bench` are committed only as small machine-readable metadata;
- source archives, build package, logs and binaries remain outside Git.

## Authority continuity

The acceptance branch is based on current main `b411a960cc259919e701704bfa652bd06d33c7d8`. The seven commits after the build SHA touched only public web/layout governance paths and did not alter TAI, llama.cpp authority, verifier or controlled build workflow.

## Exact scope

Exactly four files:

- `apps/tai/model-artifacts/llama-cpp-build-artifact-locator.accepted.v1.json`;
- `apps/tai/model-artifacts/llama-cpp-build-acceptance.v1.json`;
- `apps/tai/governance/scopes/ap-13b2b-build-acceptance-2832.json`;
- `apps/tai/tests/test_llama_toolchain_build_acceptance.py`.

Focused acceptance tests: 6 passed. Repository exact-head gates remain authoritative.

## Maturity boundary

This accepts only the verified llama.cpp toolchain build evidence. Qwen and Mistral remain `PENDING_ACQUISITION`; legal review, conversion, quantization, benchmarks and model admission remain incomplete. `production_operational_status` remains `NOT_ATTESTED`.

Controlled-build tracking item 2832 remains open until this PR is merged and the resulting exact-main TAI Release Acceptance is independently verified.