### PR TITLE
Publish exact single-server AI link image 4082387

### DIFF
--- a/.github/release-triggers/single-server-ai-link-4082387.md
+++ b/.github/release-triggers/single-server-ai-link-4082387.md
@@ -1,0 +1,3 @@
+# Single-server AI link release trigger
+
+Publishes and verifies the immutable production web image for exact single-server SHA `40823872b58094497bad41c6e25d4a2d57c552fd`.

--- a/.github/workflows/publish-single-server-ai-link-4082387.yml
+++ b/.github/workflows/publish-single-server-ai-link-4082387.yml
@@ -1,0 +1,50 @@
+name: Publish single-server AI link release 4082387
+
+on:
+  pull_request:
+    branches:
+      - claude/cabinet-design-audit-2jbv6f
+    paths:
+      - '.github/release-triggers/single-server-ai-link-4082387.md'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  TARGET_SHA: 40823872b58094497bad41c6e25d4a2d57c552fd
+  IMAGE: ghcr.io/pachaninm-lab/grainflow-web
+  IMMUTABLE_TAG: sha-40823872b58
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: 40823872b58094497bad41c6e25d4a2d57c552fd
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: pachaninm-lab
+          password: ${{ github.token }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile.web
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/pachaninm-lab/grainflow-web:sha-40823872b58
+          build-args: |
+            GIT_COMMIT=40823872b58094497bad41c6e25d4a2d57c552fd
+      - name: Verify immutable registry image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker pull "${IMAGE}:${IMMUTABLE_TAG}"
+          ACTUAL_SHA="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "${IMAGE}:${IMMUTABLE_TAG}")"
+          printf 'expected=%s\nactual=%s\n' "${TARGET_SHA}" "${ACTUAL_SHA}"
+          test "${ACTUAL_SHA}" = "${TARGET_SHA}"


### PR DESCRIPTION
Publishes and verifies the immutable production web image for exact single-server SHA `40823872b58094497bad41c6e25d4a2d57c552fd` using tag `sha-40823872b58`. This release restores the dedicated AI-in-action link block on the public home without replacing the proven single-server runtime.