### PR TITLE
Trigger final AI-in-action production release

### DIFF
--- a/.github/release-triggers/ai-in-action-b08a5cf.md
+++ b/.github/release-triggers/ai-in-action-b08a5cf.md
@@ -1,0 +1,6 @@
+# Final AI-in-action production release
+
+- Application revision: `b08a5cf24622681047d7a2a25f910803f5c28862`
+- Route: `/platform-v7/ai-in-action`
+- Scope: final iPhone mobile polish
+- Image: `ghcr.io/pachaninm-lab/grainflow-web:latest`


### PR DESCRIPTION
Trigger the isolated exact-image workflow for `b08a5cf24622681047d7a2a25f910803f5c28862`. Production acceptance requires the new `linux/amd64` image and subsequent VPS update.