### PR TITLE
fix(ui): restore unified public dock and enforce terminal spacing

### DIFF
--- a/apps/web/components/platform-v7/HydrationSafeChatSupport.tsx
+++ b/apps/web/components/platform-v7/HydrationSafeChatSupport.tsx
@@ -8,6 +8,11 @@ export type HydrationSafeChatSupportProps = {
   renderDock?: boolean;
 };
 
+const ContextualSupportOrAssistant = dynamic<HydrationSafeChatSupportProps>(
+  () => import('@/components/platform-v7/ContextualSupportOrAssistant').then((module) => module.ContextualSupportOrAssistant),
+  { ssr: false, loading: () => null },
+);
+
 /**
  * Public pages keep the contact-support form. Authenticated platform-v7 workspaces
  * receive one role-scoped conversational assistant with presence, structured
@@ -15,7 +20,57 @@ export type HydrationSafeChatSupportProps = {
  * The surface remains browser-only so time-aware greetings, focus management and
  * route context never destabilize streamed HTML or hydration.
  */
-export const HydrationSafeChatSupport = dynamic<HydrationSafeChatSupportProps>(
-  () => import('@/components/platform-v7/ContextualSupportOrAssistant').then((module) => module.ContextualSupportOrAssistant),
-  { ssr: false, loading: () => null },
-);
+export function HydrationSafeChatSupport(props: HydrationSafeChatSupportProps) {
+  return (
+    <>
+      <ContextualSupportOrAssistant {...props} />
+      <style>{terminalPublicSpacingCss}</style>
+    </>
+  );
+}
+
+const terminalPublicSpacingCss = `
+html body .pc-ppe-page .pc-ppe-section {
+  padding-block: 48px;
+}
+html body .pc-ppe-page .pc-ppe-section-header {
+  margin-bottom: 20px;
+}
+html body .pc-ppe-page .pc-ppe-hero {
+  padding-top: 36px;
+  padding-bottom: 36px;
+}
+html body .pc-ppe-page .pc-ppe-explorer-intro {
+  padding-block: 32px;
+}
+html body .pc-ppe-page .pc-ppe-final-cta {
+  padding-top: 48px;
+  padding-bottom: 72px;
+}
+html body .pc-ppe-page :where(.pc-ppe-section, .pc-ppe-final-cta) + :where(.pc-ppe-section, .pc-ppe-final-cta) {
+  margin-top: 0;
+}
+
+@media (max-width: 720px) {
+  html body .pc-ppe-page .pc-ppe-hero {
+    padding-top: 20px;
+    padding-bottom: 24px;
+  }
+  html body .pc-ppe-page .pc-ppe-section {
+    padding-block: 28px;
+  }
+  html body .pc-ppe-page .pc-ppe-section-header {
+    margin-bottom: 16px;
+  }
+  html body .pc-ppe-page .pc-ppe-explorer-intro {
+    padding-block: 20px;
+  }
+  html body .pc-ppe-page .pc-ppe-final-cta {
+    padding-top: 32px;
+    padding-bottom: 72px;
+  }
+  html body .pc-ppe-page .pc-ppe-shell {
+    padding-bottom: 88px;
+  }
+}
+`;


### PR DESCRIPTION
## Исправление

- единая плашка `ИИ / Поддержка / Позвонить` монтируется на фактическом дереве `/platform-v7` через существующий runtime-контур;
- spacing-правила рендерятся после route content и перекрывают legacy v3/v4/v5;
- protected routes не затрагиваются;
- PR временно поставлен поверх `agent/pc-crop-01b2-service-command-authority`, потому что именно там уже синхронизирована Prisma-authority для принятой commodity-profile migration. Это устраняет ложные CI/security падения от schema drift без удаления промышленной migration-authority.

## Проверка

- `/platform-v7` mobile 390/430;
- `/platform-v7/how-it-works`;
- login/register;
- наличие трёх действий в dock;
- отсутствие одиночной зелёной кнопки;
- уменьшенный hero и section vertical rhythm;
- exact-head CI/security acceptance на новой базе.

После merge PR #2892 base должен быть возвращён на `main` без изменения UI-среза.