### PR TITLE
TAI AP-13B.3: acquire and cleanly reverify exact model sources

### DIFF
--- a/.github/workflows/tai-model-source-acquisition.yml
+++ b/.github/workflows/tai-model-source-acquisition.yml
@@ -91,7 +91,10 @@ jobs:
 
           validation = json.loads(Path('authority-validation.json').read_text())
           build = json.loads(
-              Path('repository/apps/tai/model-artifacts/llama-cpp-build-acceptance.v1.json').read_text()
+              Path(
+                  'repository/apps/tai/model-artifacts/'
+                  'llama-cpp-build-acceptance.v1.json'
+              ).read_text()
           )
           assert validation['status'] == 'VALID'
           assert validation['authority_sha256'] == (
@@ -100,7 +103,10 @@ jobs:
           assert build['status'] == 'VERIFIED_RESTORED'
           assert build['evidence']['verification_report']['status'] == 'VERIFIED'
           assert build['evidence']['verification_report']['reasons'] == []
-          assert build['maturity_boundary']['production_operational_status'] == 'NOT_ATTESTED'
+          assert (
+              build['maturity_boundary']['production_operational_status']
+              == 'NOT_ATTESTED'
+          )
           PY
 
       - name: Reconcile exact Hugging Face revision inventory
@@ -110,7 +116,11 @@ jobs:
           REVISION: ${{ matrix.revision }}
         run: |
           set -euo pipefail
-          mkdir -p "$EVIDENCE_ROOT" "$EVIDENCE_ROOT/legal" "$ORIGINAL_ROOT" "$RESTORE_ROOT"
+          mkdir -p \
+            "$EVIDENCE_ROOT" \
+            "$EVIDENCE_ROOT/legal" \
+            "$ORIGINAL_ROOT" \
+            "$RESTORE_ROOT"
           chmod 700 "$ORIGINAL_ROOT" "$RESTORE_ROOT"
           observed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           curl --fail --silent --show-error --location \
@@ -133,9 +143,9 @@ jobs:
         run: |
           set -euo pipefail
           selected_bytes="$(python -c 'import json; print(json.load(open("model-source-evidence/${{ matrix.key }}/download-plan.json"))["selected_total_bytes"])')"
-          available_bytes="$(df -P -B1 --output=avail "$RUNNER_TEMP" | tail -1 | tr -d ' ')"
+          available_bytes="$(df -B1 --output=avail "$RUNNER_TEMP" | tail -1 | tr -d ' ')"
           memory_total_bytes="$(awk '/MemTotal:/{printf "%.0f", $2 * 1024}' /proc/meminfo)"
-          required_bytes=$((selected_bytes + SELECTED_MARGIN_BYTES))
+          required_bytes=$((selected_bytes * 2 + SELECTED_MARGIN_BYTES))
           printf '%s\n' \
             "selected_bytes=$selected_bytes" \
             "available_bytes=$available_bytes" \
@@ -153,7 +163,11 @@ jobs:
           import json
           from pathlib import Path
 
-          plan = json.loads(Path('model-source-evidence/${{ matrix.key }}/download-plan.json').read_text())
+          plan = json.loads(
+              Path(
+                  'model-source-evidence/${{ matrix.key }}/download-plan.json'
+              ).read_text()
+          )
           for item in plan['entries']:
               values = (item['path'], item['download_uri'], str(item['size_bytes']))
               if any('\t' in value or '\n' in value for value in values):
@@ -220,11 +234,17 @@ jobs:
           from pathlib import Path
 
           packet = json.loads(
-              Path('model-source-evidence/${{ matrix.key }}/legal-review-packet.json').read_text()
+              Path(
+                  'model-source-evidence/${{ matrix.key }}/'
+                  'legal-review-packet.json'
+              ).read_text()
           )
           assert packet['status'] == 'PENDING_HUMAN_DECISION'
           assert packet['required_human_record']['decision'] is None
-          assert packet['automation_boundary'] == 'AUTOMATION_MUST_NOT_APPROVE_OR_REJECT'
+          assert (
+              packet['automation_boundary']
+              == 'AUTOMATION_MUST_NOT_APPROVE_OR_REJECT'
+          )
           PY
 
       - name: Independently re-download exact sources into clean restore root
@@ -283,7 +303,8 @@ jobs:
           rm -rf "$ORIGINAL_ROOT" "$RESTORE_ROOT"
           test ! -e "$ORIGINAL_ROOT"
           test ! -e "$RESTORE_ROOT"
-          if find "$EVIDENCE_ROOT" -type f -size +50000000c -print -quit | grep -q .; then
+          if find "$EVIDENCE_ROOT" -type f -size +50000000c -print -quit \
+            | grep -q .; then
             echo 'Large source bytes entered the metadata evidence directory.' >&2
             exit 1
           fi
@@ -346,8 +367,11 @@ jobs:
                   'copied_to_git_or_actions_artifact': False,
               },
           }
-          Path('model-source-locator/${{ matrix.key }}/locator.json').write_text(
-              json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n'
+          Path(
+              'model-source-locator/${{ matrix.key }}/locator.json'
+          ).write_text(
+              json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+              + '\n'
           )
           PY
 
@@ -379,15 +403,10 @@ jobs:
           import os
           from pathlib import Path
 
-          report = json.loads(
-              Path('model-source-evidence/${{ matrix.key }}/acquisition-report.json').read_text()
-          )
-          manifest = json.loads(
-              Path('model-source-evidence/${{ matrix.key }}/source-manifest.json').read_text()
-          )
-          inventory = json.loads(
-              Path('model-source-evidence/${{ matrix.key }}/remote-inventory.json').read_text()
-          )
+          root = Path('model-source-evidence/${{ matrix.key }}')
+          report = json.loads((root / 'acquisition-report.json').read_text())
+          manifest = json.loads((root / 'source-manifest.json').read_text())
+          inventory = json.loads((root / 'remote-inventory.json').read_text())
           lines = [
               f"## TAI exact source acquisition — {report['model_id']}",
               '',
@@ -397,9 +416,17 @@ jobs:
               f"- selected source bytes: `{inventory['selected_total_bytes']}`;",
               f"- selected source files: `{len(manifest['files'])}`;",
               f"- source-files SHA-256: `{report['source_files_sha256']}`;",
-              f"- clean re-download/rehash: `VERIFIED_SOURCE_RESTORED`;",
-              f"- evidence artifact: `{os.environ['EVIDENCE_ARTIFACT_ID']}` / `{os.environ['EVIDENCE_ARTIFACT_DIGEST']}`;",
-              f"- locator artifact: `{os.environ['LOCATOR_ARTIFACT_ID']}` / `{os.environ['LOCATOR_ARTIFACT_DIGEST']}`;",
+              '- clean re-download/rehash: `VERIFIED_SOURCE_RESTORED`;',
+              (
+                  '- evidence artifact: '
+                  f"`{os.environ['EVIDENCE_ARTIFACT_ID']}` / "
+                  f"`{os.environ['EVIDENCE_ARTIFACT_DIGEST']}`;"
+              ),
+              (
+                  '- locator artifact: '
+                  f"`{os.environ['LOCATOR_ARTIFACT_ID']}` / "
+                  f"`{os.environ['LOCATOR_ARTIFACT_DIGEST']}`;"
+              ),
               '- source weights copied to Git or Actions artifact: `false`;',
               '- legal review: `PENDING_HUMAN_DECISION`;',
               '- conversion: `NOT_RUN`;',
@@ -422,7 +449,9 @@ jobs:
           from pathlib import Path
 
           report = json.loads(
-              Path('model-source-evidence/${{ matrix.key }}/acquisition-report.json').read_text()
+              Path(
+                  'model-source-evidence/${{ matrix.key }}/acquisition-report.json'
+              ).read_text()
           )
           assert report['status'] == 'VERIFIED_SOURCE_RESTORED_LEGAL_PENDING'
           assert report['reasons'] == []

--- a/.github/workflows/tai-model-source-acquisition.yml
+++ b/.github/workflows/tai-model-source-acquisition.yml
@@ -1,0 +1,434 @@
+name: TAI Exact Model Source Acquisition
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: tai-exact-model-source-acquisition
+  cancel-in-progress: false
+
+jobs:
+  acquire:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      github.actor == github.repository_owner &&
+      github.triggering_actor == github.repository_owner &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.action == 'created' &&
+          github.event.issue.pull_request == null &&
+          github.event.issue.number == 2835 &&
+          github.event.comment.body == '/tai acquire model-sources exact-main' &&
+          github.event.comment.author_association == 'OWNER' &&
+          github.event.comment.user.login == github.repository_owner
+        )
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - key: qwen3-8b
+            model_id: Qwen/Qwen3-8B
+            revision: 895c8d171bc03c30e113cd7a28c02494b5e068b7
+            model_card_path: sources/qwen3-8b/README.md
+          - key: mistral-7b-instruct-v0.3
+            model_id: mistralai/Mistral-7B-Instruct-v0.3
+            revision: c170c708c41dac9275d15a8fff4eca08d52bab71
+            model_card_path: sources/mistral-7b-instruct-v0.3/README.md
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
+    env:
+      AUTHORITY_PATH: repository/apps/tai/model-artifacts/model-bundle-authority.v2.json
+      EVIDENCE_ROOT: model-source-evidence/${{ matrix.key }}
+      LICENSE_URI: https://www.apache.org/licenses/LICENSE-2.0.txt
+      ORIGINAL_ROOT: ${{ runner.temp }}/tai-${{ matrix.key }}-original
+      RESTORE_ROOT: ${{ runner.temp }}/tai-${{ matrix.key }}-restore
+      SELECTED_MARGIN_BYTES: 25000000000
+
+    steps:
+      - name: Checkout exact main authority
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          path: repository
+
+      - name: Verify exact checked-out main revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = 'refs/heads/main'
+          test "$(git -C repository rev-parse HEAD)" = "$GITHUB_SHA"
+          git -C repository fetch --no-tags --depth=1 origin main
+          test "$(git -C repository rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate exact authority and accepted toolchain dependency
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH=repository/apps/tai python -m tai.model_artifact_registry_cli \
+            validate-bundle-authority-v2 \
+            "$AUTHORITY_PATH" \
+            --output authority-validation.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          validation = json.loads(Path('authority-validation.json').read_text())
+          build = json.loads(
+              Path('repository/apps/tai/model-artifacts/llama-cpp-build-acceptance.v1.json').read_text()
+          )
+          assert validation['status'] == 'VALID'
+          assert validation['authority_sha256'] == (
+              '3391ea2ba4ddd855b45c5f389f12ffe3ddffb7cc4f46a4048d7357ffcdda6022'
+          )
+          assert build['status'] == 'VERIFIED_RESTORED'
+          assert build['evidence']['verification_report']['status'] == 'VERIFIED'
+          assert build['evidence']['verification_report']['reasons'] == []
+          assert build['maturity_boundary']['production_operational_status'] == 'NOT_ATTESTED'
+          PY
+
+      - name: Reconcile exact Hugging Face revision inventory
+        shell: bash
+        env:
+          MODEL_ID: ${{ matrix.model_id }}
+          REVISION: ${{ matrix.revision }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$EVIDENCE_ROOT" "$EVIDENCE_ROOT/legal" "$ORIGINAL_ROOT" "$RESTORE_ROOT"
+          chmod 700 "$ORIGINAL_ROOT" "$RESTORE_ROOT"
+          observed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          curl --fail --silent --show-error --location \
+            --proto '=https' --tlsv1.2 \
+            --retry 6 --retry-all-errors --max-time 90 \
+            "https://huggingface.co/api/models/$MODEL_ID/revision/$REVISION?blobs=true" \
+            --output "$EVIDENCE_ROOT/huggingface-api-response.json"
+          PYTHONPATH=repository/apps/tai python -m tai.model_source_acquisition_cli \
+            reconcile-inventory \
+            "$AUTHORITY_PATH" "$MODEL_ID" "$REVISION" \
+            "$EVIDENCE_ROOT/huggingface-api-response.json" \
+            --observed-at "$observed_at" \
+            --output "$EVIDENCE_ROOT/remote-inventory.json"
+          PYTHONPATH=repository/apps/tai python -m tai.model_source_acquisition_cli \
+            download-plan "$EVIDENCE_ROOT/remote-inventory.json" \
+            --output "$EVIDENCE_ROOT/download-plan.json"
+
+      - name: Enforce actual free runner capacity
+        shell: bash
+        run: |
+          set -euo pipefail
+          selected_bytes="$(python -c 'import json; print(json.load(open("model-source-evidence/${{ matrix.key }}/download-plan.json"))["selected_total_bytes"])')"
+          available_bytes="$(df -P -B1 --output=avail "$RUNNER_TEMP" | tail -1 | tr -d ' ')"
+          memory_total_bytes="$(awk '/MemTotal:/{printf "%.0f", $2 * 1024}' /proc/meminfo)"
+          required_bytes=$((selected_bytes + SELECTED_MARGIN_BYTES))
+          printf '%s\n' \
+            "selected_bytes=$selected_bytes" \
+            "available_bytes=$available_bytes" \
+            "required_bytes=$required_bytes" \
+            "memory_total_bytes=$memory_total_bytes" \
+            > "$EVIDENCE_ROOT/capacity.env"
+          test "$available_bytes" -ge "$required_bytes"
+          test "$memory_total_bytes" -ge 12000000000
+
+      - name: Download and hash exact selected source files
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY' > "$EVIDENCE_ROOT/download-plan.tsv"
+          import json
+          from pathlib import Path
+
+          plan = json.loads(Path('model-source-evidence/${{ matrix.key }}/download-plan.json').read_text())
+          for item in plan['entries']:
+              values = (item['path'], item['download_uri'], str(item['size_bytes']))
+              if any('\t' in value or '\n' in value for value in values):
+                  raise SystemExit('unsafe download-plan value')
+              print('\t'.join(values))
+          PY
+          : > "$EVIDENCE_ROOT/original-download.log"
+          while IFS=$'\t' read -r relative_path uri expected_size; do
+            target="$ORIGINAL_ROOT/$relative_path"
+            partial="${target}.partial"
+            mkdir -p "$(dirname "$target")"
+            printf 'START\t%s\t%s\n' "$relative_path" "$expected_size" \
+              >> "$EVIDENCE_ROOT/original-download.log"
+            curl --fail --silent --show-error --location \
+              --proto '=https' --tlsv1.2 \
+              --retry 12 --retry-all-errors --retry-delay 5 \
+              --connect-timeout 30 --max-time 7200 \
+              --continue-at - --output "$partial" "$uri"
+            test "$(stat --format='%s' "$partial")" = "$expected_size"
+            mv "$partial" "$target"
+            printf 'DONE\t%s\t%s\n' "$relative_path" "$expected_size" \
+              >> "$EVIDENCE_ROOT/original-download.log"
+          done < "$EVIDENCE_ROOT/download-plan.tsv"
+
+      - name: Collect fail-closed source manifest and shard-index evidence
+        shell: bash
+        env:
+          MODEL_ID: ${{ matrix.model_id }}
+          REVISION: ${{ matrix.revision }}
+        run: |
+          set -euo pipefail
+          PYTHONPATH=repository/apps/tai python -m tai.model_source_acquisition_cli \
+            collect-source \
+            "$AUTHORITY_PATH" "$MODEL_ID" "$REVISION" \
+            "$EVIDENCE_ROOT/remote-inventory.json" "$ORIGINAL_ROOT" \
+            --output "$EVIDENCE_ROOT/source-manifest.json"
+
+      - name: Prepare exact license evidence without manufacturing approval
+        shell: bash
+        env:
+          MODEL_CARD_PATH: ${{ matrix.model_card_path }}
+          MODEL_ID: ${{ matrix.model_id }}
+          REVISION: ${{ matrix.revision }}
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location \
+            --proto '=https' --tlsv1.2 \
+            --retry 6 --retry-all-errors --max-time 90 \
+            "$LICENSE_URI" \
+            --output "$EVIDENCE_ROOT/legal/LICENSE-2.0.txt"
+          test -s "$EVIDENCE_ROOT/legal/LICENSE-2.0.txt"
+          cp "$ORIGINAL_ROOT/$MODEL_CARD_PATH" "$EVIDENCE_ROOT/legal/model-card.md"
+          prepared_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          PYTHONPATH=repository/apps/tai python -m tai.model_source_acquisition_cli \
+            legal-packet \
+            "$AUTHORITY_PATH" "$MODEL_ID" "$REVISION" \
+            "$EVIDENCE_ROOT/source-manifest.json" "$ORIGINAL_ROOT" \
+            "$EVIDENCE_ROOT/legal/LICENSE-2.0.txt" \
+            --license-uri "$LICENSE_URI" \
+            --prepared-at "$prepared_at" \
+            --output "$EVIDENCE_ROOT/legal-review-packet.json"
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          packet = json.loads(
+              Path('model-source-evidence/${{ matrix.key }}/legal-review-packet.json').read_text()
+          )
+          assert packet['status'] == 'PENDING_HUMAN_DECISION'
+          assert packet['required_human_record']['decision'] is None
+          assert packet['automation_boundary'] == 'AUTOMATION_MUST_NOT_APPROVE_OR_REJECT'
+          PY
+
+      - name: Independently re-download exact sources into clean restore root
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -z "$(find "$RESTORE_ROOT" -mindepth 1 -print -quit)"
+          : > "$EVIDENCE_ROOT/restore-download.log"
+          while IFS=$'\t' read -r relative_path uri expected_size; do
+            target="$RESTORE_ROOT/$relative_path"
+            partial="${target}.partial"
+            mkdir -p "$(dirname "$target")"
+            printf 'START\t%s\t%s\n' "$relative_path" "$expected_size" \
+              >> "$EVIDENCE_ROOT/restore-download.log"
+            curl --fail --silent --show-error --location \
+              --proto '=https' --tlsv1.2 \
+              --retry 12 --retry-all-errors --retry-delay 5 \
+              --connect-timeout 30 --max-time 7200 \
+              --continue-at - --output "$partial" "$uri"
+            test "$(stat --format='%s' "$partial")" = "$expected_size"
+            mv "$partial" "$target"
+            printf 'DONE\t%s\t%s\n' "$relative_path" "$expected_size" \
+              >> "$EVIDENCE_ROOT/restore-download.log"
+          done < "$EVIDENCE_ROOT/download-plan.tsv"
+
+      - name: Verify clean source restore and assemble acquisition report
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHONPATH=repository/apps/tai python -m tai.model_source_acquisition_cli \
+            verify-restore \
+            "$EVIDENCE_ROOT/source-manifest.json" "$RESTORE_ROOT" \
+            --output "$EVIDENCE_ROOT/restore-verification.json"
+          PYTHONPATH=repository/apps/tai python -m tai.model_source_acquisition_cli \
+            assemble-report \
+            "$EVIDENCE_ROOT/remote-inventory.json" \
+            "$EVIDENCE_ROOT/source-manifest.json" \
+            "$EVIDENCE_ROOT/legal-review-packet.json" \
+            "$EVIDENCE_ROOT/restore-verification.json" \
+            --repository-sha "$GITHUB_SHA" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --output "$EVIDENCE_ROOT/acquisition-report.json"
+          sha256sum \
+            "$EVIDENCE_ROOT/remote-inventory.json" \
+            "$EVIDENCE_ROOT/source-manifest.json" \
+            "$EVIDENCE_ROOT/legal-review-packet.json" \
+            "$EVIDENCE_ROOT/restore-verification.json" \
+            "$EVIDENCE_ROOT/acquisition-report.json" \
+            > "$EVIDENCE_ROOT/evidence-sha256.txt"
+
+      - name: Remove multi-gigabyte source bytes before evidence upload
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$ORIGINAL_ROOT" "$RESTORE_ROOT"
+          test ! -e "$ORIGINAL_ROOT"
+          test ! -e "$RESTORE_ROOT"
+          if find "$EVIDENCE_ROOT" -type f -size +50000000c -print -quit | grep -q .; then
+            echo 'Large source bytes entered the metadata evidence directory.' >&2
+            exit 1
+          fi
+
+      - name: Upload immutable source-acquisition metadata
+        id: evidence_upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: tai-model-source-${{ matrix.key }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: model-source-evidence/${{ matrix.key }}
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false
+
+      - name: Create machine-readable metadata locator
+        shell: bash
+        env:
+          ARTIFACT_ID: ${{ steps.evidence_upload.outputs.artifact-id }}
+          ARTIFACT_URL: ${{ steps.evidence_upload.outputs.artifact-url }}
+          ARTIFACT_DIGEST: ${{ steps.evidence_upload.outputs.artifact-digest }}
+        run: |
+          set -euo pipefail
+          test -n "$ARTIFACT_ID"
+          test -n "$ARTIFACT_URL"
+          test -n "$ARTIFACT_DIGEST"
+          mkdir -p "model-source-locator/${{ matrix.key }}"
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path('model-source-evidence/${{ matrix.key }}')
+          report_path = root / 'acquisition-report.json'
+          report = json.loads(report_path.read_text())
+          payload = {
+              'schema_version': 'tai.model-source-acquisition-artifact-locator.v1',
+              'status': report['status'],
+              'model_id': report['model_id'],
+              'revision': report['revision'],
+              'repository_sha': report['repository_sha'],
+              'workflow_run_id': report['workflow_run_id'],
+              'workflow_run_attempt': report['workflow_run_attempt'],
+              'artifact': {
+                  'id': os.environ['ARTIFACT_ID'],
+                  'url': os.environ['ARTIFACT_URL'],
+                  'digest': os.environ['ARTIFACT_DIGEST'],
+                  'retention_days': 90,
+              },
+              'acquisition_report': {
+                  'sha256': hashlib.sha256(report_path.read_bytes()).hexdigest(),
+                  'content': report,
+              },
+              'source_bytes_storage': {
+                  'type': 'UPSTREAM_EXACT_REVISION_RESTORABLE',
+                  'locally_hashed': True,
+                  'clean_redownload_reverified': True,
+                  'copied_to_git_or_actions_artifact': False,
+              },
+          }
+          Path('model-source-locator/${{ matrix.key }}/locator.json').write_text(
+              json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n'
+          )
+          PY
+
+      - name: Upload immutable source-acquisition locator
+        id: locator_upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: tai-model-source-locator-${{ matrix.key }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: model-source-locator/${{ matrix.key }}
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false
+
+      - name: Publish bounded acquisition summary to issue 2835
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          EVIDENCE_ARTIFACT_ID: ${{ steps.evidence_upload.outputs.artifact-id }}
+          EVIDENCE_ARTIFACT_DIGEST: ${{ steps.evidence_upload.outputs.artifact-digest }}
+          LOCATOR_ARTIFACT_ID: ${{ steps.locator_upload.outputs.artifact-id }}
+          LOCATOR_ARTIFACT_DIGEST: ${{ steps.locator_upload.outputs.artifact-digest }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(
+              Path('model-source-evidence/${{ matrix.key }}/acquisition-report.json').read_text()
+          )
+          manifest = json.loads(
+              Path('model-source-evidence/${{ matrix.key }}/source-manifest.json').read_text()
+          )
+          inventory = json.loads(
+              Path('model-source-evidence/${{ matrix.key }}/remote-inventory.json').read_text()
+          )
+          lines = [
+              f"## TAI exact source acquisition — {report['model_id']}",
+              '',
+              f"- status: `{report['status']}`;",
+              f"- exact revision: `{report['revision']}`;",
+              f"- exact-main: `{report['repository_sha']}`;",
+              f"- selected source bytes: `{inventory['selected_total_bytes']}`;",
+              f"- selected source files: `{len(manifest['files'])}`;",
+              f"- source-files SHA-256: `{report['source_files_sha256']}`;",
+              f"- clean re-download/rehash: `VERIFIED_SOURCE_RESTORED`;",
+              f"- evidence artifact: `{os.environ['EVIDENCE_ARTIFACT_ID']}` / `{os.environ['EVIDENCE_ARTIFACT_DIGEST']}`;",
+              f"- locator artifact: `{os.environ['LOCATOR_ARTIFACT_ID']}` / `{os.environ['LOCATOR_ARTIFACT_DIGEST']}`;",
+              '- source weights copied to Git or Actions artifact: `false`;',
+              '- legal review: `PENDING_HUMAN_DECISION`;',
+              '- conversion: `NOT_RUN`;',
+              '- quantization: `NOT_RUN`;',
+              '- model admission: `NOT_DONE`;',
+              '- production operational status: `NOT_ATTESTED`.',
+          ]
+          Path('issue-comment.md').write_text('\n'.join(lines) + '\n')
+          PY
+          gh api "/repos/$REPOSITORY/issues/2835/comments" \
+            --method POST \
+            --raw-field body="$(cat issue-comment.md)"
+
+      - name: Enforce honest acquisition maturity boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(
+              Path('model-source-evidence/${{ matrix.key }}/acquisition-report.json').read_text()
+          )
+          assert report['status'] == 'VERIFIED_SOURCE_RESTORED_LEGAL_PENDING'
+          assert report['reasons'] == []
+          assert report['legal_review_status'] == 'PENDING_HUMAN_DECISION'
+          assert report['conversion_status'] == 'NOT_RUN'
+          assert report['quantization_status'] == 'NOT_RUN'
+          assert report['model_admission_status'] == 'NOT_DONE'
+          assert report['production_operational_status'] == 'NOT_ATTESTED'
+          PY

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,2 +1,5 @@
 # False positive: a removed deterministic test idempotency fixture, not a credential.
 b11c310787b81cfcfddd0be67f515f8f4a32cebd:apps/tai/tests/test_tool_planner.py:generic-api-key:42
+
+# False positive: public immutable Hugging Face model revision, not an API key.
+c5077eebcc9bbc47e3d650795e11b55f265428e8:.github/workflows/tai-model-source-acquisition.yml:generic-api-key:43

--- a/apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json
+++ b/apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json
@@ -11,6 +11,7 @@
     "apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json",
     "apps/tai/tai/model_source_acquisition.py",
     "apps/tai/tai/model_source_acquisition_cli.py",
+    "apps/tai/tests/test_gitleaks_release_authority.py",
     "apps/tai/tests/test_model_source_acquisition.py",
     "apps/tai/tests/test_model_source_acquisition_workflow.py"
   ],
@@ -35,6 +36,7 @@
     "only bounded metadata, review material and locators enter Actions artifacts",
     "source weights are not copied to Git or Actions artifacts",
     "the only secret-scan suppression is fingerprint-bound to one public immutable model revision false positive",
+    "the release-authority test attests the complete exact gitleaks exception set",
     "Qwen and Mistral remain legally pending and no conversion or admission is claimed",
     "production_operational_status remains NOT_ATTESTED",
     "Ruff, strict mypy, full pytest/coverage, security/runtime and exact-head CI pass"

--- a/apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json
+++ b/apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json
@@ -6,6 +6,7 @@
   "issue": 2835,
   "maturity_boundary": "exact-source-acquisition-and-clean-restore-with-human-legal-decision-pending",
   "allowed_paths": [
+    ".gitleaksignore",
     ".github/workflows/tai-model-source-acquisition.yml",
     "apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json",
     "apps/tai/tai/model_source_acquisition.py",
@@ -33,6 +34,7 @@
     "a clean independent re-download matches every source size and SHA-256",
     "only bounded metadata, review material and locators enter Actions artifacts",
     "source weights are not copied to Git or Actions artifacts",
+    "the only secret-scan suppression is fingerprint-bound to one public immutable model revision false positive",
     "Qwen and Mistral remain legally pending and no conversion or admission is claimed",
     "production_operational_status remains NOT_ATTESTED",
     "Ruff, strict mypy, full pytest/coverage, security/runtime and exact-head CI pass"

--- a/apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json
+++ b/apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "tai.concurrent-scope.v1",
+  "branch": "agent/tai-ap-13b3-source-acquisition",
+  "status": "active",
+  "parent_issue": 2726,
+  "issue": 2835,
+  "maturity_boundary": "exact-source-acquisition-and-clean-restore-with-human-legal-decision-pending",
+  "allowed_paths": [
+    ".github/workflows/tai-model-source-acquisition.yml",
+    "apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json",
+    "apps/tai/tai/model_source_acquisition.py",
+    "apps/tai/tai/model_source_acquisition_cli.py",
+    "apps/tai/tests/test_model_source_acquisition.py",
+    "apps/tai/tests/test_model_source_acquisition_workflow.py"
+  ],
+  "forbidden_capabilities": [
+    "mutable branch, tag, latest model or short revision download",
+    "unselected or excluded source weight download",
+    "model weight, tokenizer, source archive or GGUF commit to Git",
+    "model weight upload to GitHub Actions artifacts",
+    "automated APPROVED or REJECTED legal decision",
+    "conversion, quantization, benchmark or model admission claim",
+    "production readiness or operational attestation claim"
+  ],
+  "acceptance": [
+    "workflow is owner-only, issue 2835 command-bound and exact-main",
+    "official Hugging Face API inventory matches every authority path including exclusions",
+    "only exact selected files from each pinned 40-character revision are downloaded",
+    "actual runner disk and RAM capacity pass fixed fail-closed margins before download",
+    "every selected source byte is locally size-checked and SHA-256 hashed",
+    "the shard index references exactly the selected weight shards",
+    "canonical Apache-2.0 text and exact model card are preserved in a legal packet with PENDING_HUMAN_DECISION",
+    "a clean independent re-download matches every source size and SHA-256",
+    "only bounded metadata, review material and locators enter Actions artifacts",
+    "source weights are not copied to Git or Actions artifacts",
+    "Qwen and Mistral remain legally pending and no conversion or admission is claimed",
+    "production_operational_status remains NOT_ATTESTED",
+    "Ruff, strict mypy, full pytest/coverage, security/runtime and exact-head CI pass"
+  ]
+}

--- a/apps/tai/tai/model_source_acquisition.py
+++ b/apps/tai/tai/model_source_acquisition.py
@@ -237,7 +237,9 @@ def build_legal_review_packet(
         for item in _object_array(source_manifest, "files")
         if item.get("role") == SourceFileRole.MODEL_CARD.value
     )
-    model_card_path = _bounded_regular_file(source_root.resolve(strict=True), _string(model_card, "path"))
+    model_card_path = _bounded_regular_file(
+        source_root.resolve(strict=True), _string(model_card, "path")
+    )
     if _sha256_file(model_card_path) != _string(model_card, "sha256"):
         raise ValueError("model card digest changed after source collection")
     if not license_text_path.is_file() or license_text_path.is_symlink():
@@ -433,13 +435,15 @@ def _bounded_regular_file(root: Path, relative_path: str) -> Path:
     if pure.is_absolute() or ".." in pure.parts or not pure.parts:
         raise ValueError("file path must be bounded and relative")
     path = root.joinpath(*pure.parts)
+    if path.is_symlink():
+        raise ValueError("evidence file must be a regular non-symlink file")
     try:
         resolved = path.resolve(strict=True)
     except FileNotFoundError as error:
         raise ValueError(f"required file is missing: {relative_path}") from error
     if not resolved.is_relative_to(root):
         raise ValueError("file path escapes evidence root")
-    if path.is_symlink() or not resolved.is_file():
+    if not resolved.is_file():
         raise ValueError("evidence file must be a regular non-symlink file")
     return resolved
 

--- a/apps/tai/tai/model_source_acquisition.py
+++ b/apps/tai/tai/model_source_acquisition.py
@@ -1,0 +1,535 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import quote
+
+from tai.model_bundle_v2 import (
+    InventoryDisposition,
+    ModelBundleAuthority,
+    ModelBundlePlan,
+    SourceFileRole,
+    authority_sha256_v2,
+    load_model_bundle_authority_v2,
+)
+
+_REMOTE_SCHEMA = "tai.remote-model-inventory-evidence.v1"
+_SOURCE_SCHEMA = "tai.model-source-manifest.v1"
+_LEGAL_PACKET_SCHEMA = "tai.model-legal-review-packet.v1"
+_RESTORE_SCHEMA = "tai.model-source-restore-verification.v1"
+_REPORT_SCHEMA = "tai.model-source-acquisition-report.v1"
+
+
+def reconcile_huggingface_inventory(
+    *,
+    authority_path: Path,
+    model_id: str,
+    revision: str,
+    api_response_path: Path,
+    observed_at: str,
+) -> dict[str, object]:
+    authority = load_model_bundle_authority_v2(authority_path)
+    plan = _model_plan(authority, model_id, revision)
+    observed = _strict_json_object(api_response_path)
+    _timestamp(observed_at)
+
+    if observed.get("sha") != revision:
+        raise ValueError("Hugging Face API revision does not match authority")
+    card_data = observed.get("cardData")
+    if not isinstance(card_data, dict):
+        raise ValueError("Hugging Face API cardData is missing")
+    upstream_license = card_data.get("license")
+    if not isinstance(upstream_license, str):
+        raise ValueError("Hugging Face API license metadata is missing")
+    if upstream_license.casefold() != plan.license_spdx.casefold():
+        raise ValueError("Hugging Face API license metadata does not match authority")
+
+    siblings = observed.get("siblings")
+    if not isinstance(siblings, list):
+        raise ValueError("Hugging Face API siblings are missing")
+    by_path: dict[str, dict[str, Any]] = {}
+    for raw in siblings:
+        if not isinstance(raw, dict):
+            raise ValueError("Hugging Face API sibling must be an object")
+        path = raw.get("rfilename")
+        if not isinstance(path, str) or not path:
+            raise ValueError("Hugging Face API sibling path is invalid")
+        if path in by_path:
+            raise ValueError("Hugging Face API sibling paths must be unique")
+        by_path[path] = raw
+
+    prefix = _inventory_prefix(plan)
+    entries: list[dict[str, object]] = []
+    selected_total = 0
+    for entry in plan.inventory:
+        if not entry.path.startswith(prefix):
+            raise ValueError("authority inventory path does not match model prefix")
+        remote_path = entry.path.removeprefix(prefix)
+        raw = by_path.get(remote_path)
+        if raw is None:
+            raise ValueError(f"authority path is absent upstream: {remote_path}")
+        size_bytes = _remote_size(raw, remote_path)
+        identity = _remote_identity(raw)
+        disposition = entry.disposition.value
+        record: dict[str, object] = {
+            "path": entry.path,
+            "remote_path": remote_path,
+            "role": entry.role.value,
+            "disposition": disposition,
+            "exclusion_reason": entry.exclusion_reason,
+            "size_bytes": size_bytes,
+            "remote_identity": identity,
+            "download_uri": _download_uri(model_id, revision, remote_path),
+        }
+        entries.append(record)
+        if entry.disposition is InventoryDisposition.SELECTED:
+            selected_total += size_bytes
+
+    authority_remote_paths = {str(item["remote_path"]) for item in entries}
+    upstream_paths = set(by_path)
+    if authority_remote_paths != upstream_paths:
+        missing = sorted(authority_remote_paths - upstream_paths)
+        ungoverned = sorted(upstream_paths - authority_remote_paths)
+        raise ValueError(
+            "upstream inventory drift: "
+            f"missing={missing!r}, ungoverned={ungoverned!r}"
+        )
+
+    payload: dict[str, object] = {
+        "schema_version": _REMOTE_SCHEMA,
+        "status": "RECONCILED",
+        "authority_sha256": authority_sha256_v2(authority),
+        "model_id": model_id,
+        "revision": revision,
+        "source_uri": plan.source_uri,
+        "observed_at": observed_at,
+        "upstream_license_metadata": upstream_license,
+        "api_response_sha256": _sha256_file(api_response_path),
+        "selected_total_bytes": selected_total,
+        "entries": sorted(entries, key=lambda item: str(item["path"])),
+    }
+    payload["inventory_sha256"] = _canonical_sha256(payload)
+    return payload
+
+
+def download_plan(remote_inventory: dict[str, object]) -> dict[str, object]:
+    _expect_schema(remote_inventory, _REMOTE_SCHEMA)
+    selected = [
+        item
+        for item in _object_array(remote_inventory, "entries")
+        if item.get("disposition") == InventoryDisposition.SELECTED.value
+    ]
+    if not selected:
+        raise ValueError("remote inventory has no selected files")
+    return {
+        "schema_version": "tai.model-source-download-plan.v1",
+        "model_id": _string(remote_inventory, "model_id"),
+        "revision": _string(remote_inventory, "revision"),
+        "selected_total_bytes": _integer(remote_inventory, "selected_total_bytes"),
+        "entries": [
+            {
+                "path": _string(item, "path"),
+                "download_uri": _string(item, "download_uri"),
+                "size_bytes": _integer(item, "size_bytes"),
+                "role": _string(item, "role"),
+            }
+            for item in selected
+        ],
+    }
+
+
+def collect_source_manifest(
+    *,
+    authority_path: Path,
+    model_id: str,
+    revision: str,
+    remote_inventory: dict[str, object],
+    source_root: Path,
+) -> dict[str, object]:
+    authority = load_model_bundle_authority_v2(authority_path)
+    plan = _model_plan(authority, model_id, revision)
+    _expect_identity(remote_inventory, model_id, revision, _REMOTE_SCHEMA)
+    if _string(remote_inventory, "authority_sha256") != authority_sha256_v2(authority):
+        raise ValueError("remote inventory authority digest mismatch")
+
+    expected_remote = {
+        _string(item, "path"): item
+        for item in _object_array(remote_inventory, "entries")
+        if item.get("disposition") == InventoryDisposition.SELECTED.value
+    }
+    expected_paths = {item.path for item in plan.selected_inventory}
+    if set(expected_remote) != expected_paths:
+        raise ValueError("remote inventory selected paths do not match authority")
+
+    source_root = source_root.resolve(strict=True)
+    observed_files = {
+        path.relative_to(source_root).as_posix()
+        for path in source_root.rglob("*")
+        if path.is_file()
+    }
+    if observed_files != expected_paths:
+        raise ValueError("local source file set does not match authority")
+
+    files: list[dict[str, object]] = []
+    for entry in sorted(plan.selected_inventory, key=lambda item: item.path):
+        path = _bounded_regular_file(source_root, entry.path)
+        expected_size = _integer(expected_remote[entry.path], "size_bytes")
+        size_bytes = path.stat().st_size
+        if size_bytes != expected_size:
+            raise ValueError(f"source size mismatch: {entry.path}")
+        files.append(
+            {
+                "path": entry.path,
+                "role": entry.role.value,
+                "size_bytes": size_bytes,
+                "sha256": _sha256_file(path),
+            }
+        )
+
+    shard_index = next(
+        item for item in files if item["role"] == SourceFileRole.SHARD_INDEX.value
+    )
+    _verify_shard_index(
+        source_root / str(shard_index["path"]),
+        {
+            PurePosixPath(str(item["path"])).name
+            for item in files
+            if item["role"] == SourceFileRole.WEIGHT_SHARD.value
+        },
+    )
+    payload: dict[str, object] = {
+        "schema_version": _SOURCE_SCHEMA,
+        "status": "COLLECTED",
+        "authority_sha256": authority_sha256_v2(authority),
+        "model_id": model_id,
+        "revision": revision,
+        "remote_inventory_sha256": _canonical_sha256(remote_inventory),
+        "files": files,
+    }
+    payload["source_files_sha256"] = _canonical_sha256(files)
+    payload["manifest_sha256"] = _canonical_sha256(payload)
+    return payload
+
+
+def build_legal_review_packet(
+    *,
+    authority_path: Path,
+    model_id: str,
+    revision: str,
+    source_manifest: dict[str, object],
+    source_root: Path,
+    license_text_path: Path,
+    license_text_uri: str,
+    prepared_at: str,
+) -> dict[str, object]:
+    authority = load_model_bundle_authority_v2(authority_path)
+    plan = _model_plan(authority, model_id, revision)
+    _expect_identity(source_manifest, model_id, revision, _SOURCE_SCHEMA)
+    _timestamp(prepared_at)
+    if not license_text_uri.startswith("https://"):
+        raise ValueError("license text URI must use HTTPS")
+
+    model_card = next(
+        item
+        for item in _object_array(source_manifest, "files")
+        if item.get("role") == SourceFileRole.MODEL_CARD.value
+    )
+    model_card_path = _bounded_regular_file(source_root.resolve(strict=True), _string(model_card, "path"))
+    if _sha256_file(model_card_path) != _string(model_card, "sha256"):
+        raise ValueError("model card digest changed after source collection")
+    if not license_text_path.is_file() or license_text_path.is_symlink():
+        raise ValueError("license text must be a regular non-symlink file")
+
+    return {
+        "schema_version": _LEGAL_PACKET_SCHEMA,
+        "status": "PENDING_HUMAN_DECISION",
+        "model_id": model_id,
+        "revision": revision,
+        "role": plan.role.value,
+        "prepared_at": prepared_at,
+        "upstream_license_metadata": plan.license_spdx,
+        "model_card": _declared_file(model_card_path, _string(model_card, "path")),
+        "license_text": {
+            **_declared_file(license_text_path, "legal/LICENSE-2.0.txt"),
+            "source_uri": license_text_uri,
+        },
+        "required_human_record": {
+            "schema_version": "tai.model-legal-review-record.v1",
+            "decision": None,
+            "reviewer_type": "HUMAN",
+            "reviewer_id": None,
+            "reviewer_name": None,
+            "reviewed_at": None,
+            "license_spdx": plan.license_spdx,
+            "decision_basis": None,
+            "conditions": [],
+            "record_type": None,
+            "attestation_reference": None,
+            "license_text_sha256": _sha256_file(license_text_path),
+        },
+        "automation_boundary": "AUTOMATION_MUST_NOT_APPROVE_OR_REJECT",
+    }
+
+
+def verify_restored_sources(
+    *, source_manifest: dict[str, object], restored_root: Path
+) -> dict[str, object]:
+    _expect_schema(source_manifest, _SOURCE_SCHEMA)
+    restored_root = restored_root.resolve(strict=True)
+    expected = {
+        _string(item, "path"): item
+        for item in _object_array(source_manifest, "files")
+    }
+    observed_files = {
+        path.relative_to(restored_root).as_posix()
+        for path in restored_root.rglob("*")
+        if path.is_file()
+    }
+    if observed_files != set(expected):
+        raise ValueError("restored source file set does not match manifest")
+
+    verified: list[str] = []
+    for relative_path, declared in sorted(expected.items()):
+        path = _bounded_regular_file(restored_root, relative_path)
+        if path.stat().st_size != _integer(declared, "size_bytes"):
+            raise ValueError(f"restored source size mismatch: {relative_path}")
+        if _sha256_file(path) != _string(declared, "sha256"):
+            raise ValueError(f"restored source digest mismatch: {relative_path}")
+        verified.append(relative_path)
+
+    payload: dict[str, object] = {
+        "schema_version": _RESTORE_SCHEMA,
+        "status": "VERIFIED_SOURCE_RESTORED",
+        "model_id": _string(source_manifest, "model_id"),
+        "revision": _string(source_manifest, "revision"),
+        "source_manifest_sha256": _canonical_sha256(source_manifest),
+        "verified_files": verified,
+        "reasons": [],
+    }
+    payload["report_sha256"] = _canonical_sha256(payload)
+    return payload
+
+
+def assemble_acquisition_report(
+    *,
+    remote_inventory: dict[str, object],
+    source_manifest: dict[str, object],
+    legal_packet: dict[str, object],
+    restore_report: dict[str, object],
+    repository_sha: str,
+    workflow_run_id: str,
+    workflow_run_attempt: str,
+) -> dict[str, object]:
+    model_id = _string(source_manifest, "model_id")
+    revision = _string(source_manifest, "revision")
+    _expect_identity(remote_inventory, model_id, revision, _REMOTE_SCHEMA)
+    _expect_identity(legal_packet, model_id, revision, _LEGAL_PACKET_SCHEMA)
+    _expect_identity(restore_report, model_id, revision, _RESTORE_SCHEMA)
+    if _string(restore_report, "status") != "VERIFIED_SOURCE_RESTORED":
+        raise ValueError("source restore report is not verified")
+    if _string(legal_packet, "status") != "PENDING_HUMAN_DECISION":
+        raise ValueError("source acquisition must not manufacture a legal decision")
+
+    payload: dict[str, object] = {
+        "schema_version": _REPORT_SCHEMA,
+        "status": "VERIFIED_SOURCE_RESTORED_LEGAL_PENDING",
+        "model_id": model_id,
+        "revision": revision,
+        "repository_sha": repository_sha,
+        "workflow_run_id": workflow_run_id,
+        "workflow_run_attempt": workflow_run_attempt,
+        "remote_inventory_sha256": _canonical_sha256(remote_inventory),
+        "source_manifest_sha256": _canonical_sha256(source_manifest),
+        "source_files_sha256": _string(source_manifest, "source_files_sha256"),
+        "legal_packet_sha256": _canonical_sha256(legal_packet),
+        "restore_report_sha256": _canonical_sha256(restore_report),
+        "legal_review_status": "PENDING_HUMAN_DECISION",
+        "conversion_status": "NOT_RUN",
+        "quantization_status": "NOT_RUN",
+        "model_admission_status": "NOT_DONE",
+        "production_operational_status": "NOT_ATTESTED",
+        "reasons": [],
+    }
+    payload["report_sha256"] = _canonical_sha256(payload)
+    return payload
+
+
+def _model_plan(
+    authority: ModelBundleAuthority, model_id: str, revision: str
+) -> ModelBundlePlan:
+    matches = [
+        plan
+        for plan in authority.models
+        if plan.model_id == model_id and plan.revision == revision
+    ]
+    if len(matches) != 1:
+        raise ValueError("model identity is not uniquely present in authority")
+    return matches[0]
+
+
+def _inventory_prefix(plan: ModelBundlePlan) -> str:
+    prefixes = {
+        "/".join(PurePosixPath(item.path).parts[:2]) + "/"
+        for item in plan.inventory
+    }
+    if len(prefixes) != 1:
+        raise ValueError("authority inventory must use one model source prefix")
+    return prefixes.pop()
+
+
+def _remote_size(raw: dict[str, Any], path: str) -> int:
+    size = raw.get("size")
+    lfs = raw.get("lfs")
+    if not isinstance(size, int) and isinstance(lfs, dict):
+        size = lfs.get("size")
+    if not isinstance(size, int) or size < 1:
+        raise ValueError(f"upstream size is missing for {path}")
+    return size
+
+
+def _remote_identity(raw: dict[str, Any]) -> str:
+    lfs = raw.get("lfs")
+    if not isinstance(lfs, dict):
+        lfs = {}
+    value = {
+        "blob_id": raw.get("blobId"),
+        "lfs_oid": lfs.get("oid"),
+        "lfs_pointer_size": lfs.get("pointerSize"),
+    }
+    rendered = json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+    if len(rendered) > 300:
+        raise ValueError("remote identity exceeds bounded length")
+    return rendered
+
+
+def _download_uri(model_id: str, revision: str, remote_path: str) -> str:
+    return (
+        f"https://huggingface.co/{model_id}/resolve/{revision}/"
+        + quote(remote_path, safe="/")
+    )
+
+
+def _verify_shard_index(path: Path, expected_shards: set[str]) -> None:
+    payload = _strict_json_object(path)
+    weight_map = payload.get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise ValueError("shard index weight_map is missing")
+    actual = set()
+    for value in weight_map.values():
+        if not isinstance(value, str) or not value:
+            raise ValueError("shard index contains an invalid shard name")
+        if PurePosixPath(value).name != value:
+            raise ValueError("shard index must use bounded shard basenames")
+        actual.add(value)
+    if actual != expected_shards:
+        raise ValueError("shard index does not reference the exact selected shard set")
+
+
+def _bounded_regular_file(root: Path, relative_path: str) -> Path:
+    pure = PurePosixPath(relative_path)
+    if pure.is_absolute() or ".." in pure.parts or not pure.parts:
+        raise ValueError("file path must be bounded and relative")
+    path = root.joinpath(*pure.parts)
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError as error:
+        raise ValueError(f"required file is missing: {relative_path}") from error
+    if not resolved.is_relative_to(root):
+        raise ValueError("file path escapes evidence root")
+    if path.is_symlink() or not resolved.is_file():
+        raise ValueError("evidence file must be a regular non-symlink file")
+    return resolved
+
+
+def _declared_file(path: Path, relative_path: str) -> dict[str, object]:
+    return {
+        "path": relative_path,
+        "sha256": _sha256_file(path),
+        "size_bytes": path.stat().st_size,
+    }
+
+
+def _strict_json_object(path: Path) -> dict[str, Any]:
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key: {key}")
+            result[key] = value
+        return result
+
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicates
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"invalid JSON evidence: {path}") from error
+    if not isinstance(value, dict):
+        raise ValueError("JSON evidence must be an object")
+    return value
+
+
+def _expect_identity(
+    value: dict[str, object], model_id: str, revision: str, schema: str
+) -> None:
+    _expect_schema(value, schema)
+    if _string(value, "model_id") != model_id or _string(value, "revision") != revision:
+        raise ValueError("model evidence identity mismatch")
+
+
+def _expect_schema(value: dict[str, object], schema: str) -> None:
+    if _string(value, "schema_version") != schema:
+        raise ValueError(f"unsupported evidence schema: {schema}")
+
+
+def _object_array(value: dict[str, object], key: str) -> list[dict[str, object]]:
+    raw = value.get(key)
+    if not isinstance(raw, list):
+        raise ValueError(f"{key} must be an array")
+    result: list[dict[str, object]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError(f"{key} entries must be objects")
+        result.append(item)
+    return result
+
+
+def _string(value: dict[str, object], key: str) -> str:
+    raw = value.get(key)
+    if not isinstance(raw, str) or not raw:
+        raise ValueError(f"{key} must be a non-empty string")
+    return raw
+
+
+def _integer(value: dict[str, object], key: str) -> int:
+    raw = value.get(key)
+    if not isinstance(raw, int) or isinstance(raw, bool) or raw < 0:
+        raise ValueError(f"{key} must be a non-negative integer")
+    return raw
+
+
+def _timestamp(value: str) -> None:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError("timestamp must use ISO 8601") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("timestamp must include a timezone")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_sha256(value: object) -> str:
+    rendered = json.dumps(
+        value, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(rendered).hexdigest()

--- a/apps/tai/tai/model_source_acquisition_cli.py
+++ b/apps/tai/tai/model_source_acquisition_cli.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from tai.model_source_acquisition import (
+    assemble_acquisition_report,
+    build_legal_review_packet,
+    collect_source_manifest,
+    download_plan,
+    reconcile_huggingface_inventory,
+    verify_restored_sources,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tai-model-source-acquisition",
+        description="Collect and verify exact model source acquisition evidence.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    reconcile = commands.add_parser("reconcile-inventory")
+    _identity_arguments(reconcile)
+    reconcile.add_argument("api_response", type=Path)
+    reconcile.add_argument("--observed-at", required=True)
+    reconcile.add_argument("--output", type=Path, required=True)
+
+    plan = commands.add_parser("download-plan")
+    plan.add_argument("remote_inventory", type=Path)
+    plan.add_argument("--output", type=Path, required=True)
+
+    collect = commands.add_parser("collect-source")
+    _identity_arguments(collect)
+    collect.add_argument("remote_inventory", type=Path)
+    collect.add_argument("source_root", type=Path)
+    collect.add_argument("--output", type=Path, required=True)
+
+    legal = commands.add_parser("legal-packet")
+    _identity_arguments(legal)
+    legal.add_argument("source_manifest", type=Path)
+    legal.add_argument("source_root", type=Path)
+    legal.add_argument("license_text", type=Path)
+    legal.add_argument("--license-uri", required=True)
+    legal.add_argument("--prepared-at", required=True)
+    legal.add_argument("--output", type=Path, required=True)
+
+    restore = commands.add_parser("verify-restore")
+    restore.add_argument("source_manifest", type=Path)
+    restore.add_argument("restored_root", type=Path)
+    restore.add_argument("--output", type=Path, required=True)
+
+    report = commands.add_parser("assemble-report")
+    report.add_argument("remote_inventory", type=Path)
+    report.add_argument("source_manifest", type=Path)
+    report.add_argument("legal_packet", type=Path)
+    report.add_argument("restore_report", type=Path)
+    report.add_argument("--repository-sha", required=True)
+    report.add_argument("--workflow-run-id", required=True)
+    report.add_argument("--workflow-run-attempt", required=True)
+    report.add_argument("--output", type=Path, required=True)
+
+    arguments = parser.parse_args(argv)
+    try:
+        payload = _execute(arguments)
+        _write_json(arguments.output, payload)
+        return 0
+    except ValueError as error:
+        _write_json(
+            getattr(arguments, "output", None),
+            {
+                "schema_version": "tai.model-source-acquisition-cli-error.v1",
+                "status": "INVALID",
+                "error": str(error),
+            },
+        )
+        return 2
+
+
+def _identity_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("authority", type=Path)
+    parser.add_argument("model_id")
+    parser.add_argument("revision")
+
+
+def _execute(arguments: argparse.Namespace) -> dict[str, object]:
+    if arguments.command == "reconcile-inventory":
+        return reconcile_huggingface_inventory(
+            authority_path=arguments.authority,
+            model_id=arguments.model_id,
+            revision=arguments.revision,
+            api_response_path=arguments.api_response,
+            observed_at=arguments.observed_at,
+        )
+    if arguments.command == "download-plan":
+        return download_plan(_load_object(arguments.remote_inventory))
+    if arguments.command == "collect-source":
+        return collect_source_manifest(
+            authority_path=arguments.authority,
+            model_id=arguments.model_id,
+            revision=arguments.revision,
+            remote_inventory=_load_object(arguments.remote_inventory),
+            source_root=arguments.source_root,
+        )
+    if arguments.command == "legal-packet":
+        return build_legal_review_packet(
+            authority_path=arguments.authority,
+            model_id=arguments.model_id,
+            revision=arguments.revision,
+            source_manifest=_load_object(arguments.source_manifest),
+            source_root=arguments.source_root,
+            license_text_path=arguments.license_text,
+            license_text_uri=arguments.license_uri,
+            prepared_at=arguments.prepared_at,
+        )
+    if arguments.command == "verify-restore":
+        return verify_restored_sources(
+            source_manifest=_load_object(arguments.source_manifest),
+            restored_root=arguments.restored_root,
+        )
+    if arguments.command == "assemble-report":
+        return assemble_acquisition_report(
+            remote_inventory=_load_object(arguments.remote_inventory),
+            source_manifest=_load_object(arguments.source_manifest),
+            legal_packet=_load_object(arguments.legal_packet),
+            restore_report=_load_object(arguments.restore_report),
+            repository_sha=arguments.repository_sha,
+            workflow_run_id=arguments.workflow_run_id,
+            workflow_run_attempt=arguments.workflow_run_attempt,
+        )
+    raise ValueError("unsupported command")
+
+
+def _load_object(path: Path) -> dict[str, object]:
+    try:
+        value: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"invalid JSON evidence: {path}") from error
+    if not isinstance(value, dict):
+        raise ValueError("JSON evidence must be an object")
+    return value
+
+
+def _write_json(path: Path | None, payload: dict[str, object]) -> None:
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if path is None:
+        sys.stdout.write(rendered)
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(rendered, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/tai/tests/test_gitleaks_release_authority.py
+++ b/apps/tai/tests/test_gitleaks_release_authority.py
@@ -28,6 +28,8 @@ def test_gitleaks_exceptions_are_exact_and_release_attested() -> None:
     assert ".gitleaksignore" in manifest["files"]
     assert entries == [
         "b11c310787b81cfcfddd0be67f515f8f4a32cebd:"
-        "apps/tai/tests/test_tool_planner.py:generic-api-key:42"
+        "apps/tai/tests/test_tool_planner.py:generic-api-key:42",
+        "c5077eebcc9bbc47e3d650795e11b55f265428e8:"
+        ".github/workflows/tai-model-source-acquisition.yml:generic-api-key:43",
     ]
     assert all(_FINGERPRINT.fullmatch(entry) is not None for entry in entries)

--- a/apps/tai/tests/test_model_source_acquisition.py
+++ b/apps/tai/tests/test_model_source_acquisition.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tai.model_bundle_v2 import load_model_bundle_authority_v2
+from tai.model_source_acquisition import (
+    assemble_acquisition_report,
+    build_legal_review_packet,
+    collect_source_manifest,
+    download_plan,
+    reconcile_huggingface_inventory,
+    verify_restored_sources,
+)
+
+AUTHORITY_PATH = (
+    Path(__file__).parents[1]
+    / "model-artifacts"
+    / "model-bundle-authority.v2.json"
+)
+MODEL_ID = "Qwen/Qwen3-8B"
+REVISION = "895c8d171bc03c30e113cd7a28c02494b5e068b7"
+OBSERVED_AT = "2026-07-20T09:29:20Z"
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, dict[str, bytes]]:
+    authority = load_model_bundle_authority_v2(AUTHORITY_PATH)
+    plan = next(item for item in authority.models if item.model_id == MODEL_ID)
+    selected_weights = [
+        Path(item.path).name
+        for item in plan.selected_inventory
+        if item.role.value == "WEIGHT_SHARD"
+    ]
+    contents: dict[str, bytes] = {}
+    for item in plan.inventory:
+        relative = item.path.removeprefix("sources/qwen3-8b/")
+        if relative == "model.safetensors.index.json":
+            weight_map = {
+                f"layer.{index}": shard
+                for index, shard in enumerate(selected_weights, start=1)
+            }
+            content = json.dumps({"weight_map": weight_map}, sort_keys=True).encode()
+        else:
+            content = f"fixture:{relative}\n".encode()
+        contents[relative] = content
+
+    api = {
+        "sha": REVISION,
+        "cardData": {"license": "apache-2.0"},
+        "siblings": [
+            {
+                "rfilename": relative,
+                "size": len(content),
+                "blobId": f"blob-{index:02d}",
+                "lfs": {
+                    "oid": f"oid-{index:02d}",
+                    "pointerSize": 128,
+                    "size": len(content),
+                },
+            }
+            for index, (relative, content) in enumerate(
+                sorted(contents.items()), start=1
+            )
+        ],
+    }
+    api_path = tmp_path / "api.json"
+    api_path.write_text(json.dumps(api), encoding="utf-8")
+
+    source_root = tmp_path / "original"
+    for item in plan.selected_inventory:
+        relative = item.path.removeprefix("sources/qwen3-8b/")
+        path = source_root / item.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(contents[relative])
+    return api_path, source_root, contents
+
+
+def _evidence(tmp_path: Path) -> tuple[dict[str, Any], dict[str, Any], Path]:
+    api_path, source_root, _ = _fixture(tmp_path)
+    remote = reconcile_huggingface_inventory(
+        authority_path=AUTHORITY_PATH,
+        model_id=MODEL_ID,
+        revision=REVISION,
+        api_response_path=api_path,
+        observed_at=OBSERVED_AT,
+    )
+    manifest = collect_source_manifest(
+        authority_path=AUTHORITY_PATH,
+        model_id=MODEL_ID,
+        revision=REVISION,
+        remote_inventory=remote,
+        source_root=source_root,
+    )
+    return remote, manifest, source_root
+
+
+def test_reconcile_collect_restore_and_assemble_honest_source_evidence(
+    tmp_path: Path,
+) -> None:
+    remote, manifest, source_root = _evidence(tmp_path)
+    plan = download_plan(remote)
+
+    assert remote["status"] == "RECONCILED"
+    assert remote["model_id"] == MODEL_ID
+    assert remote["revision"] == REVISION
+    assert len(plan["entries"]) == 13
+    assert manifest["status"] == "COLLECTED"
+    assert len(manifest["files"]) == 13
+
+    license_text = tmp_path / "LICENSE-2.0.txt"
+    license_text.write_text("Apache License Version 2.0 fixture\n", encoding="utf-8")
+    legal = build_legal_review_packet(
+        authority_path=AUTHORITY_PATH,
+        model_id=MODEL_ID,
+        revision=REVISION,
+        source_manifest=manifest,
+        source_root=source_root,
+        license_text_path=license_text,
+        license_text_uri="https://www.apache.org/licenses/LICENSE-2.0.txt",
+        prepared_at="2026-07-20T09:40:00Z",
+    )
+    assert legal["status"] == "PENDING_HUMAN_DECISION"
+    assert legal["required_human_record"]["decision"] is None
+    assert legal["automation_boundary"] == "AUTOMATION_MUST_NOT_APPROVE_OR_REJECT"
+
+    restored_root = tmp_path / "restored"
+    shutil.copytree(source_root, restored_root)
+    restore = verify_restored_sources(
+        source_manifest=manifest,
+        restored_root=restored_root,
+    )
+    report = assemble_acquisition_report(
+        remote_inventory=remote,
+        source_manifest=manifest,
+        legal_packet=legal,
+        restore_report=restore,
+        repository_sha="a" * 40,
+        workflow_run_id="123",
+        workflow_run_attempt="1",
+    )
+
+    assert restore["status"] == "VERIFIED_SOURCE_RESTORED"
+    assert restore["reasons"] == []
+    assert report["status"] == "VERIFIED_SOURCE_RESTORED_LEGAL_PENDING"
+    assert report["legal_review_status"] == "PENDING_HUMAN_DECISION"
+    assert report["conversion_status"] == "NOT_RUN"
+    assert report["quantization_status"] == "NOT_RUN"
+    assert report["model_admission_status"] == "NOT_DONE"
+    assert report["production_operational_status"] == "NOT_ATTESTED"
+
+
+def test_inventory_rejects_ungoverned_upstream_path(tmp_path: Path) -> None:
+    api_path, _, _ = _fixture(tmp_path)
+    api = json.loads(api_path.read_text())
+    api["siblings"].append(
+        {"rfilename": "unexpected.bin", "size": 1, "blobId": "unexpected"}
+    )
+    api_path.write_text(json.dumps(api), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="upstream inventory drift"):
+        reconcile_huggingface_inventory(
+            authority_path=AUTHORITY_PATH,
+            model_id=MODEL_ID,
+            revision=REVISION,
+            api_response_path=api_path,
+            observed_at=OBSERVED_AT,
+        )
+
+
+def test_source_collection_rejects_shard_index_drift(tmp_path: Path) -> None:
+    api_path, source_root, _ = _fixture(tmp_path)
+    index_path = source_root / "sources/qwen3-8b/model.safetensors.index.json"
+    index_path.write_text(
+        json.dumps({"weight_map": {"layer.1": "unknown.safetensors"}}),
+        encoding="utf-8",
+    )
+    api = json.loads(api_path.read_text())
+    for item in api["siblings"]:
+        if item["rfilename"] == "model.safetensors.index.json":
+            item["size"] = index_path.stat().st_size
+            item["lfs"]["size"] = index_path.stat().st_size
+    api_path.write_text(json.dumps(api), encoding="utf-8")
+    remote = reconcile_huggingface_inventory(
+        authority_path=AUTHORITY_PATH,
+        model_id=MODEL_ID,
+        revision=REVISION,
+        api_response_path=api_path,
+        observed_at=OBSERVED_AT,
+    )
+
+    with pytest.raises(ValueError, match="exact selected shard set"):
+        collect_source_manifest(
+            authority_path=AUTHORITY_PATH,
+            model_id=MODEL_ID,
+            revision=REVISION,
+            remote_inventory=remote,
+            source_root=source_root,
+        )
+
+
+def test_source_collection_and_restore_reject_symlink_or_tampering(
+    tmp_path: Path,
+) -> None:
+    remote, manifest, source_root = _evidence(tmp_path)
+    target = source_root / "sources/qwen3-8b/config.json"
+    original = target.read_bytes()
+    target.unlink()
+    external = tmp_path / "external-config.json"
+    external.write_bytes(original)
+    target.symlink_to(external)
+
+    with pytest.raises(ValueError, match="non-symlink"):
+        collect_source_manifest(
+            authority_path=AUTHORITY_PATH,
+            model_id=MODEL_ID,
+            revision=REVISION,
+            remote_inventory=remote,
+            source_root=source_root,
+        )
+
+    target.unlink()
+    target.write_bytes(original)
+    restored_root = tmp_path / "restored"
+    shutil.copytree(source_root, restored_root)
+    restored_target = restored_root / "sources/qwen3-8b/config.json"
+    restored_target.write_bytes(b"tampered")
+    with pytest.raises(ValueError, match="restored source size mismatch"):
+        verify_restored_sources(
+            source_manifest=manifest,
+            restored_root=restored_root,
+        )
+
+
+def test_assemble_rejects_automated_legal_decision(tmp_path: Path) -> None:
+    remote, manifest, source_root = _evidence(tmp_path)
+    license_text = tmp_path / "LICENSE-2.0.txt"
+    license_text.write_text("Apache License Version 2.0 fixture\n", encoding="utf-8")
+    legal = build_legal_review_packet(
+        authority_path=AUTHORITY_PATH,
+        model_id=MODEL_ID,
+        revision=REVISION,
+        source_manifest=manifest,
+        source_root=source_root,
+        license_text_path=license_text,
+        license_text_uri="https://www.apache.org/licenses/LICENSE-2.0.txt",
+        prepared_at="2026-07-20T09:40:00Z",
+    )
+    legal["status"] = "APPROVED"
+    restored_root = tmp_path / "restored"
+    shutil.copytree(source_root, restored_root)
+    restore = verify_restored_sources(
+        source_manifest=manifest,
+        restored_root=restored_root,
+    )
+
+    with pytest.raises(ValueError, match="must not manufacture"):
+        assemble_acquisition_report(
+            remote_inventory=remote,
+            source_manifest=manifest,
+            legal_packet=legal,
+            restore_report=restore,
+            repository_sha="a" * 40,
+            workflow_run_id="123",
+            workflow_run_attempt="1",
+        )

--- a/apps/tai/tests/test_model_source_acquisition_workflow.py
+++ b/apps/tai/tests/test_model_source_acquisition_workflow.py
@@ -14,6 +14,7 @@ SCOPE_PATH = (
 )
 
 EXPECTED_PATHS = {
+    ".gitleaksignore",
     ".github/workflows/tai-model-source-acquisition.yml",
     "apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json",
     "apps/tai/tai/model_source_acquisition.py",

--- a/apps/tai/tests/test_model_source_acquisition_workflow.py
+++ b/apps/tai/tests/test_model_source_acquisition_workflow.py
@@ -68,7 +68,11 @@ def test_workflow_is_owner_only_exact_main_and_issue_bound() -> None:
     assert "github.event.comment.author_association == 'OWNER'" in workflow
     assert "github.event.comment.user.login == github.repository_owner" in workflow
     assert "cancel-in-progress: false" in workflow
-    assert "test \"$(git -C repository rev-parse refs/remotes/origin/main)\" = \"$GITHUB_SHA\"" in workflow
+    exact_main_guard = (
+        'test "$(git -C repository rev-parse refs/remotes/origin/main)" = '
+        '"$GITHUB_SHA"'
+    )
+    assert exact_main_guard in workflow
 
 
 def test_workflow_has_bounded_permissions_and_exact_model_matrix() -> None:
@@ -97,17 +101,20 @@ def test_workflow_reconciles_downloads_hashes_and_cleanly_restores() -> None:
     assert "assemble-report" in workflow
     assert workflow.count("--continue-at - --output") == 2
     assert workflow.count("--proto '=https' --tlsv1.2") >= 4
-    assert "selected_bytes + SELECTED_MARGIN_BYTES" in workflow
-    assert "test \"$available_bytes\" -ge \"$required_bytes\"" in workflow
-    assert "test \"$memory_total_bytes\" -ge 12000000000" in workflow
-    assert "test -z \"$(find \"$RESTORE_ROOT\" -mindepth 1 -print -quit)\"" in workflow
+    assert "selected_bytes * 2 + SELECTED_MARGIN_BYTES" in workflow
+    assert 'test "$available_bytes" -ge "$required_bytes"' in workflow
+    assert 'test "$memory_total_bytes" -ge 12000000000' in workflow
+    assert (
+        'test -z "$(find "$RESTORE_ROOT" -mindepth 1 -print -quit)"'
+        in workflow
+    )
     assert "VERIFIED_SOURCE_RESTORED" in workflow
 
 
 def test_workflow_never_uploads_source_bytes_and_keeps_legal_pending() -> None:
     workflow = _workflow()
 
-    assert "rm -rf \"$ORIGINAL_ROOT\" \"$RESTORE_ROOT\"" in workflow
+    assert 'rm -rf "$ORIGINAL_ROOT" "$RESTORE_ROOT"' in workflow
     assert "Large source bytes entered the metadata evidence directory." in workflow
     assert "actions/upload-artifact@v4" in workflow
     assert workflow.count("retention-days: 90") == 2

--- a/apps/tai/tests/test_model_source_acquisition_workflow.py
+++ b/apps/tai/tests/test_model_source_acquisition_workflow.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).parents[3]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "tai-model-source-acquisition.yml"
+SCOPE_PATH = (
+    Path(__file__).parents[1]
+    / "governance"
+    / "scopes"
+    / "ap-13b3-source-acquisition-2835.json"
+)
+
+EXPECTED_PATHS = {
+    ".github/workflows/tai-model-source-acquisition.yml",
+    "apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json",
+    "apps/tai/tai/model_source_acquisition.py",
+    "apps/tai/tai/model_source_acquisition_cli.py",
+    "apps/tai/tests/test_model_source_acquisition.py",
+    "apps/tai/tests/test_model_source_acquisition_workflow.py",
+}
+COMMAND = "/tai acquire model-sources exact-main"
+
+
+def _scope() -> dict[str, Any]:
+    return json.loads(SCOPE_PATH.read_text(encoding="utf-8"))
+
+
+def _workflow() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def test_scope_is_exact_and_preserves_legal_and_maturity_boundaries() -> None:
+    scope = _scope()
+
+    assert scope["schema_version"] == "tai.concurrent-scope.v1"
+    assert scope["branch"] == "agent/tai-ap-13b3-source-acquisition"
+    assert scope["status"] == "active"
+    assert scope["parent_issue"] == 2726
+    assert scope["issue"] == 2835
+    assert set(scope["allowed_paths"]) == EXPECTED_PATHS
+    assert len(scope["allowed_paths"]) == len(EXPECTED_PATHS)
+    assert "automated APPROVED or REJECTED legal decision" in scope[
+        "forbidden_capabilities"
+    ]
+    assert "production readiness or operational attestation claim" in scope[
+        "forbidden_capabilities"
+    ]
+
+
+def test_workflow_is_owner_only_exact_main_and_issue_bound() -> None:
+    workflow = _workflow()
+
+    assert "workflow_dispatch:" in workflow
+    assert "issue_comment:" in workflow
+    assert "types: [created]" in workflow
+    assert "pull_request:" not in workflow
+    assert "push:" not in workflow
+    assert "schedule:" not in workflow
+    assert "github.ref == 'refs/heads/main'" in workflow
+    assert "github.actor == github.repository_owner" in workflow
+    assert "github.triggering_actor == github.repository_owner" in workflow
+    assert "github.event.issue.pull_request == null" in workflow
+    assert "github.event.issue.number == 2835" in workflow
+    assert f"github.event.comment.body == '{COMMAND}'" in workflow
+    assert "github.event.comment.author_association == 'OWNER'" in workflow
+    assert "github.event.comment.user.login == github.repository_owner" in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "test \"$(git -C repository rev-parse refs/remotes/origin/main)\" = \"$GITHUB_SHA\"" in workflow
+
+
+def test_workflow_has_bounded_permissions_and_exact_model_matrix() -> None:
+    workflow = _workflow()
+
+    assert "permissions:\n  actions: read\n  contents: read\n  issues: write" in workflow
+    assert "contents: write" not in workflow
+    assert "packages: write" not in workflow
+    assert "id-token: write" not in workflow
+    assert "secrets." not in workflow
+    assert "Qwen/Qwen3-8B" in workflow
+    assert "895c8d171bc03c30e113cd7a28c02494b5e068b7" in workflow
+    assert "mistralai/Mistral-7B-Instruct-v0.3" in workflow
+    assert "c170c708c41dac9275d15a8fff4eca08d52bab71" in workflow
+    assert "https://www.apache.org/licenses/LICENSE-2.0.txt" in workflow
+
+
+def test_workflow_reconciles_downloads_hashes_and_cleanly_restores() -> None:
+    workflow = _workflow()
+
+    assert "reconcile-inventory" in workflow
+    assert "download-plan" in workflow
+    assert "collect-source" in workflow
+    assert "legal-packet" in workflow
+    assert "verify-restore" in workflow
+    assert "assemble-report" in workflow
+    assert workflow.count("--continue-at - --output") == 2
+    assert workflow.count("--proto '=https' --tlsv1.2") >= 4
+    assert "selected_bytes + SELECTED_MARGIN_BYTES" in workflow
+    assert "test \"$available_bytes\" -ge \"$required_bytes\"" in workflow
+    assert "test \"$memory_total_bytes\" -ge 12000000000" in workflow
+    assert "test -z \"$(find \"$RESTORE_ROOT\" -mindepth 1 -print -quit)\"" in workflow
+    assert "VERIFIED_SOURCE_RESTORED" in workflow
+
+
+def test_workflow_never_uploads_source_bytes_and_keeps_legal_pending() -> None:
+    workflow = _workflow()
+
+    assert "rm -rf \"$ORIGINAL_ROOT\" \"$RESTORE_ROOT\"" in workflow
+    assert "Large source bytes entered the metadata evidence directory." in workflow
+    assert "actions/upload-artifact@v4" in workflow
+    assert workflow.count("retention-days: 90") == 2
+    assert workflow.count("compression-level: 0") == 2
+    assert workflow.count("overwrite: false") == 2
+    assert "source weights copied to Git or Actions artifact: `false`" in workflow
+    assert "PENDING_HUMAN_DECISION" in workflow
+    assert "AUTOMATION_MUST_NOT_APPROVE_OR_REJECT" in workflow
+    assert "conversion_status'] == 'NOT_RUN'" in workflow
+    assert "quantization_status'] == 'NOT_RUN'" in workflow
+    assert "model_admission_status'] == 'NOT_DONE'" in workflow
+    assert "production_operational_status'] == 'NOT_ATTESTED'" in workflow
+
+
+def test_workflow_does_not_contain_conversion_quantization_or_model_publication() -> None:
+    workflow = _workflow()
+
+    forbidden = (
+        "convert_hf_to_gguf.py",
+        "llama-quantize",
+        "oras push",
+        "docker push",
+        "ghcr.io/",
+        "ADMITTED",
+        "APPROVED",
+        "REJECTED",
+        "production_operational_status=ATTESTED",
+    )
+    for token in forbidden:
+        assert token not in workflow

--- a/apps/tai/tests/test_model_source_acquisition_workflow.py
+++ b/apps/tai/tests/test_model_source_acquisition_workflow.py
@@ -19,6 +19,7 @@ EXPECTED_PATHS = {
     "apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json",
     "apps/tai/tai/model_source_acquisition.py",
     "apps/tai/tai/model_source_acquisition_cli.py",
+    "apps/tai/tests/test_gitleaks_release_authority.py",
     "apps/tai/tests/test_model_source_acquisition.py",
     "apps/tai/tests/test_model_source_acquisition_workflow.py",
 }


### PR DESCRIPTION
## Purpose

Adds the real owner-triggered source-acquisition stage for Qwen and Mistral under the accepted AP-13B.3 v2 authority.

## Controlled execution

The workflow runs only from current `main` by the repository owner via `/tai acquire model-sources exact-main` on issue #2835 (or owner workflow dispatch). It processes the two accepted immutable revisions in separate free public runners, reconciles official inventory, enforces actual two-copy disk/RAM capacity, downloads only selected files, hashes every byte, verifies shard indexes, creates an explicitly pending legal packet, independently re-downloads into a clean root and removes every multi-gigabyte source file before metadata upload.

## Exact scope

Eight paths:

- `.gitleaksignore` — one fingerprint-bound false-positive exception for the public immutable Qwen revision;
- `.github/workflows/tai-model-source-acquisition.yml`;
- `apps/tai/governance/scopes/ap-13b3-source-acquisition-2835.json`;
- `apps/tai/tai/model_source_acquisition.py`;
- `apps/tai/tai/model_source_acquisition_cli.py`;
- `apps/tai/tests/test_gitleaks_release_authority.py` — exact release-attested exception set;
- `apps/tai/tests/test_model_source_acquisition.py`;
- `apps/tai/tests/test_model_source_acquisition_workflow.py`.

## Maturity boundary

This stage does not convert, quantize, benchmark or admit either model. It does not upload weights to Git or Actions artifacts. Human legal review remains mandatory. `production_operational_status` remains `NOT_ATTESTED`.

Part of #2835 and #2726. It intentionally does not close either issue.