### PR TITLE
fix(tai): align conversion wait with release acceptance

### DIFF
--- a/apps/tai/model-artifacts/model-conversion-prerequisites.v1.sh
+++ b/apps/tai/model-artifacts/model-conversion-prerequisites.v1.sh
@@ -17,6 +17,8 @@ SOURCE_ACCEPTANCE="apps/tai/model-artifacts/model-source-acquisition-acceptance.
 REMOTE_ROOT="/srv/tai-models/conversion-runs/$GITHUB_SHA/$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
 SUMMARY_PATH="conversion-summary.md"
 MONITOR_STATE="FAILED_CLOSED"
+RELEASE_WAIT_ATTEMPTS=180
+RELEASE_WAIT_INTERVAL_SECONDS=20
 
 write_summary() {
   SUMMARY_STATE="$MONITOR_STATE" SUMMARY_REMOTE_ROOT="$REMOTE_ROOT" python - <<'PY' > "$SUMMARY_PATH"
@@ -58,7 +60,7 @@ trap 'write_summary' EXIT
 
 mkdir -p prerequisite-evidence/release remote-evidence
 
-for attempt in $(seq 1 30); do
+for attempt in $(seq 1 "$RELEASE_WAIT_ATTEMPTS"); do
   gh api -H 'Accept: application/vnd.github+json' \
     -H 'X-GitHub-Api-Version: 2022-11-28' \
     "repos/$REPOSITORY/actions/runs?head_sha=$GITHUB_SHA&per_page=100" \
@@ -94,8 +96,11 @@ PY
   set -e
   if [[ "$status" -eq 0 ]]; then break; fi
   if [[ "$status" -eq 2 ]]; then echo 'Exact-main Release Acceptance failed.' >&2; exit 1; fi
-  if [[ "$attempt" -eq 30 ]]; then echo 'Exact-main Release Acceptance is pending or absent.' >&2; exit 1; fi
-  sleep 20
+  if [[ "$attempt" -eq "$RELEASE_WAIT_ATTEMPTS" ]]; then
+    echo 'Exact-main Release Acceptance is pending or absent.' >&2
+    exit 1
+  fi
+  sleep "$RELEASE_WAIT_INTERVAL_SECONDS"
 done
 
 export RELEASE_RUN_ID="$(python -c 'import json; print(json.load(open("prerequisite-evidence/release/selected-run.json"))["id"])')"
@@ -176,4 +181,3 @@ Path('prerequisite-evidence/conversion-authority-sha256.txt').write_text(
     hashlib.sha256(canonical(conversion).encode()).hexdigest() + '\n'
 )
 PY
-

--- a/apps/tai/tests/test_model_conversion_workflow.py
+++ b/apps/tai/tests/test_model_conversion_workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).parents[3]
@@ -173,6 +174,24 @@ def test_workflow_verifies_release_legal_source_and_toolchain_before_remote_star
     assert "artifact.zip" in orchestrator
     assert "control-manifest.sha256" in orchestrator
     assert "model-conversion-driver.v1.sh" in orchestrator
+
+
+def test_release_acceptance_wait_covers_upstream_timeout() -> None:
+    prerequisites = ORCHESTRATOR_PATHS[0].read_text(encoding="utf-8")
+    attempts_match = re.search(
+        r"^RELEASE_WAIT_ATTEMPTS=(\d+)$", prerequisites, re.MULTILINE
+    )
+    interval_match = re.search(
+        r"^RELEASE_WAIT_INTERVAL_SECONDS=(\d+)$", prerequisites, re.MULTILINE
+    )
+    assert attempts_match is not None
+    assert interval_match is not None
+    attempts = int(attempts_match.group(1))
+    interval_seconds = int(interval_match.group(1))
+    assert attempts * interval_seconds >= 60 * 60
+    assert 'seq 1 "$RELEASE_WAIT_ATTEMPTS"' in prerequisites
+    assert '"$attempt" -eq "$RELEASE_WAIT_ATTEMPTS"' in prerequisites
+    assert 'sleep "$RELEASE_WAIT_INTERVAL_SECONDS"' in prerequisites
 
 
 def test_driver_confines_mutation_and_executes_only_declared_outputs() -> None:


### PR DESCRIPTION
Extends the conversion prerequisite wait from 10 to 60 minutes and adds a regression test. Refs #2932 and #2835.