### PR TITLE
Fix immutable image verification quoting

### DIFF
--- a/.github/workflows/publish-ai-visual-acceptance-85a5215.yml
+++ b/.github/workflows/publish-ai-visual-acceptance-85a5215.yml
@@ -43,4 +43,6 @@ jobs:
       - name: Verify immutable registry image
         run: |
           docker pull "${IMAGE}:${IMMUTABLE_TAG}"
-          test "$(docker image inspect --format '{{ index .Config.Labels \"org.opencontainers.image.revision\" }}' "${IMAGE}:${IMMUTABLE_TAG}")" = "${TARGET_SHA}"
+          ACTUAL_SHA="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "${IMAGE}:${IMMUTABLE_TAG}")"
+          printf 'expected=%s\nactual=%s\n' "${TARGET_SHA}" "${ACTUAL_SHA}"
+          test "${ACTUAL_SHA}" = "${TARGET_SHA}"


### PR DESCRIPTION
Corrects the `docker image inspect` Go-template quoting used by the exact AI entry release workflow.

The image build and GHCR push already succeeded for `sha-1a0bf1bcd89f`; only the verification command failed. This change records the actual OCI revision label and compares it with the full target SHA.