### PR TITLE
Tighten AI in action mobile composition

### DIFF
--- a/apps/web/app/platform-v7/ai-in-action/page.tsx
+++ b/apps/web/app/platform-v7/ai-in-action/page.tsx
@@ -6,6 +6,7 @@ import '@/styles/platform-v7-public-product-experience-v3-refinement.css';
 import '@/styles/platform-v7-public-product-experience-v4.css';
 import '@/styles/platform-v7-public-product-entry-variants.css';
 import '@/styles/platform-v7-public-product-experience-v5.css';
+import '@/styles/platform-v7-ai-in-action-density.css';
 import type { Metadata } from 'next';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { PublicAiInActionExperience } from '@/components/platform-v7/PublicAiInActionExperience';

--- a/apps/web/styles/platform-v7-ai-in-action-density.css
+++ b/apps/web/styles/platform-v7-ai-in-action-density.css
@@ -1,0 +1,312 @@
+/* Route-scoped density and mobile composition refinements for /platform-v7/ai-in-action. */
+
+.pc-ai-in-action-page [class*='PublicAiInActionExperience_finalSection__'] {
+  padding-bottom: 24px;
+}
+
+.pc-ai-in-action-page .pc-ppe-footer {
+  margin-top: 0;
+  padding-top: 28px;
+  padding-bottom: max(22px, env(safe-area-inset-bottom));
+}
+
+.pc-ai-in-action-page .pc-ppe-footer-grid {
+  row-gap: 18px;
+}
+
+@media (max-width: 760px) {
+  .pc-ai-in-action-page .pc-site-header {
+    --pc-site-control-height: 34px !important;
+    height: 50px !important;
+    min-height: 50px !important;
+    padding-inline: 10px !important;
+  }
+
+  .pc-ai-in-action-page .pc-site-brand-mark,
+  .pc-ai-in-action-page .pc-site-brand-mark[data-brand-mark='transparent-price-canonical'] {
+    width: 30px !important;
+    height: 30px !important;
+    flex-basis: 30px !important;
+  }
+
+  .pc-ai-in-action-page .pc-site-brand-text strong {
+    font-size: 14px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_hero__'] {
+    padding-top: 68px !important;
+    padding-bottom: 32px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroGrid__'] {
+    gap: 24px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroCopy__'] h1 {
+    margin: 11px 0 13px !important;
+    font-size: clamp(33px, 9.5vw, 42px) !important;
+    line-height: 1.01 !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroCopy__'] > p {
+    font-size: 15px !important;
+    line-height: 1.42 !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroSignalCard__'] {
+    min-height: 0 !important;
+    margin-top: 14px !important;
+    padding: 10px 12px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroActions__'] {
+    grid-template-columns: 1fr 1fr !important;
+    gap: 8px !important;
+    margin-top: 16px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_primaryLink__'],
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_secondaryLink__'] {
+    min-height: 44px !important;
+    padding: 9px 11px !important;
+    font-size: 12px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroVisual__'] {
+    min-height: 276px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroCore__'] {
+    top: 38% !important;
+    width: 96px !important;
+    height: 96px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroResult__'] {
+    padding: 11px 12px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_scenarioSection__'],
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_boundarySection__'] {
+    padding-top: 34px !important;
+    padding-bottom: 34px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_sectionHeader__'] {
+    margin-bottom: 14px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_sectionHeader__'] h2,
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_finalPanel__'] h2 {
+    margin-top: 9px !important;
+    font-size: clamp(27px, 7.3vw, 34px) !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_selectorGrid__'] {
+    gap: 7px !important;
+    margin-bottom: 8px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_selector__'] {
+    padding: 7px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_segmented__'] button {
+    min-height: 36px !important;
+    padding: 6px 5px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_phaseHeader__'] {
+    gap: 7px !important;
+    margin-bottom: 8px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_runStatus__'] {
+    min-height: 38px !important;
+    padding: 7px 10px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_phaseTrack__'],
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_factRail__'] {
+    position: relative;
+    overscroll-behavior-inline: contain;
+    scrollbar-width: auto !important;
+    scrollbar-color: #7fb090 #e7efe9;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_phaseTrack__'] {
+    grid-template-columns: repeat(5, 82px) !important;
+    gap: 5px !important;
+    padding: 0 22px 7px 0 !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_phaseTrack__'] button {
+    min-height: 40px !important;
+    padding: 5px 6px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_phaseTrack__'] button > span {
+    width: 20px !important;
+    height: 20px !important;
+    flex-basis: 20px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_workspace__'] {
+    gap: 8px !important;
+    padding: 7px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_stagePanel__'] > header,
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_resultPanel__'] > header {
+    padding-top: 12px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_stageBody__'] {
+    gap: 8px !important;
+    padding: 12px 14px 10px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_orbit__'] {
+    width: 132px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_aiOrb__'] {
+    width: 66px !important;
+    height: 66px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_stageNarrative__'] h3 {
+    margin: 5px 0 7px !important;
+    font-size: 24px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_stageNarrative__'] strong {
+    margin-top: 8px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_factArea__'] {
+    padding: 0 12px 12px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_factAreaLabel__'] {
+    padding-top: 10px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_factRail__'] {
+    grid-template-columns: repeat(4, 138px) !important;
+    margin-top: 7px !important;
+    padding: 0 22px 7px 0 !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_factRail__'] button {
+    min-height: 68px !important;
+    padding: 7px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_evidenceDetail__'] {
+    min-height: 0 !important;
+    margin-top: 7px !important;
+    padding: 9px 10px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_resultPanel__'] {
+    padding-bottom: 12px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_resultPanel__'] > h3 {
+    margin-top: 14px !important;
+    margin-bottom: 8px !important;
+    font-size: 25px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_reasonCard__'],
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_nextAction__'] {
+    padding: 9px 10px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_metrics__'] {
+    margin-top: 8px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_metrics__'] > div {
+    min-height: 58px !important;
+    padding: 8px 9px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_confirmButton__'] {
+    min-height: 42px !important;
+    margin-top: 8px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_transportControls__'] {
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+    gap: 5px !important;
+    margin-top: 8px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_transportControls__'] button {
+    min-height: 38px !important;
+    padding: 6px 5px !important;
+    font-size: 10px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_resetButton__'] {
+    grid-column: auto !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_boundaryGrid__'] {
+    gap: 7px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_boundaryGrid__'] article {
+    grid-template-columns: 34px minmax(0, 1fr) !important;
+    column-gap: 10px !important;
+    padding: 11px 12px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_boundaryIcon__'] {
+    width: 34px !important;
+    height: 34px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_boundaryGrid__'] h3 {
+    margin: 0 0 3px !important;
+    font-size: 16px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_boundaryGrid__'] p {
+    font-size: 11px !important;
+    line-height: 1.4 !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_finalSection__'] {
+    padding-bottom: 16px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_finalPanel__'] {
+    padding: 20px 16px !important;
+  }
+
+  .pc-ai-in-action-page .pc-ppe-footer {
+    padding-top: 20px !important;
+    padding-bottom: max(18px, env(safe-area-inset-bottom)) !important;
+  }
+
+  .pc-ai-in-action-page .pc-ppe-footer-grid {
+    row-gap: 12px !important;
+  }
+}
+
+@media (max-width: 420px) {
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroActions__'] {
+    grid-template-columns: 1fr !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroVisual__'] {
+    min-height: 258px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_transportControls__'] {
+    grid-template-columns: 1fr 1fr !important;
+  }
+}


### PR DESCRIPTION
## Scope
- remove excessive bottom whitespace before the shared footer
- reduce mobile header and hero height
- compress scenario selectors, phase controls, workspace, and result panels
- add clearer horizontal-scroll affordance through visible mobile scrollbars and trailing space
- compact the three-boundary cards
- keep all changes route-scoped to `/platform-v7/ai-in-action`

## Verification target
- iPhone widths: 390–430 px
- no changes to other public or authenticated routes
- production deploy only after exact-head checks pass