### PR TITLE
TAI AP-13B.3c: establish human-only model legal review intake

### DIFF
--- a/.github/workflows/tai-model-legal-review.yml
+++ b/.github/workflows/tai-model-legal-review.yml
@@ -1,0 +1,176 @@
+name: TAI Human Model Legal Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/tai-model-legal-review.yml'
+      - 'apps/tai/model-artifacts/model-legal-review-authority.v1.json'
+      - 'apps/tai/model-artifacts/model-legal-review-record.schema.v1.json'
+      - 'apps/tai/model-artifacts/model-legal-review-attestation.schema.v1.json'
+      - 'apps/tai/model-artifacts/model-legal-review-runbook.v1.md'
+      - 'apps/tai/model-artifacts/legal-reviews/**'
+      - 'apps/tai/tai/model_legal_review*.py'
+      - 'apps/tai/tests/test_model_legal_review*.py'
+      - 'apps/tai/governance/scopes/ap-13b3c-human-legal-intake-2877.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tai-human-model-legal-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  legal-review:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      AUTHORITY_PATH: apps/tai/model-artifacts/model-legal-review-authority.v1.json
+      ACCEPTANCE_PATH: apps/tai/model-artifacts/model-source-acquisition-acceptance.v1.json
+      EVIDENCE_ROOT: apps/tai
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout exact pull-request head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify exact checked-out head
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          git cat-file -e "$BASE_SHA^{commit}"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install TAI legal review authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e 'apps/tai[dev]'
+
+      - name: Validate authority and human decision pairs
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p legal-review-evidence
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > legal-review-evidence/changed-files.txt
+          PYTHONPATH=apps/tai python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from tai.model_legal_review import (
+              HumanLegalReviewStatus,
+              authority_sha256,
+              evaluate_all_model_reviews,
+              evaluate_model_review,
+              intended_use_sha256,
+              load_model_legal_review_authority,
+              report_payload,
+              validate_source_acceptance,
+          )
+
+          authority_path = Path(os.environ['AUTHORITY_PATH'])
+          acceptance_path = Path(os.environ['ACCEPTANCE_PATH'])
+          evidence_root = Path(os.environ['EVIDENCE_ROOT'])
+          authority = load_model_legal_review_authority(authority_path)
+          validate_source_acceptance(authority, acceptance_path)
+
+          changed = {
+              line.strip()
+              for line in Path('legal-review-evidence/changed-files.txt').read_text().splitlines()
+              if line.strip()
+          }
+          authorized_review_paths = {
+              f"apps/tai/{plan.review_record_path}"
+              for plan in authority.models
+          } | {
+              f"apps/tai/{plan.attestation_path}"
+              for plan in authority.models
+          }
+          changed_review_paths = {
+              path
+              for path in changed
+              if path.startswith('apps/tai/model-artifacts/legal-reviews/')
+          }
+          unknown = sorted(changed_review_paths - authorized_review_paths)
+          if unknown:
+              raise SystemExit(f'unauthorized legal-review paths: {unknown}')
+
+          reports = []
+          completed_pairs = 0
+          for plan in authority.models:
+              record = evidence_root / plan.review_record_path
+              attestation = evidence_root / plan.attestation_path
+              record_exists = record.exists() or record.is_symlink()
+              attestation_exists = attestation.exists() or attestation.is_symlink()
+              if record_exists != attestation_exists:
+                  raise SystemExit(f'incomplete legal-review pair: {plan.model_id}')
+              report = evaluate_model_review(
+                  authority=authority,
+                  acceptance_path=acceptance_path,
+                  evidence_root=evidence_root,
+                  model_id=plan.model_id,
+                  revision=plan.revision,
+              )
+              reports.append(report_payload(report))
+              if record_exists:
+                  completed_pairs += 1
+                  if report.status not in {
+                      HumanLegalReviewStatus.APPROVED_FOR_CONVERSION,
+                      HumanLegalReviewStatus.REJECTED,
+                  }:
+                      raise SystemExit(
+                          f'invalid completed legal-review pair: {plan.model_id}'
+                      )
+
+          if changed_review_paths and completed_pairs == 0:
+              raise SystemExit('legal-review paths changed without a completed pair')
+
+          evaluation = evaluate_all_model_reviews(
+              authority=authority,
+              acceptance_path=acceptance_path,
+              evidence_root=evidence_root,
+          )
+          if evaluation['status'] == 'INVALID':
+              raise SystemExit('aggregate legal-review evaluation is invalid')
+          payload = {
+              'schema_version': 'tai.model-legal-review-pr-evidence.v1',
+              'base_sha': os.environ['BASE_SHA'],
+              'head_sha': os.environ['HEAD_SHA'],
+              'authority_sha256': authority_sha256(authority),
+              'intended_use_sha256': intended_use_sha256(authority),
+              'changed_review_paths': sorted(changed_review_paths),
+              'completed_pairs': completed_pairs,
+              'models': reports,
+              'aggregate': evaluation,
+              'automation_boundary': 'DECISION_READ_ONLY_HUMAN_AUTHORED',
+              'production_operational_status': 'NOT_ATTESTED',
+          }
+          Path('legal-review-evidence/pr-evaluation.json').write_text(
+              json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+              + '\n'
+          )
+          print(json.dumps(payload, sort_keys=True))
+          PY
+
+      - name: Upload bounded legal review evaluation
+        uses: actions/upload-artifact@v4
+        with:
+          name: tai-human-model-legal-review-${{ github.event.pull_request.head.sha }}
+          path: legal-review-evidence
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false

--- a/apps/tai/governance/scopes/ap-13b3c-human-legal-intake-2877.json
+++ b/apps/tai/governance/scopes/ap-13b3c-human-legal-intake-2877.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "tai.concurrent-scope.v1",
+  "branch": "agent/tai-ap-13b3c-human-legal-intake",
+  "status": "active",
+  "program_issue": 2726,
+  "parent_issue": 2835,
+  "issue": 2877,
+  "maturity_boundary": "human-legal-review-intake-and-validation-only",
+  "allowed_paths": [
+    ".github/workflows/tai-model-legal-review.yml",
+    "apps/tai/governance/scopes/ap-13b3c-human-legal-intake-2877.json",
+    "apps/tai/model-artifacts/model-legal-review-authority.v1.json",
+    "apps/tai/model-artifacts/model-legal-review-record.schema.v1.json",
+    "apps/tai/model-artifacts/model-legal-review-attestation.schema.v1.json",
+    "apps/tai/model-artifacts/model-legal-review-runbook.v1.md",
+    "apps/tai/tai/model_legal_review.py",
+    "apps/tai/tai/model_legal_review_authority.py",
+    "apps/tai/tai/model_legal_review_authority_parse.py",
+    "apps/tai/tai/model_legal_review_cli.py",
+    "apps/tai/tai/model_legal_review_evidence.py",
+    "apps/tai/tai/model_legal_review_evidence_parse.py",
+    "apps/tai/tai/model_legal_review_source.py",
+    "apps/tai/tai/model_legal_review_verify.py",
+    "apps/tai/tests/test_model_legal_review.py",
+    "apps/tai/tests/test_model_legal_review_workflow.py"
+  ],
+  "forbidden_capabilities": [
+    "automated legal decision generation or mutation",
+    "anonymous, bot or service reviewer acceptance",
+    "mutable model, license or source evidence substitution",
+    "model weights, tokenizer files, source archives or GGUF in Git",
+    "conversion, quantization or model admission",
+    "benchmark or production readiness claim",
+    "production deployment or operational attestation"
+  ],
+  "acceptance": [
+    "authority binds exact accepted Qwen and Mistral source evidence and intended use",
+    "completed human review records remain bundle-v2 compatible",
+    "attestation envelopes bind exact model, revision, role, source hashes, intended use and record digest",
+    "reviewer identity is namespaced and bot identities are rejected",
+    "ATTRIBUTED_RECORD binds issue 2877 and an immutable SHA-256 reference",
+    "SIGNED_RECORD requires an immutable versioned or digest-bound locator",
+    "reviews predating accepted source evidence are rejected",
+    "APPROVED authorizes only a later conversion proposal",
+    "REJECTED is a valid record that blocks conversion",
+    "absence of both files remains PENDING_HUMAN_DECISION",
+    "incomplete, malformed or mismatched pairs fail closed",
+    "dedicated workflow is pull-request-only and contents-read-only",
+    "no automation writes or infers a human decision",
+    "Ruff, strict mypy, full pytest/coverage, security/runtime and exact-head CI pass",
+    "production_operational_status remains NOT_ATTESTED"
+  ]
+}

--- a/apps/tai/model-artifacts/model-legal-review-attestation.schema.v1.json
+++ b/apps/tai/model-artifacts/model-legal-review-attestation.schema.v1.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://transparent-price.example/schemas/tai/model-legal-review-attestation.v1.json",
+  "title": "TAI model legal review attestation envelope v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "authority_sha256",
+    "model_id",
+    "revision",
+    "role",
+    "source_acceptance_exact_main_sha",
+    "source_acceptance_git_blob_sha",
+    "model_card_sha256",
+    "license_text_sha256",
+    "legal_packet_sha256",
+    "source_manifest_sha256",
+    "source_files_sha256",
+    "intended_use_sha256",
+    "review_record",
+    "decision",
+    "reviewer_id",
+    "reviewed_at",
+    "attestation_reference"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "tai.model-legal-review-attestation.v1"
+    },
+    "authority_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "model_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "revision": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "role": {
+      "enum": [
+        "PRIMARY",
+        "FALLBACK"
+      ]
+    },
+    "source_acceptance_exact_main_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "source_acceptance_git_blob_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "model_card_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "license_text_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "legal_packet_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "source_manifest_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "source_files_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "intended_use_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "review_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "sha256",
+        "size_bytes"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500,
+          "not": {
+            "anyOf": [
+              {
+                "pattern": "^/"
+              },
+              {
+                "pattern": "^\\./"
+              },
+              {
+                "pattern": "(^|/)\\.\\.(/|$)"
+              }
+            ]
+          }
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "size_bytes": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "decision": {
+      "enum": [
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "reviewer_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "reviewed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "attestation_reference": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000,
+      "pattern": "(@sha256:|#sha256=|versionId=)"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/apps/tai/model-artifacts/model-legal-review-authority.v1.json
+++ b/apps/tai/model-artifacts/model-legal-review-authority.v1.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "tai.model-legal-review-authority.v1",
+  "program_issue": 2726,
+  "parent_issue": 2835,
+  "issue": 2877,
+  "source_acceptance": {
+    "path": "model-artifacts/model-source-acquisition-acceptance.v1.json",
+    "git_blob_sha": "9d5390d2592c707a1ce995ce15cccf8df58c6a70",
+    "accepted_main_sha": "7439ed17c94b173da1bb0c37e0d74ffdfb848d49",
+    "source_exact_main_sha": "4a7b04731aa204b741691a334d7adfe7785d6463",
+    "model_bundle_authority_sha256": "3391ea2ba4ddd855b45c5f389f12ffe3ddffb7cc4f46a4048d7357ffcdda6022",
+    "status": "VERIFIED_SOURCE_RESTORED_LEGAL_PENDING"
+  },
+  "review_not_before": "2026-07-20T11:18:55Z",
+  "intended_use": {
+    "product": "Transparent Agro Intelligence",
+    "platform": "Прозрачная Цена",
+    "use_class": "LOCAL_COMMERCIAL_INFERENCE",
+    "operation_scope": "CONTROLLED_INFRASTRUCTURE",
+    "conversion_toolchain": {
+      "name": "ggml-org/llama.cpp",
+      "release": "b9637",
+      "commit": "aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3",
+      "authority_sha256": "3064250e63baed7bdcfd20851e1d3ea2c86fc33f087b69a2a4fcff18c384374b"
+    },
+    "source_weight_redistribution": false,
+    "community_prebuilt_artifacts": false,
+    "benchmark_or_admission_claim": false,
+    "production_readiness_claim": false
+  },
+  "reviewer_type": "HUMAN",
+  "accepted_decisions": [
+    "APPROVED",
+    "REJECTED"
+  ],
+  "accepted_record_types": [
+    "ATTRIBUTED_RECORD",
+    "SIGNED_RECORD"
+  ],
+  "models": [
+    {
+      "role": "PRIMARY",
+      "model_id": "Qwen/Qwen3-8B",
+      "revision": "895c8d171bc03c30e113cd7a28c02494b5e068b7",
+      "license_spdx": "Apache-2.0",
+      "model_card_sha256": "2d321409d3083a11c13cf00baa2d7adf0eac68ddaf484fcd46e6f5b313c5f95c",
+      "license_text_sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+      "legal_packet_sha256": "aace040831e8f304729d90c8cf51a5f90d92c414f7cfbf4a5e23e7087df06bb2",
+      "source_manifest_sha256": "7c61e18eb68fc1d4f48e3f1c6ac59093e06e9d1484414dda776daea3374a5644",
+      "source_files_sha256": "d3ef5d7334761a40cf857c247d2e2e2af383cd7c3c1e7c180414d07a15f9f2d4",
+      "review_record_path": "model-artifacts/legal-reviews/qwen3-8b.review-record.v1.json",
+      "attestation_path": "model-artifacts/legal-reviews/qwen3-8b.review-attestation.v1.json"
+    },
+    {
+      "role": "FALLBACK",
+      "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+      "revision": "c170c708c41dac9275d15a8fff4eca08d52bab71",
+      "license_spdx": "Apache-2.0",
+      "model_card_sha256": "3166974023134d972368b585d730fa5f70100873684f90a10a773b20e80b30ba",
+      "license_text_sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+      "legal_packet_sha256": "a4a1eeca2db59a7e22f26a664016abd7892736ccb83ce0e78669e4e2acc38280",
+      "source_manifest_sha256": "504b55481b74f7975119a12d88bb5fb00380bdf50f9a219f1d26813bb7e6ef84",
+      "source_files_sha256": "377ffe04a6583e425ca78709afd065989bc6055dd12fcdc904837edffba3cc9e",
+      "review_record_path": "model-artifacts/legal-reviews/mistral-7b-instruct-v0.3.review-record.v1.json",
+      "attestation_path": "model-artifacts/legal-reviews/mistral-7b-instruct-v0.3.review-attestation.v1.json"
+    }
+  ],
+  "maturity_boundary": {
+    "legal_decision": "PENDING_HUMAN_DECISION",
+    "conversion": "NOT_RUN",
+    "quantization": "NOT_RUN",
+    "benchmarks": "NOT_RUN",
+    "model_admission": "NOT_DONE",
+    "production_operational_status": "NOT_ATTESTED"
+  }
+}

--- a/apps/tai/model-artifacts/model-legal-review-authority.v1.json
+++ b/apps/tai/model-artifacts/model-legal-review-authority.v1.json
@@ -29,6 +29,13 @@
     "production_readiness_claim": false
   },
   "reviewer_type": "HUMAN",
+  "reviewer_identity_prefixes": [
+    "github:",
+    "employee:",
+    "contractor:",
+    "legal:"
+  ],
+  "attributed_record_issue": 2877,
   "accepted_decisions": [
     "APPROVED",
     "REJECTED"

--- a/apps/tai/model-artifacts/model-legal-review-record.schema.v1.json
+++ b/apps/tai/model-artifacts/model-legal-review-record.schema.v1.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://transparent-price.example/schemas/tai/model-legal-review-record.v1.json",
+  "title": "TAI human model legal review record v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "decision",
+    "reviewer_type",
+    "reviewer_id",
+    "reviewer_name",
+    "reviewed_at",
+    "license_spdx",
+    "decision_basis",
+    "conditions",
+    "record_type",
+    "attestation_reference",
+    "license_text_sha256"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "tai.model-legal-review-record.v1"
+    },
+    "decision": {
+      "enum": [
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "reviewer_type": {
+      "const": "HUMAN"
+    },
+    "reviewer_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/+@-]{0,199}$"
+    },
+    "reviewer_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "reviewed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "license_spdx": {
+      "const": "Apache-2.0"
+    },
+    "decision_basis": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2000
+    },
+    "conditions": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 1000
+      }
+    },
+    "record_type": {
+      "enum": [
+        "ATTRIBUTED_RECORD",
+        "SIGNED_RECORD"
+      ]
+    },
+    "attestation_reference": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000,
+      "pattern": "(@sha256:|#sha256=|versionId=)"
+    },
+    "license_text_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/apps/tai/model-artifacts/model-legal-review-runbook.v1.md
+++ b/apps/tai/model-artifacts/model-legal-review-runbook.v1.md
@@ -1,0 +1,128 @@
+# AP-13B.3c human model legal review runbook
+
+## Boundary
+
+This procedure records a human legal decision for the exact Qwen and Mistral revisions accepted by source-acquisition evidence. Automation validates the decision but never creates, changes or infers it.
+
+A valid `APPROVED` record authorizes only the next controlled conversion stage. A valid `REJECTED` record blocks conversion. Neither outcome is a benchmark, model admission or production-readiness decision. `production_operational_status` remains `NOT_ATTESTED`.
+
+Tracking issue: #2877. Parent: #2835. Program: #2726.
+
+## Accepted source evidence
+
+Use only:
+
+- authority: `model-legal-review-authority.v1.json`;
+- source acceptance: `model-source-acquisition-acceptance.v1.json`;
+- Qwen exact revision `895c8d171bc03c30e113cd7a28c02494b5e068b7`;
+- Mistral exact revision `c170c708c41dac9275d15a8fff4eca08d52bab71`;
+- exact Apache-2.0 text SHA-256 `cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30`.
+
+Do not review a mutable branch, tag, community GGUF or substituted license text.
+
+## 1. Validate the authority
+
+```bash
+cd apps/tai
+python -m tai.model_legal_review_cli validate-authority \
+  model-artifacts/model-legal-review-authority.v1.json \
+  model-artifacts/model-source-acquisition-acceptance.v1.json \
+  --output /tmp/tai-legal-authority-validation.json
+```
+
+The command must return exit `0`, status `VALID`, an `authority_sha256` and an `intended_use_sha256`. Copy those exact digests into the attestation envelope. Do not edit them.
+
+## 2. Inspect the exact evidence
+
+For the selected model, inspect:
+
+- exact model identity and 40-character revision;
+- exact model card and its SHA-256;
+- exact Apache-2.0 text and its SHA-256;
+- accepted source manifest and source-files digests;
+- intended use in the authority;
+- conditions or restrictions relevant to commercial local inference, conversion, quantization, storage and operation on controlled infrastructure.
+
+The source metadata saying `apache-2.0` is not itself the human decision.
+
+## 3. Create the human review record
+
+Create exactly one of the authority-declared paths:
+
+- `model-artifacts/legal-reviews/qwen3-8b.review-record.v1.json`;
+- `model-artifacts/legal-reviews/mistral-7b-instruct-v0.3.review-record.v1.json`.
+
+The file must conform to `model-legal-review-record.schema.v1.json`:
+
+```json
+{
+  "schema_version": "tai.model-legal-review-record.v1",
+  "decision": "APPROVED",
+  "reviewer_type": "HUMAN",
+  "reviewer_id": "legal:stable-human-identifier",
+  "reviewer_name": "Full reviewer name",
+  "reviewed_at": "2030-01-01T12:00:00+03:00",
+  "license_spdx": "Apache-2.0",
+  "decision_basis": "Human-authored basis covering the exact revision and intended use.",
+  "conditions": [],
+  "record_type": "SIGNED_RECORD",
+  "attestation_reference": "storage://legal/review/versionId=immutable-version",
+  "license_text_sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
+}
+```
+
+Use decision `REJECTED` when required. Do not use `PENDING` inside a completed record; absence of both files is the pending state.
+
+Allowed reviewer ID namespaces are fixed by the authority: `github:`, `employee:`, `contractor:` or `legal:`. Bot/service identities are rejected.
+
+For `ATTRIBUTED_RECORD`, the immutable reference must bind a human-authored record in issue #2877 and include a SHA-256 marker. For `SIGNED_RECORD`, use a versioned or digest-bound signed-document locator.
+
+## 4. Create the attestation envelope
+
+Create the matching authority-declared attestation path. The file must conform to `model-legal-review-attestation.schema.v1.json` and bind:
+
+- the legal authority SHA-256;
+- exact model, revision and role;
+- accepted-main SHA `7439ed17c94b173da1bb0c37e0d74ffdfb848d49`;
+- accepted source-evidence Git blob `9d5390d2592c707a1ce995ce15cccf8df58c6a70`;
+- model-card, license, legal-packet, source-manifest and source-files SHA-256 values from the authority;
+- intended-use SHA-256;
+- exact review-record relative path, byte size and SHA-256;
+- the same decision, reviewer ID, review timestamp and immutable attestation reference as the review record.
+
+No field is optional. Unknown or duplicate JSON keys are rejected.
+
+## 5. Verify locally
+
+```bash
+python -m tai.model_legal_review_cli verify-model \
+  model-artifacts/model-legal-review-authority.v1.json \
+  model-artifacts/model-source-acquisition-acceptance.v1.json \
+  . \
+  '<EXACT_MODEL_ID>' \
+  '<EXACT_REVISION>' \
+  --output /tmp/tai-model-legal-review.json
+```
+
+Expected outcomes:
+
+- `APPROVED_FOR_CONVERSION`, exit `0`: valid human approval; conversion may be proposed separately;
+- `REJECTED`, exit `0`: valid human rejection; conversion is blocked;
+- `PENDING_HUMAN_DECISION`, exit `2`: no completed pair exists;
+- `INVALID`, exit `2`: malformed, incomplete, automated, stale or mismatched evidence.
+
+Evaluate both models:
+
+```bash
+python -m tai.model_legal_review_cli evaluate-all \
+  model-artifacts/model-legal-review-authority.v1.json \
+  model-artifacts/model-source-acquisition-acceptance.v1.json \
+  . \
+  --output /tmp/tai-model-legal-review-all.json
+```
+
+## 6. Publish a decision PR
+
+A decision PR may add one model pair at a time. It must contain both the review record and its attestation envelope. The dedicated legal-review workflow verifies all present pairs and emits a small evaluation artifact.
+
+Do not include model weights, tokenizer files, license credentials, private signing keys, GGUF files or conversion outputs. The human decision must be separately reviewed and accepted in exact-main before any conversion workflow is enabled.

--- a/apps/tai/tai/model_legal_review.py
+++ b/apps/tai/tai/model_legal_review.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tai.model_bundle_v2_common import _canonical_json, _sha256_text
+from tai.model_legal_review_authority import ModelLegalReviewAuthority
+from tai.model_legal_review_authority_parse import (
+    authority_sha256,
+    authority_to_canonical_json,
+    intended_use_sha256,
+    load_model_legal_review_authority,
+)
+from tai.model_legal_review_evidence import (
+    HumanLegalDecision,
+    HumanLegalRecordType,
+    HumanLegalReviewAttestation,
+    HumanLegalReviewRecord,
+    HumanLegalReviewStatus,
+    ModelLegalReviewReport,
+)
+from tai.model_legal_review_evidence_parse import (
+    load_human_legal_review_attestation,
+    load_human_legal_review_record,
+)
+from tai.model_legal_review_source import validate_source_acceptance
+from tai.model_legal_review_verify import evaluate_model_review
+
+
+def evaluate_all_model_reviews(
+    *,
+    authority: ModelLegalReviewAuthority,
+    acceptance_path: Path,
+    evidence_root: Path,
+) -> dict[str, object]:
+    reports = [
+        evaluate_model_review(
+            authority=authority,
+            acceptance_path=acceptance_path,
+            evidence_root=evidence_root,
+            model_id=plan.model_id,
+            revision=plan.revision,
+        )
+        for plan in authority.models
+    ]
+    statuses = {report.status for report in reports}
+    if HumanLegalReviewStatus.INVALID in statuses:
+        overall = "INVALID"
+    elif HumanLegalReviewStatus.PENDING_HUMAN_DECISION in statuses:
+        overall = "PENDING_HUMAN_DECISION"
+    elif HumanLegalReviewStatus.REJECTED in statuses:
+        overall = "COMPLETE_WITH_REJECTION"
+    else:
+        overall = "ALL_APPROVED_FOR_CONVERSION"
+    payload: dict[str, object] = {
+        "schema_version": "tai.model-legal-review-evaluation.v1",
+        "status": overall,
+        "authority_sha256": authority_sha256(authority),
+        "intended_use_sha256": intended_use_sha256(authority),
+        "models": [report_payload(report) for report in reports],
+        "conversion_authorized_models": sorted(
+            report.model_id for report in reports if report.conversion_allowed
+        ),
+        "maturity_boundary": {
+            "conversion": "NOT_RUN",
+            "quantization": "NOT_RUN",
+            "benchmarks": "NOT_RUN",
+            "model_admission": "NOT_DONE",
+            "production_operational_status": "NOT_ATTESTED",
+        },
+    }
+    payload["evaluation_sha256"] = _sha256_text(_canonical_json(payload))
+    return payload
+
+
+def report_payload(report: ModelLegalReviewReport) -> dict[str, object]:
+    return {
+        "model_id": report.model_id,
+        "revision": report.revision,
+        "role": report.role.value,
+        "status": report.status.value,
+        "valid_record": report.valid_record,
+        "conversion_allowed": report.conversion_allowed,
+        "decision": report.decision.value if report.decision is not None else None,
+        "reviewer_id": report.reviewer_id,
+        "reviewed_at": report.reviewed_at,
+        "review_record_sha256": report.review_record_sha256,
+        "attestation_sha256": report.attestation_sha256,
+        "reasons": list(report.reasons),
+        "authority_sha256": report.authority_sha256,
+        "intended_use_sha256": report.intended_use_sha256,
+    }
+
+
+__all__ = [
+    "HumanLegalDecision",
+    "HumanLegalRecordType",
+    "HumanLegalReviewAttestation",
+    "HumanLegalReviewRecord",
+    "HumanLegalReviewStatus",
+    "ModelLegalReviewAuthority",
+    "ModelLegalReviewReport",
+    "authority_sha256",
+    "authority_to_canonical_json",
+    "evaluate_all_model_reviews",
+    "evaluate_model_review",
+    "intended_use_sha256",
+    "load_human_legal_review_attestation",
+    "load_human_legal_review_record",
+    "load_model_legal_review_authority",
+    "report_payload",
+    "validate_source_acceptance",
+]

--- a/apps/tai/tai/model_legal_review_authority.py
+++ b/apps/tai/tai/model_legal_review_authority.py
@@ -132,9 +132,14 @@ class ModelLegalReviewAuthority:
             raise ValueError("legal reviewer type must be HUMAN")
         if not self.reviewer_identity_prefixes:
             raise ValueError("legal reviewer identity prefixes must not be empty")
-        if len(self.reviewer_identity_prefixes) != len(set(self.reviewer_identity_prefixes)):
+        if len(self.reviewer_identity_prefixes) != len(
+            set(self.reviewer_identity_prefixes)
+        ):
             raise ValueError("legal reviewer identity prefixes must be unique")
-        if any(not item.endswith(":") or len(item) > 40 for item in self.reviewer_identity_prefixes):
+        if any(
+            not item.endswith(":") or len(item) > 40
+            for item in self.reviewer_identity_prefixes
+        ):
             raise ValueError("legal reviewer identity prefix is invalid")
         if self.attributed_record_issue != self.issue:
             raise ValueError("attributed record issue must equal legal review issue")

--- a/apps/tai/tai/model_legal_review_authority.py
+++ b/apps/tai/tai/model_legal_review_authority.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tai.model_bundle_v2_common import (
+    _bounded_text,
+    _identity,
+    _parse_timestamp,
+    _relative_path,
+    _revision,
+    _sha256,
+)
+from tai.model_bundle_v2_types import CandidateRole
+
+
+@dataclass(frozen=True, slots=True)
+class SourceAcceptanceReference:
+    path: str
+    git_blob_sha: str
+    accepted_main_sha: str
+    source_exact_main_sha: str
+    model_bundle_authority_sha256: str
+    status: str
+
+    def __post_init__(self) -> None:
+        _relative_path(self.path, "source acceptance path")
+        _revision(self.git_blob_sha, "source acceptance git blob sha")
+        _revision(self.accepted_main_sha, "source acceptance accepted main sha")
+        _revision(self.source_exact_main_sha, "source acquisition exact main sha")
+        _sha256(
+            self.model_bundle_authority_sha256,
+            "source acceptance model bundle authority sha256",
+        )
+        if self.status != "VERIFIED_SOURCE_RESTORED_LEGAL_PENDING":
+            raise ValueError("source acceptance status must remain legal-pending")
+
+
+@dataclass(frozen=True, slots=True)
+class LegalReviewToolchain:
+    name: str
+    release: str
+    commit: str
+    authority_sha256: str
+
+    def __post_init__(self) -> None:
+        _identity(self.name, "legal review toolchain name")
+        _identity(self.release, "legal review toolchain release")
+        _revision(self.commit, "legal review toolchain commit")
+        _sha256(self.authority_sha256, "legal review toolchain authority sha256")
+
+
+@dataclass(frozen=True, slots=True)
+class IntendedUse:
+    product: str
+    platform: str
+    use_class: str
+    operation_scope: str
+    conversion_toolchain: LegalReviewToolchain
+    source_weight_redistribution: bool
+    community_prebuilt_artifacts: bool
+    benchmark_or_admission_claim: bool
+    production_readiness_claim: bool
+
+    def __post_init__(self) -> None:
+        _bounded_text(self.product, "intended use product", maximum=200)
+        _bounded_text(self.platform, "intended use platform", maximum=200)
+        _identity(self.use_class, "intended use class")
+        _identity(self.operation_scope, "intended use operation scope")
+        if self.source_weight_redistribution:
+            raise ValueError("source weight redistribution must remain disabled")
+        if self.community_prebuilt_artifacts:
+            raise ValueError("community prebuilt artifacts must remain disabled")
+        if self.benchmark_or_admission_claim:
+            raise ValueError("legal review cannot make benchmark or admission claims")
+        if self.production_readiness_claim:
+            raise ValueError("legal review cannot make production readiness claims")
+
+
+@dataclass(frozen=True, slots=True)
+class LegalReviewModelPlan:
+    role: CandidateRole
+    model_id: str
+    revision: str
+    license_spdx: str
+    model_card_sha256: str
+    license_text_sha256: str
+    legal_packet_sha256: str
+    source_manifest_sha256: str
+    source_files_sha256: str
+    review_record_path: str
+    attestation_path: str
+
+    def __post_init__(self) -> None:
+        _identity(self.model_id, "legal review model id")
+        _revision(self.revision, "legal review model revision")
+        _identity(self.license_spdx, "legal review license SPDX")
+        for value, name in (
+            (self.model_card_sha256, "model card sha256"),
+            (self.license_text_sha256, "license text sha256"),
+            (self.legal_packet_sha256, "legal packet sha256"),
+            (self.source_manifest_sha256, "source manifest sha256"),
+            (self.source_files_sha256, "source files sha256"),
+        ):
+            _sha256(value, name)
+        _relative_path(self.review_record_path, "legal review record path")
+        _relative_path(self.attestation_path, "legal review attestation path")
+        if self.review_record_path == self.attestation_path:
+            raise ValueError("legal review record and attestation paths must differ")
+
+
+@dataclass(frozen=True, slots=True)
+class ModelLegalReviewAuthority:
+    program_issue: int
+    parent_issue: int
+    issue: int
+    source_acceptance: SourceAcceptanceReference
+    review_not_before: str
+    intended_use: IntendedUse
+    reviewer_type: str
+    reviewer_identity_prefixes: tuple[str, ...]
+    attributed_record_issue: int
+    accepted_decisions: tuple[str, ...]
+    accepted_record_types: tuple[str, ...]
+    models: tuple[LegalReviewModelPlan, ...]
+    maturity_boundary: dict[str, str]
+
+    def __post_init__(self) -> None:
+        if (self.program_issue, self.parent_issue, self.issue) != (2726, 2835, 2877):
+            raise ValueError("legal review issue chain is invalid")
+        _parse_timestamp(self.review_not_before, "legal review not-before timestamp")
+        if self.reviewer_type != "HUMAN":
+            raise ValueError("legal reviewer type must be HUMAN")
+        if not self.reviewer_identity_prefixes:
+            raise ValueError("legal reviewer identity prefixes must not be empty")
+        if len(self.reviewer_identity_prefixes) != len(set(self.reviewer_identity_prefixes)):
+            raise ValueError("legal reviewer identity prefixes must be unique")
+        if any(not item.endswith(":") or len(item) > 40 for item in self.reviewer_identity_prefixes):
+            raise ValueError("legal reviewer identity prefix is invalid")
+        if self.attributed_record_issue != self.issue:
+            raise ValueError("attributed record issue must equal legal review issue")
+        if set(self.accepted_decisions) != {"APPROVED", "REJECTED"}:
+            raise ValueError("legal review authority requires APPROVED and REJECTED")
+        if set(self.accepted_record_types) != {"ATTRIBUTED_RECORD", "SIGNED_RECORD"}:
+            raise ValueError("legal review authority requires both record types")
+        if len(self.models) != 2:
+            raise ValueError("legal review authority requires exactly two models")
+        if len({(item.model_id, item.revision) for item in self.models}) != 2:
+            raise ValueError("legal review model identities must be unique")
+        if {item.role for item in self.models} != {
+            CandidateRole.PRIMARY,
+            CandidateRole.FALLBACK,
+        }:
+            raise ValueError("legal review authority requires primary and fallback")
+        expected = {
+            "legal_decision": "PENDING_HUMAN_DECISION",
+            "conversion": "NOT_RUN",
+            "quantization": "NOT_RUN",
+            "benchmarks": "NOT_RUN",
+            "model_admission": "NOT_DONE",
+            "production_operational_status": "NOT_ATTESTED",
+        }
+        if self.maturity_boundary != expected:
+            raise ValueError("legal review maturity boundary is invalid")

--- a/apps/tai/tai/model_legal_review_authority_parse.py
+++ b/apps/tai/tai/model_legal_review_authority_parse.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tai.model_bundle_v2_common import (
+    _array,
+    _canonical_json,
+    _expect_keys,
+    _integer,
+    _load_json_strict,
+    _object,
+    _sha256_text,
+    _string,
+    _strings,
+)
+from tai.model_bundle_v2_types import CandidateRole
+from tai.model_legal_review_authority import (
+    IntendedUse,
+    LegalReviewModelPlan,
+    LegalReviewToolchain,
+    ModelLegalReviewAuthority,
+    SourceAcceptanceReference,
+)
+
+
+def load_model_legal_review_authority(path: Path) -> ModelLegalReviewAuthority:
+    payload = _load_json_strict(path)
+    _expect_keys(
+        payload,
+        {
+            "schema_version",
+            "program_issue",
+            "parent_issue",
+            "issue",
+            "source_acceptance",
+            "review_not_before",
+            "intended_use",
+            "reviewer_type",
+            "reviewer_identity_prefixes",
+            "attributed_record_issue",
+            "accepted_decisions",
+            "accepted_record_types",
+            "models",
+            "maturity_boundary",
+        },
+        set(),
+        "model legal review authority",
+    )
+    if _string(payload, "schema_version") != "tai.model-legal-review-authority.v1":
+        raise ValueError("unsupported model legal review authority schema")
+    return ModelLegalReviewAuthority(
+        program_issue=_integer(payload, "program_issue"),
+        parent_issue=_integer(payload, "parent_issue"),
+        issue=_integer(payload, "issue"),
+        source_acceptance=_parse_source_acceptance(payload.get("source_acceptance")),
+        review_not_before=_string(payload, "review_not_before"),
+        intended_use=_parse_intended_use(payload.get("intended_use")),
+        reviewer_type=_string(payload, "reviewer_type"),
+        reviewer_identity_prefixes=tuple(_strings(payload, "reviewer_identity_prefixes")),
+        attributed_record_issue=_integer(payload, "attributed_record_issue"),
+        accepted_decisions=tuple(_strings(payload, "accepted_decisions")),
+        accepted_record_types=tuple(_strings(payload, "accepted_record_types")),
+        models=tuple(_parse_model_plan(item) for item in _array(payload, "models")),
+        maturity_boundary=_string_map(payload.get("maturity_boundary"), "maturity boundary"),
+    )
+
+
+def authority_to_canonical_json(authority: ModelLegalReviewAuthority) -> str:
+    return _canonical_json(authority_payload(authority))
+
+
+def authority_sha256(authority: ModelLegalReviewAuthority) -> str:
+    return _sha256_text(authority_to_canonical_json(authority))
+
+
+def intended_use_sha256(authority: ModelLegalReviewAuthority) -> str:
+    return _sha256_text(_canonical_json(intended_use_payload(authority.intended_use)))
+
+
+def authority_payload(authority: ModelLegalReviewAuthority) -> dict[str, object]:
+    return {
+        "schema_version": "tai.model-legal-review-authority.v1",
+        "program_issue": authority.program_issue,
+        "parent_issue": authority.parent_issue,
+        "issue": authority.issue,
+        "source_acceptance": {
+            "path": authority.source_acceptance.path,
+            "git_blob_sha": authority.source_acceptance.git_blob_sha,
+            "accepted_main_sha": authority.source_acceptance.accepted_main_sha,
+            "source_exact_main_sha": authority.source_acceptance.source_exact_main_sha,
+            "model_bundle_authority_sha256": (
+                authority.source_acceptance.model_bundle_authority_sha256
+            ),
+            "status": authority.source_acceptance.status,
+        },
+        "review_not_before": authority.review_not_before,
+        "intended_use": intended_use_payload(authority.intended_use),
+        "reviewer_type": authority.reviewer_type,
+        "reviewer_identity_prefixes": list(authority.reviewer_identity_prefixes),
+        "attributed_record_issue": authority.attributed_record_issue,
+        "accepted_decisions": list(authority.accepted_decisions),
+        "accepted_record_types": list(authority.accepted_record_types),
+        "models": [
+            {
+                "role": model.role.value,
+                "model_id": model.model_id,
+                "revision": model.revision,
+                "license_spdx": model.license_spdx,
+                "model_card_sha256": model.model_card_sha256,
+                "license_text_sha256": model.license_text_sha256,
+                "legal_packet_sha256": model.legal_packet_sha256,
+                "source_manifest_sha256": model.source_manifest_sha256,
+                "source_files_sha256": model.source_files_sha256,
+                "review_record_path": model.review_record_path,
+                "attestation_path": model.attestation_path,
+            }
+            for model in authority.models
+        ],
+        "maturity_boundary": authority.maturity_boundary,
+    }
+
+
+def intended_use_payload(intended_use: IntendedUse) -> dict[str, object]:
+    return {
+        "product": intended_use.product,
+        "platform": intended_use.platform,
+        "use_class": intended_use.use_class,
+        "operation_scope": intended_use.operation_scope,
+        "conversion_toolchain": {
+            "name": intended_use.conversion_toolchain.name,
+            "release": intended_use.conversion_toolchain.release,
+            "commit": intended_use.conversion_toolchain.commit,
+            "authority_sha256": intended_use.conversion_toolchain.authority_sha256,
+        },
+        "source_weight_redistribution": intended_use.source_weight_redistribution,
+        "community_prebuilt_artifacts": intended_use.community_prebuilt_artifacts,
+        "benchmark_or_admission_claim": intended_use.benchmark_or_admission_claim,
+        "production_readiness_claim": intended_use.production_readiness_claim,
+    }
+
+
+def _parse_source_acceptance(value: object) -> SourceAcceptanceReference:
+    payload = _object(value, "source acceptance reference")
+    _expect_keys(
+        payload,
+        {
+            "path",
+            "git_blob_sha",
+            "accepted_main_sha",
+            "source_exact_main_sha",
+            "model_bundle_authority_sha256",
+            "status",
+        },
+        set(),
+        "source acceptance reference",
+    )
+    return SourceAcceptanceReference(
+        path=_string(payload, "path"),
+        git_blob_sha=_string(payload, "git_blob_sha"),
+        accepted_main_sha=_string(payload, "accepted_main_sha"),
+        source_exact_main_sha=_string(payload, "source_exact_main_sha"),
+        model_bundle_authority_sha256=_string(
+            payload, "model_bundle_authority_sha256"
+        ),
+        status=_string(payload, "status"),
+    )
+
+
+def _parse_intended_use(value: object) -> IntendedUse:
+    payload = _object(value, "intended use")
+    _expect_keys(
+        payload,
+        {
+            "product",
+            "platform",
+            "use_class",
+            "operation_scope",
+            "conversion_toolchain",
+            "source_weight_redistribution",
+            "community_prebuilt_artifacts",
+            "benchmark_or_admission_claim",
+            "production_readiness_claim",
+        },
+        set(),
+        "intended use",
+    )
+    toolchain = _object(payload.get("conversion_toolchain"), "conversion toolchain")
+    _expect_keys(
+        toolchain,
+        {"name", "release", "commit", "authority_sha256"},
+        set(),
+        "conversion toolchain",
+    )
+    return IntendedUse(
+        product=_string(payload, "product"),
+        platform=_string(payload, "platform"),
+        use_class=_string(payload, "use_class"),
+        operation_scope=_string(payload, "operation_scope"),
+        conversion_toolchain=LegalReviewToolchain(
+            name=_string(toolchain, "name"),
+            release=_string(toolchain, "release"),
+            commit=_string(toolchain, "commit"),
+            authority_sha256=_string(toolchain, "authority_sha256"),
+        ),
+        source_weight_redistribution=_boolean(payload, "source_weight_redistribution"),
+        community_prebuilt_artifacts=_boolean(payload, "community_prebuilt_artifacts"),
+        benchmark_or_admission_claim=_boolean(payload, "benchmark_or_admission_claim"),
+        production_readiness_claim=_boolean(payload, "production_readiness_claim"),
+    )
+
+
+def _parse_model_plan(value: object) -> LegalReviewModelPlan:
+    payload = _object(value, "legal review model plan")
+    required = {
+        "role",
+        "model_id",
+        "revision",
+        "license_spdx",
+        "model_card_sha256",
+        "license_text_sha256",
+        "legal_packet_sha256",
+        "source_manifest_sha256",
+        "source_files_sha256",
+        "review_record_path",
+        "attestation_path",
+    }
+    _expect_keys(payload, required, set(), "legal review model plan")
+    return LegalReviewModelPlan(
+        role=CandidateRole(_string(payload, "role")),
+        model_id=_string(payload, "model_id"),
+        revision=_string(payload, "revision"),
+        license_spdx=_string(payload, "license_spdx"),
+        model_card_sha256=_string(payload, "model_card_sha256"),
+        license_text_sha256=_string(payload, "license_text_sha256"),
+        legal_packet_sha256=_string(payload, "legal_packet_sha256"),
+        source_manifest_sha256=_string(payload, "source_manifest_sha256"),
+        source_files_sha256=_string(payload, "source_files_sha256"),
+        review_record_path=_string(payload, "review_record_path"),
+        attestation_path=_string(payload, "attestation_path"),
+    )
+
+
+def _string_map(value: object, name: str) -> dict[str, str]:
+    payload = _object(value, name)
+    result: dict[str, str] = {}
+    for key, item in payload.items():
+        if not isinstance(item, str) or not item:
+            raise ValueError(f"{name} values must be non-empty strings")
+        result[key] = item
+    return result
+
+
+def _boolean(payload: dict[str, Any], key: str) -> bool:
+    value = payload.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value

--- a/apps/tai/tai/model_legal_review_cli.py
+++ b/apps/tai/tai/model_legal_review_cli.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from tai.model_legal_review import (
+    HumanLegalReviewStatus,
+    authority_sha256,
+    evaluate_all_model_reviews,
+    evaluate_model_review,
+    intended_use_sha256,
+    load_model_legal_review_authority,
+    report_payload,
+    validate_source_acceptance,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tai-model-legal-review",
+        description="Validate human-only legal review evidence for exact model sources.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    validate = commands.add_parser("validate-authority")
+    validate.add_argument("authority", type=Path)
+    validate.add_argument("source_acceptance", type=Path)
+    validate.add_argument("--output", type=Path)
+
+    evaluate = commands.add_parser("evaluate-all")
+    evaluate.add_argument("authority", type=Path)
+    evaluate.add_argument("source_acceptance", type=Path)
+    evaluate.add_argument("evidence_root", type=Path)
+    evaluate.add_argument("--output", type=Path)
+
+    model = commands.add_parser("verify-model")
+    model.add_argument("authority", type=Path)
+    model.add_argument("source_acceptance", type=Path)
+    model.add_argument("evidence_root", type=Path)
+    model.add_argument("model_id")
+    model.add_argument("revision")
+    model.add_argument("--output", type=Path)
+
+    arguments = parser.parse_args(argv)
+    try:
+        authority = load_model_legal_review_authority(arguments.authority)
+        if arguments.command == "validate-authority":
+            validate_source_acceptance(authority, arguments.source_acceptance)
+            payload: dict[str, object] = {
+                "schema_version": "tai.model-legal-review-authority-validation.v1",
+                "status": "VALID",
+                "authority_sha256": authority_sha256(authority),
+                "intended_use_sha256": intended_use_sha256(authority),
+                "model_count": len(authority.models),
+                "legal_decision": "PENDING_HUMAN_DECISION",
+                "production_operational_status": "NOT_ATTESTED",
+            }
+            _write(payload, arguments.output)
+            return 0
+        if arguments.command == "evaluate-all":
+            payload = evaluate_all_model_reviews(
+                authority=authority,
+                acceptance_path=arguments.source_acceptance,
+                evidence_root=arguments.evidence_root,
+            )
+            _write(payload, arguments.output)
+            return 0 if payload["status"] in {
+                "ALL_APPROVED_FOR_CONVERSION",
+                "COMPLETE_WITH_REJECTION",
+            } else 2
+        report = evaluate_model_review(
+            authority=authority,
+            acceptance_path=arguments.source_acceptance,
+            evidence_root=arguments.evidence_root,
+            model_id=arguments.model_id,
+            revision=arguments.revision,
+        )
+        _write(report_payload(report), arguments.output)
+        return 0 if report.status in {
+            HumanLegalReviewStatus.APPROVED_FOR_CONVERSION,
+            HumanLegalReviewStatus.REJECTED,
+        } else 2
+    except (ValueError, OSError) as error:
+        _write(
+            {
+                "schema_version": "tai.model-legal-review-cli-error.v1",
+                "status": "INVALID",
+                "error": str(error),
+                "production_operational_status": "NOT_ATTESTED",
+            },
+            getattr(arguments, "output", None),
+        )
+        return 2
+
+
+def _write(payload: dict[str, object], output: Path | None) -> None:
+    rendered = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if output is None:
+        sys.stdout.write(rendered)
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/tai/tai/model_legal_review_evidence.py
+++ b/apps/tai/tai/model_legal_review_evidence.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from tai.model_bundle_v2_common import (
+    _bounded_text,
+    _identity,
+    _immutable_locator,
+    _parse_timestamp,
+    _revision,
+    _sha256,
+)
+from tai.model_bundle_v2_types import CandidateRole, DeclaredFile
+
+
+class HumanLegalDecision(StrEnum):
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+
+class HumanLegalRecordType(StrEnum):
+    ATTRIBUTED_RECORD = "ATTRIBUTED_RECORD"
+    SIGNED_RECORD = "SIGNED_RECORD"
+
+
+class HumanLegalReviewStatus(StrEnum):
+    PENDING_HUMAN_DECISION = "PENDING_HUMAN_DECISION"
+    APPROVED_FOR_CONVERSION = "APPROVED_FOR_CONVERSION"
+    REJECTED = "REJECTED"
+    INVALID = "INVALID"
+
+
+@dataclass(frozen=True, slots=True)
+class HumanLegalReviewRecord:
+    decision: HumanLegalDecision
+    reviewer_type: str
+    reviewer_id: str
+    reviewer_name: str
+    reviewed_at: str
+    license_spdx: str
+    decision_basis: str
+    conditions: tuple[str, ...]
+    record_type: HumanLegalRecordType
+    attestation_reference: str
+    license_text_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.reviewer_type != "HUMAN":
+            raise ValueError("legal review record reviewer_type must be HUMAN")
+        _identity(self.reviewer_id, "legal reviewer id")
+        _bounded_text(self.reviewer_name, "legal reviewer name", maximum=200)
+        _parse_timestamp(self.reviewed_at, "legal reviewed_at")
+        _identity(self.license_spdx, "legal review license SPDX")
+        _bounded_text(self.decision_basis, "legal decision basis", maximum=2_000)
+        if len(self.conditions) > 32 or len(self.conditions) != len(set(self.conditions)):
+            raise ValueError("legal review conditions must be bounded and unique")
+        for condition in self.conditions:
+            _bounded_text(condition, "legal review condition", maximum=1_000)
+        _immutable_locator(self.attestation_reference)
+        _sha256(self.license_text_sha256, "legal review license text sha256")
+
+
+@dataclass(frozen=True, slots=True)
+class HumanLegalReviewAttestation:
+    authority_sha256: str
+    model_id: str
+    revision: str
+    role: CandidateRole
+    source_acceptance_exact_main_sha: str
+    source_acceptance_git_blob_sha: str
+    model_card_sha256: str
+    license_text_sha256: str
+    legal_packet_sha256: str
+    source_manifest_sha256: str
+    source_files_sha256: str
+    intended_use_sha256: str
+    review_record: DeclaredFile
+    decision: HumanLegalDecision
+    reviewer_id: str
+    reviewed_at: str
+    attestation_reference: str
+
+    def __post_init__(self) -> None:
+        _sha256(self.authority_sha256, "legal review authority sha256")
+        _identity(self.model_id, "legal review attestation model id")
+        _revision(self.revision, "legal review attestation revision")
+        _revision(self.source_acceptance_exact_main_sha, "source acceptance exact main")
+        _revision(self.source_acceptance_git_blob_sha, "source acceptance git blob")
+        for value, name in (
+            (self.model_card_sha256, "attestation model card sha256"),
+            (self.license_text_sha256, "attestation license text sha256"),
+            (self.legal_packet_sha256, "attestation legal packet sha256"),
+            (self.source_manifest_sha256, "attestation source manifest sha256"),
+            (self.source_files_sha256, "attestation source files sha256"),
+            (self.intended_use_sha256, "attestation intended use sha256"),
+        ):
+            _sha256(value, name)
+        _identity(self.reviewer_id, "legal review attestation reviewer id")
+        _parse_timestamp(self.reviewed_at, "legal review attestation reviewed_at")
+        _immutable_locator(self.attestation_reference)
+
+
+@dataclass(frozen=True, slots=True)
+class ModelLegalReviewReport:
+    model_id: str
+    revision: str
+    role: CandidateRole
+    status: HumanLegalReviewStatus
+    valid_record: bool
+    conversion_allowed: bool
+    decision: HumanLegalDecision | None
+    reviewer_id: str | None
+    reviewed_at: str | None
+    review_record_sha256: str | None
+    attestation_sha256: str | None
+    reasons: tuple[str, ...]
+    authority_sha256: str
+    intended_use_sha256: str

--- a/apps/tai/tai/model_legal_review_evidence_parse.py
+++ b/apps/tai/tai/model_legal_review_evidence_parse.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tai.model_bundle_v2_common import (
+    _array,
+    _expect_keys,
+    _integer,
+    _load_json_strict,
+    _object,
+    _string,
+)
+from tai.model_bundle_v2_types import CandidateRole, DeclaredFile
+from tai.model_legal_review_evidence import (
+    HumanLegalDecision,
+    HumanLegalRecordType,
+    HumanLegalReviewAttestation,
+    HumanLegalReviewRecord,
+)
+
+
+def load_human_legal_review_record(path: Path) -> HumanLegalReviewRecord:
+    payload = _load_json_strict(path)
+    _expect_keys(
+        payload,
+        {
+            "schema_version",
+            "decision",
+            "reviewer_type",
+            "reviewer_id",
+            "reviewer_name",
+            "reviewed_at",
+            "license_spdx",
+            "decision_basis",
+            "conditions",
+            "record_type",
+            "attestation_reference",
+            "license_text_sha256",
+        },
+        set(),
+        "human legal review record",
+    )
+    if _string(payload, "schema_version") != "tai.model-legal-review-record.v1":
+        raise ValueError("unsupported human legal review record schema")
+    return HumanLegalReviewRecord(
+        decision=HumanLegalDecision(_string(payload, "decision")),
+        reviewer_type=_string(payload, "reviewer_type"),
+        reviewer_id=_string(payload, "reviewer_id"),
+        reviewer_name=_string(payload, "reviewer_name"),
+        reviewed_at=_string(payload, "reviewed_at"),
+        license_spdx=_string(payload, "license_spdx"),
+        decision_basis=_string(payload, "decision_basis"),
+        conditions=tuple(_string_array_allow_empty(payload, "conditions")),
+        record_type=HumanLegalRecordType(_string(payload, "record_type")),
+        attestation_reference=_string(payload, "attestation_reference"),
+        license_text_sha256=_string(payload, "license_text_sha256"),
+    )
+
+
+def load_human_legal_review_attestation(path: Path) -> HumanLegalReviewAttestation:
+    payload = _load_json_strict(path)
+    _expect_keys(
+        payload,
+        {
+            "schema_version",
+            "authority_sha256",
+            "model_id",
+            "revision",
+            "role",
+            "source_acceptance_exact_main_sha",
+            "source_acceptance_git_blob_sha",
+            "model_card_sha256",
+            "license_text_sha256",
+            "legal_packet_sha256",
+            "source_manifest_sha256",
+            "source_files_sha256",
+            "intended_use_sha256",
+            "review_record",
+            "decision",
+            "reviewer_id",
+            "reviewed_at",
+            "attestation_reference",
+        },
+        set(),
+        "human legal review attestation",
+    )
+    if _string(payload, "schema_version") != "tai.model-legal-review-attestation.v1":
+        raise ValueError("unsupported human legal review attestation schema")
+    return HumanLegalReviewAttestation(
+        authority_sha256=_string(payload, "authority_sha256"),
+        model_id=_string(payload, "model_id"),
+        revision=_string(payload, "revision"),
+        role=CandidateRole(_string(payload, "role")),
+        source_acceptance_exact_main_sha=_string(
+            payload, "source_acceptance_exact_main_sha"
+        ),
+        source_acceptance_git_blob_sha=_string(
+            payload, "source_acceptance_git_blob_sha"
+        ),
+        model_card_sha256=_string(payload, "model_card_sha256"),
+        license_text_sha256=_string(payload, "license_text_sha256"),
+        legal_packet_sha256=_string(payload, "legal_packet_sha256"),
+        source_manifest_sha256=_string(payload, "source_manifest_sha256"),
+        source_files_sha256=_string(payload, "source_files_sha256"),
+        intended_use_sha256=_string(payload, "intended_use_sha256"),
+        review_record=_parse_declared_file(payload.get("review_record")),
+        decision=HumanLegalDecision(_string(payload, "decision")),
+        reviewer_id=_string(payload, "reviewer_id"),
+        reviewed_at=_string(payload, "reviewed_at"),
+        attestation_reference=_string(payload, "attestation_reference"),
+    )
+
+
+def _parse_declared_file(value: object) -> DeclaredFile:
+    payload = _object(value, "declared review record file")
+    _expect_keys(
+        payload,
+        {"path", "sha256", "size_bytes"},
+        set(),
+        "declared review record file",
+    )
+    return DeclaredFile(
+        path=_string(payload, "path"),
+        sha256=_string(payload, "sha256"),
+        size_bytes=_integer(payload, "size_bytes"),
+    )
+
+
+def _string_array_allow_empty(payload: dict[str, Any], key: str) -> list[str]:
+    values = _array(payload, key)
+    if any(not isinstance(item, str) or not item.strip() for item in values):
+        raise ValueError(f"{key} must contain only non-empty strings")
+    return [str(item) for item in values]

--- a/apps/tai/tai/model_legal_review_source.py
+++ b/apps/tai/tai/model_legal_review_source.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tai.model_bundle_v2_common import _load_json_strict, _object, _string
+from tai.model_legal_review_authority import ModelLegalReviewAuthority
+
+
+def validate_source_acceptance(
+    authority: ModelLegalReviewAuthority,
+    acceptance_path: Path,
+) -> None:
+    payload = _load_json_strict(acceptance_path)
+    reference = authority.source_acceptance
+    if payload.get("schema_version") != "tai.model-source-acquisition-acceptance.v1":
+        raise ValueError("source acquisition acceptance schema mismatch")
+    if payload.get("exact_main_sha") != reference.source_exact_main_sha:
+        raise ValueError("source acquisition exact-main mismatch")
+    if payload.get("authority_sha256") != reference.model_bundle_authority_sha256:
+        raise ValueError("source acquisition authority digest mismatch")
+    if payload.get("status") != reference.status:
+        raise ValueError("source acquisition acceptance status mismatch")
+
+    boundary = _object(payload.get("maturity_boundary"), "source maturity boundary")
+    expected_boundary = {
+        "legal_review": "PENDING_HUMAN_DECISION",
+        "conversion": "NOT_RUN",
+        "quantization": "NOT_RUN",
+        "benchmarks": "NOT_RUN",
+        "model_admission": "NOT_DONE",
+        "production_operational_status": "NOT_ATTESTED",
+    }
+    for key, expected in expected_boundary.items():
+        if boundary.get(key) != expected:
+            raise ValueError(f"source acquisition maturity mismatch: {key}")
+
+    release = _object(payload.get("release_acceptance"), "source release acceptance")
+    attestation = _object(release.get("attestation"), "source release attestation")
+    if attestation.get("accepted") is not True or attestation.get("reasons") != []:
+        raise ValueError("source acquisition release attestation is not accepted")
+    if attestation.get("production_operational_status") != "NOT_ATTESTED":
+        raise ValueError("source acquisition release attestation overstates operations")
+
+    raw_models = payload.get("models")
+    if not isinstance(raw_models, list):
+        raise ValueError("source acquisition model evidence is missing")
+    by_identity: dict[tuple[str, str], dict[str, Any]] = {}
+    for raw in raw_models:
+        model = _object(raw, "source acquisition model evidence")
+        identity = (_string(model, "model_id"), _string(model, "revision"))
+        if identity in by_identity:
+            raise ValueError("source acquisition model evidence is duplicated")
+        by_identity[identity] = model
+    expected_identities = {(item.model_id, item.revision) for item in authority.models}
+    if set(by_identity) != expected_identities:
+        raise ValueError("source acquisition model evidence set mismatch")
+
+    for plan in authority.models:
+        _validate_model(plan=plan, model=by_identity[(plan.model_id, plan.revision)])
+
+
+def _validate_model(*, plan: Any, model: dict[str, Any]) -> None:
+    expected = {
+        "role": plan.role.value,
+        "status": "VERIFIED_SOURCE_RESTORED_LEGAL_PENDING",
+        "source_manifest_sha256": plan.source_manifest_sha256,
+        "source_files_sha256": plan.source_files_sha256,
+        "legal_packet_sha256": plan.legal_packet_sha256,
+        "legal_review_status": "PENDING_HUMAN_DECISION",
+        "conversion_status": "NOT_RUN",
+        "quantization_status": "NOT_RUN",
+        "model_admission_status": "NOT_DONE",
+    }
+    for key, value in expected.items():
+        if model.get(key) != value:
+            raise ValueError(f"source acquisition model evidence mismatch: {key}")
+    if model.get("reasons") != []:
+        raise ValueError("source acquisition model evidence has rejection reasons")
+    storage = _object(model.get("source_bytes_storage"), "source storage evidence")
+    if storage.get("locally_hashed") is not True:
+        raise ValueError("source acquisition local hashing is not verified")
+    if storage.get("clean_redownload_reverified") is not True:
+        raise ValueError("source acquisition clean restore is not verified")
+    if storage.get("copied_to_git_or_actions_artifact") is not False:
+        raise ValueError("source acquisition copied model bytes into metadata storage")

--- a/apps/tai/tai/model_legal_review_verify.py
+++ b/apps/tai/tai/model_legal_review_verify.py
@@ -102,9 +102,12 @@ def evaluate_model_review(
         authority.review_not_before, "legal review not-before timestamp"
     ):
         reasons.append("LEGAL_REVIEW_PREDATES_ACCEPTED_SOURCE_EVIDENCE")
-    if record.record_type is HumanLegalRecordType.ATTRIBUTED_RECORD:
-        if f"issues/{authority.attributed_record_issue}" not in record.attestation_reference:
-            reasons.append("ATTRIBUTED_RECORD_ISSUE_REFERENCE_MISMATCH")
+    if (
+        record.record_type is HumanLegalRecordType.ATTRIBUTED_RECORD
+        and f"issues/{authority.attributed_record_issue}"
+        not in record.attestation_reference
+    ):
+        reasons.append("ATTRIBUTED_RECORD_ISSUE_REFERENCE_MISMATCH")
 
     expected = {
         "authority_sha256": authority_digest,

--- a/apps/tai/tai/model_legal_review_verify.py
+++ b/apps/tai/tai/model_legal_review_verify.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import tai.model_legal_review_source as legal_review_source
 from tai.model_bundle_v2_common import (
     _bounded_regular_file,
     _file_sha256,
@@ -25,7 +26,6 @@ from tai.model_legal_review_evidence_parse import (
     load_human_legal_review_attestation,
     load_human_legal_review_record,
 )
-from tai.model_legal_review_source import validate_source_acceptance
 
 
 _AUTOMATED_REVIEWER_IDS = {
@@ -45,7 +45,7 @@ def evaluate_model_review(
     model_id: str,
     revision: str,
 ) -> ModelLegalReviewReport:
-    validate_source_acceptance(authority, acceptance_path)
+    legal_review_source.validate_source_acceptance(authority, acceptance_path)
     plan = _find_plan(authority, model_id, revision)
     authority_digest = authority_sha256(authority)
     use_digest = intended_use_sha256(authority)

--- a/apps/tai/tai/model_legal_review_verify.py
+++ b/apps/tai/tai/model_legal_review_verify.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tai.model_bundle_v2_common import (
+    _bounded_regular_file,
+    _file_sha256,
+    _parse_timestamp,
+)
+from tai.model_legal_review_authority import (
+    LegalReviewModelPlan,
+    ModelLegalReviewAuthority,
+)
+from tai.model_legal_review_authority_parse import (
+    authority_sha256,
+    intended_use_sha256,
+)
+from tai.model_legal_review_evidence import (
+    HumanLegalDecision,
+    HumanLegalRecordType,
+    HumanLegalReviewStatus,
+    ModelLegalReviewReport,
+)
+from tai.model_legal_review_evidence_parse import (
+    load_human_legal_review_attestation,
+    load_human_legal_review_record,
+)
+from tai.model_legal_review_source import validate_source_acceptance
+
+
+_AUTOMATED_REVIEWER_IDS = {
+    "chatgpt",
+    "codex",
+    "dependabot",
+    "github-actions",
+    "renovate",
+}
+
+
+def evaluate_model_review(
+    *,
+    authority: ModelLegalReviewAuthority,
+    acceptance_path: Path,
+    evidence_root: Path,
+    model_id: str,
+    revision: str,
+) -> ModelLegalReviewReport:
+    validate_source_acceptance(authority, acceptance_path)
+    plan = _find_plan(authority, model_id, revision)
+    authority_digest = authority_sha256(authority)
+    use_digest = intended_use_sha256(authority)
+    record_candidate = evidence_root / plan.review_record_path
+    attestation_candidate = evidence_root / plan.attestation_path
+    record_exists = record_candidate.exists() or record_candidate.is_symlink()
+    attestation_exists = attestation_candidate.exists() or attestation_candidate.is_symlink()
+
+    if not record_exists and not attestation_exists:
+        return _report(
+            plan=plan,
+            status=HumanLegalReviewStatus.PENDING_HUMAN_DECISION,
+            reasons=("HUMAN_REVIEW_PENDING",),
+            authority_digest=authority_digest,
+            use_digest=use_digest,
+        )
+    if record_exists != attestation_exists:
+        return _report(
+            plan=plan,
+            status=HumanLegalReviewStatus.INVALID,
+            reasons=("LEGAL_REVIEW_PAIR_INCOMPLETE",),
+            authority_digest=authority_digest,
+            use_digest=use_digest,
+        )
+
+    try:
+        record_path = _bounded_regular_file(evidence_root, plan.review_record_path)
+        attestation_path = _bounded_regular_file(evidence_root, plan.attestation_path)
+        record = load_human_legal_review_record(record_path)
+        attestation = load_human_legal_review_attestation(attestation_path)
+    except ValueError as error:
+        return _report(
+            plan=plan,
+            status=HumanLegalReviewStatus.INVALID,
+            reasons=(f"LEGAL_REVIEW_EVIDENCE_INVALID:{error}",),
+            authority_digest=authority_digest,
+            use_digest=use_digest,
+        )
+
+    reasons: list[str] = []
+    if not any(
+        record.reviewer_id.startswith(prefix)
+        for prefix in authority.reviewer_identity_prefixes
+    ):
+        reasons.append("LEGAL_REVIEWER_IDENTITY_PREFIX_NOT_AUTHORIZED")
+    reviewer_identity = record.reviewer_id.split(":", maxsplit=1)[-1].casefold()
+    if reviewer_identity in _AUTOMATED_REVIEWER_IDS or reviewer_identity.endswith("[bot]"):
+        reasons.append("LEGAL_REVIEWER_IDENTITY_IS_AUTOMATED")
+    if record.license_spdx != plan.license_spdx:
+        reasons.append("LEGAL_REVIEW_LICENSE_SPDX_MISMATCH")
+    if record.license_text_sha256 != plan.license_text_sha256:
+        reasons.append("LEGAL_REVIEW_LICENSE_TEXT_SHA256_MISMATCH")
+    if _parse_timestamp(record.reviewed_at, "legal reviewed_at") < _parse_timestamp(
+        authority.review_not_before, "legal review not-before timestamp"
+    ):
+        reasons.append("LEGAL_REVIEW_PREDATES_ACCEPTED_SOURCE_EVIDENCE")
+    if record.record_type is HumanLegalRecordType.ATTRIBUTED_RECORD:
+        if f"issues/{authority.attributed_record_issue}" not in record.attestation_reference:
+            reasons.append("ATTRIBUTED_RECORD_ISSUE_REFERENCE_MISMATCH")
+
+    expected = {
+        "authority_sha256": authority_digest,
+        "model_id": plan.model_id,
+        "revision": plan.revision,
+        "role": plan.role,
+        "source_acceptance_exact_main_sha": authority.source_acceptance.accepted_main_sha,
+        "source_acceptance_git_blob_sha": authority.source_acceptance.git_blob_sha,
+        "model_card_sha256": plan.model_card_sha256,
+        "license_text_sha256": plan.license_text_sha256,
+        "legal_packet_sha256": plan.legal_packet_sha256,
+        "source_manifest_sha256": plan.source_manifest_sha256,
+        "source_files_sha256": plan.source_files_sha256,
+        "intended_use_sha256": use_digest,
+        "decision": record.decision,
+        "reviewer_id": record.reviewer_id,
+        "reviewed_at": record.reviewed_at,
+        "attestation_reference": record.attestation_reference,
+    }
+    for key, value in expected.items():
+        if getattr(attestation, key) != value:
+            reasons.append(f"LEGAL_REVIEW_ATTESTATION_MISMATCH:{key}")
+    if attestation.review_record.path != plan.review_record_path:
+        reasons.append("LEGAL_REVIEW_RECORD_PATH_MISMATCH")
+    record_sha256 = _file_sha256(record_path)
+    if attestation.review_record.sha256 != record_sha256:
+        reasons.append("LEGAL_REVIEW_RECORD_SHA256_MISMATCH")
+    if attestation.review_record.size_bytes != record_path.stat().st_size:
+        reasons.append("LEGAL_REVIEW_RECORD_SIZE_MISMATCH")
+
+    unique_reasons = tuple(sorted(set(reasons)))
+    if unique_reasons:
+        return _report(
+            plan=plan,
+            status=HumanLegalReviewStatus.INVALID,
+            reasons=unique_reasons,
+            authority_digest=authority_digest,
+            use_digest=use_digest,
+            decision=record.decision,
+            reviewer_id=record.reviewer_id,
+            reviewed_at=record.reviewed_at,
+            review_record_sha256=record_sha256,
+            attestation_sha256=_file_sha256(attestation_path),
+        )
+    status = (
+        HumanLegalReviewStatus.APPROVED_FOR_CONVERSION
+        if record.decision is HumanLegalDecision.APPROVED
+        else HumanLegalReviewStatus.REJECTED
+    )
+    return _report(
+        plan=plan,
+        status=status,
+        reasons=(),
+        authority_digest=authority_digest,
+        use_digest=use_digest,
+        decision=record.decision,
+        reviewer_id=record.reviewer_id,
+        reviewed_at=record.reviewed_at,
+        review_record_sha256=record_sha256,
+        attestation_sha256=_file_sha256(attestation_path),
+    )
+
+
+def _find_plan(
+    authority: ModelLegalReviewAuthority,
+    model_id: str,
+    revision: str,
+) -> LegalReviewModelPlan:
+    matches = [
+        plan
+        for plan in authority.models
+        if plan.model_id == model_id and plan.revision == revision
+    ]
+    if len(matches) != 1:
+        raise ValueError("model is not uniquely authorized for legal review")
+    return matches[0]
+
+
+def _report(
+    *,
+    plan: LegalReviewModelPlan,
+    status: HumanLegalReviewStatus,
+    reasons: tuple[str, ...],
+    authority_digest: str,
+    use_digest: str,
+    decision: HumanLegalDecision | None = None,
+    reviewer_id: str | None = None,
+    reviewed_at: str | None = None,
+    review_record_sha256: str | None = None,
+    attestation_sha256: str | None = None,
+) -> ModelLegalReviewReport:
+    valid_record = status in {
+        HumanLegalReviewStatus.APPROVED_FOR_CONVERSION,
+        HumanLegalReviewStatus.REJECTED,
+    }
+    return ModelLegalReviewReport(
+        model_id=plan.model_id,
+        revision=plan.revision,
+        role=plan.role,
+        status=status,
+        valid_record=valid_record,
+        conversion_allowed=status is HumanLegalReviewStatus.APPROVED_FOR_CONVERSION,
+        decision=decision,
+        reviewer_id=reviewer_id,
+        reviewed_at=reviewed_at,
+        review_record_sha256=review_record_sha256,
+        attestation_sha256=attestation_sha256,
+        reasons=reasons,
+        authority_sha256=authority_digest,
+        intended_use_sha256=use_digest,
+    )

--- a/apps/tai/tai/model_legal_review_verify.py
+++ b/apps/tai/tai/model_legal_review_verify.py
@@ -27,7 +27,6 @@ from tai.model_legal_review_evidence_parse import (
     load_human_legal_review_record,
 )
 
-
 _AUTOMATED_REVIEWER_IDS = {
     "chatgpt",
     "codex",

--- a/apps/tai/tests/test_model_legal_review.py
+++ b/apps/tai/tests/test_model_legal_review.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tai.model_legal_review import (
+    HumanLegalDecision,
+    HumanLegalReviewStatus,
+    authority_sha256,
+    evaluate_all_model_reviews,
+    evaluate_model_review,
+    intended_use_sha256,
+    load_model_legal_review_authority,
+    validate_source_acceptance,
+)
+
+TAI_ROOT = Path(__file__).parents[1]
+AUTHORITY_PATH = TAI_ROOT / "model-artifacts" / "model-legal-review-authority.v1.json"
+ACCEPTANCE_PATH = (
+    TAI_ROOT / "model-artifacts" / "model-source-acquisition-acceptance.v1.json"
+)
+
+
+def _authority() -> Any:
+    return load_model_legal_review_authority(AUTHORITY_PATH)
+
+
+def _write_pair(
+    root: Path,
+    *,
+    role: str = "PRIMARY",
+    decision: str = "APPROVED",
+    reviewer_id: str = "legal:reviewer-001",
+    reviewed_at: str = "2026-07-20T12:00:00Z",
+    record_type: str = "SIGNED_RECORD",
+    reference: str = "storage://legal/review/versionId=review-001",
+    attestation_mutation: dict[str, object] | None = None,
+) -> Any:
+    authority = _authority()
+    plan = next(item for item in authority.models if item.role.value == role)
+    record = {
+        "schema_version": "tai.model-legal-review-record.v1",
+        "decision": decision,
+        "reviewer_type": "HUMAN",
+        "reviewer_id": reviewer_id,
+        "reviewer_name": "Human Legal Reviewer",
+        "reviewed_at": reviewed_at,
+        "license_spdx": plan.license_spdx,
+        "decision_basis": (
+            "Human review of the exact model revision, exact Apache-2.0 text, "
+            "accepted source evidence and intended local commercial use."
+        ),
+        "conditions": [],
+        "record_type": record_type,
+        "attestation_reference": reference,
+        "license_text_sha256": plan.license_text_sha256,
+    }
+    record_path = root / plan.review_record_path
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    record_path.write_text(
+        json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    record_bytes = record_path.read_bytes()
+    attestation: dict[str, object] = {
+        "schema_version": "tai.model-legal-review-attestation.v1",
+        "authority_sha256": authority_sha256(authority),
+        "model_id": plan.model_id,
+        "revision": plan.revision,
+        "role": plan.role.value,
+        "source_acceptance_exact_main_sha": (
+            authority.source_acceptance.accepted_main_sha
+        ),
+        "source_acceptance_git_blob_sha": authority.source_acceptance.git_blob_sha,
+        "model_card_sha256": plan.model_card_sha256,
+        "license_text_sha256": plan.license_text_sha256,
+        "legal_packet_sha256": plan.legal_packet_sha256,
+        "source_manifest_sha256": plan.source_manifest_sha256,
+        "source_files_sha256": plan.source_files_sha256,
+        "intended_use_sha256": intended_use_sha256(authority),
+        "review_record": {
+            "path": plan.review_record_path,
+            "sha256": hashlib.sha256(record_bytes).hexdigest(),
+            "size_bytes": len(record_bytes),
+        },
+        "decision": decision,
+        "reviewer_id": reviewer_id,
+        "reviewed_at": reviewed_at,
+        "attestation_reference": reference,
+    }
+    if attestation_mutation:
+        attestation.update(attestation_mutation)
+    attestation_path = root / plan.attestation_path
+    attestation_path.parent.mkdir(parents=True, exist_ok=True)
+    attestation_path.write_text(
+        json.dumps(attestation, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return plan
+
+
+def _evaluate(root: Path, plan: Any) -> Any:
+    return evaluate_model_review(
+        authority=_authority(),
+        acceptance_path=ACCEPTANCE_PATH,
+        evidence_root=root,
+        model_id=plan.model_id,
+        revision=plan.revision,
+    )
+
+
+def test_authority_binds_accepted_sources_and_pending_baseline(tmp_path: Path) -> None:
+    authority = _authority()
+    validate_source_acceptance(authority, ACCEPTANCE_PATH)
+
+    assert len(authority.models) == 2
+    assert len(authority_sha256(authority)) == 64
+    assert len(intended_use_sha256(authority)) == 64
+    evaluation = evaluate_all_model_reviews(
+        authority=authority,
+        acceptance_path=ACCEPTANCE_PATH,
+        evidence_root=tmp_path,
+    )
+    assert evaluation["status"] == "PENDING_HUMAN_DECISION"
+    assert evaluation["conversion_authorized_models"] == []
+    assert {
+        item["status"] for item in evaluation["models"]
+    } == {"PENDING_HUMAN_DECISION"}
+    assert evaluation["maturity_boundary"]["production_operational_status"] == (
+        "NOT_ATTESTED"
+    )
+
+
+def test_valid_human_approval_authorizes_only_conversion_stage(tmp_path: Path) -> None:
+    plan = _write_pair(tmp_path)
+    report = _evaluate(tmp_path, plan)
+
+    assert report.status is HumanLegalReviewStatus.APPROVED_FOR_CONVERSION
+    assert report.valid_record is True
+    assert report.conversion_allowed is True
+    assert report.decision is HumanLegalDecision.APPROVED
+    assert report.reasons == ()
+
+
+def test_valid_human_rejection_is_accepted_but_blocks_conversion(tmp_path: Path) -> None:
+    plan = _write_pair(tmp_path, decision="REJECTED")
+    report = _evaluate(tmp_path, plan)
+
+    assert report.status is HumanLegalReviewStatus.REJECTED
+    assert report.valid_record is True
+    assert report.conversion_allowed is False
+    assert report.decision is HumanLegalDecision.REJECTED
+    assert report.reasons == ()
+
+
+def test_attributed_record_must_bind_issue_2877(tmp_path: Path) -> None:
+    plan = _write_pair(
+        tmp_path,
+        record_type="ATTRIBUTED_RECORD",
+        reference="github://pachaninm-lab/pachanin-demo/issues/9999/comments/1#sha256="
+        + "a" * 64,
+    )
+    report = _evaluate(tmp_path, plan)
+
+    assert report.status is HumanLegalReviewStatus.INVALID
+    assert "ATTRIBUTED_RECORD_ISSUE_REFERENCE_MISMATCH" in report.reasons
+
+
+def test_automated_or_stale_reviewer_evidence_is_rejected(tmp_path: Path) -> None:
+    plan = _write_pair(
+        tmp_path,
+        reviewer_id="github:github-actions",
+        reviewed_at="2026-07-20T10:00:00Z",
+    )
+    report = _evaluate(tmp_path, plan)
+
+    assert report.status is HumanLegalReviewStatus.INVALID
+    assert "LEGAL_REVIEWER_IDENTITY_IS_AUTOMATED" in report.reasons
+    assert "LEGAL_REVIEW_PREDATES_ACCEPTED_SOURCE_EVIDENCE" in report.reasons
+
+
+def test_incomplete_pair_and_attestation_hash_drift_fail_closed(tmp_path: Path) -> None:
+    authority = _authority()
+    plan = authority.models[0]
+    record_path = tmp_path / plan.review_record_path
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    record_path.write_text("{}\n", encoding="utf-8")
+    incomplete = _evaluate(tmp_path, plan)
+    assert incomplete.status is HumanLegalReviewStatus.INVALID
+    assert incomplete.reasons == ("LEGAL_REVIEW_PAIR_INCOMPLETE",)
+
+    tmp_path = tmp_path / "drift"
+    plan = _write_pair(
+        tmp_path,
+        attestation_mutation={"source_files_sha256": "f" * 64},
+    )
+    drift = _evaluate(tmp_path, plan)
+    assert drift.status is HumanLegalReviewStatus.INVALID
+    assert "LEGAL_REVIEW_ATTESTATION_MISMATCH:source_files_sha256" in drift.reasons
+
+
+def test_source_acceptance_tampering_blocks_legal_review(tmp_path: Path) -> None:
+    acceptance = json.loads(ACCEPTANCE_PATH.read_text(encoding="utf-8"))
+    acceptance["maturity_boundary"]["conversion"] = "DONE"
+    tampered = tmp_path / "acceptance.json"
+    tampered.write_text(json.dumps(acceptance), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="maturity mismatch: conversion"):
+        validate_source_acceptance(_authority(), tampered)

--- a/apps/tai/tests/test_model_legal_review_workflow.py
+++ b/apps/tai/tests/test_model_legal_review_workflow.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).parents[3]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "tai-model-legal-review.yml"
+SCOPE_PATH = (
+    Path(__file__).parents[1]
+    / "governance"
+    / "scopes"
+    / "ap-13b3c-human-legal-intake-2877.json"
+)
+
+EXPECTED_PATHS = {
+    ".github/workflows/tai-model-legal-review.yml",
+    "apps/tai/governance/scopes/ap-13b3c-human-legal-intake-2877.json",
+    "apps/tai/model-artifacts/model-legal-review-authority.v1.json",
+    "apps/tai/model-artifacts/model-legal-review-record.schema.v1.json",
+    "apps/tai/model-artifacts/model-legal-review-attestation.schema.v1.json",
+    "apps/tai/model-artifacts/model-legal-review-runbook.v1.md",
+    "apps/tai/tai/model_legal_review.py",
+    "apps/tai/tai/model_legal_review_authority.py",
+    "apps/tai/tai/model_legal_review_authority_parse.py",
+    "apps/tai/tai/model_legal_review_cli.py",
+    "apps/tai/tai/model_legal_review_evidence.py",
+    "apps/tai/tai/model_legal_review_evidence_parse.py",
+    "apps/tai/tai/model_legal_review_source.py",
+    "apps/tai/tai/model_legal_review_verify.py",
+    "apps/tai/tests/test_model_legal_review.py",
+    "apps/tai/tests/test_model_legal_review_workflow.py",
+}
+
+
+def _workflow() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _scope() -> dict[str, Any]:
+    return json.loads(SCOPE_PATH.read_text(encoding="utf-8"))
+
+
+def test_scope_is_exact_and_preserves_human_decision_boundary() -> None:
+    scope = _scope()
+
+    assert scope["schema_version"] == "tai.concurrent-scope.v1"
+    assert scope["branch"] == "agent/tai-ap-13b3c-human-legal-intake"
+    assert scope["status"] == "active"
+    assert scope["program_issue"] == 2726
+    assert scope["parent_issue"] == 2835
+    assert scope["issue"] == 2877
+    assert set(scope["allowed_paths"]) == EXPECTED_PATHS
+    assert len(scope["allowed_paths"]) == len(EXPECTED_PATHS)
+    assert "automated legal decision generation or mutation" in scope[
+        "forbidden_capabilities"
+    ]
+    assert "conversion, quantization or model admission" in scope[
+        "forbidden_capabilities"
+    ]
+
+
+def test_workflow_is_pull_request_only_and_read_only() -> None:
+    workflow = _workflow()
+
+    assert "pull_request:" in workflow
+    assert "issue_comment:" not in workflow
+    assert "workflow_dispatch:" not in workflow
+    assert "push:" not in workflow
+    assert "schedule:" not in workflow
+    assert "permissions:\n  contents: read" in workflow
+    assert "contents: write" not in workflow
+    assert "issues: write" not in workflow
+    assert "pull-requests: write" not in workflow
+    assert "packages: write" not in workflow
+    assert "id-token: write" not in workflow
+    assert "secrets." not in workflow
+
+
+def test_workflow_checks_exact_head_and_authorized_review_paths() -> None:
+    workflow = _workflow()
+
+    assert "ref: ${{ github.event.pull_request.head.sha }}" in workflow
+    assert 'test "$(git rev-parse HEAD)" = "$HEAD_SHA"' in workflow
+    assert 'git cat-file -e "$BASE_SHA^{commit}"' in workflow
+    assert 'git diff --name-only "$BASE_SHA" "$HEAD_SHA"' in workflow
+    assert "authorized_review_paths" in workflow
+    assert "unauthorized legal-review paths" in workflow
+    assert "incomplete legal-review pair" in workflow
+    assert "legal-review paths changed without a completed pair" in workflow
+
+
+def test_workflow_validates_but_never_authors_human_decisions() -> None:
+    workflow = _workflow()
+
+    assert "load_model_legal_review_authority" in workflow
+    assert "validate_source_acceptance" in workflow
+    assert "evaluate_model_review" in workflow
+    assert "evaluate_all_model_reviews" in workflow
+    assert "DECISION_READ_ONLY_HUMAN_AUTHORED" in workflow
+    assert "APPROVED_FOR_CONVERSION" in workflow
+    assert "HumanLegalReviewStatus.REJECTED" in workflow
+    assert "model-artifacts/legal-reviews/" in workflow
+    assert "write_text" in workflow
+    assert "legal-review-evidence/pr-evaluation.json" in workflow
+    assert "review-record.v1.json').write_text" not in workflow
+    assert "review-attestation.v1.json').write_text" not in workflow
+    assert "gh api" not in workflow
+
+
+def test_workflow_never_downloads_or_converts_models() -> None:
+    workflow = _workflow()
+
+    forbidden = (
+        "huggingface.co",
+        ".safetensors",
+        ".gguf",
+        "convert_hf_to_gguf.py",
+        "llama-quantize",
+        "docker pull",
+        "docker push",
+        "oras push",
+        "ADMITTED",
+        "production_operational_status=ATTESTED",
+    )
+    for token in forbidden:
+        assert token not in workflow
+
+
+def test_workflow_uploads_only_bounded_evaluation_artifact() -> None:
+    workflow = _workflow()
+
+    assert "actions/upload-artifact@v4" in workflow
+    assert "path: legal-review-evidence" in workflow
+    assert "retention-days: 30" in workflow
+    assert "compression-level: 0" in workflow
+    assert "overwrite: false" in workflow
+    assert "production_operational_status': 'NOT_ATTESTED'" in workflow


### PR DESCRIPTION
## Purpose

Establishes the human-only legal decision gate required by #2877 before any Qwen or Mistral conversion, quantization or complete v2 bundle verification.

## Accepted evidence base

The authority is bound to accepted source-acquisition evidence from PR #2874 / exact-main `7439ed17c94b173da1bb0c37e0d74ffdfb848d49`:

- Qwen/Qwen3-8B exact revision `895c8d171bc03c30e113cd7a28c02494b5e068b7`;
- mistralai/Mistral-7B-Instruct-v0.3 exact revision `c170c708c41dac9275d15a8fff4eca08d52bab71`;
- exact model-card, license-text, source-manifest, source-files and legal-packet SHA-256 bindings;
- accepted llama.cpp b9637 toolchain identity;
- intended use limited to local commercial inference on controlled infrastructure with no source-weight redistribution in this slice.

## What this implements

- versioned legal-review authority for the two exact model revisions;
- strict record and attestation JSON schemas;
- human reviewer identity namespace and bot/service-account rejection;
- `ATTRIBUTED_RECORD` and `SIGNED_RECORD` immutable-reference rules;
- review timestamp fencing after accepted source evidence;
- exact binding to model/revision, role, license, intended use and acquisition hashes;
- deterministic outcomes: `PENDING_HUMAN_DECISION`, `APPROVED_FOR_CONVERSION`, `REJECTED`, or `INVALID`;
- rejection is a valid legal outcome but remains fail-closed for conversion;
- read-only PR workflow that validates human-authored pairs and never writes decisions;
- operator runbook and adversarial tests.

## Exact scope

16 new files only under `.github/workflows` and `apps/tai` legal authority, parser, verifier, CLI, schemas, runbook, governance and tests.

## Hard boundary

This PR contains no human approval or rejection, no model download, no GGUF conversion, no quantization, no benchmark, no model admission and no production activation. Automation may validate a decision but may never generate, infer or mutate it. `production_operational_status` remains `NOT_ATTESTED`.

Refs #2877, #2835 and #2726. It closes none of them.