### PR TITLE
Finalize AI-in-action mobile polish

### DIFF
--- a/apps/web/styles/platform-v7-ai-in-action-density.css
+++ b/apps/web/styles/platform-v7-ai-in-action-density.css
@@ -15,6 +15,10 @@
 }
 
 @media (max-width: 760px) {
+  .pc-ai-in-action-page {
+    scroll-padding-top: 58px;
+  }
+
   .pc-ai-in-action-page .pc-site-header {
     --pc-site-control-height: 34px !important;
     height: 50px !important;
@@ -90,6 +94,7 @@
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_boundarySection__'] {
     padding-top: 34px !important;
     padding-bottom: 34px !important;
+    scroll-margin-top: 58px !important;
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_sectionHeader__'] {
@@ -132,12 +137,14 @@
     overscroll-behavior-inline: contain;
     scrollbar-width: auto !important;
     scrollbar-color: #7fb090 #e7efe9;
+    -webkit-overflow-scrolling: touch;
+    mask-image: linear-gradient(90deg, #000 0, #000 calc(100% - 24px), transparent 100%);
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_phaseTrack__'] {
     grid-template-columns: repeat(5, 82px) !important;
     gap: 5px !important;
-    padding: 0 22px 7px 0 !important;
+    padding: 0 26px 7px 0 !important;
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_phaseTrack__'] button {
@@ -195,7 +202,7 @@
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_factRail__'] {
     grid-template-columns: repeat(4, 138px) !important;
     margin-top: 7px !important;
-    padding: 0 22px 7px 0 !important;
+    padding: 0 26px 7px 0 !important;
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_factRail__'] button {
@@ -210,13 +217,13 @@
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_resultPanel__'] {
-    padding-bottom: 12px !important;
+    padding-bottom: 10px !important;
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_resultPanel__'] > h3 {
-    margin-top: 14px !important;
-    margin-bottom: 8px !important;
-    font-size: 25px !important;
+    margin-top: 12px !important;
+    margin-bottom: 7px !important;
+    font-size: 24px !important;
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_reasonCard__'],
@@ -225,17 +232,31 @@
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_metrics__'] {
-    margin-top: 8px !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 6px !important;
+    margin-top: 7px !important;
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_metrics__'] > div {
-    min-height: 58px !important;
-    padding: 8px 9px !important;
+    min-height: 54px !important;
+    padding: 7px 8px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_metricWide__'] {
+    grid-column: 1 / -1 !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_nextAction__'] {
+    margin-top: 8px !important;
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_confirmButton__'] {
-    min-height: 42px !important;
+    min-height: 40px !important;
     margin-top: 8px !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_controlNote__'] {
+    margin-top: 6px !important;
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_transportControls__'] {
@@ -280,7 +301,7 @@
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_finalSection__'] {
-    padding-bottom: 16px !important;
+    padding-bottom: 12px !important;
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_finalPanel__'] {
@@ -288,25 +309,33 @@
   }
 
   .pc-ai-in-action-page .pc-ppe-footer {
-    padding-top: 20px !important;
-    padding-bottom: max(18px, env(safe-area-inset-bottom)) !important;
+    padding-top: 16px !important;
+    padding-bottom: max(16px, env(safe-area-inset-bottom)) !important;
   }
 
   .pc-ai-in-action-page .pc-ppe-footer-grid {
-    row-gap: 12px !important;
+    row-gap: 10px !important;
+  }
+
+  .pc-ai-in-action-page .pc-ppe-footer nav {
+    gap: 10px 18px !important;
   }
 }
 
 @media (max-width: 420px) {
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroActions__'] {
-    grid-template-columns: 1fr !important;
+    grid-template-columns: 1fr 1fr !important;
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_heroVisual__'] {
-    min-height: 258px !important;
+    min-height: 248px !important;
   }
 
   .pc-ai-in-action-page [class*='PublicAiInActionExperience_transportControls__'] {
-    grid-template-columns: 1fr 1fr !important;
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+  }
+
+  .pc-ai-in-action-page [class*='PublicAiInActionExperience_transportControls__'] button {
+    font-size: 9px !important;
   }
 }


### PR DESCRIPTION
## Mobile acceptance fixes
- preserve compact two-column hero actions at iPhone widths
- reduce result-panel height by restoring a two-column metrics layout
- keep all four transport controls in one compact row
- add clear fade affordance to horizontally scrollable phase and fact rails
- add scroll offsets for the sticky public header
- further tighten final section and footer spacing

All changes remain route-scoped to `/platform-v7/ai-in-action`.