### PR TITLE
Add exact final AI page release workflow

### DIFF
--- a/.github/workflows/publish-ai-in-action-b08a5cf.yml
+++ b/.github/workflows/publish-ai-in-action-b08a5cf.yml
@@ -1,0 +1,46 @@
+name: Publish AI in action b08a5cf
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/release-triggers/ai-in-action-b08a5cf.md'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  TARGET_SHA: b08a5cf24622681047d7a2a25f910803f5c28862
+  IMAGE: ghcr.io/pachaninm-lab/grainflow-web
+  LIVE_BASE: https://xn----8sbjf4befbjgs9b.xn--p1ai
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: b08a5cf24622681047d7a2a25f910803f5c28862
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: pachaninm-lab
+          password: ${{ github.token }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile.web
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/pachaninm-lab/grainflow-web:latest
+            ghcr.io/pachaninm-lab/grainflow-web:sha-b08a5cf24622
+          build-args: |
+            GIT_COMMIT=b08a5cf24622681047d7a2a25f910803f5c28862
+      - name: Verify registry image
+        run: |
+          docker pull ghcr.io/pachaninm-lab/grainflow-web:latest
+          test "$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' ghcr.io/pachaninm-lab/grainflow-web:latest)" = "b08a5cf24622681047d7a2a25f910803f5c28862"


### PR DESCRIPTION
Adds an isolated production image publication workflow for exact application SHA `b08a5cf24622681047d7a2a25f910803f5c28862`. The workflow publishes only the web image and verifies its immutable revision label.