### PR TITLE
Add release workflow for final AI visual acceptance

### DIFF
--- a/.github/workflows/publish-ai-visual-acceptance-85a5215.yml
+++ b/.github/workflows/publish-ai-visual-acceptance-85a5215.yml
@@ -1,0 +1,45 @@
+name: Publish AI visual acceptance 85a5215
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/release-triggers/ai-visual-acceptance-85a5215.md'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  TARGET_SHA: 85a52156f4dbd17fa6100fec8380332f9b66b6e9
+  IMAGE: ghcr.io/pachaninm-lab/grainflow-web
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: 85a52156f4dbd17fa6100fec8380332f9b66b6e9
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: pachaninm-lab
+          password: ${{ github.token }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile.web
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/pachaninm-lab/grainflow-web:latest
+            ghcr.io/pachaninm-lab/grainflow-web:sha-85a52156f4db
+          build-args: |
+            GIT_COMMIT=85a52156f4dbd17fa6100fec8380332f9b66b6e9
+      - name: Verify registry image
+        run: |
+          docker pull ghcr.io/pachaninm-lab/grainflow-web:latest
+          test "$(docker image inspect --format '{{ index .Config.Labels \"org.opencontainers.image.revision\" }}' ghcr.io/pachaninm-lab/grainflow-web:latest)" = "85a52156f4dbd17fa6100fec8380332f9b66b6e9"


### PR DESCRIPTION
Publishes the exact production web image for application SHA `85a52156f4dbd17fa6100fec8380332f9b66b6e9` and verifies the immutable revision label.