### PR TITLE
Restore AI link block on single-server home

### DIFF
--- a/.github/workflows/single-server-ui-acceptance.yml
+++ b/.github/workflows/single-server-ui-acceptance.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'apps/web/components/platform-v7/SingleServerPublicDock.tsx'
       - 'apps/web/components/platform-v7/SingleServerPublicSpacing.tsx'
+      - 'apps/web/components/platform-v7/SingleServerHomeAiEntry.tsx'
       - 'apps/web/components/platform-v7/HydrationSafeChatSupport.tsx'
       - '.github/workflows/single-server-ui-acceptance.yml'
 
@@ -27,16 +28,21 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Verify unified dock contract
+      - name: Verify unified dock and AI entry contracts
         shell: bash
         run: |
           set -euo pipefail
-          file='apps/web/components/platform-v7/SingleServerPublicDock.tsx'
-          grep -Fq "ai: 'ИИ'" "$file"
-          grep -Fq "support: 'Поддержка'" "$file"
-          grep -Fq "call: 'Позвонить'" "$file"
-          grep -Fq "tel:+79162778989" "$file"
-          grep -Fq '.p7-support-chat-button' "$file"
-          grep -Fq 'SingleServerPublicSpacing' apps/web/components/platform-v7/HydrationSafeChatSupport.tsx
+          dock='apps/web/components/platform-v7/SingleServerPublicDock.tsx'
+          ai_entry='apps/web/components/platform-v7/SingleServerHomeAiEntry.tsx'
+          mount='apps/web/components/platform-v7/HydrationSafeChatSupport.tsx'
+          grep -Fq "ai: 'ИИ'" "$dock"
+          grep -Fq "support: 'Поддержка'" "$dock"
+          grep -Fq "call: 'Позвонить'" "$dock"
+          grep -Fq "tel:+79162778989" "$dock"
+          grep -Fq '.p7-support-chat-button' "$dock"
+          grep -Fq "ИИ работает в платформе" "$ai_entry"
+          grep -Fq "/platform-v7/ai-in-action?lang=" "$ai_entry"
+          grep -Fq "SingleServerHomeAiEntry" "$mount"
+          grep -Fq 'SingleServerPublicSpacing' "$mount"
       - name: Build production web
         run: pnpm --filter @pc/web build

--- a/apps/web/components/platform-v7/HydrationSafeChatSupport.tsx
+++ b/apps/web/components/platform-v7/HydrationSafeChatSupport.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { SingleServerHomeAiEntry } from '@/components/platform-v7/SingleServerHomeAiEntry';
 import { SingleServerPublicSpacing } from '@/components/platform-v7/SingleServerPublicSpacing';
 
 const ChatSupportWidget = dynamic(
@@ -23,6 +24,7 @@ export function HydrationSafeChatSupport() {
     <>
       <ChatSupportWidget />
       <SingleServerPublicDock />
+      <SingleServerHomeAiEntry />
       <SingleServerPublicSpacing />
     </>
   );

--- a/apps/web/components/platform-v7/SingleServerHomeAiEntry.tsx
+++ b/apps/web/components/platform-v7/SingleServerHomeAiEntry.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import * as React from 'react';
+import { ArrowRight } from 'lucide-react';
+import { createPortal } from 'react-dom';
+
+type Locale = 'ru' | 'en' | 'zh';
+
+const COPY = {
+  ru: {
+    title: 'ИИ работает в платформе',
+    text: 'Показывает риски, объясняет причины и готовит следующий шаг. Критические действия остаются за участником.',
+    aria: 'Открыть страницу о работе ИИ в платформе',
+  },
+  en: {
+    title: 'AI is active in the platform',
+    text: 'Highlights risks, explains causes and prepares the next step. Consequential actions remain with the participant.',
+    aria: 'Open the platform AI in action page',
+  },
+  zh: {
+    title: 'AI 已在平台中运行',
+    text: '识别风险、解释原因并准备下一步。重要操作仍由参与方确认和执行。',
+    aria: '打开平台 AI 工作说明页面',
+  },
+} as const;
+
+function resolveLocale(): Locale {
+  const query = new URLSearchParams(window.location.search).get('lang');
+  if (query === 'en' || query === 'zh') return query;
+  const htmlLocale = document.documentElement.lang.toLowerCase();
+  if (htmlLocale.startsWith('en')) return 'en';
+  if (htmlLocale.startsWith('zh')) return 'zh';
+  return 'ru';
+}
+
+function isPublicHome(pathname: string): boolean {
+  const clean = pathname.replace(/\/+$/u, '') || '/';
+  return clean === '/' || clean === '/platform-v7' || clean === '/pc-public-entry/platform-v7';
+}
+
+export function SingleServerHomeAiEntry() {
+  const [mount, setMount] = React.useState<HTMLElement | null>(null);
+  const [locale, setLocale] = React.useState<Locale>('ru');
+
+  React.useEffect(() => {
+    if (!isPublicHome(window.location.pathname)) return;
+
+    setLocale(resolveLocale());
+    const hero = document.querySelector<HTMLElement>('.pc-ppe-hero-copy');
+    if (!hero) return;
+
+    const existing = hero.querySelector<HTMLElement>("[data-single-server-ai-entry='true']");
+    if (existing) {
+      setMount(existing);
+      return;
+    }
+
+    const node = document.createElement('div');
+    node.dataset.singleServerAiEntry = 'true';
+    const publicMode = hero.querySelector<HTMLElement>('.pc-ppe-public-status');
+    if (publicMode) hero.insertBefore(node, publicMode);
+    else hero.appendChild(node);
+    setMount(node);
+
+    return () => node.remove();
+  }, []);
+
+  if (!mount) return null;
+  const ui = COPY[locale];
+
+  return createPortal(
+    <>
+      <a
+        className='pc-ss-home-ai-entry'
+        href={`/platform-v7/ai-in-action?lang=${locale}`}
+        aria-label={ui.aria}
+      >
+        <span>
+          <strong>{ui.title}</strong>
+          <small>{ui.text}</small>
+        </span>
+        <ArrowRight size={20} aria-hidden='true' />
+      </a>
+      <style>{css}</style>
+    </>,
+    mount,
+  );
+}
+
+const css = `
+[data-single-server-ai-entry='true']{display:block;margin-top:16px}
+.pc-ss-home-ai-entry{display:grid;grid-template-columns:minmax(0,1fr) 32px;align-items:center;gap:12px;min-height:72px;padding:13px 14px;border:1px solid #9fceb0;border-radius:15px;background:linear-gradient(145deg,#eff9f2,#e5f4ea);color:#07572e;text-decoration:none;box-shadow:0 8px 22px rgba(8,57,36,.06)}
+.pc-ss-home-ai-entry>span{display:grid;gap:4px;min-width:0}.pc-ss-home-ai-entry strong{font-size:15px;line-height:1.22;font-weight:850;letter-spacing:-.012em}.pc-ss-home-ai-entry small{display:-webkit-box;overflow:hidden;-webkit-line-clamp:2;-webkit-box-orient:vertical;color:#496158;font-size:13px;line-height:1.4;font-weight:560}.pc-ss-home-ai-entry>svg{justify-self:end;color:#087a3b;transition:transform .16s ease}.pc-ss-home-ai-entry:hover>svg,.pc-ss-home-ai-entry:focus-visible>svg{transform:translateX(3px)}.pc-ss-home-ai-entry:focus-visible{outline:3px solid #17649b;outline-offset:3px}
+[data-single-server-ai-entry='true']+.pc-ppe-public-status{margin-top:8px!important;padding:10px 12px!important;border-radius:12px!important;background:#f8faf9!important;box-shadow:none!important}[data-single-server-ai-entry='true']+.pc-ppe-public-status strong{font-size:12px!important}[data-single-server-ai-entry='true']+.pc-ppe-public-status>span{font-size:12px!important;line-height:1.38!important}
+@media(min-width:761px){[data-single-server-ai-entry='true']{max-width:760px;margin-top:22px}.pc-ss-home-ai-entry{min-height:78px;padding:15px 16px}.pc-ss-home-ai-entry strong{font-size:16px}.pc-ss-home-ai-entry small{font-size:14px}}
+@media(prefers-reduced-motion:reduce){.pc-ss-home-ai-entry>svg{transition:none}}
+`;


### PR DESCRIPTION
Restores the dedicated “ИИ работает в платформе” callout on the production single-server public home. The block links to `/platform-v7/ai-in-action`, supports RU/EN/ZH, is inserted before the existing public-mode disclosure, and is covered by the single-server production build acceptance.