### PR TITLE
Publish exact single-server AI route image 88c67a4

### DIFF
--- a/.github/release-triggers/single-server-ai-route-88c67a4.md
+++ b/.github/release-triggers/single-server-ai-route-88c67a4.md
@@ -1,0 +1,3 @@
+# Single-server AI route release trigger
+
+Publishes and verifies the immutable production web image for exact single-server SHA `88c67a4c8fd0c5a1d93943b36d21558a48127756`.

--- a/.github/workflows/publish-single-server-ai-route-88c67a4.yml
+++ b/.github/workflows/publish-single-server-ai-route-88c67a4.yml
@@ -1,0 +1,50 @@
+name: Publish single-server AI route release 88c67a4
+
+on:
+  pull_request:
+    branches:
+      - claude/cabinet-design-audit-2jbv6f
+    paths:
+      - '.github/release-triggers/single-server-ai-route-88c67a4.md'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  TARGET_SHA: 88c67a4c8fd0c5a1d93943b36d21558a48127756
+  IMAGE: ghcr.io/pachaninm-lab/grainflow-web
+  IMMUTABLE_TAG: sha-88c67a4c8fd
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: 88c67a4c8fd0c5a1d93943b36d21558a48127756
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: pachaninm-lab
+          password: ${{ github.token }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile.web
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/pachaninm-lab/grainflow-web:sha-88c67a4c8fd
+          build-args: |
+            GIT_COMMIT=88c67a4c8fd0c5a1d93943b36d21558a48127756
+      - name: Verify immutable registry image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker pull "${IMAGE}:${IMMUTABLE_TAG}"
+          ACTUAL_SHA="$(docker image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "${IMAGE}:${IMMUTABLE_TAG}")"
+          printf 'expected=%s\nactual=%s\n' "${TARGET_SHA}" "${ACTUAL_SHA}"
+          test "${ACTUAL_SHA}" = "${TARGET_SHA}"


### PR DESCRIPTION
Publishes and verifies the immutable production web image for exact single-server SHA `88c67a4c8fd0c5a1d93943b36d21558a48127756` using tag `sha-88c67a4c8fd`. This image contains the restored `/platform-v7/ai-in-action` route and the interactive RU/EN/ZH AI explainer.