### PR TITLE
chore: completed source acceptance exact-main observation

### DIFF
--- a/.github/workflows/tai-source-acceptance-main-observer.yml
+++ b/.github/workflows/tai-source-acceptance-main-observer.yml
@@ -1,0 +1,39 @@
+name: TAI Source Acceptance Exact Main Observer
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/tai-source-acceptance-main-observer.yml
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  observe:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 8
+    steps:
+      - name: Observe exact-main release acceptance
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          EXPECTED_MAIN: 7439ed17c94b173da1bb0c37e0d74ffdfb848d49
+        run: |
+          set -euo pipefail
+          actual_main="$(gh api "/repos/$REPOSITORY/commits/main" --jq '.sha')"
+          printf 'EXPECTED_MAIN=%s\nACTUAL_MAIN=%s\n' "$EXPECTED_MAIN" "$actual_main"
+          test "$actual_main" = "$EXPECTED_MAIN"
+          gh api "/repos/$REPOSITORY/actions/workflows/tai-release-acceptance.yml/runs?event=push&per_page=100" > runs.json
+          jq -r --arg sha "$EXPECTED_MAIN" \
+            '.workflow_runs[] | select(.head_sha == $sha) | ["RUN",.id,.status,.conclusion,.run_number,.run_attempt,.created_at,.updated_at] | @tsv' \
+            runs.json
+          run_id="$(jq -r --arg sha "$EXPECTED_MAIN" '[.workflow_runs[] | select(.head_sha == $sha)] | sort_by(.created_at) | reverse | .[0].id // empty' runs.json)"
+          test -n "$run_id"
+          gh api "/repos/$REPOSITORY/actions/runs/$run_id/jobs?per_page=100" > jobs.json
+          jq -r '.jobs[] | ["JOB",.id,.name,.status,.conclusion,.started_at,.completed_at] | @tsv' jobs.json
+          jq -r '.jobs[] | .name as $job | .steps[]? | ["STEP",$job,.number,.name,.status,.conclusion] | @tsv' jobs.json
+          gh api "/repos/$REPOSITORY/actions/runs/$run_id/artifacts?per_page=100" > artifacts.json
+          jq -r '.artifacts[] | ["ARTIFACT",.id,.name,.size_in_bytes,.expired,.digest,.created_at,.expires_at] | @tsv' artifacts.json

--- a/.github/workflows/tai-source-acceptance-main-observer.yml
+++ b/.github/workflows/tai-source-acceptance-main-observer.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 8
     steps:
-      - name: Observe exact-main release acceptance
+      - name: Observe exact-main push workflows and release acceptance
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -26,14 +26,15 @@ jobs:
           actual_main="$(gh api "/repos/$REPOSITORY/commits/main" --jq '.sha')"
           printf 'EXPECTED_MAIN=%s\nACTUAL_MAIN=%s\n' "$EXPECTED_MAIN" "$actual_main"
           test "$actual_main" = "$EXPECTED_MAIN"
-          gh api "/repos/$REPOSITORY/actions/workflows/tai-release-acceptance.yml/runs?event=push&per_page=100" > runs.json
-          jq -r --arg sha "$EXPECTED_MAIN" \
-            '.workflow_runs[] | select(.head_sha == $sha) | ["RUN",.id,.status,.conclusion,.run_number,.run_attempt,.created_at,.updated_at] | @tsv' \
-            runs.json
-          run_id="$(jq -r --arg sha "$EXPECTED_MAIN" '[.workflow_runs[] | select(.head_sha == $sha)] | sort_by(.created_at) | reverse | .[0].id // empty' runs.json)"
+
+          gh api "/repos/$REPOSITORY/actions/runs?event=push&head_sha=$EXPECTED_MAIN&per_page=100" > all-runs.json
+          jq -r '.workflow_runs[] | ["PUSH",.id,.name,.status,.conclusion,.run_number,.run_attempt,.created_at,.updated_at] | @tsv' all-runs.json
+
+          gh api "/repos/$REPOSITORY/actions/workflows/tai-release-acceptance.yml/runs?event=push&per_page=100" > release-runs.json
+          run_id="$(jq -r --arg sha "$EXPECTED_MAIN" '[.workflow_runs[] | select(.head_sha == $sha)] | sort_by(.created_at) | reverse | .[0].id // empty' release-runs.json)"
           test -n "$run_id"
-          gh api "/repos/$REPOSITORY/actions/runs/$run_id/jobs?per_page=100" > jobs.json
-          jq -r '.jobs[] | ["JOB",.id,.name,.status,.conclusion,.started_at,.completed_at] | @tsv' jobs.json
-          jq -r '.jobs[] | .name as $job | .steps[]? | ["STEP",$job,.number,.name,.status,.conclusion] | @tsv' jobs.json
+          gh api "/repos/$REPOSITORY/actions/runs/$run_id/jobs?per_page=100" > release-jobs.json
+          jq -r '.jobs[] | ["RELEASE_JOB",.id,.name,.status,.conclusion,.started_at,.completed_at] | @tsv' release-jobs.json
+          jq -r '.jobs[] | .name as $job | .steps[]? | ["RELEASE_STEP",$job,.number,.name,.status,.conclusion] | @tsv' release-jobs.json
           gh api "/repos/$REPOSITORY/actions/runs/$run_id/artifacts?per_page=100" > artifacts.json
           jq -r '.artifacts[] | ["ARTIFACT",.id,.name,.size_in_bytes,.expired,.digest,.created_at,.expires_at] | @tsv' artifacts.json


### PR DESCRIPTION
Observation complete. Exact-main `7439ed17c94b173da1bb0c37e0d74ffdfb848d49` passed TAI Release Acceptance run `29737765872`; artifact `8459173971` contains `accepted=true`, `reasons=[]`, exact SHA binding and `production_operational_status=NOT_ATTESTED`. Closed without merge.