### PR TITLE
Trigger exact AI-in-action production publication

### DIFF
--- a/.github/release-triggers/ai-in-action-c549d344.md
+++ b/.github/release-triggers/ai-in-action-c549d344.md
@@ -4,3 +4,4 @@
 - Public route: `/platform-v7/ai-in-action`
 - Scope: mobile density, footer whitespace, compact controls and boundaries
 - Acceptance: exact `linux/amd64` image, exact live manifest SHA, canonical route authority and current Russian hero copy.
+- Trigger: `2026-07-20T15:52Z`


### PR DESCRIPTION
Trigger only the isolated publication workflow for application revision `c549d34414b28dcf6eaef68a42a3c254c48c009c`. Acceptance requires the exact live manifest SHA and the canonical `/platform-v7/ai-in-action` route markers.