### PR TITLE
Publish exact production web image 6878deb

### DIFF
--- a/.github/release-triggers/mobile-density-52c2762.md
+++ b/.github/release-triggers/mobile-density-52c2762.md
@@ -1,3 +1,3 @@
 # Exact production web release trigger
 
-Publishes and verifies the immutable production web image for exact main SHA `6878deb5b24a37b2a22be7ca98df92cc76bec373` using tag `sha-6878deb5b24a`.
+Publishes and verifies the immutable production web image for latest accepted main SHA `52c27627050638499188207877a1c197bba70310` using tag `sha-52c27627050`.

--- a/.github/release-triggers/mobile-density-52c2762.md
+++ b/.github/release-triggers/mobile-density-52c2762.md
@@ -1,3 +1,3 @@
-# Mobile density release trigger
+# Exact production web release trigger
 
-Publishes and verifies the immutable production web image for exact main SHA `52c27627050638499188207877a1c197bba70310`.
+Publishes and verifies the immutable production web image for exact main SHA `6878deb5b24a37b2a22be7ca98df92cc76bec373` using tag `sha-6878deb5b24a`.

--- a/.github/release-triggers/mobile-density-52c2762.md
+++ b/.github/release-triggers/mobile-density-52c2762.md
@@ -1,0 +1,3 @@
+# Mobile density release trigger
+
+Publishes and verifies the immutable production web image for exact main SHA `52c27627050638499188207877a1c197bba70310`.

--- a/.github/workflows/publish-ai-visual-acceptance-85a5215.yml
+++ b/.github/workflows/publish-ai-visual-acceptance-85a5215.yml
@@ -1,19 +1,19 @@
-name: Publish AI entry release 1a0bf1b
+name: Publish mobile density release 52c2762
 
 on:
   pull_request:
     branches: [main]
     paths:
-      - '.github/release-triggers/ai-entry-1a0bf1b.md'
+      - '.github/release-triggers/mobile-density-52c2762.md'
 
 permissions:
   contents: read
   packages: write
 
 env:
-  TARGET_SHA: 1a0bf1bcd89f492ecce6645fcbe5c28b2266e115
+  TARGET_SHA: 52c27627050638499188207877a1c197bba70310
   IMAGE: ghcr.io/pachaninm-lab/grainflow-web
-  IMMUTABLE_TAG: sha-1a0bf1bcd89f
+  IMMUTABLE_TAG: sha-52c27627050
 
 jobs:
   publish:
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: 1a0bf1bcd89f492ecce6645fcbe5c28b2266e115
+          ref: 52c27627050638499188207877a1c197bba70310
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -37,9 +37,9 @@ jobs:
           push: true
           tags: |
             ghcr.io/pachaninm-lab/grainflow-web:latest
-            ghcr.io/pachaninm-lab/grainflow-web:sha-1a0bf1bcd89f
+            ghcr.io/pachaninm-lab/grainflow-web:sha-52c27627050
           build-args: |
-            GIT_COMMIT=1a0bf1bcd89f492ecce6645fcbe5c28b2266e115
+            GIT_COMMIT=52c27627050638499188207877a1c197bba70310
       - name: Verify immutable registry image
         run: |
           docker pull "${IMAGE}:${IMMUTABLE_TAG}"

--- a/.github/workflows/publish-ai-visual-acceptance-85a5215.yml
+++ b/.github/workflows/publish-ai-visual-acceptance-85a5215.yml
@@ -1,4 +1,4 @@
-name: Publish exact production web release 6878deb
+name: Publish exact production web release 52c2762
 
 on:
   pull_request:
@@ -11,9 +11,9 @@ permissions:
   packages: write
 
 env:
-  TARGET_SHA: 6878deb5b24a37b2a22be7ca98df92cc76bec373
+  TARGET_SHA: 52c27627050638499188207877a1c197bba70310
   IMAGE: ghcr.io/pachaninm-lab/grainflow-web
-  IMMUTABLE_TAG: sha-6878deb5b24a
+  IMMUTABLE_TAG: sha-52c27627050
 
 jobs:
   publish:
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: 6878deb5b24a37b2a22be7ca98df92cc76bec373
+          ref: 52c27627050638499188207877a1c197bba70310
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -37,9 +37,9 @@ jobs:
           push: true
           tags: |
             ghcr.io/pachaninm-lab/grainflow-web:latest
-            ghcr.io/pachaninm-lab/grainflow-web:sha-6878deb5b24a
+            ghcr.io/pachaninm-lab/grainflow-web:sha-52c27627050
           build-args: |
-            GIT_COMMIT=6878deb5b24a37b2a22be7ca98df92cc76bec373
+            GIT_COMMIT=52c27627050638499188207877a1c197bba70310
       - name: Verify immutable registry image
         run: |
           docker pull "${IMAGE}:${IMMUTABLE_TAG}"

--- a/.github/workflows/publish-ai-visual-acceptance-85a5215.yml
+++ b/.github/workflows/publish-ai-visual-acceptance-85a5215.yml
@@ -1,4 +1,4 @@
-name: Publish mobile density release 52c2762
+name: Publish exact production web release 6878deb
 
 on:
   pull_request:
@@ -11,9 +11,9 @@ permissions:
   packages: write
 
 env:
-  TARGET_SHA: 52c27627050638499188207877a1c197bba70310
+  TARGET_SHA: 6878deb5b24a37b2a22be7ca98df92cc76bec373
   IMAGE: ghcr.io/pachaninm-lab/grainflow-web
-  IMMUTABLE_TAG: sha-52c27627050
+  IMMUTABLE_TAG: sha-6878deb5b24a
 
 jobs:
   publish:
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: 52c27627050638499188207877a1c197bba70310
+          ref: 6878deb5b24a37b2a22be7ca98df92cc76bec373
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -37,9 +37,9 @@ jobs:
           push: true
           tags: |
             ghcr.io/pachaninm-lab/grainflow-web:latest
-            ghcr.io/pachaninm-lab/grainflow-web:sha-52c27627050
+            ghcr.io/pachaninm-lab/grainflow-web:sha-6878deb5b24a
           build-args: |
-            GIT_COMMIT=52c27627050638499188207877a1c197bba70310
+            GIT_COMMIT=6878deb5b24a37b2a22be7ca98df92cc76bec373
       - name: Verify immutable registry image
         run: |
           docker pull "${IMAGE}:${IMMUTABLE_TAG}"


### PR DESCRIPTION
Publishes and verifies the immutable production web image for exact main SHA `6878deb5b24a37b2a22be7ca98df92cc76bec373` using tag `sha-6878deb5b24a`.

This image contains the merged unified public dock and the latest accepted mobile public-layout refinements. Production deployment remains manual and exact-tagged; the broken Watchtower instance is not used.