### PR TITLE
TAI: add exact conversion status relay

### DIFF
--- a/.github/workflows/tai-model-conversion.yml
+++ b/.github/workflows/tai-model-conversion.yml
@@ -105,3 +105,37 @@ jobs:
           fi
           jq -n --rawfile body conversion-summary.md '{body: $body}' \
             | gh api --method POST "repos/$REPOSITORY/issues/2835/comments" --input -
+
+  status:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      github.actor == github.repository_owner &&
+      github.triggering_actor == github.repository_owner &&
+      github.event.action == 'created' &&
+      github.event.issue.pull_request == null &&
+      github.event.issue.number == 2932 &&
+      github.event.comment.body == '/tai conversion status exact-main' &&
+      github.event.comment.author_association == 'OWNER' &&
+      github.event.comment.user.login == github.repository_owner
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      EXACT_MAIN: ${{ github.sha }}
+
+    steps:
+      - name: Relay latest bounded conversion summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/$REPOSITORY/issues/2835/comments?per_page=100" \
+            > comments.json
+          jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("## TAI governed model conversion")))] | last' \
+            comments.json > latest.json
+          test "$(jq -r '.id // empty' latest.json)" != ""
+          jq -n --arg exact_main "$EXACT_MAIN" --slurpfile latest latest.json \
+            '{body: ("## Latest governed conversion status\n\n- status request exact-main: `" + $exact_main + "`;\n- source issue: `#2835`;\n- source comment id: `" + ($latest[0].id | tostring) + "`;\n- source created at: `" + $latest[0].created_at + "`.\n\n" + $latest[0].body)}' \
+            | gh api --method POST "repos/$REPOSITORY/issues/2932/comments" --input -

--- a/apps/tai/tests/test_model_conversion_workflow.py
+++ b/apps/tai/tests/test_model_conversion_workflow.py
@@ -37,6 +37,7 @@ EXPECTED_PATHS = {
     "apps/tai/tests/test_model_conversion_workflow.py",
 }
 COMMAND = "/tai convert model-bundles exact-main"
+STATUS_COMMAND = "/tai conversion status exact-main"
 QWEN_REVISION = "895c8d171bc03c30e113cd7a28c02494b5e068b7"
 MISTRAL_REVISION = "c170c708c41dac9275d15a8fff4eca08d52bab71"
 
@@ -154,6 +155,21 @@ def test_workflow_is_owner_only_exact_main_and_dedicated_host_only() -> None:
         "195.19.12.120",
     ):
         assert forbidden not in workflow
+
+
+def test_workflow_exposes_owner_only_bounded_status_relay() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "  status:" in workflow
+    assert "github.event.issue.number == 2932" in workflow
+    assert f"github.event.comment.body == '{STATUS_COMMAND}'" in workflow
+    assert '"repos/$REPOSITORY/issues/2835/comments?per_page=100"' in workflow
+    assert '.user.login == "github-actions[bot]"' in workflow
+    assert 'startswith("## TAI governed model conversion")' in workflow
+    assert '"repos/$REPOSITORY/issues/2932/comments"' in workflow
+    assert "TAI_MODEL_HOST" not in workflow[workflow.index("  status:") :]
+    assert "production operational status" not in workflow[
+        workflow.index("  status:") :
+    ]
 
 
 def test_workflow_verifies_release_legal_source_and_toolchain_before_remote_start() -> None:


### PR DESCRIPTION
Adds an owner-only read-only command in #2932: `/tai conversion status exact-main`. It copies the latest bounded `TAI governed model conversion` summary from #2835, including source comment identity and request exact-main, without SSH/model secrets or any model-host mutation. This closes the observability gap that hid fail-closed workflow results from the connector. No benchmark, admission or production attestation claim. Status remains `NOT_ATTESTED`.