### PR TITLE
TAI AP-13B.3e: remove model-bundle archive self-reference

### DIFF
--- a/apps/tai/governance/scopes/ap-13b3e-model-bundle-nonselfref-2944.json
+++ b/apps/tai/governance/scopes/ap-13b3e-model-bundle-nonselfref-2944.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "tai.concurrent-scope.v1",
+  "branch": "fix/tai-model-bundle-nonselfref-v2",
+  "program_issue": 2726,
+  "parent_issue": 2835,
+  "issue": 2944,
+  "allowed_paths": [
+    "apps/tai/governance/scopes/ap-13b3e-model-bundle-nonselfref-2944.json",
+    "apps/tai/model-artifacts/model-bundle-acquisition-runbook.v2.md",
+    "apps/tai/tai/model_bundle_storage.py",
+    "apps/tai/tai/model_bundle_storage_cli.py",
+    "apps/tai/tests/test_model_bundle_storage_contract.py"
+  ],
+  "forbidden_capabilities": [
+    "model download, conversion, quantization or deployment execution",
+    "model weights, GGUF, archives or binaries committed to Git",
+    "benchmark, model admission or production-readiness claim",
+    "copytree or copied-original evidence accepted as independent restore",
+    "production credentials or production-host fallback"
+  ],
+  "acceptance": [
+    "payload archive contains only payload files and cannot reference itself",
+    "payload index is semantic and exactly bound to original, archive and restored payloads",
+    "storage archive and upload/restore records remain bounded sidecar evidence",
+    "archive traversal, links, duplicates, extra files, hash mismatch and copytree restore fail closed",
+    "legacy v2 semantic verifier remains required through a compatibility verification view",
+    "production_operational_status remains NOT_ATTESTED"
+  ]
+}

--- a/apps/tai/model-artifacts/model-bundle-acquisition-runbook.v2.md
+++ b/apps/tai/model-artifacts/model-bundle-acquisition-runbook.v2.md
@@ -1,197 +1,165 @@
-# AP-13B.3 model bundle acquisition and verification runbook
+# AP-13B.3 model bundle acquisition, immutable storage and restore verification
 
 ## Purpose
 
-This runbook creates external, reproducible evidence for the model bundles governed by `model-bundle-authority.v2.json`. It does not admit a model, publish benchmark results or change production readiness. The verifier is read-only and never executes manifest argv.
+This runbook creates external, reproducible model-bundle evidence governed by `model-bundle-authority.v2.json`. It does not admit a model, publish benchmark results or change production readiness. Model weights, source files, GGUF files, binaries and archives remain outside Git.
 
 ## Preconditions
 
-Before acquiring either model:
+1. The exact model revision has verified source acquisition evidence.
+2. A human legal review is `APPROVED_FOR_CONVERSION` for that exact revision and intended use.
+3. The accepted llama.cpp package is `VERIFIED_RESTORED` for release `b9637`, commit `aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3`.
+4. Conversion and every registered quantization completed with exit code `0`, exact argv, logs, sizes and SHA-256.
+5. The controlled workspace has sufficient capacity for the original payload, one content-addressed archive and one clean restore root.
+6. The storage destination is outside the conversion run root and exposes an immutable version or content-addressed locator.
 
-1. AP-13B.2a is merged and issue #2828 is closed by that merge.
-2. The controlled-build workflow is merged after AP-13B.2a.
-3. AP-13B.2b has produced a `VERIFIED` exact-main llama.cpp package for release `b9637`, commit `aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3` and profile `linux-x86_64-cpu-release-static-v1`.
-4. The package has an immutable locator, archive SHA-256/size, build manifest, verification report, and SHA-256/size for `llama-cli`, `llama-server`, `llama-quantize` and `llama-bench`.
-5. The operator has a non-shared controlled Linux workspace, sufficient disk capacity and an external immutable storage destination.
+No branch, mutable tag, community GGUF, copied web hash or inferred legal approval may be substituted.
 
-Do not substitute a release tag, branch, short commit, community GGUF or prebuilt binary.
+## Non-self-referential storage contract
 
-## 1. Establish the controlled workspace
+A model bundle consists of two layers:
 
-Use a dedicated non-symlink directory with restrictive permissions. Record OS, architecture, filesystem and available capacity. Keep acquisition, conversion and restore roots separate.
+### Payload layer
 
-```bash
-umask 077
-export TAI_WORK=/secure/tai-model-bundles
-mkdir -p "$TAI_WORK"/{acquisition,original,restore,reports}
-```
-
-Validate the committed authority and retain its canonical digest:
-
-```bash
-cd apps/tai
-python -m tai.model_artifact_registry_cli validate-bundle-authority-v2 \
-  model-artifacts/model-bundle-authority.v2.json \
-  --output "$TAI_WORK/reports/authority-validation.v2.json"
-```
-
-## 2. Acquire the exact upstream revision
-
-Acquire only the full revision recorded in the authority:
-
-- Qwen: `Qwen/Qwen3-8B@895c8d171bc03c30e113cd7a28c02494b5e068b7`;
-- Mistral: `mistralai/Mistral-7B-Instruct-v0.3@c170c708c41dac9275d15a8fff4eca08d52bab71`.
-
-Capture a machine-readable remote inventory before download. The evidence record must use schema `tai.remote-model-inventory-evidence.v1` and bind the exact `model_id`, full `revision`, immutable revision-qualified `source_uri`, timezone-aware `observed_at` and every authority entry with disposition, role, path, size, remote identity and exclusion reason. Preserve it as `evidence/remote-inventory.json`.
-
-The observed inventory must exactly match the authority and include excluded files as well as selected files. Exclusion does not mean omission from provenance. A model identity, revision, source URI, entry or content mismatch blocks verification.
-
-## 3. Enforce the selected source sets
-
-For Qwen, acquire and hash:
-
-- all five `model-0000*-of-00005.safetensors` shards;
-- `model.safetensors.index.json`;
-- `tokenizer.json`, `tokenizer_config.json`, `merges.txt`, `vocab.json`;
-- `config.json`, `generation_config.json`;
-- `README.md`.
-
-For Mistral, acquire and hash:
-
-- all three `model-0000*-of-00003.safetensors` shards;
-- `model.safetensors.index.json`;
-- `tokenizer.model` and `tokenizer.model.v3`;
-- `tokenizer.json`, `tokenizer_config.json`, `special_tokens_map.json`;
-- `config.json`, `generation_config.json`, `params.json`;
-- `README.md`.
-
-`consolidated.safetensors` remains in the remote inventory with disposition `EXCLUDED`. Do not download it into the governed conversion input set and do not mix it with the three-shard Hugging Face layout.
-
-For every selected source file, record the exact relative path, SHA-256 and byte size. Parse `model.safetensors.index.json` and confirm that its `weight_map` references every selected shard and no other shard.
-
-## 4. Capture human legal review
-
-Store the exact license text as an immutable evidence file. A human reviewer must inspect the exact model revision, license text and intended use, then create a signed or otherwise attributable review record containing:
-
-- decision `APPROVED` or `REJECTED`;
-- reviewer type `HUMAN`;
-- stable reviewer identifier and display name;
-- timezone-aware review timestamp;
-- SPDX identity;
-- decision basis and scope;
-- explicit approval conditions, including an empty list when no conditions apply;
-- record type `ATTRIBUTED_RECORD` or `SIGNED_RECORD`;
-- immutable `attestation_reference`;
-- SHA-256 of the exact reviewed license text.
-
-The review record must use schema `tai.model-legal-review-record.v1`, and its semantic fields must exactly match the manifest. Metadata from the upstream model card is not human legal approval. A pending, absent or automated decision cannot verify. A `REJECTED` decision terminates acquisition for that model.
-
-## 5. Restore and reverify the llama.cpp package
-
-Download the AP-13B.2b package from its immutable locator into the model bundle. The locator must bind the exact package archive SHA-256. Verify the package archive, build manifest, verification report and all four binaries before conversion. The embedded verification report must have status `VERIFIED`, the accepted toolchain authority digest and the complete target set.
-
-Preserve the exact converter script from the same source commit at `toolchain/source/convert_hf_to_gguf.py`. Record its SHA-256 and byte size.
-
-## 6. Freeze the Python conversion environment
-
-Use a dedicated environment. Record the full Python identity and a deterministic dependency record such as a hashed lockfile or complete `pip freeze` output. Do not use an unrecorded global environment.
-
-The evidence manifest binds:
-
-- Python identity;
-- dependency record;
-- converter script;
-- canonical digest of all selected source files;
-- exact toolchain package SHA-256;
-- exact argv and log;
-- intermediate GGUF SHA-256 and byte size.
-
-## 7. Execute the governed conversion
-
-Read the exact argv from `model-bundle-authority.v2.json`, review it, and execute it manually in the controlled environment. The verifier does not execute it.
-
-Qwen produces `artifacts/qwen3-8b-bf16.gguf`. Mistral produces `artifacts/mistral-7b-instruct-v0.3-f16.gguf`. Capture stdout, stderr, exit status and timestamps in the conversion log. Hash the completed intermediate GGUF.
-
-Any argv drift, missing input, failed command or unrecorded dependency invalidates the evidence.
-
-## 8. Execute every registered quantization
-
-Use only the verified `toolchain/bin/llama-quantize` binary and the exact authority argv.
-
-Required outputs:
-
-- Qwen CPU: `Q4_K_M`;
-- Qwen GPU/shared: `Q8_0`;
-- Mistral CPU: `Q4_K_M`.
-
-For each quantization, preserve the exact argv and log, and bind:
-
-- intermediate GGUF SHA-256;
-- `llama-quantize` SHA-256;
-- output GGUF SHA-256 and byte size;
-- runtime class and quantization identity.
-
-## 9. Assemble the external bundle
-
-The external original root contains at least:
+The payload archive contains only files that define and reproduce the model bundle:
 
 ```text
-original/
-  sources/<model>/...
-  legal/LICENSE.txt
-  legal/review.json
-  evidence/remote-inventory.json
-  toolchain/package.tar.zst
-  toolchain/build-manifest.json
-  toolchain/verification-report.json
-  toolchain/bin/llama-cli
-  toolchain/bin/llama-server
-  toolchain/bin/llama-quantize
-  toolchain/bin/llama-bench
-  toolchain/source/convert_hf_to_gguf.py
-  conversion/python-dependencies.txt
-  conversion/convert.log
-  quantization/*.log
-  artifacts/*.gguf
-  storage/payload-index.json
-  storage/upload-record.json
-  storage/restore-record.json
-  storage/bundle.tar.zst
+sources/<model>/...
+evidence/remote-inventory.json
+legal/LICENSE.txt
+legal/review.json
+toolchain/package.tar.zst
+toolchain/build-manifest.json
+toolchain/verification-report.json
+toolchain/bin/llama-cli
+toolchain/bin/llama-server
+toolchain/bin/llama-quantize
+toolchain/bin/llama-bench
+toolchain/source/convert_hf_to_gguf.py
+conversion/python-dependencies.txt
+conversion/convert.log
+artifacts/<intermediate>.gguf
+quantization/*.log
+artifacts/<quantized>.gguf
 ```
 
-Create `bundle.v2.json` outside the archive construction process so no self-referential digest is required. Every declared file path must be unique and bounded beneath the root. Symlinks, non-regular files and hard-link aliases are forbidden.
+### Storage sidecar layer
 
-## 10. Upload immutably and restore independently
+The following files are outside the payload archive:
 
-Upload the bundle archive to content-addressed or versioned external storage. Record an immutable locator that binds the exact archive SHA-256. Preserve a semantic `tai.model-bundle-upload-record.v1` containing the locator, archive SHA-256, timezone-aware `uploaded_at`, positive `retention_days` and exact `retention_expires_at = uploaded_at + retention_days`.
+```text
+storage/bundle.tar
+storage/payload-index.json
+storage/upload-record.json
+storage/restore-record.json
+```
 
-Download from that locator into a clean restore root, extract it, and preserve a semantic `tai.model-bundle-restore-record.v1` containing the same locator and archive SHA-256 plus timezone-aware `restored_at`. The restore must occur no later than `retention_expires_at`. Do not copy the original directory to manufacture restore evidence. The restore root must originate from the immutable external object.
+This separation is mandatory. The archive cannot contain itself, and upload/restore records containing the archive digest cannot participate in that archive digest.
 
-## 11. Run fail-closed verification
+## 1. Build the exact payload index
+
+Create `storage/payload-index.json` with schema `tai.model-bundle-payload-index.v1`:
+
+```json
+{
+  "schema_version": "tai.model-bundle-payload-index.v1",
+  "model_id": "<exact model id>",
+  "revision": "<exact 40-character revision>",
+  "entries": [
+    {"path": "...", "sha256": "...", "size_bytes": 1}
+  ]
+}
+```
+
+Requirements:
+
+- entries are sorted by path;
+- the set equals every non-storage `DeclaredFile` in `bundle.v2.json`;
+- no storage sidecar path is present;
+- paths are bounded relative paths;
+- symlinks, hard-link aliases and non-regular files are forbidden;
+- SHA-256 and byte size are calculated from local bytes.
+
+## 2. Create the payload archive
+
+Create a regular tar archive containing exactly the payload-index entries. Do not add directory entries, symlinks, hard links, devices, FIFOs, absolute paths, `..` paths, duplicate paths or undeclared files.
+
+For large safetensor and GGUF payloads, an uncompressed deterministic tar is permitted because these formats are generally not materially compressible. The archive name may be `storage/bundle.tar`.
+
+Hash the completed archive locally and record its exact byte size. Do not modify it after its digest is recorded.
+
+## 3. Upload to immutable storage
+
+Upload the archive to content-addressed or versioned storage outside the conversion run root. The immutable locator must bind the exact archive SHA-256 using `@sha256:`, `#sha256=` or a version identifier.
+
+Create `storage/upload-record.json` with schema `tai.model-bundle-upload-record.v1`, exact archive SHA-256, locator, timezone-aware `uploaded_at`, positive `retention_days`, and `retention_expires_at = uploaded_at + retention_days`.
+
+The archive and upload record are sidecars; neither is an archive member.
+
+## 4. Restore independently
+
+1. Create a new empty restore root.
+2. Download the archive from the immutable locator; do not read it from the original bundle directory.
+3. Verify the downloaded archive SHA-256 before extraction.
+4. Inspect all archive entries fail-closed before extraction.
+5. Extract only regular bounded payload files into the clean restore root.
+6. Do not copy the original root and do not add storage sidecars to the restore root.
+7. Create `storage/restore-record.json` outside the restored payload with schema `tai.model-bundle-restore-record.v1`, exact archive SHA-256, immutable locator and timezone-aware `restored_at` within retention.
+
+A copied original directory contains storage sidecars and must fail exact restored-file-set validation.
+
+## 5. Run both verification layers
+
+The storage verifier validates:
+
+- exact original file set: payload plus four storage sidecars;
+- exact payload-index semantics;
+- original payload hashes and sizes;
+- exact safe archive member set and member hashes;
+- exact clean restored payload set and hashes;
+- absence of storage sidecars in the restored payload;
+- existing v2 authority, source, legal, toolchain, conversion and quantization semantics through the legacy verifier.
 
 ```bash
 cd apps/tai
-python -m tai.model_artifact_registry_cli verify-bundle-v2 \
+python -m tai.model_bundle_storage_cli \
   model-artifacts/model-bundle-authority.v2.json \
-  "$TAI_WORK/<model>/bundle.v2.json" \
-  "$TAI_WORK/<model>/original" \
-  "$TAI_WORK/<model>/restore" \
-  --output "$TAI_WORK/<model>/verification-report.v2.json"
+  /secure/<model>/bundle.v2.json \
+  /secure/<model>/original \
+  /secure/<model>/restore \
+  --output /secure/<model>/storage-verification-report.v1.json
 ```
 
-Exit code `0` and status `VERIFIED` are required. Exit code `2`, `PENDING_ACQUISITION`, `REJECTED`, parser failure, missing evidence or any original/restore mismatch blocks acceptance.
+Exit code `0` and status `VERIFIED` are required. Exit code `2`, `REJECTED`, parser failure, missing evidence, archive mismatch, unsafe archive member, copied restore, extra file or original/restore mismatch blocks acceptance.
 
-## 12. Publish the acceptance PR
+The existing command remains available for semantic diagnosis, but it must not be used alone as proof that a clean root originated from a non-self-referential immutable archive:
+
+```bash
+python -m tai.model_artifact_registry_cli verify-bundle-v2 \
+  model-artifacts/model-bundle-authority.v2.json \
+  /secure/<model>/bundle.v2.json \
+  /secure/<model>/original \
+  /secure/<model>/compatibility-restore \
+  --output /secure/<model>/legacy-verification-report.v2.json
+```
+
+## 6. Publish acceptance metadata
 
 The acceptance PR commits only small records:
 
+- model id, role and exact revision;
 - immutable locator;
 - archive SHA-256 and size;
-- authority, manifest and verification-report SHA-256;
-- exact-main commit and workflow run identity;
-- final `VERIFIED` status;
+- payload-index SHA-256;
+- manifest SHA-256;
+- legacy v2 report SHA-256;
+- storage-verification report SHA-256;
+- exact-main and workflow run identity;
+- final bundle status `VERIFIED`;
 - issue linkage.
 
-Do not commit model weights, GGUF files, binaries, source archives, license evidence containing restricted material, logs with secrets or storage credentials.
+Never commit source/model/GGUF bytes, binaries, large archives, restricted license material, credentials or secret-bearing logs.
 
-The acceptance PR does not assert AP-13C benchmark performance, AP-13D admission or production readiness. TAI remains `NOT_ATTESTED` until all later gates are complete.
+## Maturity boundary
+
+Successful bundle storage and restore verification does not constitute AP-13C benchmark acceptance, AP-13D model admission or production operational attestation. `production_operational_status` remains `NOT_ATTESTED`.

--- a/apps/tai/tai/model_bundle_storage.py
+++ b/apps/tai/tai/model_bundle_storage.py
@@ -288,27 +288,26 @@ def _index_entries(payload: dict[str, object] | None) -> dict[str, tuple[int, st
 def _inspect_archive(path: Path, reasons: list[str]) -> dict[str, tuple[int, str]]:
     observed: dict[str, tuple[int, str]] = {}
     try:
-        archive_context = tarfile.open(path, mode="r:*")
+        with tarfile.open(path, mode="r:*") as archive:
+            for member in archive:
+                safe_path = _safe_archive_member(member.name)
+                if safe_path is None or not member.isfile():
+                    reasons.append(f"ARCHIVE_MEMBER_UNSAFE:{member.name}")
+                    continue
+                if safe_path in observed:
+                    reasons.append(f"ARCHIVE_MEMBER_DUPLICATE:{safe_path}")
+                    continue
+                stream = archive.extractfile(member)
+                if stream is None:
+                    reasons.append(f"ARCHIVE_MEMBER_UNREADABLE:{safe_path}")
+                    continue
+                digest, size = _stream_sha256(stream)
+                if size != member.size:
+                    reasons.append(f"ARCHIVE_MEMBER_SIZE_METADATA_MISMATCH:{safe_path}")
+                observed[safe_path] = (size, digest)
     except (tarfile.TarError, OSError) as error:
         reasons.append(f"ARCHIVE_INVALID:{error}")
         return observed
-    with archive_context as archive:
-        for member in archive:
-            safe_path = _safe_archive_member(member.name)
-            if safe_path is None or not member.isfile():
-                reasons.append(f"ARCHIVE_MEMBER_UNSAFE:{member.name}")
-                continue
-            if safe_path in observed:
-                reasons.append(f"ARCHIVE_MEMBER_DUPLICATE:{safe_path}")
-                continue
-            stream = archive.extractfile(member)
-            if stream is None:
-                reasons.append(f"ARCHIVE_MEMBER_UNREADABLE:{safe_path}")
-                continue
-            digest, size = _stream_sha256(stream)
-            if size != member.size:
-                reasons.append(f"ARCHIVE_MEMBER_SIZE_METADATA_MISMATCH:{safe_path}")
-            observed[safe_path] = (size, digest)
     return observed
 
 

--- a/apps/tai/tai/model_bundle_storage.py
+++ b/apps/tai/tai/model_bundle_storage.py
@@ -7,7 +7,7 @@ import shutil
 import tarfile
 from pathlib import Path, PurePosixPath
 from tempfile import TemporaryDirectory
-from typing import BinaryIO
+from typing import IO
 
 from tai.model_bundle_v2 import (
     BundleVerificationStatus,
@@ -385,7 +385,7 @@ def _file_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _stream_sha256(handle: BinaryIO) -> tuple[str, int]:
+def _stream_sha256(handle: IO[bytes]) -> tuple[str, int]:
     digest = hashlib.sha256()
     size = 0
     for chunk in iter(lambda: handle.read(_CHUNK_SIZE), b""):

--- a/apps/tai/tai/model_bundle_storage.py
+++ b/apps/tai/tai/model_bundle_storage.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tarfile
+from pathlib import Path, PurePosixPath
+from tempfile import TemporaryDirectory
+from typing import BinaryIO
+
+from tai.model_bundle_v2 import (
+    BundleVerificationStatus,
+    DeclaredFile,
+    LocalModelBundleV2,
+    ModelBundleAuthority,
+    load_local_model_bundle_v2,
+    load_model_bundle_authority_v2,
+    report_payload_v2,
+    verify_local_model_bundle_v2,
+)
+
+_PAYLOAD_INDEX_SCHEMA = "tai.model-bundle-payload-index.v1"
+_REPORT_SCHEMA = "tai.model-bundle-storage-verification-report.v1"
+_CHUNK_SIZE = 1024 * 1024
+
+
+def verify_bundle_storage_v2(
+    *,
+    authority_path: Path,
+    manifest_path: Path,
+    original_root: Path,
+    restored_root: Path,
+) -> dict[str, object]:
+    authority = load_model_bundle_authority_v2(authority_path)
+    bundle = load_local_model_bundle_v2(manifest_path)
+    return verify_loaded_bundle_storage_v2(
+        authority=authority,
+        bundle=bundle,
+        original_root=original_root,
+        restored_root=restored_root,
+    )
+
+
+def verify_loaded_bundle_storage_v2(
+    *,
+    authority: ModelBundleAuthority,
+    bundle: LocalModelBundleV2,
+    original_root: Path,
+    restored_root: Path,
+) -> dict[str, object]:
+    reasons: list[str] = []
+    payload_files = _payload_declared_files(bundle)
+    storage_files = _storage_declared_files(bundle)
+    payload_by_path = {item.path: item for item in payload_files}
+
+    if len(payload_by_path) != len(payload_files):
+        reasons.append("PAYLOAD_DECLARED_FILE_PATH_DUPLICATE")
+
+    storage = bundle.storage
+    if storage is None:
+        reasons.append("STORAGE_SECTION_MISSING")
+        return _report(bundle, reasons, (), (), None, None, None)
+
+    expected_original = set(payload_by_path) | {item.path for item in storage_files}
+    expected_restored = set(payload_by_path)
+    original_paths = _safe_root_file_set(original_root, "ORIGINAL", reasons)
+    restored_paths = _safe_root_file_set(restored_root, "RESTORED", reasons)
+    _compare_file_set("ORIGINAL", original_paths, expected_original, reasons)
+    _compare_file_set("RESTORED", restored_paths, expected_restored, reasons)
+
+    index_payload = _load_payload_index(
+        original_root=original_root,
+        declared=storage.payload_index,
+        bundle=bundle,
+        expected=payload_by_path,
+        reasons=reasons,
+    )
+    index_entries = _index_entries(index_payload)
+
+    original_entries = _hash_declared_root(
+        root=original_root,
+        declared=payload_files,
+        prefix="ORIGINAL",
+        reasons=reasons,
+    )
+    _compare_entry_map("ORIGINAL", original_entries, index_entries, reasons)
+
+    archive_path = _declared_file_path(original_root, storage.bundle_archive, "ARCHIVE", reasons)
+    archive_entries: dict[str, tuple[int, str]] = {}
+    if archive_path is not None:
+        archive_entries = _inspect_archive(archive_path, reasons)
+        _compare_entry_map("ARCHIVE", archive_entries, index_entries, reasons)
+
+    restored_entries = _hash_declared_root(
+        root=restored_root,
+        declared=payload_files,
+        prefix="RESTORED",
+        reasons=reasons,
+    )
+    _compare_entry_map("RESTORED", restored_entries, index_entries, reasons)
+
+    legacy_payload: dict[str, object] | None = None
+    with TemporaryDirectory(prefix="tai-bundle-compat-") as temporary:
+        compatibility_root = Path(temporary) / "restore"
+        if restored_root.is_dir():
+            shutil.copytree(restored_root, compatibility_root, symlinks=False)
+            for item in storage_files:
+                source = _declared_file_path(original_root, item, "STORAGE", reasons)
+                if source is None:
+                    continue
+                destination = compatibility_root / item.path
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, destination)
+            legacy = verify_local_model_bundle_v2(
+                authority=authority,
+                bundle=bundle,
+                bundle_root=original_root,
+                restored_root=compatibility_root,
+            )
+            legacy_payload = report_payload_v2(legacy)
+            if legacy.status is not BundleVerificationStatus.VERIFIED:
+                reasons.extend(f"LEGACY_V2:{reason}" for reason in legacy.reasons)
+        else:
+            reasons.append("RESTORED_ROOT_MISSING")
+
+    index_sha256 = storage.payload_index.sha256
+    archive_sha256 = storage.bundle_archive.sha256
+    legacy_report_sha256 = (
+        str(legacy_payload.get("report_sha256")) if legacy_payload is not None else None
+    )
+    return _report(
+        bundle,
+        reasons,
+        tuple(sorted(original_entries)),
+        tuple(sorted(restored_entries)),
+        index_sha256,
+        archive_sha256,
+        legacy_report_sha256,
+    )
+
+
+def _payload_declared_files(bundle: LocalModelBundleV2) -> tuple[DeclaredFile, ...]:
+    files: list[DeclaredFile] = [item.file for item in bundle.source_files]
+    if bundle.remote_inventory is not None:
+        files.append(bundle.remote_inventory.evidence_file)
+    if bundle.legal_review is not None:
+        files.extend([bundle.legal_review.license_text, bundle.legal_review.review_record])
+    if bundle.toolchain_package is not None:
+        package = bundle.toolchain_package
+        files.extend([package.package, package.build_manifest, package.verification_report])
+        files.extend(item.file for item in package.binaries)
+    if bundle.conversion is not None:
+        conversion = bundle.conversion
+        files.extend(
+            [
+                conversion.python_dependencies,
+                conversion.converter,
+                conversion.log,
+                conversion.intermediate,
+            ]
+        )
+    for quantization in bundle.quantizations:
+        files.extend([quantization.log, quantization.output])
+    return tuple(files)
+
+
+def _storage_declared_files(bundle: LocalModelBundleV2) -> tuple[DeclaredFile, ...]:
+    storage = bundle.storage
+    if storage is None:
+        return ()
+    return (
+        storage.bundle_archive,
+        storage.payload_index,
+        storage.upload_record,
+        storage.restore_record,
+    )
+
+
+def _safe_root_file_set(root: Path, prefix: str, reasons: list[str]) -> set[str]:
+    if not root.is_dir() or root.is_symlink():
+        reasons.append(f"{prefix}_ROOT_INVALID")
+        return set()
+    found: set[str] = set()
+    for current, directories, files in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        safe_directories: list[str] = []
+        for name in directories:
+            candidate = current_path / name
+            if candidate.is_symlink():
+                reasons.append(f"{prefix}_FILE_UNSAFE:{candidate.relative_to(root).as_posix()}:symlink")
+            else:
+                safe_directories.append(name)
+        directories[:] = safe_directories
+        for name in files:
+            candidate = current_path / name
+            relative = candidate.relative_to(root).as_posix()
+            if candidate.is_symlink() or not candidate.is_file():
+                reasons.append(f"{prefix}_FILE_UNSAFE:{relative}:non-regular")
+                continue
+            found.add(relative)
+    return found
+
+
+def _compare_file_set(
+    prefix: str, observed: set[str], expected: set[str], reasons: list[str]
+) -> None:
+    for path in sorted(expected - observed):
+        reasons.append(f"{prefix}_FILE_MISSING:{path}")
+    for path in sorted(observed - expected):
+        reasons.append(f"{prefix}_FILE_EXTRA:{path}")
+
+
+def _declared_file_path(
+    root: Path, declared: DeclaredFile, prefix: str, reasons: list[str]
+) -> Path | None:
+    candidate = root / declared.path
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved = candidate.resolve(strict=True)
+    except OSError:
+        reasons.append(f"{prefix}_FILE_MISSING:{declared.path}")
+        return None
+    if resolved_root not in resolved.parents or candidate.is_symlink() or not candidate.is_file():
+        reasons.append(f"{prefix}_FILE_UNSAFE:{declared.path}")
+        return None
+    metadata = candidate.stat()
+    digest = _file_sha256(candidate)
+    if metadata.st_size != declared.size_bytes:
+        reasons.append(f"{prefix}_FILE_SIZE_MISMATCH:{declared.path}")
+    if digest != declared.sha256:
+        reasons.append(f"{prefix}_FILE_SHA256_MISMATCH:{declared.path}")
+    return candidate
+
+
+def _load_payload_index(
+    *,
+    original_root: Path,
+    declared: DeclaredFile,
+    bundle: LocalModelBundleV2,
+    expected: dict[str, DeclaredFile],
+    reasons: list[str],
+) -> dict[str, object] | None:
+    path = _declared_file_path(original_root, declared, "PAYLOAD_INDEX", reasons)
+    if path is None:
+        return None
+    try:
+        payload = _strict_json(path)
+    except ValueError as error:
+        reasons.append(f"PAYLOAD_INDEX_INVALID:{error}")
+        return None
+    expected_payload: dict[str, object] = {
+        "schema_version": _PAYLOAD_INDEX_SCHEMA,
+        "model_id": bundle.model_id,
+        "revision": bundle.revision,
+        "entries": [
+            {
+                "path": item.path,
+                "sha256": item.sha256,
+                "size_bytes": item.size_bytes,
+            }
+            for item in sorted(expected.values(), key=lambda value: value.path)
+        ],
+    }
+    if payload != expected_payload:
+        reasons.append("PAYLOAD_INDEX_MISMATCH")
+    return payload
+
+
+def _index_entries(payload: dict[str, object] | None) -> dict[str, tuple[int, str]]:
+    if payload is None:
+        return {}
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        return {}
+    result: dict[str, tuple[int, str]] = {}
+    for item in entries:
+        if not isinstance(item, dict):
+            continue
+        path = item.get("path")
+        size = item.get("size_bytes")
+        digest = item.get("sha256")
+        if isinstance(path, str) and isinstance(size, int) and isinstance(digest, str):
+            result[path] = (size, digest)
+    return result
+
+
+def _inspect_archive(path: Path, reasons: list[str]) -> dict[str, tuple[int, str]]:
+    observed: dict[str, tuple[int, str]] = {}
+    try:
+        archive = tarfile.open(path, mode="r:*")
+    except (tarfile.TarError, OSError) as error:
+        reasons.append(f"ARCHIVE_INVALID:{error}")
+        return observed
+    with archive:
+        for member in archive:
+            safe_path = _safe_archive_member(member.name)
+            if safe_path is None or not member.isfile():
+                reasons.append(f"ARCHIVE_MEMBER_UNSAFE:{member.name}")
+                continue
+            if safe_path in observed:
+                reasons.append(f"ARCHIVE_MEMBER_DUPLICATE:{safe_path}")
+                continue
+            stream = archive.extractfile(member)
+            if stream is None:
+                reasons.append(f"ARCHIVE_MEMBER_UNREADABLE:{safe_path}")
+                continue
+            digest, size = _stream_sha256(stream)
+            if size != member.size:
+                reasons.append(f"ARCHIVE_MEMBER_SIZE_METADATA_MISMATCH:{safe_path}")
+            observed[safe_path] = (size, digest)
+    return observed
+
+
+def _safe_archive_member(value: str) -> str | None:
+    path = PurePosixPath(value)
+    if path.is_absolute() or not path.parts or any(part in {"", ".", ".."} for part in path.parts):
+        return None
+    return path.as_posix()
+
+
+def _hash_declared_root(
+    *,
+    root: Path,
+    declared: tuple[DeclaredFile, ...],
+    prefix: str,
+    reasons: list[str],
+) -> dict[str, tuple[int, str]]:
+    observed: dict[str, tuple[int, str]] = {}
+    seen_inodes: set[tuple[int, int]] = set()
+    for item in declared:
+        path = _declared_file_path(root, item, prefix, reasons)
+        if path is None:
+            continue
+        metadata = path.stat()
+        inode = (metadata.st_dev, metadata.st_ino)
+        if inode in seen_inodes:
+            reasons.append(f"{prefix}_FILE_INODE_ALIAS:{item.path}")
+            continue
+        seen_inodes.add(inode)
+        observed[item.path] = (metadata.st_size, _file_sha256(path))
+    return observed
+
+
+def _compare_entry_map(
+    prefix: str,
+    observed: dict[str, tuple[int, str]],
+    expected: dict[str, tuple[int, str]],
+    reasons: list[str],
+) -> None:
+    observed_paths = set(observed)
+    expected_paths = set(expected)
+    for path in sorted(expected_paths - observed_paths):
+        reasons.append(f"{prefix}_ENTRY_MISSING:{path}")
+    for path in sorted(observed_paths - expected_paths):
+        reasons.append(f"{prefix}_ENTRY_EXTRA:{path}")
+    for path in sorted(observed_paths & expected_paths):
+        actual_size, actual_digest = observed[path]
+        expected_size, expected_digest = expected[path]
+        if actual_size != expected_size:
+            reasons.append(f"{prefix}_ENTRY_SIZE_MISMATCH:{path}")
+        if actual_digest != expected_digest:
+            reasons.append(f"{prefix}_ENTRY_SHA256_MISMATCH:{path}")
+
+
+def _strict_json(path: Path) -> dict[str, object]:
+    def reject_duplicate(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key: {key}")
+            result[key] = value
+        return result
+
+    payload = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicate)
+    if not isinstance(payload, dict):
+        raise ValueError("JSON root must be an object")
+    return payload
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_CHUNK_SIZE), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _stream_sha256(handle: BinaryIO) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    for chunk in iter(lambda: handle.read(_CHUNK_SIZE), b""):
+        digest.update(chunk)
+        size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def _canonical_json(payload: object) -> str:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _report(
+    bundle: LocalModelBundleV2,
+    reasons: list[str],
+    verified_payload_files: tuple[str, ...],
+    restored_payload_files: tuple[str, ...],
+    payload_index_sha256: str | None,
+    archive_sha256: str | None,
+    legacy_report_sha256: str | None,
+) -> dict[str, object]:
+    unique_reasons = sorted(set(reasons))
+    payload: dict[str, object] = {
+        "schema_version": _REPORT_SCHEMA,
+        "model_id": bundle.model_id,
+        "revision": bundle.revision,
+        "status": "VERIFIED" if not unique_reasons else "REJECTED",
+        "reasons": unique_reasons,
+        "payload_index_sha256": payload_index_sha256,
+        "archive_sha256": archive_sha256,
+        "legacy_v2_report_sha256": legacy_report_sha256,
+        "verified_payload_files": list(verified_payload_files),
+        "restored_payload_files": list(restored_payload_files),
+    }
+    payload["report_sha256"] = hashlib.sha256(_canonical_json(payload).encode()).hexdigest()
+    return payload

--- a/apps/tai/tai/model_bundle_storage.py
+++ b/apps/tai/tai/model_bundle_storage.py
@@ -288,11 +288,11 @@ def _index_entries(payload: dict[str, object] | None) -> dict[str, tuple[int, st
 def _inspect_archive(path: Path, reasons: list[str]) -> dict[str, tuple[int, str]]:
     observed: dict[str, tuple[int, str]] = {}
     try:
-        archive = tarfile.open(path, mode="r:*")
+        archive_context = tarfile.open(path, mode="r:*")
     except (tarfile.TarError, OSError) as error:
         reasons.append(f"ARCHIVE_INVALID:{error}")
         return observed
-    with archive:
+    with archive_context as archive:
         for member in archive:
             safe_path = _safe_archive_member(member.name)
             if safe_path is None or not member.isfile():

--- a/apps/tai/tai/model_bundle_storage_cli.py
+++ b/apps/tai/tai/model_bundle_storage_cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from tai.model_bundle_storage import verify_bundle_storage_v2
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify non-self-referential TAI model bundle storage"
+    )
+    parser.add_argument("authority", type=Path)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("original_root", type=Path)
+    parser.add_argument("restored_root", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    report = verify_bundle_storage_v2(
+        authority_path=args.authority,
+        manifest_path=args.manifest,
+        original_root=args.original_root,
+        restored_root=args.restored_root,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    )
+    print(json.dumps(report, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+    return 0 if report["status"] == "VERIFIED" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/tai/tests/test_model_bundle_storage_contract.py
+++ b/apps/tai/tests/test_model_bundle_storage_contract.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import tarfile
+from pathlib import Path
+from typing import Any, cast
+
+from model_bundle_v2_support import (
+    AUTHORITY_PATH,
+    _manifest_payload,
+    _sha256,
+    _write,
+    _write_json,
+)
+
+from tai.model_bundle_storage import verify_bundle_storage_v2
+from tai.model_bundle_storage_cli import main
+
+
+def _payload_declarations(payload: dict[str, Any]) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
+    result.extend(cast(list[dict[str, object]], payload["source_files"]))
+    remote = cast(dict[str, Any], payload["remote_inventory"])
+    result.append(cast(dict[str, object], remote["evidence_file"]))
+    legal = cast(dict[str, Any], payload["legal_review"])
+    result.extend(
+        [
+            cast(dict[str, object], legal["license_text"]),
+            cast(dict[str, object], legal["review_record"]),
+        ]
+    )
+    toolchain = cast(dict[str, Any], payload["toolchain_package"])
+    result.extend(
+        [
+            cast(dict[str, object], toolchain["package"]),
+            cast(dict[str, object], toolchain["build_manifest"]),
+            cast(dict[str, object], toolchain["verification_report"]),
+        ]
+    )
+    for binary in cast(list[dict[str, Any]], toolchain["binaries"]):
+        result.append(cast(dict[str, object], binary["file"]))
+    conversion = cast(dict[str, Any], payload["conversion"])
+    result.extend(
+        [
+            cast(dict[str, object], conversion["python_dependencies"]),
+            cast(dict[str, object], conversion["converter"]),
+            cast(dict[str, object], conversion["log"]),
+            cast(dict[str, object], conversion["intermediate"]),
+        ]
+    )
+    for quantization in cast(list[dict[str, Any]], payload["quantizations"]):
+        result.extend(
+            [
+                cast(dict[str, object], quantization["log"]),
+                cast(dict[str, object], quantization["output"]),
+            ]
+        )
+    return sorted(result, key=lambda item: cast(str, item["path"]))
+
+
+def _write_payload_index(original: Path, payload: dict[str, Any]) -> None:
+    entries = [
+        {
+            "path": item["path"],
+            "sha256": item["sha256"],
+            "size_bytes": item["size_bytes"],
+        }
+        for item in _payload_declarations(payload)
+    ]
+    content = json.dumps(
+        {
+            "schema_version": "tai.model-bundle-payload-index.v1",
+            "model_id": payload["model_id"],
+            "revision": payload["revision"],
+            "entries": entries,
+        },
+        sort_keys=True,
+    ).encode()
+    storage = cast(dict[str, Any], payload["storage"])
+    storage["payload_index"] = _write(
+        original, "storage/payload-index.json", content
+    )
+
+
+def _create_archive(
+    original: Path, payload: dict[str, Any], *, malicious: bool = False
+) -> None:
+    storage = cast(dict[str, Any], payload["storage"])
+    old_path = original / cast(dict[str, Any], storage["bundle_archive"])["path"]
+    old_path.unlink(missing_ok=True)
+    archive_path = original / "storage/bundle.tar"
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive_path, "w") as archive:
+        for item in _payload_declarations(payload):
+            relative = cast(str, item["path"])
+            archive.add(original / relative, arcname=relative, recursive=False)
+        if malicious:
+            data = b"escape"
+            member = tarfile.TarInfo("../escape")
+            member.size = len(data)
+            archive.addfile(member, io.BytesIO(data))
+    content = archive_path.read_bytes()
+    storage["bundle_archive"] = {
+        "path": "storage/bundle.tar",
+        "sha256": _sha256(content),
+        "size_bytes": len(content),
+    }
+    storage["immutable_locator"] = (
+        "file+sha256://tai-model-bundles/objects/"
+        f"sha256:{storage['bundle_archive']['sha256']}"
+    )
+
+
+def _refresh_storage_records(original: Path, payload: dict[str, Any]) -> None:
+    storage = cast(dict[str, Any], payload["storage"])
+    upload = {
+        "schema_version": "tai.model-bundle-upload-record.v1",
+        "archive_sha256": storage["bundle_archive"]["sha256"],
+        "immutable_locator": storage["immutable_locator"],
+        "uploaded_at": storage["uploaded_at"],
+        "retention_days": storage["retention_days"],
+        "retention_expires_at": storage["retention_expires_at"],
+    }
+    restore = {
+        "schema_version": "tai.model-bundle-restore-record.v1",
+        "archive_sha256": storage["bundle_archive"]["sha256"],
+        "immutable_locator": storage["immutable_locator"],
+        "restored_at": storage["restored_at"],
+    }
+    storage["upload_record"] = _write(
+        original,
+        "storage/upload-record.json",
+        json.dumps(upload, sort_keys=True).encode(),
+    )
+    storage["restore_record"] = _write(
+        original,
+        "storage/restore-record.json",
+        json.dumps(restore, sort_keys=True).encode(),
+    )
+
+
+def _extract_payload_archive(
+    original: Path, restored: Path, payload: dict[str, Any]
+) -> None:
+    storage = cast(dict[str, Any], payload["storage"])
+    archive_path = original / cast(dict[str, Any], storage["bundle_archive"])["path"]
+    restored.mkdir(parents=True)
+    with tarfile.open(archive_path, "r:*") as archive:
+        archive.extractall(restored, filter="data")
+
+
+def _honest_bundle(tmp_path: Path) -> tuple[Path, Path, Path, dict[str, Any]]:
+    manifest, original, restored, payload = _manifest_payload(tmp_path)
+    shutil.rmtree(restored)
+    _write_payload_index(original, payload)
+    _create_archive(original, payload)
+    _refresh_storage_records(original, payload)
+    _write_json(manifest, payload)
+    _extract_payload_archive(original, restored, payload)
+    return manifest, original, restored, payload
+
+
+def test_non_self_referential_archive_and_clean_restore_verify(
+    tmp_path: Path,
+) -> None:
+    manifest, original, restored, payload = _honest_bundle(tmp_path)
+    report = verify_bundle_storage_v2(
+        authority_path=AUTHORITY_PATH,
+        manifest_path=manifest,
+        original_root=original,
+        restored_root=restored,
+    )
+    assert report["status"] == "VERIFIED"
+    assert report["reasons"] == []
+    assert "storage/bundle.tar" not in {
+        item["path"] for item in _payload_declarations(payload)
+    }
+    assert len(cast(list[str], report["verified_payload_files"])) == len(
+        cast(list[str], report["restored_payload_files"])
+    )
+
+
+def test_copytree_restore_is_rejected_by_exact_payload_set(tmp_path: Path) -> None:
+    manifest, original, restored, _ = _honest_bundle(tmp_path)
+    shutil.rmtree(restored)
+    shutil.copytree(original, restored)
+    report = verify_bundle_storage_v2(
+        authority_path=AUTHORITY_PATH,
+        manifest_path=manifest,
+        original_root=original,
+        restored_root=restored,
+    )
+    assert report["status"] == "REJECTED"
+    assert any(
+        cast(str, reason).startswith("RESTORED_FILE_EXTRA:storage/")
+        for reason in cast(list[str], report["reasons"])
+    )
+
+
+def test_archive_content_must_match_payload_index(tmp_path: Path) -> None:
+    manifest, original, restored, payload = _honest_bundle(tmp_path)
+    shutil.rmtree(restored)
+    first = _payload_declarations(payload)[0]
+    target = original / cast(str, first["path"])
+    original_content = target.read_bytes()
+    target.write_bytes(b"tampered")
+    _create_archive(original, payload)
+    target.write_bytes(original_content)
+    _refresh_storage_records(original, payload)
+    _write_json(manifest, payload)
+    _extract_payload_archive(original, restored, payload)
+    report = verify_bundle_storage_v2(
+        authority_path=AUTHORITY_PATH,
+        manifest_path=manifest,
+        original_root=original,
+        restored_root=restored,
+    )
+    assert report["status"] == "REJECTED"
+    assert any(
+        cast(str, reason).startswith("ARCHIVE_ENTRY_")
+        for reason in cast(list[str], report["reasons"])
+    )
+
+
+def test_archive_path_traversal_is_rejected(tmp_path: Path) -> None:
+    manifest, original, restored, payload = _honest_bundle(tmp_path)
+    shutil.rmtree(restored)
+    _create_archive(original, payload, malicious=True)
+    _refresh_storage_records(original, payload)
+    _write_json(manifest, payload)
+    restored.mkdir()
+    report = verify_bundle_storage_v2(
+        authority_path=AUTHORITY_PATH,
+        manifest_path=manifest,
+        original_root=original,
+        restored_root=restored,
+    )
+    assert report["status"] == "REJECTED"
+    assert "ARCHIVE_MEMBER_UNSAFE:../escape" in report["reasons"]
+
+
+def test_payload_index_is_semantic_and_cli_fails_closed(tmp_path: Path) -> None:
+    manifest, original, restored, payload = _honest_bundle(tmp_path)
+    storage = cast(dict[str, Any], payload["storage"])
+    index_path = original / cast(dict[str, Any], storage["payload_index"])["path"]
+    index = json.loads(index_path.read_text())
+    index["entries"].pop()
+    storage["payload_index"] = _write(
+        original,
+        "storage/payload-index.json",
+        json.dumps(index, sort_keys=True).encode(),
+    )
+    _write_json(manifest, payload)
+    output = tmp_path / "report.json"
+    assert (
+        main(
+            [
+                str(AUTHORITY_PATH),
+                str(manifest),
+                str(original),
+                str(restored),
+                "--output",
+                str(output),
+            ]
+        )
+        == 2
+    )
+    report = json.loads(output.read_text())
+    assert "PAYLOAD_INDEX_MISMATCH" in report["reasons"]

--- a/apps/tai/tests/test_model_bundle_storage_contract.py
+++ b/apps/tai/tests/test_model_bundle_storage_contract.py
@@ -108,8 +108,8 @@ def _create_archive(
         "size_bytes": len(content),
     }
     storage["immutable_locator"] = (
-        "file+sha256://tai-model-bundles/objects/"
-        f"sha256:{storage['bundle_archive']['sha256']}"
+        "file+sha256://tai-model-bundles/objects/bundle"
+        f"@sha256:{storage['bundle_archive']['sha256']}"
     )
 
 


### PR DESCRIPTION
Closes #2944. Refs #2835 and #2726.

Corrects the model-bundle storage contract so the immutable payload archive does not contain itself or sidecar records containing its own digest.

Adds fail-closed verification for the exact original payload, archive members, clean restored payload and existing v2 semantic contract. Copying the original directory is rejected as restore evidence.

No model bytes, GGUF, archive, benchmark, admission or production-readiness claim is introduced. `production_operational_status` remains `NOT_ATTESTED`.