### PR TITLE
TAI AP-13B.3: fix source acquisition workflow validation

### DIFF
--- a/.github/workflows/tai-model-source-acquisition.yml
+++ b/.github/workflows/tai-model-source-acquisition.yml
@@ -50,8 +50,6 @@ jobs:
       AUTHORITY_PATH: repository/apps/tai/model-artifacts/model-bundle-authority.v2.json
       EVIDENCE_ROOT: model-source-evidence/${{ matrix.key }}
       LICENSE_URI: https://www.apache.org/licenses/LICENSE-2.0.txt
-      ORIGINAL_ROOT: ${{ runner.temp }}/tai-${{ matrix.key }}-original
-      RESTORE_ROOT: ${{ runner.temp }}/tai-${{ matrix.key }}-restore
       SELECTED_MARGIN_BYTES: 25000000000
 
     steps:
@@ -71,6 +69,15 @@ jobs:
           test "$(git -C repository rev-parse HEAD)" = "$GITHUB_SHA"
           git -C repository fetch --no-tags --depth=1 origin main
           test "$(git -C repository rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
+
+      - name: Prepare ephemeral source roots
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            printf 'ORIGINAL_ROOT=%s\n' "$RUNNER_TEMP/tai-${{ matrix.key }}-original"
+            printf 'RESTORE_ROOT=%s\n' "$RUNNER_TEMP/tai-${{ matrix.key }}-restore"
+          } >> "$GITHUB_ENV"
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/apps/tai/governance/scopes/ap-13b3-source-acquisition-workflow-fix-2835.json
+++ b/apps/tai/governance/scopes/ap-13b3-source-acquisition-workflow-fix-2835.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "tai.concurrent-scope.v1",
+  "branch": "agent/tai-ap-13b3-source-acquisition-workflow-fix",
+  "status": "active",
+  "parent_issue": 2726,
+  "issue": 2835,
+  "maturity_boundary": "workflow-validation-repair-only-without-acquisition-or-model-admission",
+  "allowed_paths": [
+    ".github/workflows/tai-model-source-acquisition.yml",
+    "apps/tai/governance/scopes/ap-13b3-source-acquisition-workflow-fix-2835.json",
+    "apps/tai/tests/test_model_source_acquisition_workflow_runtime_context.py"
+  ],
+  "forbidden_capabilities": [
+    "model source, tokenizer, weight or GGUF byte download during repository acceptance",
+    "change to exact model identities, revisions, selected source inventory or hash semantics",
+    "automated legal approval or rejection",
+    "conversion, quantization, benchmark, admission or activation claim",
+    "production readiness or operational attestation claim"
+  ],
+  "acceptance": [
+    "job-level env no longer uses the unavailable runner context",
+    "ephemeral original and restore roots are derived from RUNNER_TEMP inside a shell step and exported through GITHUB_ENV",
+    "actionlint validates the workflow without expression-context errors",
+    "owner-only exact-main issue 2835 command and workflow_dispatch triggers remain unchanged",
+    "source acquisition, clean re-download, local hashing, shard verification, deletion before artifact upload and 90-day evidence remain unchanged",
+    "legal review remains PENDING_HUMAN_DECISION",
+    "conversion, quantization and model admission remain NOT_RUN or NOT_DONE",
+    "production_operational_status remains NOT_ATTESTED",
+    "Ruff, strict mypy, full pytest/coverage, security/runtime and exact-head CI pass"
+  ]
+}

--- a/apps/tai/tests/test_model_source_acquisition_workflow_runtime_context.py
+++ b/apps/tai/tests/test_model_source_acquisition_workflow_runtime_context.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).parents[3]
+TAI_ROOT = Path(__file__).parents[1]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "tai-model-source-acquisition.yml"
+SCOPE_PATH = (
+    TAI_ROOT
+    / "governance"
+    / "scopes"
+    / "ap-13b3-source-acquisition-workflow-fix-2835.json"
+)
+
+EXPECTED_PATHS = {
+    ".github/workflows/tai-model-source-acquisition.yml",
+    "apps/tai/governance/scopes/ap-13b3-source-acquisition-workflow-fix-2835.json",
+    "apps/tai/tests/test_model_source_acquisition_workflow_runtime_context.py",
+}
+
+
+def _load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _workflow() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def test_repair_scope_is_exact_and_does_not_expand_maturity() -> None:
+    scope = _load(SCOPE_PATH)
+
+    assert scope["schema_version"] == "tai.concurrent-scope.v1"
+    assert scope["branch"] == "agent/tai-ap-13b3-source-acquisition-workflow-fix"
+    assert scope["status"] == "active"
+    assert scope["parent_issue"] == 2726
+    assert scope["issue"] == 2835
+    assert set(scope["allowed_paths"]) == EXPECTED_PATHS
+    assert len(scope["allowed_paths"]) == len(EXPECTED_PATHS)
+    assert "automated legal approval or rejection" in scope["forbidden_capabilities"]
+    assert (
+        "production readiness or operational attestation claim"
+        in scope["forbidden_capabilities"]
+    )
+
+
+def test_job_env_does_not_use_runner_context() -> None:
+    workflow = _workflow()
+    env_block = workflow[
+        workflow.index("    env:\n") : workflow.index("\n\n    steps:\n")
+    ]
+
+    assert "${{ runner.temp }}" not in workflow
+    assert "ORIGINAL_ROOT:" not in env_block
+    assert "RESTORE_ROOT:" not in env_block
+    assert "EVIDENCE_ROOT: model-source-evidence/${{ matrix.key }}" in env_block
+    assert "SELECTED_MARGIN_BYTES: 25000000000" in env_block
+
+
+def test_ephemeral_roots_are_exported_at_step_runtime() -> None:
+    workflow = _workflow()
+    start = workflow.index("      - name: Prepare ephemeral source roots")
+    end = workflow.index("\n\n      - name: Setup Python", start)
+    step = workflow[start:end]
+
+    assert '"$RUNNER_TEMP/tai-${{ matrix.key }}-original"' in step
+    assert '"$RUNNER_TEMP/tai-${{ matrix.key }}-restore"' in step
+    assert '>> "$GITHUB_ENV"' in step
+    assert "ORIGINAL_ROOT=%s" in step
+    assert "RESTORE_ROOT=%s" in step
+
+
+def test_owner_trigger_and_exact_main_guard_remain_unchanged() -> None:
+    workflow = _workflow()
+
+    assert "github.ref == 'refs/heads/main'" in workflow
+    assert "github.actor == github.repository_owner" in workflow
+    assert "github.triggering_actor == github.repository_owner" in workflow
+    assert "github.event.issue.number == 2835" in workflow
+    assert (
+        "github.event.comment.body == '/tai acquire model-sources exact-main'"
+        in workflow
+    )
+    assert "github.event.comment.author_association == 'OWNER'" in workflow
+    assert "github.event.comment.user.login == github.repository_owner" in workflow
+    assert 'test "$GITHUB_REF" = \'refs/heads/main\'' in workflow
+    assert (
+        'test "$(git -C repository rev-parse refs/remotes/origin/main)" = '
+        '"$GITHUB_SHA"'
+        in workflow
+    )
+
+
+def test_acquisition_evidence_and_cleanup_contract_remain_intact() -> None:
+    workflow = _workflow()
+
+    required_tokens = (
+        "reconcile-inventory",
+        "download-plan",
+        "collect-source",
+        "legal-packet",
+        "verify-restore",
+        "assemble-report",
+        "selected_bytes * 2 + SELECTED_MARGIN_BYTES",
+        'rm -rf "$ORIGINAL_ROOT" "$RESTORE_ROOT"',
+        "Large source bytes entered the metadata evidence directory.",
+        "PENDING_HUMAN_DECISION",
+        "AUTOMATION_MUST_NOT_APPROVE_OR_REJECT",
+        "VERIFIED_SOURCE_RESTORED_LEGAL_PENDING",
+        "production_operational_status'] == 'NOT_ATTESTED'",
+    )
+    for token in required_tokens:
+        assert token in workflow
+
+    assert workflow.count("--continue-at - --output") == 2
+    assert workflow.count("retention-days: 90") == 2
+    assert workflow.count("compression-level: 0") == 2
+    assert workflow.count("overwrite: false") == 2
+
+
+def test_fix_does_not_add_model_execution_or_admission() -> None:
+    workflow = _workflow()
+
+    forbidden = (
+        "convert_hf_to_gguf.py",
+        "llama-quantize",
+        "docker push",
+        "oras push",
+        "production_operational_status=ATTESTED",
+    )
+    for token in forbidden:
+        assert token not in workflow


### PR DESCRIPTION
## Root cause

The merged source-acquisition workflow never created jobs. GitHub registered immediate failed runs with `jobs=[]` because the workflow was invalid before scheduling.

Pinned `actionlint v1.7.7` identified the exact errors:

- line 53: context `runner` is not allowed in job-level `env`;
- line 54: context `runner` is not allowed in job-level `env`.

The invalid values were `ORIGINAL_ROOT: ${{ runner.temp }}/...` and `RESTORE_ROOT: ${{ runner.temp }}/...`.

## Fix

- removes both `runner.temp` expressions from job-level `env`;
- adds one shell step after exact-main checkout;
- derives both ephemeral roots from the runtime shell variable `$RUNNER_TEMP`;
- exports the values through `$GITHUB_ENV` for every later step.

The acquisition contract is unchanged: exact revisions, full selected source download, local hashes, shard-index verification, clean re-download/rehash, pending human legal packet, deletion of multi-gigabyte bytes before upload, two 90-day metadata/locator artifacts, no conversion or admission.

## Validation

- pinned `actionlint v1.7.7`: PASS on branch head;
- exact diff: 3 files, workflow change `+9/-2`;
- regression tests assert context availability, trigger invariants, evidence/cleanup contract and `NOT_ATTESTED` boundary.

Repository exact-head Ruff, strict mypy, full pytest/coverage, CI, security and runtime gates remain authoritative.

## Maturity boundary

This PR does not perform acquisition and does not approve a license. Qwen and Mistral remain pending execution until the fixed workflow is merged and explicitly triggered once. Conversion, quantization and model admission remain `NOT_RUN`/`NOT_DONE`; `production_operational_status` remains `NOT_ATTESTED`.

Part of #2835 and #2726.