### PR TITLE
Restore prominent AI page entry and immutable release path

### DIFF
--- a/.github/release-triggers/ai-page-entry-and-release-note.md
+++ b/.github/release-triggers/ai-page-entry-and-release-note.md
@@ -1,0 +1,1 @@
+Direct public entry and immutable production release for `/platform-v7/ai-in-action`.

--- a/.github/release-triggers/ai-page-entry-and-release.md
+++ b/.github/release-triggers/ai-page-entry-and-release.md
@@ -1,0 +1,6 @@
+# AI page entry and release acceptance
+
+- Keep `/platform-v7/ai-in-action` as a direct public route.
+- Make its entry on `/platform-v7` visually prominent.
+- Publish production images with an immutable SHA tag.
+- Verify the immutable SHA tag before moving the server alias.

--- a/apps/web/styles/platform-v7-public-header.css
+++ b/apps/web/styles/platform-v7-public-header.css
@@ -207,20 +207,6 @@
   background: #066832;
 }
 
-.pc-ppe-page .pc-ppe-ai-status-link::before {
-  content: 'Открыть страницу «ИИ в работе»';
-  font-weight: 850;
-}
-
-.pc-ppe-page .pc-ppe-ai-status-link strong {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  white-space: nowrap;
-}
-
 @media (max-width: 1080px) {
   .pc-site-nav {
     display: none;

--- a/apps/web/styles/platform-v7-public-header.css
+++ b/apps/web/styles/platform-v7-public-header.css
@@ -172,6 +172,55 @@
   border-radius: 12px;
 }
 
+/* The AI page is a primary public product entry, not a secondary text note. */
+.pc-ppe-page .pc-ppe-public-status {
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid #91c8a7;
+  border-left: 5px solid #087a3b;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #effaf3 0%, #ffffff 100%);
+  box-shadow: 0 10px 28px rgba(8, 122, 59, 0.10);
+}
+
+.pc-ppe-page .pc-ppe-ai-status-link {
+  width: 100% !important;
+  min-height: 52px;
+  display: flex !important;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-radius: 11px !important;
+  background: #087a3b;
+  color: #ffffff !important;
+  box-shadow: 0 8px 20px rgba(8, 122, 59, 0.22);
+}
+
+.pc-ppe-page .pc-ppe-ai-status-link strong {
+  font-size: 16px !important;
+  line-height: 1.25 !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+}
+
+.pc-ppe-page .pc-ppe-ai-status-link:hover,
+.pc-ppe-page .pc-ppe-ai-status-link:focus-visible {
+  background: #066832;
+}
+
+.pc-ppe-page .pc-ppe-ai-status-link::before {
+  content: 'Открыть страницу «ИИ в работе»';
+  font-weight: 850;
+}
+
+.pc-ppe-page .pc-ppe-ai-status-link strong {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
 @media (max-width: 1080px) {
   .pc-site-nav {
     display: none;
@@ -200,6 +249,15 @@
     min-width: 50px;
     height: 40px;
     padding: 0 8px;
+  }
+
+  .pc-ppe-page .pc-ppe-public-status {
+    padding: 13px;
+  }
+
+  .pc-ppe-page .pc-ppe-ai-status-link {
+    min-height: 56px;
+    padding: 14px 16px;
   }
 }
 


### PR DESCRIPTION
## Исправление

- делает существующую прямую ссылку на `/platform-v7/ai-in-action` крупной зелёной CTA-кнопкой на первом экране главной;
- сохраняет локализованную подпись RU/EN/ZH;
- устраняет ситуацию, когда ссылка визуально воспринималась как обычная подпись;
- фиксирует требование проверять production image по immutable SHA tag, а не по конфликтующему `latest`.

## Найденная причина production

Предыдущий workflow успешно собрал и отправил image, но упал на проверке `latest`: тег был перезаписан параллельным release workflow. Сам маршрут в коде существует. Следующий release должен использовать exact SHA tag.