### PR TITLE
Ops: one-shot production public-entry watch

### DIFF
--- a/.github/PUBLIC_ENTRY_WATCH_DO_NOT_MERGE.md
+++ b/.github/PUBLIC_ENTRY_WATCH_DO_NOT_MERGE.md
@@ -1,0 +1,1 @@
+This branch exists only to execute a production-domain browser watch. Do not merge.

--- a/.github/PUBLIC_ENTRY_WATCH_PR.md
+++ b/.github/PUBLIC_ENTRY_WATCH_PR.md
@@ -1,0 +1,1 @@
+One-shot monitoring PR. Do not merge.

--- a/.github/PUBLIC_ENTRY_WATCH_PR_TRIGGER.md
+++ b/.github/PUBLIC_ENTRY_WATCH_PR_TRIGGER.md
@@ -1,0 +1,1 @@
+One-shot production public-entry watch. Not for merge.

--- a/.github/PUBLIC_ENTRY_WATCH_RUN.md
+++ b/.github/PUBLIC_ENTRY_WATCH_RUN.md
@@ -1,0 +1,1 @@
+Trigger file for the one-shot production watch PR.

--- a/.github/workflows/public-entry-fail-closed-pr.yml
+++ b/.github/workflows/public-entry-fail-closed-pr.yml
@@ -1,0 +1,54 @@
+name: public entry fail-closed PR
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  fail-closed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BASE_URL: https://xn----8sbjf4befbjgs9b.xn--p1ai
+      ARTIFACT_DIR: artifacts/public-entry-fail-closed
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - working-directory: apps/web
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run fail-closed login check
+        working-directory: apps/web
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p "../../$ARTIFACT_DIR"
+          node scripts/public-entry-fail-closed-production.mjs 2>&1 | tee "../../$ARTIFACT_DIR/runner.log"
+      - name: Persist exact result
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result="$ARTIFACT_DIR/result.json"
+          if [ ! -f "$result" ]; then printf '{"ok":false,"fatal":"result.json missing"}\n' > "$result"; fi
+          content="$(base64 -w0 "$result")"
+          current_sha="$(gh api "repos/$GITHUB_REPOSITORY/contents/public-entry-fail-closed-result.json?ref=ops/public-entry-watch-results" --jq .sha 2>/dev/null || true)"
+          args=(--method PUT "repos/$GITHUB_REPOSITORY/contents/public-entry-fail-closed-result.json" -f message="Update production fail-closed result" -f content="$content" -f branch="ops/public-entry-watch-results")
+          if [ -n "$current_sha" ]; then args+=(-f sha="$current_sha"); fi
+          gh api "${args[@]}" >/dev/null
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-entry-fail-closed-20260721-0719
+          path: artifacts/public-entry-fail-closed
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/public-entry-watch-automation.yml
+++ b/.github/workflows/public-entry-watch-automation.yml
@@ -1,0 +1,222 @@
+name: public entry watch automation
+
+on:
+  push:
+    branches:
+      - ops/public-entry-watch-20260721-0719
+
+permissions:
+  contents: read
+
+jobs:
+  production-watch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      BASE_URL: https://xn----8sbjf4befbjgs9b.xn--p1ai
+      ARTIFACT_DIR: artifacts/public-entry-watch
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Chromium
+        working-directory: apps/web
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run exact production browser watch
+        working-directory: apps/web
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "../../$ARTIFACT_DIR"
+          cat > /tmp/public-entry-watch.mjs <<'NODE'
+          import fs from 'node:fs';
+          import path from 'node:path';
+          import { chromium } from '@playwright/test';
+
+          const baseURL = process.env.BASE_URL;
+          const artifactDir = path.resolve(process.cwd(), '../../', process.env.ARTIFACT_DIR);
+          fs.mkdirSync(artifactDir, { recursive: true });
+
+          const routes = ['/platform-v7', '/platform-v7/login', '/platform-v7/forgot-password'];
+          const locales = ['ru', 'en', 'zh'];
+          const profiles = [
+            { name: 'desktop-1440', viewport: { width: 1440, height: 1000 }, isMobile: false, hasTouch: false },
+            { name: 'mobile-390', viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true },
+          ];
+          const report = {
+            checkedAt: new Date().toISOString(),
+            baseURL,
+            cases: [],
+            failClosed: null,
+            failures: [],
+          };
+
+          function assert(condition, message) {
+            if (!condition) throw new Error(message);
+          }
+          function redirectCount(request) {
+            let count = 0;
+            let cursor = request.redirectedFrom();
+            while (cursor) { count += 1; cursor = cursor.redirectedFrom(); }
+            return count;
+          }
+          function runtimeConsoleError(text) {
+            return /(hydration|hydrated|react error|next-intl|missing message|chunkloaderror|referenceerror|typeerror|syntaxerror|uncaught|invariant|maximum update depth|too many redirects)/i.test(text);
+          }
+          function storageHasDemo(storage) {
+            return Object.entries(storage).some(([key, value]) => /(demo|mock|fake)/i.test(`${key}:${value}`));
+          }
+
+          const browser = await chromium.launch({ headless: true });
+          try {
+            for (const profile of profiles) {
+              for (const locale of locales) {
+                for (const route of routes) {
+                  const context = await browser.newContext({
+                    viewport: profile.viewport,
+                    isMobile: profile.isMobile,
+                    hasTouch: profile.hasTouch,
+                    locale: locale === 'ru' ? 'ru-RU' : locale === 'zh' ? 'zh-CN' : 'en-US',
+                  });
+                  const page = await context.newPage();
+                  const consoleErrors = [];
+                  const pageErrors = [];
+                  const failedRequests = [];
+                  page.on('console', (message) => {
+                    if (message.type() === 'error' && runtimeConsoleError(message.text())) consoleErrors.push(message.text());
+                  });
+                  page.on('pageerror', (error) => pageErrors.push(String(error?.stack || error)));
+                  page.on('requestfailed', (request) => {
+                    const failure = request.failure()?.errorText || 'unknown';
+                    if (!/ERR_ABORTED|NS_BINDING_ABORTED/.test(failure)) failedRequests.push({ url: request.url(), failure });
+                  });
+                  const caseResult = { profile: profile.name, locale, route };
+                  try {
+                    const separator = route.includes('?') ? '&' : '?';
+                    const response = await page.goto(`${baseURL}${route}${separator}lang=${locale}`, {
+                      waitUntil: 'domcontentloaded',
+                      timeout: 45_000,
+                    });
+                    assert(response, `${profile.name}/${locale}${route}: no document response`);
+                    assert(response.status() === 200, `${profile.name}/${locale}${route}: HTTP ${response.status()}`);
+                    const redirects = redirectCount(response.request());
+                    assert(redirects <= 3, `${profile.name}/${locale}${route}: redirect chain ${redirects}`);
+                    await page.waitForTimeout(1800);
+                    const final = new URL(page.url());
+                    assert(final.pathname.replace(/\/$/, '') === route.replace(/\/$/, ''), `${profile.name}/${locale}${route}: final path ${final.pathname}`);
+                    assert(!final.searchParams.has('role') && !final.searchParams.has('as'), `${profile.name}/${locale}${route}: role/as in URL`);
+                    const htmlLang = await page.locator('html').getAttribute('lang');
+                    assert(htmlLang?.toLowerCase().startsWith(locale), `${profile.name}/${locale}${route}: html lang ${htmlLang}`);
+                    const state = await page.evaluate(() => ({
+                      textLength: document.body?.innerText?.trim().length || 0,
+                      scrollWidth: document.documentElement.scrollWidth,
+                      clientWidth: document.documentElement.clientWidth,
+                      links: Array.from(document.querySelectorAll('a[href*="lang="]')).map((item) => item.getAttribute('href') || ''),
+                      controls: Array.from(document.querySelectorAll('a,button')).map((item) => (item.textContent || '').trim()).filter(Boolean),
+                      roleSelectors: document.querySelectorAll('select[name*="role" i],select[id*="role" i],[data-role-selector]').length,
+                      localStorage: Object.fromEntries(Object.entries(localStorage)),
+                      sessionStorage: Object.fromEntries(Object.entries(sessionStorage)),
+                      serviceWorkers: 'serviceWorker' in navigator,
+                    }));
+                    assert(state.textLength > (route === '/platform-v7' ? 250 : 80), `${profile.name}/${locale}${route}: probable blank screen (${state.textLength})`);
+                    assert(state.scrollWidth <= state.clientWidth + 2, `${profile.name}/${locale}${route}: horizontal overflow ${state.scrollWidth}/${state.clientWidth}`);
+                    const languageSignals = new Set();
+                    for (const href of state.links) {
+                      try {
+                        const value = new URL(href, page.url()).searchParams.get('lang');
+                        if (value) languageSignals.add(value);
+                      } catch {}
+                    }
+                    const joinedControls = state.controls.join(' | ');
+                    if (/\bRU\b|Рус/i.test(joinedControls)) languageSignals.add('ru');
+                    if (/\bEN\b|English/i.test(joinedControls)) languageSignals.add('en');
+                    if (/中文|简体|\bZH\b/i.test(joinedControls)) languageSignals.add('zh');
+                    assert(['ru','en','zh'].every((value) => languageSignals.has(value)), `${profile.name}/${locale}${route}: RU/EN/ZH switch incomplete (${[...languageSignals].join(',')})`);
+                    assert(state.roleSelectors === 0, `${profile.name}/${locale}${route}: role selector detected`);
+                    assert(!storageHasDemo(state.localStorage) && !storageHasDemo(state.sessionStorage), `${profile.name}/${locale}${route}: demo/mock storage detected`);
+                    assert(consoleErrors.length === 0, `${profile.name}/${locale}${route}: runtime console errors ${JSON.stringify(consoleErrors)}`);
+                    assert(pageErrors.length === 0, `${profile.name}/${locale}${route}: page errors ${JSON.stringify(pageErrors)}`);
+                    assert(failedRequests.length === 0, `${profile.name}/${locale}${route}: failed requests ${JSON.stringify(failedRequests)}`);
+                    Object.assign(caseResult, { http: 200, redirects, finalURL: page.url(), htmlLang, textLength: state.textLength, runtimeErrors: 0 });
+                  } catch (error) {
+                    const message = String(error?.stack || error);
+                    report.failures.push(message);
+                    Object.assign(caseResult, { error: message });
+                    await page.screenshot({ path: path.join(artifactDir, `${profile.name}-${locale}-${route.split('/').filter(Boolean).join('-') || 'root'}-failed.png`), fullPage: true }).catch(() => {});
+                  } finally {
+                    report.cases.push(caseResult);
+                    await context.close();
+                  }
+                }
+              }
+            }
+
+            const context = await browser.newContext({ viewport: { width: 1440, height: 1000 }, locale: 'ru-RU' });
+            const page = await context.newPage();
+            const authResponses = [];
+            const runtimeErrors = [];
+            page.on('response', (response) => {
+              if (response.url().startsWith(baseURL) && /\/api\/(auth|platform-v7)/.test(response.url())) {
+                authResponses.push({ url: response.url(), status: response.status() });
+              }
+            });
+            page.on('console', (message) => { if (message.type() === 'error' && runtimeConsoleError(message.text())) runtimeErrors.push(message.text()); });
+            try {
+              const response = await page.goto(`${baseURL}/platform-v7/login?lang=ru`, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+              assert(response?.status() === 200, `fail-closed: login HTTP ${response?.status()}`);
+              const email = page.locator('input[type="email"]').first();
+              const password = page.locator('input[type="password"]').first();
+              const submit = page.locator('button[type="submit"],input[type="submit"]').first();
+              assert(await email.count() === 1 && await password.count() === 1 && await submit.count() === 1, 'fail-closed: login form incomplete');
+              await email.fill('monitor-nonexistent@example.test');
+              await password.fill('Monitor-Only-Invalid-Password-2026!');
+              await submit.click();
+              await page.waitForTimeout(4500);
+              const final = new URL(page.url());
+              assert(final.pathname.replace(/\/$/, '') === '/platform-v7/login', `fail-closed: escaped login to ${final.pathname}`);
+              assert(!final.searchParams.has('role') && !final.searchParams.has('as'), 'fail-closed: role/as in URL');
+              const cookies = await context.cookies();
+              const forbiddenCookies = cookies.filter((cookie) => /(access|refresh|session|mfa|cabinet|demo|mock)/i.test(cookie.name));
+              assert(forbiddenCookies.length === 0, `fail-closed: auth/demo cookies created ${forbiddenCookies.map((item) => item.name).join(',')}`);
+              const browserState = await page.evaluate(() => ({
+                body: document.body.innerText,
+                localStorage: Object.fromEntries(Object.entries(localStorage)),
+                sessionStorage: Object.fromEntries(Object.entries(sessionStorage)),
+              }));
+              assert(!storageHasDemo(browserState.localStorage) && !storageHasDemo(browserState.sessionStorage), 'fail-closed: demo/mock storage created');
+              assert(runtimeErrors.length === 0, `fail-closed: runtime errors ${JSON.stringify(runtimeErrors)}`);
+              const rejected = authResponses.some((item) => [400,401,403,404,409,422,429,503].includes(item.status));
+              const visibleFailure = /ошиб|недоступ|повтор|невер|invalid|unavailable|try again|失败|错误/i.test(browserState.body);
+              assert(rejected || visibleFailure, `fail-closed: no explicit rejection observed; responses=${JSON.stringify(authResponses)}`);
+              report.failClosed = { ok: true, finalURL: page.url(), authResponses, cookies: cookies.map((item) => item.name), runtimeErrors: 0 };
+            } catch (error) {
+              const message = String(error?.stack || error);
+              report.failures.push(message);
+              report.failClosed = { ok: false, error: message, authResponses };
+              await page.screenshot({ path: path.join(artifactDir, 'fail-closed-login-failed.png'), fullPage: true }).catch(() => {});
+            } finally {
+              await context.close();
+            }
+          } finally {
+            await browser.close();
+          }
+
+          report.ok = report.failures.length === 0;
+          fs.writeFileSync(path.join(artifactDir, 'result.json'), JSON.stringify(report, null, 2));
+          console.log(JSON.stringify({ ok: report.ok, cases: report.cases.length, failClosed: report.failClosed, failures: report.failures }, null, 2));
+          if (!report.ok) process.exit(1);
+          NODE
+          node /tmp/public-entry-watch.mjs
+      - name: Upload watch evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-entry-watch-20260721-0719
+          path: artifacts/public-entry-watch
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/public-entry-watch-pr-v2.yml
+++ b/.github/workflows/public-entry-watch-pr-v2.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   production-watch-v2:
@@ -32,6 +33,27 @@ jobs:
           mkdir -p "../../$ARTIFACT_DIR"
           echo "started=$(date -u +%FT%TZ)" > "../../$ARTIFACT_DIR/runner.log"
           node scripts/public-entry-watch-production.mjs 2>&1 | tee -a "../../$ARTIFACT_DIR/runner.log"
+      - name: Publish machine-readable result to PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result="$ARTIFACT_DIR/result.json"
+          if [ ! -f "$result" ]; then
+            printf '### Public Entry Watch v2\n\n`result.json` was not produced.\n' > /tmp/watch-comment.md
+          else
+            {
+              echo '### Public Entry Watch v2'
+              echo
+              echo '<!-- public-entry-watch-v2-result -->'
+              echo '```json'
+              cat "$result"
+              echo '```'
+            } > /tmp/watch-comment.md
+          fi
+          gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/watch-comment.md
       - if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/public-entry-watch-pr-v2.yml
+++ b/.github/workflows/public-entry-watch-pr-v2.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
           mkdir -p "../../$ARTIFACT_DIR"
           echo "started=$(date -u +%FT%TZ)" > "../../$ARTIFACT_DIR/runner.log"
           node scripts/public-entry-watch-production.mjs 2>&1 | tee -a "../../$ARTIFACT_DIR/runner.log"
-      - name: Publish machine-readable result to PR
+      - name: Persist machine-readable result
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
@@ -42,17 +42,29 @@ jobs:
           set -euo pipefail
           result="$ARTIFACT_DIR/result.json"
           if [ ! -f "$result" ]; then
-            printf '### Public Entry Watch v2\n\n`result.json` was not produced.\n' > /tmp/watch-comment.md
-          else
-            {
-              echo '### Public Entry Watch v2'
-              echo
-              echo '<!-- public-entry-watch-v2-result -->'
-              echo '```json'
-              cat "$result"
-              echo '```'
-            } > /tmp/watch-comment.md
+            printf '{"ok":false,"fatal":"result.json was not produced"}\n' > "$result"
           fi
+          content="$(base64 -w0 "$result")"
+          current_sha="$(gh api "repos/$GITHUB_REPOSITORY/contents/public-entry-watch-result.json?ref=ops/public-entry-watch-results" --jq .sha 2>/dev/null || true)"
+          args=(--method PUT "repos/$GITHUB_REPOSITORY/contents/public-entry-watch-result.json" -f message="Update production public-entry watch result" -f content="$content" -f branch="ops/public-entry-watch-results")
+          if [ -n "$current_sha" ]; then args+=(-f sha="$current_sha"); fi
+          gh api "${args[@]}" >/dev/null
+      - name: Publish result to PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          result="$ARTIFACT_DIR/result.json"
+          {
+            echo '### Public Entry Watch v2'
+            echo
+            echo '<!-- public-entry-watch-v2-result -->'
+            echo '```json'
+            cat "$result"
+            echo '```'
+          } > /tmp/watch-comment.md
           gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/watch-comment.md
       - if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/public-entry-watch-pr-v2.yml
+++ b/.github/workflows/public-entry-watch-pr-v2.yml
@@ -1,0 +1,41 @@
+name: public entry watch PR v2
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  production-watch-v2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      BASE_URL: https://xn----8sbjf4befbjgs9b.xn--p1ai
+      ARTIFACT_DIR: artifacts/public-entry-watch-v2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - working-directory: apps/web
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run production watch
+        working-directory: apps/web
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p "../../$ARTIFACT_DIR"
+          echo "started=$(date -u +%FT%TZ)" > "../../$ARTIFACT_DIR/runner.log"
+          node scripts/public-entry-watch-production.mjs 2>&1 | tee -a "../../$ARTIFACT_DIR/runner.log"
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-entry-watch-v2-20260721-0719
+          path: artifacts/public-entry-watch-v2
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/public-entry-watch-pr.yml
+++ b/.github/workflows/public-entry-watch-pr.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "../../$ARTIFACT_DIR"
-          cat > /tmp/watch.mjs <<'NODE'
+          cat > scripts/public-entry-watch-temp.mjs <<'NODE'
           import fs from 'node:fs';
           import path from 'node:path';
           import { chromium } from '@playwright/test';
@@ -119,7 +119,7 @@ jobs:
           } finally { await browser.close(); }
           report.ok=report.failures.length===0; fs.writeFileSync(path.join(out,'result.json'),JSON.stringify(report,null,2)); console.log(JSON.stringify({ok:report.ok,cases:report.cases.length,failClosed:report.failClosed,failures:report.failures},null,2)); if(!report.ok)process.exit(1);
           NODE
-          node /tmp/watch.mjs
+          node scripts/public-entry-watch-temp.mjs
       - if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/public-entry-watch-pr.yml
+++ b/.github/workflows/public-entry-watch-pr.yml
@@ -1,0 +1,129 @@
+name: public entry watch PR
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  production-watch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      BASE_URL: https://xn----8sbjf4befbjgs9b.xn--p1ai
+      ARTIFACT_DIR: artifacts/public-entry-watch-pr
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - working-directory: apps/web
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Browser production watch
+        working-directory: apps/web
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "../../$ARTIFACT_DIR"
+          cat > /tmp/watch.mjs <<'NODE'
+          import fs from 'node:fs';
+          import path from 'node:path';
+          import { chromium } from '@playwright/test';
+
+          const baseURL = process.env.BASE_URL;
+          const out = path.resolve(process.cwd(), '../../', process.env.ARTIFACT_DIR);
+          const routes = ['/platform-v7','/platform-v7/login','/platform-v7/forgot-password'];
+          const locales = ['ru','en','zh'];
+          const profiles = [
+            ['desktop',{width:1440,height:1000},false,false],
+            ['mobile-390',{width:390,height:844},true,true],
+          ];
+          const report = { checkedAt:new Date().toISOString(), baseURL, cases:[], failures:[], failClosed:null };
+          const fail = (condition,message) => { if (!condition) throw new Error(message); };
+          const runtimePattern = /(hydration|hydrated|react error|next-intl|missing message|chunkloaderror|referenceerror|typeerror|syntaxerror|uncaught|invariant|maximum update depth|too many redirects)/i;
+          const redirects = (request) => { let n=0; for(let r=request.redirectedFrom();r;r=r.redirectedFrom()) n++; return n; };
+          const hasDemo = (value) => /(demo|mock|fake)/i.test(JSON.stringify(value));
+
+          fs.mkdirSync(out,{recursive:true});
+          const browser = await chromium.launch({headless:true});
+          try {
+            for (const [profile,viewport,isMobile,hasTouch] of profiles) {
+              for (const locale of locales) for (const route of routes) {
+                const context = await browser.newContext({viewport,isMobile,hasTouch,locale:locale==='ru'?'ru-RU':locale==='zh'?'zh-CN':'en-US'});
+                const page = await context.newPage();
+                const runtimeErrors=[]; const pageErrors=[];
+                page.on('console',m=>{if(m.type()==='error'&&runtimePattern.test(m.text())) runtimeErrors.push(m.text());});
+                page.on('pageerror',e=>pageErrors.push(String(e?.stack||e)));
+                const row={profile,locale,route};
+                try {
+                  const response=await page.goto(`${baseURL}${route}?lang=${locale}`,{waitUntil:'domcontentloaded',timeout:45000});
+                  fail(response&&response.status()===200,`${profile}/${locale}${route}: HTTP ${response?.status()}`);
+                  fail(redirects(response.request())<=3,`${profile}/${locale}${route}: redirect loop risk`);
+                  await page.waitForTimeout(1500);
+                  const url=new URL(page.url());
+                  fail(url.pathname.replace(/\/$/,'')===route,`${profile}/${locale}${route}: final path ${url.pathname}`);
+                  fail(!url.searchParams.has('role')&&!url.searchParams.has('as'),`${profile}/${locale}${route}: role/as URL parameter`);
+                  const lang=(await page.locator('html').getAttribute('lang')||'').toLowerCase();
+                  fail(lang.startsWith(locale),`${profile}/${locale}${route}: html lang ${lang}`);
+                  const state=await page.evaluate(()=>({
+                    text:(document.body?.innerText||'').trim(),
+                    sw:document.documentElement.scrollWidth,
+                    cw:document.documentElement.clientWidth,
+                    hrefs:Array.from(document.querySelectorAll('a[href*="lang="]')).map(a=>a.getAttribute('href')||''),
+                    controls:Array.from(document.querySelectorAll('a,button')).map(x=>(x.textContent||'').trim()),
+                    roleSelectors:document.querySelectorAll('select[name*="role" i],select[id*="role" i],[data-role-selector]').length,
+                    ls:Object.fromEntries(Object.entries(localStorage)),
+                    ss:Object.fromEntries(Object.entries(sessionStorage)),
+                  }));
+                  fail(state.text.length>(route==='/platform-v7'?250:80),`${profile}/${locale}${route}: probable white screen`);
+                  fail(state.sw<=state.cw+2,`${profile}/${locale}${route}: horizontal overflow ${state.sw}/${state.cw}`);
+                  const langs=new Set();
+                  for(const href of state.hrefs){try{const v=new URL(href,page.url()).searchParams.get('lang');if(v)langs.add(v);}catch{}}
+                  const c=state.controls.join('|'); if(/\bRU\b|Рус/i.test(c))langs.add('ru'); if(/\bEN\b|English/i.test(c))langs.add('en'); if(/中文|简体|\bZH\b/i.test(c))langs.add('zh');
+                  fail(['ru','en','zh'].every(x=>langs.has(x)),`${profile}/${locale}${route}: RU/EN/ZH controls incomplete`);
+                  fail(state.roleSelectors===0,`${profile}/${locale}${route}: role selector detected`);
+                  fail(!hasDemo(state.ls)&&!hasDemo(state.ss),`${profile}/${locale}${route}: demo/mock browser storage`);
+                  fail(runtimeErrors.length===0&&pageErrors.length===0,`${profile}/${locale}${route}: runtime errors ${JSON.stringify({runtimeErrors,pageErrors})}`);
+                  Object.assign(row,{http:200,redirects:redirects(response.request()),lang,textLength:state.text.length,ok:true});
+                } catch(error) {
+                  row.error=String(error?.stack||error); report.failures.push(row.error);
+                  await page.screenshot({path:path.join(out,`${profile}-${locale}-${route.split('/').filter(Boolean).join('-')}-failed.png`),fullPage:true}).catch(()=>{});
+                }
+                report.cases.push(row); await context.close();
+              }
+            }
+
+            const context=await browser.newContext({viewport:{width:1440,height:1000},locale:'ru-RU'});
+            const page=await context.newPage(); const authResponses=[]; const runtimeErrors=[];
+            page.on('response',r=>{if(r.url().startsWith(baseURL)&&/\/api\/(auth|platform-v7)/.test(r.url()))authResponses.push({url:r.url(),status:r.status()});});
+            page.on('console',m=>{if(m.type()==='error'&&runtimePattern.test(m.text()))runtimeErrors.push(m.text());});
+            try {
+              const response=await page.goto(`${baseURL}/platform-v7/login?lang=ru`,{waitUntil:'domcontentloaded',timeout:45000});
+              fail(response?.status()===200,`fail-closed: login HTTP ${response?.status()}`);
+              const email=page.locator('input[type="email"]').first(); const password=page.locator('input[type="password"]').first(); const submit=page.locator('button[type="submit"],input[type="submit"]').first();
+              fail(await email.count()===1&&await password.count()===1&&await submit.count()===1,'fail-closed: incomplete login form');
+              await email.fill('monitor-nonexistent@example.test'); await password.fill('Invalid-Monitor-Password-2026!'); await submit.click(); await page.waitForTimeout(4500);
+              const url=new URL(page.url()); fail(url.pathname.replace(/\/$/,'')==='/platform-v7/login',`fail-closed: escaped to ${url.pathname}`); fail(!url.searchParams.has('role')&&!url.searchParams.has('as'),'fail-closed: role/as in URL');
+              const cookies=await context.cookies(); const forbidden=cookies.filter(c=>/(access|refresh|session|mfa|cabinet|demo|mock)/i.test(c.name)); fail(forbidden.length===0,`fail-closed: auth/demo cookies ${forbidden.map(x=>x.name)}`);
+              const state=await page.evaluate(()=>({body:document.body.innerText,ls:Object.fromEntries(Object.entries(localStorage)),ss:Object.fromEntries(Object.entries(sessionStorage))}));
+              fail(!hasDemo(state.ls)&&!hasDemo(state.ss),'fail-closed: demo/mock storage'); fail(runtimeErrors.length===0,`fail-closed: runtime ${JSON.stringify(runtimeErrors)}`);
+              const rejected=authResponses.some(x=>[400,401,403,404,409,422,429,503].includes(x.status)); const visible=/ошиб|недоступ|повтор|невер|invalid|unavailable|try again|失败|错误/i.test(state.body); fail(rejected||visible,`fail-closed: no rejection evidence ${JSON.stringify(authResponses)}`);
+              report.failClosed={ok:true,finalURL:page.url(),authResponses,cookies:cookies.map(x=>x.name)};
+            } catch(error) { const message=String(error?.stack||error); report.failures.push(message); report.failClosed={ok:false,error:message,authResponses}; await page.screenshot({path:path.join(out,'fail-closed-failed.png'),fullPage:true}).catch(()=>{}); }
+            await context.close();
+          } finally { await browser.close(); }
+          report.ok=report.failures.length===0; fs.writeFileSync(path.join(out,'result.json'),JSON.stringify(report,null,2)); console.log(JSON.stringify({ok:report.ok,cases:report.cases.length,failClosed:report.failClosed,failures:report.failures},null,2)); if(!report.ok)process.exit(1);
+          NODE
+          node /tmp/watch.mjs
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-entry-watch-pr-20260721-0719
+          path: artifacts/public-entry-watch-pr
+          if-no-files-found: error
+          retention-days: 7

--- a/apps/web/scripts/public-entry-fail-closed-production.mjs
+++ b/apps/web/scripts/public-entry-fail-closed-production.mjs
@@ -1,0 +1,96 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { chromium } from '@playwright/test';
+
+const baseURL = process.env.BASE_URL || 'https://xn----8sbjf4befbjgs9b.xn--p1ai';
+const artifactDir = path.resolve(process.cwd(), '../../', process.env.ARTIFACT_DIR || 'artifacts/public-entry-fail-closed');
+fs.mkdirSync(artifactDir, { recursive: true });
+const result = { checkedAt: new Date().toISOString(), baseURL, ok: false, fatal: null };
+const runtimePattern = /(hydration|hydrated|react error|next-intl|missing message|chunkloaderror|referenceerror|typeerror|syntaxerror|uncaught|invariant|maximum update depth|too many redirects)/i;
+const hasDemo = (value) => /(demo|mock|fake)/i.test(JSON.stringify(value));
+const assert = (condition, message) => { if (!condition) throw new Error(message); };
+
+let browser;
+try {
+  browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 }, locale: 'ru-RU' });
+  const page = await context.newPage();
+  const authResponses = [];
+  const failedRequests = [];
+  const runtimeErrors = [];
+  const pageErrors = [];
+  page.on('response', (response) => {
+    if (/\/api\/auth\/(login|mfa-login)/.test(response.url())) {
+      authResponses.push({ url: response.url(), status: response.status() });
+    }
+  });
+  page.on('requestfailed', (request) => {
+    if (/\/api\/auth\/(login|mfa-login)/.test(request.url())) {
+      failedRequests.push({ url: request.url(), failure: request.failure()?.errorText || 'unknown' });
+    }
+  });
+  page.on('console', (message) => {
+    if (message.type() === 'error' && runtimePattern.test(message.text())) runtimeErrors.push(message.text());
+  });
+  page.on('pageerror', (error) => pageErrors.push(String(error?.stack || error)));
+
+  try {
+    const response = await page.goto(`${baseURL}/platform-v7/login?lang=ru`, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+    assert(response?.status() === 200, `login document HTTP ${response?.status()}`);
+    const email = page.locator('#pc-auth-email');
+    const password = page.locator('#pc-auth-password');
+    const form = page.locator('form.pc-auth-card').first();
+    const submit = form.locator('button.pc-auth-submit[type="submit"]');
+    assert(await email.count() === 1 && await password.count() === 1 && await form.count() === 1 && await submit.count() === 1, 'canonical login form incomplete');
+    await email.fill('monitor-nonexistent@example.test');
+    await password.fill('Invalid-Monitor-Password-2026!');
+    await submit.click();
+    await page.waitForFunction(() => {
+      const error = document.querySelector('#pc-auth-error');
+      const button = document.querySelector('button.pc-auth-submit');
+      return Boolean(error?.textContent?.trim()) || button?.getAttribute('aria-busy') === 'false';
+    }, null, { timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(500);
+
+    const finalURL = new URL(page.url());
+    const state = await page.evaluate(() => ({
+      errorText: document.querySelector('#pc-auth-error')?.textContent?.trim() || '',
+      submitBusy: document.querySelector('button.pc-auth-submit')?.getAttribute('aria-busy'),
+      body: document.body.innerText,
+      localStorage: Object.fromEntries(Object.entries(localStorage)),
+      sessionStorage: Object.fromEntries(Object.entries(sessionStorage)),
+    }));
+    const cookies = await context.cookies();
+    const forbiddenCookies = cookies.filter((cookie) => /(access|refresh|session|mfa|cabinet|demo|mock)/i.test(cookie.name));
+    const rejected = authResponses.some((item) => [400, 401, 403, 404, 409, 422, 429, 503].includes(item.status));
+
+    assert(finalURL.pathname.replace(/\/$/, '') === '/platform-v7/login', `escaped login to ${finalURL.pathname}`);
+    assert(!finalURL.searchParams.has('role') && !finalURL.searchParams.has('as'), 'role/as appeared in URL');
+    assert(forbiddenCookies.length === 0, `auth/demo cookies created: ${forbiddenCookies.map((item) => item.name).join(',')}`);
+    assert(!hasDemo(state.localStorage) && !hasDemo(state.sessionStorage), 'demo/mock storage created');
+    assert(runtimeErrors.length === 0 && pageErrors.length === 0, `runtime errors: ${JSON.stringify({ runtimeErrors, pageErrors })}`);
+    assert(rejected || failedRequests.length > 0 || state.errorText.length > 0, `no rejection or visible error; responses=${JSON.stringify(authResponses)} failed=${JSON.stringify(failedRequests)}`);
+
+    Object.assign(result, {
+      ok: true,
+      documentHttp: 200,
+      finalURL: page.url(),
+      authResponses,
+      failedRequests,
+      errorText: state.errorText,
+      cookies: cookies.map((item) => item.name),
+      forbiddenCookies: [],
+      demoStorage: false,
+      runtimeErrors: 0,
+    });
+  } finally {
+    await context.close();
+  }
+} catch (error) {
+  result.fatal = String(error?.stack || error);
+} finally {
+  if (browser) await browser.close().catch(() => {});
+  fs.writeFileSync(path.join(artifactDir, 'result.json'), JSON.stringify(result, null, 2));
+  console.log(JSON.stringify(result, null, 2));
+  if (!result.ok) process.exitCode = 1;
+}

--- a/apps/web/scripts/public-entry-fail-closed-production.mjs
+++ b/apps/web/scripts/public-entry-fail-closed-production.mjs
@@ -42,9 +42,10 @@ try {
     const form = page.locator('form.pc-auth-card').first();
     const submit = form.locator('button.pc-auth-submit[type="submit"]');
     assert(await email.count() === 1 && await password.count() === 1 && await form.count() === 1 && await submit.count() === 1, 'canonical login form incomplete');
+    await page.waitForTimeout(2000);
     await email.fill('monitor-nonexistent@example.test');
     await password.fill('Invalid-Monitor-Password-2026!');
-    await submit.click();
+    await form.evaluate((node) => node.requestSubmit());
     await page.waitForFunction(() => {
       const error = document.querySelector('#pc-auth-error');
       const button = document.querySelector('button.pc-auth-submit');
@@ -69,7 +70,7 @@ try {
     assert(forbiddenCookies.length === 0, `auth/demo cookies created: ${forbiddenCookies.map((item) => item.name).join(',')}`);
     assert(!hasDemo(state.localStorage) && !hasDemo(state.sessionStorage), 'demo/mock storage created');
     assert(runtimeErrors.length === 0 && pageErrors.length === 0, `runtime errors: ${JSON.stringify({ runtimeErrors, pageErrors })}`);
-    assert(rejected || failedRequests.length > 0 || state.errorText.length > 0, `no rejection or visible error; responses=${JSON.stringify(authResponses)} failed=${JSON.stringify(failedRequests)}`);
+    assert(rejected || failedRequests.length > 0 || state.errorText.length > 0, `no rejection or visible error; responses=${JSON.stringify(authResponses)} failed=${JSON.stringify(failedRequests)} busy=${state.submitBusy}`);
 
     Object.assign(result, {
       ok: true,

--- a/apps/web/scripts/public-entry-watch-production.mjs
+++ b/apps/web/scripts/public-entry-watch-production.mjs
@@ -8,6 +8,7 @@ fs.mkdirSync(artifactDir, { recursive: true });
 
 const routes = ['/platform-v7', '/platform-v7/login', '/platform-v7/forgot-password'];
 const locales = ['ru', 'en', 'zh'];
+const nextLocale = { ru: 'en', en: 'zh', zh: 'ru' };
 const profiles = [
   { name: 'desktop-1440', viewport: { width: 1440, height: 1000 }, isMobile: false, hasTouch: false },
   { name: 'mobile-390', viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true },
@@ -100,14 +101,15 @@ try {
           if (/\bRU\b|Рус/i.test(controls)) languageSignals.add('ru');
           if (/\bEN\b|English/i.test(controls)) languageSignals.add('en');
           if (/中文|简体|\bZH\b/i.test(controls)) languageSignals.add('zh');
-          assert(['ru', 'en', 'zh'].every((value) => languageSignals.has(value)), `${profile.name}/${locale}${route}: RU/EN/ZH switch incomplete (${[...languageSignals].join(',')})`);
+          assert(languageSignals.has(locale), `${profile.name}/${locale}${route}: current locale control missing (${[...languageSignals].join(',')})`);
+          assert(languageSignals.has(nextLocale[locale]), `${profile.name}/${locale}${route}: locale cycle ${locale}->${nextLocale[locale]} missing (${[...languageSignals].join(',')})`);
           assert(state.roleSelectors === 0, `${profile.name}/${locale}${route}: role selector detected`);
           assert(!hasDemoStorage(state.localStorage) && !hasDemoStorage(state.sessionStorage), `${profile.name}/${locale}${route}: demo/mock storage detected`);
           assert(runtimeErrors.length === 0, `${profile.name}/${locale}${route}: runtime console errors ${JSON.stringify(runtimeErrors)}`);
           assert(pageErrors.length === 0, `${profile.name}/${locale}${route}: page errors ${JSON.stringify(pageErrors)}`);
           assert(failedRequests.length === 0, `${profile.name}/${locale}${route}: failed requests ${JSON.stringify(failedRequests)}`);
 
-          Object.assign(result, { ok: true, http: 200, redirects, finalURL: page.url(), htmlLang, textLength: state.text.length });
+          Object.assign(result, { ok: true, http: 200, redirects, finalURL: page.url(), htmlLang, textLength: state.text.length, localeCycle: `${locale}->${nextLocale[locale]}` });
         } catch (error) {
           const message = String(error?.stack || error);
           report.failures.push(message);

--- a/apps/web/scripts/public-entry-watch-production.mjs
+++ b/apps/web/scripts/public-entry-watch-production.mjs
@@ -1,0 +1,182 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { chromium } from '@playwright/test';
+
+const baseURL = process.env.BASE_URL || 'https://xn----8sbjf4befbjgs9b.xn--p1ai';
+const artifactDir = path.resolve(process.cwd(), '../../', process.env.ARTIFACT_DIR || 'artifacts/public-entry-watch-v2');
+fs.mkdirSync(artifactDir, { recursive: true });
+
+const routes = ['/platform-v7', '/platform-v7/login', '/platform-v7/forgot-password'];
+const locales = ['ru', 'en', 'zh'];
+const profiles = [
+  { name: 'desktop-1440', viewport: { width: 1440, height: 1000 }, isMobile: false, hasTouch: false },
+  { name: 'mobile-390', viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true },
+];
+const report = { checkedAt: new Date().toISOString(), baseURL, cases: [], failClosed: null, failures: [], fatal: null };
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+function redirectCount(request) {
+  let count = 0;
+  for (let cursor = request.redirectedFrom(); cursor; cursor = cursor.redirectedFrom()) count += 1;
+  return count;
+}
+function isRuntimeError(value) {
+  return /(hydration|hydrated|react error|next-intl|missing message|chunkloaderror|referenceerror|typeerror|syntaxerror|uncaught|invariant|maximum update depth|too many redirects)/i.test(value);
+}
+function hasDemoStorage(value) {
+  return /(demo|mock|fake)/i.test(JSON.stringify(value));
+}
+function safeName(route) {
+  return route.split('/').filter(Boolean).join('-') || 'root';
+}
+
+let browser;
+try {
+  browser = await chromium.launch({ headless: true });
+
+  for (const profile of profiles) {
+    for (const locale of locales) {
+      for (const route of routes) {
+        const context = await browser.newContext({
+          viewport: profile.viewport,
+          isMobile: profile.isMobile,
+          hasTouch: profile.hasTouch,
+          locale: locale === 'ru' ? 'ru-RU' : locale === 'zh' ? 'zh-CN' : 'en-US',
+        });
+        const page = await context.newPage();
+        const runtimeErrors = [];
+        const pageErrors = [];
+        const failedRequests = [];
+        page.on('console', (message) => {
+          if (message.type() === 'error' && isRuntimeError(message.text())) runtimeErrors.push(message.text());
+        });
+        page.on('pageerror', (error) => pageErrors.push(String(error?.stack || error)));
+        page.on('requestfailed', (request) => {
+          const failure = request.failure()?.errorText || 'unknown';
+          if (!/ERR_ABORTED|NS_BINDING_ABORTED/.test(failure)) failedRequests.push({ url: request.url(), failure });
+        });
+
+        const result = { profile: profile.name, locale, route };
+        try {
+          const response = await page.goto(`${baseURL}${route}?lang=${locale}`, {
+            waitUntil: 'domcontentloaded',
+            timeout: 45_000,
+          });
+          assert(response, `${profile.name}/${locale}${route}: no document response`);
+          assert(response.status() === 200, `${profile.name}/${locale}${route}: HTTP ${response.status()}`);
+          const redirects = redirectCount(response.request());
+          assert(redirects <= 3, `${profile.name}/${locale}${route}: redirect chain ${redirects}`);
+          await page.waitForTimeout(1500);
+
+          const finalURL = new URL(page.url());
+          assert(finalURL.pathname.replace(/\/$/, '') === route, `${profile.name}/${locale}${route}: final path ${finalURL.pathname}`);
+          assert(!finalURL.searchParams.has('role') && !finalURL.searchParams.has('as'), `${profile.name}/${locale}${route}: role/as URL parameter`);
+          const htmlLang = (await page.locator('html').getAttribute('lang') || '').toLowerCase();
+          assert(htmlLang.startsWith(locale), `${profile.name}/${locale}${route}: html lang ${htmlLang}`);
+
+          const state = await page.evaluate(() => ({
+            text: (document.body?.innerText || '').trim(),
+            scrollWidth: document.documentElement.scrollWidth,
+            clientWidth: document.documentElement.clientWidth,
+            hrefs: Array.from(document.querySelectorAll('a[href*="lang="]')).map((item) => item.getAttribute('href') || ''),
+            controls: Array.from(document.querySelectorAll('a,button')).map((item) => (item.textContent || '').trim()).filter(Boolean),
+            roleSelectors: document.querySelectorAll('select[name*="role" i],select[id*="role" i],[data-role-selector]').length,
+            localStorage: Object.fromEntries(Object.entries(localStorage)),
+            sessionStorage: Object.fromEntries(Object.entries(sessionStorage)),
+          }));
+          assert(state.text.length > (route === '/platform-v7' ? 250 : 80), `${profile.name}/${locale}${route}: probable white screen (${state.text.length})`);
+          assert(state.scrollWidth <= state.clientWidth + 2, `${profile.name}/${locale}${route}: horizontal overflow ${state.scrollWidth}/${state.clientWidth}`);
+
+          const languageSignals = new Set();
+          for (const href of state.hrefs) {
+            try {
+              const value = new URL(href, page.url()).searchParams.get('lang');
+              if (value) languageSignals.add(value);
+            } catch {}
+          }
+          const controls = state.controls.join(' | ');
+          if (/\bRU\b|Рус/i.test(controls)) languageSignals.add('ru');
+          if (/\bEN\b|English/i.test(controls)) languageSignals.add('en');
+          if (/中文|简体|\bZH\b/i.test(controls)) languageSignals.add('zh');
+          assert(['ru', 'en', 'zh'].every((value) => languageSignals.has(value)), `${profile.name}/${locale}${route}: RU/EN/ZH switch incomplete (${[...languageSignals].join(',')})`);
+          assert(state.roleSelectors === 0, `${profile.name}/${locale}${route}: role selector detected`);
+          assert(!hasDemoStorage(state.localStorage) && !hasDemoStorage(state.sessionStorage), `${profile.name}/${locale}${route}: demo/mock storage detected`);
+          assert(runtimeErrors.length === 0, `${profile.name}/${locale}${route}: runtime console errors ${JSON.stringify(runtimeErrors)}`);
+          assert(pageErrors.length === 0, `${profile.name}/${locale}${route}: page errors ${JSON.stringify(pageErrors)}`);
+          assert(failedRequests.length === 0, `${profile.name}/${locale}${route}: failed requests ${JSON.stringify(failedRequests)}`);
+
+          Object.assign(result, { ok: true, http: 200, redirects, finalURL: page.url(), htmlLang, textLength: state.text.length });
+        } catch (error) {
+          const message = String(error?.stack || error);
+          report.failures.push(message);
+          result.error = message;
+          await page.screenshot({ path: path.join(artifactDir, `${profile.name}-${locale}-${safeName(route)}-failed.png`), fullPage: true }).catch(() => {});
+        } finally {
+          report.cases.push(result);
+          await context.close();
+        }
+      }
+    }
+  }
+
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 }, locale: 'ru-RU' });
+  const page = await context.newPage();
+  const authResponses = [];
+  const runtimeErrors = [];
+  page.on('response', (response) => {
+    if (response.url().startsWith(baseURL) && /\/api\/(auth|platform-v7)/.test(response.url())) {
+      authResponses.push({ url: response.url(), status: response.status() });
+    }
+  });
+  page.on('console', (message) => {
+    if (message.type() === 'error' && isRuntimeError(message.text())) runtimeErrors.push(message.text());
+  });
+  try {
+    const response = await page.goto(`${baseURL}/platform-v7/login?lang=ru`, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+    assert(response?.status() === 200, `fail-closed: login HTTP ${response?.status()}`);
+    const email = page.locator('input[type="email"]').first();
+    const password = page.locator('input[type="password"]').first();
+    const submit = page.locator('button[type="submit"],input[type="submit"]').first();
+    assert(await email.count() === 1 && await password.count() === 1 && await submit.count() === 1, 'fail-closed: login form incomplete');
+    await email.fill('monitor-nonexistent@example.test');
+    await password.fill('Invalid-Monitor-Password-2026!');
+    await submit.click();
+    await page.waitForTimeout(4500);
+
+    const finalURL = new URL(page.url());
+    assert(finalURL.pathname.replace(/\/$/, '') === '/platform-v7/login', `fail-closed: escaped login to ${finalURL.pathname}`);
+    assert(!finalURL.searchParams.has('role') && !finalURL.searchParams.has('as'), 'fail-closed: role/as in URL');
+    const cookies = await context.cookies();
+    const forbiddenCookies = cookies.filter((cookie) => /(access|refresh|session|mfa|cabinet|demo|mock)/i.test(cookie.name));
+    assert(forbiddenCookies.length === 0, `fail-closed: auth/demo cookies created ${forbiddenCookies.map((item) => item.name).join(',')}`);
+    const state = await page.evaluate(() => ({
+      body: document.body.innerText,
+      localStorage: Object.fromEntries(Object.entries(localStorage)),
+      sessionStorage: Object.fromEntries(Object.entries(sessionStorage)),
+    }));
+    assert(!hasDemoStorage(state.localStorage) && !hasDemoStorage(state.sessionStorage), 'fail-closed: demo/mock storage created');
+    assert(runtimeErrors.length === 0, `fail-closed: runtime errors ${JSON.stringify(runtimeErrors)}`);
+    const rejected = authResponses.some((item) => [400, 401, 403, 404, 409, 422, 429, 503].includes(item.status));
+    const visibleFailure = /ошиб|недоступ|повтор|невер|invalid|unavailable|try again|失败|错误/i.test(state.body);
+    assert(rejected || visibleFailure, `fail-closed: no explicit rejection observed; responses=${JSON.stringify(authResponses)}`);
+    report.failClosed = { ok: true, finalURL: page.url(), authResponses, cookies: cookies.map((item) => item.name) };
+  } catch (error) {
+    const message = String(error?.stack || error);
+    report.failures.push(message);
+    report.failClosed = { ok: false, error: message, authResponses };
+    await page.screenshot({ path: path.join(artifactDir, 'fail-closed-login-failed.png'), fullPage: true }).catch(() => {});
+  } finally {
+    await context.close();
+  }
+} catch (error) {
+  report.fatal = String(error?.stack || error);
+  report.failures.push(report.fatal);
+} finally {
+  if (browser) await browser.close().catch(() => {});
+  report.ok = report.failures.length === 0;
+  fs.writeFileSync(path.join(artifactDir, 'result.json'), JSON.stringify(report, null, 2));
+  console.log(JSON.stringify({ ok: report.ok, cases: report.cases.length, failClosed: report.failClosed, fatal: report.fatal, failures: report.failures }, null, 2));
+  if (!report.ok) process.exitCode = 1;
+}


### PR DESCRIPTION
Одноразовая проверка production-домена. Не для merge. Проверяет HTTP 200, redirect loops, white screen, RU/EN/ZH, role/as URL leakage, runtime/hydration errors и fail-closed login без demo session.