### PR TITLE
TAI AP-13B.3f: add read-only S3 bundle preflight

### DIFF
--- a/.github/workflows/tai-bundle-s3-preflight.yml
+++ b/.github/workflows/tai-bundle-s3-preflight.yml
@@ -1,0 +1,316 @@
+name: TAI Bundle S3 Read-Only Preflight
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: tai-bundle-s3-preflight
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      github.actor == github.repository_owner &&
+      github.triggering_actor == github.repository_owner &&
+      github.event.action == 'created' &&
+      github.event.issue.pull_request == null &&
+      github.event.issue.number == 2954 &&
+      github.event.comment.body == '/tai probe bundle-storage exact-main' &&
+      github.event.comment.author_association == 'OWNER' &&
+      github.event.comment.user.login == github.repository_owner
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      REPORT_ROOT: bundle-s3-preflight
+      REQUIREMENTS: apps/tai/model-artifacts/model-bundle-s3-preflight-requirements.v1.json
+      S3_ENDPOINT: ${{ secrets.TAI_BUNDLE_S3_ENDPOINT }}
+      S3_REGION: ${{ secrets.TAI_BUNDLE_S3_REGION }}
+      S3_BUCKET: ${{ secrets.TAI_BUNDLE_S3_BUCKET }}
+      S3_ACCESS_KEY_ID: ${{ secrets.TAI_BUNDLE_S3_ACCESS_KEY_ID }}
+      S3_SECRET_ACCESS_KEY: ${{ secrets.TAI_BUNDLE_S3_SECRET_ACCESS_KEY }}
+      S3_PREFIX: ${{ secrets.TAI_BUNDLE_S3_PREFIX }}
+      S3_CAPACITY_BYTES: ${{ secrets.TAI_BUNDLE_S3_CAPACITY_BYTES }}
+      AWS_EC2_METADATA_DISABLED: 'true'
+      AWS_RETRY_MODE: standard
+      AWS_MAX_ATTEMPTS: '3'
+      AWS_PAGER: ''
+
+    steps:
+      - name: Checkout exact main authority
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify exact-main owner trigger
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = 'refs/heads/main'
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git fetch --no-tags --depth=1 origin main
+          test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          mkdir -p "$REPORT_ROOT/raw"
+          chmod 700 "$REPORT_ROOT" "$REPORT_ROOT/raw"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install exact TAI authority package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e apps/tai
+
+      - name: Validate protected S3 inputs
+        id: inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            S3_ENDPOINT S3_REGION S3_BUCKET S3_ACCESS_KEY_ID \
+            S3_SECRET_ACCESS_KEY S3_PREFIX S3_CAPACITY_BYTES; do
+            if [[ -z "${!name:-}" ]]; then
+              missing=1
+            fi
+          done
+          if [[ "$missing" -eq 0 ]] && command -v aws >/dev/null 2>&1; then
+            echo 'available=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'available=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read S3 bucket controls without mutation
+        if: steps.inputs.outputs.available == 'true'
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TAI_BUNDLE_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TAI_BUNDLE_S3_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.TAI_BUNDLE_S3_REGION }}
+        run: |
+          set -euo pipefail
+          endpoint=(--endpoint-url "$S3_ENDPOINT" --region "$S3_REGION")
+          common=(--cli-connect-timeout 20 --cli-read-timeout 60)
+          run_status() {
+            local name="$1"
+            shift
+            set +e
+            "$@" > "$REPORT_ROOT/raw/${name}.json" 2> "$REPORT_ROOT/raw/${name}.stderr"
+            local status=$?
+            set -e
+            printf '%s\n' "$status" > "$REPORT_ROOT/raw/${name}.exit"
+          }
+
+          run_status head_bucket \
+            aws "${endpoint[@]}" "${common[@]}" s3api head-bucket --bucket "$S3_BUCKET"
+          run_status get_bucket_versioning \
+            aws "${endpoint[@]}" "${common[@]}" s3api get-bucket-versioning --bucket "$S3_BUCKET"
+          run_status get_public_access_block \
+            aws "${endpoint[@]}" "${common[@]}" s3api get-public-access-block --bucket "$S3_BUCKET"
+          run_status get_bucket_encryption \
+            aws "${endpoint[@]}" "${common[@]}" s3api get-bucket-encryption --bucket "$S3_BUCKET"
+          run_status get_bucket_policy \
+            aws "${endpoint[@]}" "${common[@]}" s3api get-bucket-policy --bucket "$S3_BUCKET"
+          run_status list_objects_v2 \
+            aws "${endpoint[@]}" "${common[@]}" s3api list-objects-v2 \
+              --bucket "$S3_BUCKET" --prefix "$S3_PREFIX/" --max-keys 1
+          run_status list_object_versions \
+            aws "${endpoint[@]}" "${common[@]}" s3api list-object-versions \
+              --bucket "$S3_BUCKET" --prefix "$S3_PREFIX/" --max-keys 1
+          aws --version > "$REPORT_ROOT/raw/aws-version.txt" 2>&1 || true
+
+      - name: Record unavailable protected inputs
+        if: steps.inputs.outputs.available != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in head_bucket get_bucket_versioning get_public_access_block \
+            get_bucket_encryption get_bucket_policy list_objects_v2 list_object_versions; do
+            : > "$REPORT_ROOT/raw/${name}.json"
+            printf '%s\n' 'PROTECTED_INPUT_OR_AWS_CLI_UNAVAILABLE' \
+              > "$REPORT_ROOT/raw/${name}.stderr"
+            printf '%s\n' '2' > "$REPORT_ROOT/raw/${name}.exit"
+          done
+          : > "$REPORT_ROOT/raw/aws-version.txt"
+
+      - name: Build bounded observed evidence
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ['REPORT_ROOT']) / 'raw'
+          command_names = [
+              'head_bucket',
+              'get_bucket_versioning',
+              'get_public_access_block',
+              'get_bucket_encryption',
+              'get_bucket_policy',
+              'list_objects_v2',
+              'list_object_versions',
+          ]
+
+          def exit_ok(name: str) -> bool:
+              path = root / f'{name}.exit'
+              return path.exists() and path.read_text().strip() == '0'
+
+          def object_json(name: str) -> dict[str, object]:
+              path = root / f'{name}.json'
+              if not path.exists() or not path.read_text().strip():
+                  return {}
+              try:
+                  value = json.loads(path.read_text())
+              except json.JSONDecodeError:
+                  return {}
+              return value if isinstance(value, dict) else {}
+
+          public_wrapper = object_json('get_public_access_block')
+          public_access = public_wrapper.get('PublicAccessBlockConfiguration', {})
+          if not isinstance(public_access, dict):
+              public_access = {}
+
+          policy_wrapper = object_json('get_bucket_policy')
+          raw_policy = policy_wrapper.get('Policy')
+          if isinstance(raw_policy, str):
+              try:
+                  policy = json.loads(raw_policy)
+              except json.JSONDecodeError:
+                  policy = {}
+          elif isinstance(raw_policy, dict):
+              policy = raw_policy
+          else:
+              policy = {}
+          if not isinstance(policy, dict):
+              policy = {}
+
+          capacity = os.environ.get('S3_CAPACITY_BYTES', '')
+          payload = {
+              'schema_version': 'tai.model-bundle-s3-preflight-observed.v1',
+              'endpoint': os.environ.get('S3_ENDPOINT', ''),
+              'region': os.environ.get('S3_REGION', ''),
+              'bucket': os.environ.get('S3_BUCKET', ''),
+              'prefix': os.environ.get('S3_PREFIX', ''),
+              'operator_confirmed_capacity_bytes': capacity,
+              'commands': {name: exit_ok(name) for name in command_names},
+              'versioning': object_json('get_bucket_versioning'),
+              'public_access_block': public_access,
+              'encryption': object_json('get_bucket_encryption'),
+              'policy': policy,
+              'aws_cli_identity': (root / 'aws-version.txt').read_text(errors='replace')[:500],
+              'mutation_mode': 'READ_ONLY',
+          }
+          observed = Path(os.environ['REPORT_ROOT']) / 'observed.json'
+          observed.write_text(
+              json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n'
+          )
+          PY
+
+      - name: Evaluate fail-closed S3 authority
+        id: evaluate
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          python -m tai.model_bundle_s3_preflight_cli \
+            "$REQUIREMENTS" \
+            "$REPORT_ROOT/observed.json" \
+            --exact-main "$GITHUB_SHA" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --output "$REPORT_ROOT/report.json"
+          status=$?
+          set -e
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Upload bounded S3 preflight evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tai-bundle-s3-preflight-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            bundle-s3-preflight/observed.json
+            bundle-s3-preflight/report.json
+            apps/tai/model-artifacts/model-bundle-s3-preflight-requirements.v1.json
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false
+
+      - name: Publish bounded preflight summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY' > "$REPORT_ROOT/summary.md"
+          import json
+          import os
+          from pathlib import Path
+
+          report_path = Path(os.environ['REPORT_ROOT']) / 'report.json'
+          if report_path.exists():
+              report = json.loads(report_path.read_text())
+          else:
+              report = {
+                  'status': 'NOT_READY',
+                  'reasons': ['REPORT_ABSENT'],
+                  'exact_main_sha': os.environ['GITHUB_SHA'],
+                  'observed': {},
+                  'report_sha256': None,
+              }
+          observed = report.get('observed', {})
+          lines = [
+              '## TAI bundle S3 read-only preflight',
+              '',
+              f"- exact-main: `{report.get('exact_main_sha')}`;",
+              f"- status: `{report.get('status')}`;",
+              f"- reasons: `{report.get('reasons')}`;",
+              f"- endpoint host: `{observed.get('endpoint_host')}`;",
+              f"- region: `{observed.get('region')}`;",
+              f"- bucket: `{observed.get('bucket')}`;",
+              f"- prefix: `{observed.get('prefix')}`;",
+              f"- versioning: `{observed.get('versioning_status')}`;",
+              f"- encryption: `{observed.get('default_encryption_algorithms')}`;",
+              f"- delete deny: `{observed.get('globally_denied_actions')}`;",
+              f"- confirmed capacity bytes: `{observed.get('operator_confirmed_capacity_bytes')}`;",
+              f"- report SHA-256: `{report.get('report_sha256')}`;",
+              '- mutation mode: `READ_ONLY`;',
+              '- bundle upload: `NOT_RUN`;',
+              '- clean restore: `NOT_RUN`;',
+              '- benchmark: `NOT_RUN`;',
+              '- model admission: `NOT_DONE`;',
+              '- production operational status: `NOT_ATTESTED`.',
+          ]
+          print('\n'.join(lines))
+          PY
+          jq -n --rawfile body "$REPORT_ROOT/summary.md" '{body: $body}' \
+            | gh api --method POST "repos/$REPOSITORY/issues/2954/comments" --input -
+
+      - name: Enforce ready status
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s "$REPORT_ROOT/report.json"
+          test "$(jq -r '.status' "$REPORT_ROOT/report.json")" = 'READY_FOR_BUNDLE_UPLOAD'
+          test "$(jq -r '.reasons | length' "$REPORT_ROOT/report.json")" = '0'
+          test "$(jq -r '.production_operational_status' "$REPORT_ROOT/report.json")" = 'NOT_ATTESTED'

--- a/apps/tai/governance/scopes/ap-13b3f-s3-preflight-2954.json
+++ b/apps/tai/governance/scopes/ap-13b3f-s3-preflight-2954.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "tai.concurrent-scope.v1",
+  "branch": "agent/tai-ap-13b3f-s3-preflight",
+  "program_issue": 2726,
+  "parent_issue": 2835,
+  "issue": 2954,
+  "allowed_paths": [
+    ".github/workflows/tai-bundle-s3-preflight.yml",
+    "apps/tai/governance/scopes/ap-13b3f-s3-preflight-2954.json",
+    "apps/tai/model-artifacts/model-bundle-s3-preflight-requirements.v1.json",
+    "apps/tai/tai/model_bundle_s3_preflight.py",
+    "apps/tai/tai/model_bundle_s3_preflight_cli.py",
+    "apps/tai/tests/test_model_bundle_s3_preflight.py"
+  ],
+  "forbidden_capabilities": [
+    "S3 object write, multipart upload, delete, restore or local mutation",
+    "production credentials or production-host fallback",
+    "model weights, GGUF, archives or secrets committed to Git",
+    "benchmark, model admission or production-readiness claim",
+    "inferred capacity, versioning, encryption or delete-deny evidence"
+  ],
+  "acceptance": [
+    "owner-only exact-main issue command triggers read-only S3 preflight",
+    "all required TAI_BUNDLE_S3_ protected inputs fail closed when absent",
+    "private access controls, versioning, encryption and global delete deny are verified",
+    "operator-confirmed provider capacity is at least 120000000000 bytes",
+    "bounded evidence excludes credentials and secret values",
+    "bundle upload and clean restore remain NOT_RUN",
+    "production_operational_status remains NOT_ATTESTED"
+  ]
+}

--- a/apps/tai/governance/scopes/ap-13b3f-s3-preflight-2954.json
+++ b/apps/tai/governance/scopes/ap-13b3f-s3-preflight-2954.json
@@ -21,6 +21,7 @@
   ],
   "acceptance": [
     "owner-only exact-main issue command triggers read-only S3 preflight",
+    "read-only controls complement the accepted Object Lock smoke round-trip authority from PR #2955",
     "all required TAI_BUNDLE_S3_ protected inputs fail closed when absent",
     "private access controls, versioning, encryption and global delete deny are verified",
     "operator-confirmed provider capacity is at least 120000000000 bytes",

--- a/apps/tai/model-artifacts/model-bundle-s3-preflight-requirements.v1.json
+++ b/apps/tai/model-artifacts/model-bundle-s3-preflight-requirements.v1.json
@@ -11,7 +11,8 @@
     "TAI_BUNDLE_S3_BUCKET",
     "TAI_BUNDLE_S3_ACCESS_KEY_ID",
     "TAI_BUNDLE_S3_SECRET_ACCESS_KEY",
-    "TAI_BUNDLE_S3_PREFIX"
+    "TAI_BUNDLE_S3_PREFIX",
+    "TAI_BUNDLE_S3_CAPACITY_BYTES"
   ],
   "required_bucket_controls": {
     "https_endpoint": true,

--- a/apps/tai/model-artifacts/model-bundle-s3-preflight-requirements.v1.json
+++ b/apps/tai/model-artifacts/model-bundle-s3-preflight-requirements.v1.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "tai.model-bundle-s3-preflight-requirements.v1",
+  "program_issue": 2726,
+  "parent_issue": 2835,
+  "issue": 2954,
+  "command": "/tai probe bundle-storage exact-main",
+  "target_role": "EXTERNAL_IMMUTABLE_MODEL_BUNDLE_STORAGE",
+  "required_secret_names": [
+    "TAI_BUNDLE_S3_ENDPOINT",
+    "TAI_BUNDLE_S3_REGION",
+    "TAI_BUNDLE_S3_BUCKET",
+    "TAI_BUNDLE_S3_ACCESS_KEY_ID",
+    "TAI_BUNDLE_S3_SECRET_ACCESS_KEY",
+    "TAI_BUNDLE_S3_PREFIX"
+  ],
+  "required_bucket_controls": {
+    "https_endpoint": true,
+    "versioning_status": "Enabled",
+    "public_access_block": {
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true,
+      "BlockPublicPolicy": true,
+      "RestrictPublicBuckets": true
+    },
+    "accepted_default_encryption_algorithms": [
+      "AES256",
+      "aws:kms"
+    ],
+    "required_delete_deny_actions": [
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion"
+    ],
+    "policy_scope": "GOVERNED_PREFIX"
+  },
+  "measured_payload": {
+    "selected_source_bytes": 30896839600,
+    "gguf_artifact_bytes": 48995504288,
+    "minimum_external_capacity_bytes": 120000000000,
+    "capacity_source": "OPERATOR_CONFIRMED_PROVIDER_QUOTA"
+  },
+  "mutation_mode": "READ_ONLY",
+  "production_fallback_allowed": false,
+  "production_operational_status": "NOT_ATTESTED"
+}

--- a/apps/tai/tai/model_bundle_s3_preflight.py
+++ b/apps/tai/tai/model_bundle_s3_preflight.py
@@ -4,7 +4,7 @@ import hashlib
 import ipaddress
 import json
 import re
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from typing import Any
 from urllib.parse import urlsplit
 

--- a/apps/tai/tai/model_bundle_s3_preflight.py
+++ b/apps/tai/tai/model_bundle_s3_preflight.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import re
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlsplit
+
+_REQUIREMENTS_SCHEMA = "tai.model-bundle-s3-preflight-requirements.v1"
+_OBSERVED_SCHEMA = "tai.model-bundle-s3-preflight-observed.v1"
+_REPORT_SCHEMA = "tai.model-bundle-s3-preflight-report.v1"
+_BUCKET_RE = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
+
+
+def evaluate_s3_preflight(
+    requirements: dict[str, object],
+    observed: dict[str, object],
+    *,
+    exact_main_sha: str,
+    workflow_run_id: int,
+    workflow_run_attempt: int,
+) -> dict[str, object]:
+    reasons: list[str] = []
+    _expect_schema(requirements, _REQUIREMENTS_SCHEMA, "REQUIREMENTS", reasons)
+    _expect_schema(observed, _OBSERVED_SCHEMA, "OBSERVED", reasons)
+
+    endpoint = _text(observed.get("endpoint"))
+    region = _text(observed.get("region"))
+    bucket = _text(observed.get("bucket"))
+    prefix = _text(observed.get("prefix"))
+    capacity_bytes = _integer(observed.get("operator_confirmed_capacity_bytes"))
+
+    endpoint_host = _validate_endpoint(endpoint, reasons)
+    _validate_bucket(bucket, reasons)
+    _validate_prefix(prefix, reasons)
+    if not region:
+        reasons.append("REGION_EMPTY")
+
+    commands = _mapping(observed.get("commands"))
+    for command_name in (
+        "head_bucket",
+        "get_bucket_versioning",
+        "get_public_access_block",
+        "get_bucket_encryption",
+        "get_bucket_policy",
+        "list_objects_v2",
+        "list_object_versions",
+    ):
+        if commands.get(command_name) is not True:
+            reasons.append(f"S3_COMMAND_FAILED:{command_name}")
+
+    controls = _mapping(requirements.get("required_bucket_controls"))
+    versioning = _mapping(observed.get("versioning"))
+    required_versioning = _text(controls.get("versioning_status"))
+    if _text(versioning.get("Status")) != required_versioning:
+        reasons.append("BUCKET_VERSIONING_NOT_ENABLED")
+
+    required_public_access = _mapping(controls.get("public_access_block"))
+    observed_public_access = _mapping(observed.get("public_access_block"))
+    for key, required in required_public_access.items():
+        if required is True and observed_public_access.get(key) is not True:
+            reasons.append(f"PUBLIC_ACCESS_BLOCK_NOT_ENFORCED:{key}")
+
+    accepted_encryption = {
+        value
+        for value in _string_list(controls.get("accepted_default_encryption_algorithms"))
+    }
+    encryption_algorithms = _extract_encryption_algorithms(observed.get("encryption"))
+    if not encryption_algorithms:
+        reasons.append("DEFAULT_ENCRYPTION_ABSENT")
+    elif not encryption_algorithms.issubset(accepted_encryption):
+        reasons.append("DEFAULT_ENCRYPTION_UNACCEPTED")
+
+    policy = _mapping(observed.get("policy"))
+    required_delete_actions = set(
+        _string_list(controls.get("required_delete_deny_actions"))
+    )
+    expected_resource = (
+        f"arn:aws:s3:::{bucket}/{prefix}/*" if bucket and prefix else ""
+    )
+    denied_actions = _globally_denied_actions(policy, expected_resource)
+    for action in sorted(required_delete_actions - denied_actions):
+        reasons.append(f"DELETE_DENY_MISSING:{action}")
+
+    measured_payload = _mapping(requirements.get("measured_payload"))
+    minimum_capacity = _integer(measured_payload.get("minimum_external_capacity_bytes"))
+    if capacity_bytes is None:
+        reasons.append("EXTERNAL_CAPACITY_NOT_CONFIRMED")
+    elif minimum_capacity is None or capacity_bytes < minimum_capacity:
+        reasons.append("EXTERNAL_CAPACITY_BELOW_MINIMUM")
+
+    if requirements.get("mutation_mode") != "READ_ONLY":
+        reasons.append("REQUIREMENTS_MUTATION_MODE_INVALID")
+    if observed.get("mutation_mode") != "READ_ONLY":
+        reasons.append("OBSERVED_MUTATION_MODE_INVALID")
+    if requirements.get("production_fallback_allowed") is not False:
+        reasons.append("PRODUCTION_FALLBACK_BOUNDARY_INVALID")
+    if requirements.get("production_operational_status") != "NOT_ATTESTED":
+        reasons.append("MATURITY_BOUNDARY_INVALID")
+
+    authority_sha256 = hashlib.sha256(_canonical_json(requirements).encode()).hexdigest()
+    policy_sha256 = hashlib.sha256(_canonical_json(policy).encode()).hexdigest()
+    unique_reasons = sorted(set(reasons))
+    report: dict[str, object] = {
+        "schema_version": _REPORT_SCHEMA,
+        "status": "READY_FOR_BUNDLE_UPLOAD" if not unique_reasons else "NOT_READY",
+        "reasons": unique_reasons,
+        "exact_main_sha": exact_main_sha,
+        "workflow_run_id": workflow_run_id,
+        "workflow_run_attempt": workflow_run_attempt,
+        "issue": requirements.get("issue"),
+        "command": requirements.get("command"),
+        "target_role": requirements.get("target_role"),
+        "mutation_mode": "READ_ONLY",
+        "authority_sha256": authority_sha256,
+        "observed": {
+            "endpoint_host": endpoint_host,
+            "region": region,
+            "bucket": bucket,
+            "prefix": prefix,
+            "versioning_status": _text(versioning.get("Status")),
+            "public_access_block": observed_public_access,
+            "default_encryption_algorithms": sorted(encryption_algorithms),
+            "policy_sha256": policy_sha256,
+            "globally_denied_actions": sorted(denied_actions),
+            "operator_confirmed_capacity_bytes": capacity_bytes,
+        },
+        "bundle_upload_status": "NOT_RUN",
+        "bundle_restore_status": "NOT_RUN",
+        "benchmark_status": "NOT_RUN",
+        "model_admission_status": "NOT_DONE",
+        "production_operational_status": "NOT_ATTESTED",
+    }
+    report["report_sha256"] = hashlib.sha256(_canonical_json(report).encode()).hexdigest()
+    return report
+
+
+def _validate_endpoint(value: str, reasons: list[str]) -> str:
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        reasons.append("ENDPOINT_INVALID")
+        return ""
+    if parsed.scheme != "https" or not parsed.hostname:
+        reasons.append("ENDPOINT_NOT_HTTPS")
+        return parsed.hostname or ""
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        reasons.append("ENDPOINT_CONTAINS_FORBIDDEN_COMPONENT")
+    if parsed.path not in {"", "/"}:
+        reasons.append("ENDPOINT_PATH_NOT_ROOT")
+    host = parsed.hostname
+    if host in {"localhost", "localhost.localdomain"}:
+        reasons.append("ENDPOINT_HOST_LOCAL")
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return host
+    if not address.is_global:
+        reasons.append("ENDPOINT_IP_NOT_GLOBAL")
+    return host
+
+
+def _validate_bucket(value: str, reasons: list[str]) -> None:
+    if not _BUCKET_RE.fullmatch(value):
+        reasons.append("BUCKET_NAME_INVALID")
+        return
+    if ".." in value or ".-" in value or "-." in value:
+        reasons.append("BUCKET_NAME_INVALID")
+    try:
+        ipaddress.ip_address(value)
+    except ValueError:
+        return
+    reasons.append("BUCKET_NAME_LOOKS_LIKE_IP")
+
+
+def _validate_prefix(value: str, reasons: list[str]) -> None:
+    if not value or value.startswith("/") or value.endswith("/") or "\\" in value:
+        reasons.append("PREFIX_INVALID")
+        return
+    path = PurePosixPath(value)
+    if any(part in {"", ".", ".."} for part in path.parts):
+        reasons.append("PREFIX_INVALID")
+    if path.as_posix() != value:
+        reasons.append("PREFIX_NOT_CANONICAL")
+
+
+def _extract_encryption_algorithms(value: object) -> set[str]:
+    payload = _mapping(value)
+    configuration = _mapping(payload.get("ServerSideEncryptionConfiguration"))
+    rules = configuration.get("Rules")
+    if not isinstance(rules, list):
+        return set()
+    result: set[str] = set()
+    for rule in rules:
+        rule_mapping = _mapping(rule)
+        default = _mapping(rule_mapping.get("ApplyServerSideEncryptionByDefault"))
+        algorithm = _text(default.get("SSEAlgorithm"))
+        if algorithm:
+            result.add(algorithm)
+    return result
+
+
+def _globally_denied_actions(policy: dict[str, object], resource: str) -> set[str]:
+    statements = policy.get("Statement")
+    if isinstance(statements, dict):
+        statement_list: list[object] = [statements]
+    elif isinstance(statements, list):
+        statement_list = statements
+    else:
+        return set()
+    denied: set[str] = set()
+    for statement in statement_list:
+        item = _mapping(statement)
+        if item.get("Effect") != "Deny" or not _principal_is_global(item.get("Principal")):
+            continue
+        resources = set(_string_or_list(item.get("Resource")))
+        if resource not in resources:
+            continue
+        denied.update(_string_or_list(item.get("Action")))
+    return denied
+
+
+def _principal_is_global(value: object) -> bool:
+    if value == "*":
+        return True
+    if not isinstance(value, dict):
+        return False
+    aws = value.get("AWS")
+    if aws == "*":
+        return True
+    return isinstance(aws, list) and "*" in aws
+
+
+def _expect_schema(
+    payload: dict[str, object], expected: str, prefix: str, reasons: list[str]
+) -> None:
+    if payload.get("schema_version") != expected:
+        reasons.append(f"{prefix}_SCHEMA_INVALID")
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _text(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _integer(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _string_or_list(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    return _string_list(value)

--- a/apps/tai/tai/model_bundle_s3_preflight_cli.py
+++ b/apps/tai/tai/model_bundle_s3_preflight_cli.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from tai.model_bundle_s3_preflight import evaluate_s3_preflight
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Evaluate TAI S3 bundle preflight")
+    parser.add_argument("requirements", type=Path)
+    parser.add_argument("observed", type=Path)
+    parser.add_argument("--exact-main", required=True)
+    parser.add_argument("--workflow-run-id", required=True, type=int)
+    parser.add_argument("--workflow-run-attempt", required=True, type=int)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    report = evaluate_s3_preflight(
+        _load_json(args.requirements),
+        _load_json(args.observed),
+        exact_main_sha=args.exact_main,
+        workflow_run_id=args.workflow_run_id,
+        workflow_run_attempt=args.workflow_run_attempt,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(report, ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+    return 0 if report["status"] == "READY_FOR_BUNDLE_UPLOAD" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/tai/tests/test_model_bundle_s3_preflight.py
+++ b/apps/tai/tests/test_model_bundle_s3_preflight.py
@@ -324,7 +324,7 @@ def test_workflow_is_owner_only_read_only_and_dedicated_s3_only() -> None:
         "get-bucket-policy",
         "list-objects-v2",
         "list-object-versions",
-        "bundle_upload_status",
+        "bundle upload: `NOT_RUN`",
         "NOT_ATTESTED",
     ):
         assert required in workflow

--- a/apps/tai/tests/test_model_bundle_s3_preflight.py
+++ b/apps/tai/tests/test_model_bundle_s3_preflight.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tai.model_bundle_s3_preflight import evaluate_s3_preflight
+from tai.model_bundle_s3_preflight_cli import main
+
+ROOT = Path(__file__).parents[3]
+TAI_ROOT = Path(__file__).parents[1]
+REQUIREMENTS_PATH = (
+    TAI_ROOT
+    / "model-artifacts"
+    / "model-bundle-s3-preflight-requirements.v1.json"
+)
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "tai-bundle-s3-preflight.yml"
+SCOPE_PATH = (
+    TAI_ROOT
+    / "governance"
+    / "scopes"
+    / "ap-13b3f-s3-preflight-2954.json"
+)
+COMMAND = "/tai probe bundle-storage exact-main"
+EXACT_MAIN = "a" * 40
+
+
+def _json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _valid_observed() -> dict[str, object]:
+    bucket = "tai-model-bundles"
+    prefix = "tai/model-bundles/v1"
+    return {
+        "schema_version": "tai.model-bundle-s3-preflight-observed.v1",
+        "endpoint": "https://s3.example.ru",
+        "region": "ru-1",
+        "bucket": bucket,
+        "prefix": prefix,
+        "operator_confirmed_capacity_bytes": "150000000000",
+        "commands": {
+            "head_bucket": True,
+            "get_bucket_versioning": True,
+            "get_public_access_block": True,
+            "get_bucket_encryption": True,
+            "get_bucket_policy": True,
+            "list_objects_v2": True,
+            "list_object_versions": True,
+        },
+        "versioning": {"Status": "Enabled"},
+        "public_access_block": {
+            "BlockPublicAcls": True,
+            "IgnorePublicAcls": True,
+            "BlockPublicPolicy": True,
+            "RestrictPublicBuckets": True,
+        },
+        "encryption": {
+            "ServerSideEncryptionConfiguration": {
+                "Rules": [
+                    {
+                        "ApplyServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256"
+                        }
+                    }
+                ]
+            }
+        },
+        "policy": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Deny",
+                    "Principal": "*",
+                    "Action": ["s3:DeleteObject", "s3:DeleteObjectVersion"],
+                    "Resource": f"arn:aws:s3:::{bucket}/{prefix}/*",
+                }
+            ],
+        },
+        "aws_cli_identity": "aws-cli/2.x",
+        "mutation_mode": "READ_ONLY",
+    }
+
+
+def _evaluate(observed: dict[str, object]) -> dict[str, object]:
+    return evaluate_s3_preflight(
+        _json(REQUIREMENTS_PATH),
+        observed,
+        exact_main_sha=EXACT_MAIN,
+        workflow_run_id=123,
+        workflow_run_attempt=1,
+    )
+
+
+def test_valid_s3_authority_is_ready_and_bounded() -> None:
+    report = _evaluate(_valid_observed())
+    assert report["status"] == "READY_FOR_BUNDLE_UPLOAD"
+    assert report["reasons"] == []
+    assert report["bundle_upload_status"] == "NOT_RUN"
+    assert report["bundle_restore_status"] == "NOT_RUN"
+    assert report["production_operational_status"] == "NOT_ATTESTED"
+    observed = report["observed"]
+    assert isinstance(observed, dict)
+    assert observed["endpoint_host"] == "s3.example.ru"
+    assert observed["globally_denied_actions"] == [
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+    ]
+    assert "secret" not in json.dumps(report).lower()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_reason"),
+    [
+        ({"versioning": {"Status": "Suspended"}}, "BUCKET_VERSIONING_NOT_ENABLED"),
+        (
+            {"public_access_block": {"BlockPublicAcls": False}},
+            "PUBLIC_ACCESS_BLOCK_NOT_ENFORCED:BlockPublicAcls",
+        ),
+        ({"encryption": {}}, "DEFAULT_ENCRYPTION_ABSENT"),
+        (
+            {
+                "encryption": {
+                    "ServerSideEncryptionConfiguration": {
+                        "Rules": [
+                            {
+                                "ApplyServerSideEncryptionByDefault": {
+                                    "SSEAlgorithm": "DES"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "DEFAULT_ENCRYPTION_UNACCEPTED",
+        ),
+        ({"operator_confirmed_capacity_bytes": "119999999999"}, "EXTERNAL_CAPACITY_BELOW_MINIMUM"),
+        ({"operator_confirmed_capacity_bytes": "unknown"}, "EXTERNAL_CAPACITY_NOT_CONFIRMED"),
+        ({"mutation_mode": "WRITE"}, "OBSERVED_MUTATION_MODE_INVALID"),
+        ({"region": ""}, "REGION_EMPTY"),
+    ],
+)
+def test_bucket_control_failures_are_rejected(
+    mutation: dict[str, object], expected_reason: str
+) -> None:
+    observed = _valid_observed()
+    observed.update(mutation)
+    report = _evaluate(observed)
+    assert report["status"] == "NOT_READY"
+    assert expected_reason in report["reasons"]
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected_reason"),
+    [
+        ("http://s3.example.ru", "ENDPOINT_NOT_HTTPS"),
+        ("https://localhost", "ENDPOINT_HOST_LOCAL"),
+        ("https://127.0.0.1", "ENDPOINT_IP_NOT_GLOBAL"),
+        ("https://user:pass@s3.example.ru", "ENDPOINT_CONTAINS_FORBIDDEN_COMPONENT"),
+        ("https://s3.example.ru/path", "ENDPOINT_PATH_NOT_ROOT"),
+    ],
+)
+def test_endpoint_safety_is_fail_closed(endpoint: str, expected_reason: str) -> None:
+    observed = _valid_observed()
+    observed["endpoint"] = endpoint
+    report = _evaluate(observed)
+    assert report["status"] == "NOT_READY"
+    assert expected_reason in report["reasons"]
+
+
+@pytest.mark.parametrize(
+    ("bucket", "expected_reason"),
+    [
+        ("Bad_Bucket", "BUCKET_NAME_INVALID"),
+        ("192.168.1.1", "BUCKET_NAME_LOOKS_LIKE_IP"),
+        ("a..b", "BUCKET_NAME_INVALID"),
+    ],
+)
+def test_bucket_names_are_validated(bucket: str, expected_reason: str) -> None:
+    observed = _valid_observed()
+    observed["bucket"] = bucket
+    report = _evaluate(observed)
+    assert report["status"] == "NOT_READY"
+    assert expected_reason in report["reasons"]
+
+
+@pytest.mark.parametrize("prefix", ["", "/root", "root/", "root\\child", "root//child"])
+def test_prefix_must_be_canonical(prefix: str) -> None:
+    observed = _valid_observed()
+    observed["prefix"] = prefix
+    report = _evaluate(observed)
+    assert report["status"] == "NOT_READY"
+    assert any(reason.startswith("PREFIX_") for reason in report["reasons"])
+
+
+def test_delete_deny_requires_global_principal_exact_prefix_and_both_actions() -> None:
+    cases = []
+    no_principal = _valid_observed()
+    no_principal["policy"] = {
+        "Statement": [
+            {
+                "Effect": "Deny",
+                "Principal": {"AWS": "arn:aws:iam::1:user/writer"},
+                "Action": ["s3:DeleteObject", "s3:DeleteObjectVersion"],
+                "Resource": "arn:aws:s3:::tai-model-bundles/tai/model-bundles/v1/*",
+            }
+        ]
+    }
+    cases.append(no_principal)
+
+    wrong_prefix = _valid_observed()
+    wrong_prefix["policy"] = {
+        "Statement": {
+            "Effect": "Deny",
+            "Principal": {"AWS": ["*"]},
+            "Action": ["s3:DeleteObject", "s3:DeleteObjectVersion"],
+            "Resource": "arn:aws:s3:::tai-model-bundles/other/*",
+        }
+    }
+    cases.append(wrong_prefix)
+
+    one_action = _valid_observed()
+    one_action["policy"] = {
+        "Statement": {
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:DeleteObject",
+            "Resource": "arn:aws:s3:::tai-model-bundles/tai/model-bundles/v1/*",
+        }
+    }
+    cases.append(one_action)
+
+    for observed in cases:
+        report = _evaluate(observed)
+        assert report["status"] == "NOT_READY"
+        assert any(reason.startswith("DELETE_DENY_MISSING:") for reason in report["reasons"])
+
+
+def test_command_failure_and_schema_mismatch_are_reported() -> None:
+    observed = _valid_observed()
+    commands = copy.deepcopy(observed["commands"])
+    assert isinstance(commands, dict)
+    commands["head_bucket"] = False
+    observed["commands"] = commands
+    observed["schema_version"] = "wrong"
+    report = _evaluate(observed)
+    assert "S3_COMMAND_FAILED:head_bucket" in report["reasons"]
+    assert "OBSERVED_SCHEMA_INVALID" in report["reasons"]
+
+
+def test_cli_returns_zero_only_for_ready(tmp_path: Path) -> None:
+    observed_path = tmp_path / "observed.json"
+    output_path = tmp_path / "report.json"
+    observed_path.write_text(json.dumps(_valid_observed()), encoding="utf-8")
+    assert (
+        main(
+            [
+                str(REQUIREMENTS_PATH),
+                str(observed_path),
+                "--exact-main",
+                EXACT_MAIN,
+                "--workflow-run-id",
+                "123",
+                "--workflow-run-attempt",
+                "1",
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+    observed = _valid_observed()
+    observed["versioning"] = {}
+    observed_path.write_text(json.dumps(observed), encoding="utf-8")
+    assert (
+        main(
+            [
+                str(REQUIREMENTS_PATH),
+                str(observed_path),
+                "--exact-main",
+                EXACT_MAIN,
+                "--workflow-run-id",
+                "123",
+                "--workflow-run-attempt",
+                "1",
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 2
+    )
+
+
+def test_workflow_is_owner_only_read_only_and_dedicated_s3_only() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "github.event.issue.number == 2954" in workflow
+    assert f"github.event.comment.body == '{COMMAND}'" in workflow
+    assert "github.event.comment.author_association == 'OWNER'" in workflow
+    assert "github.event.comment.user.login == github.repository_owner" in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "actions: read\n  contents: read\n  issues: write" in workflow
+    for secret in _json(REQUIREMENTS_PATH)["required_secret_names"]:
+        assert secret in workflow
+    for forbidden in (
+        "PC_PROD_",
+        "VPS_SSH_",
+        "195.19.12.120",
+        "s3api put-object",
+        "s3api delete-object",
+        "s3api create-multipart-upload",
+        "s3 cp",
+    ):
+        assert forbidden not in workflow
+    for required in (
+        "head-bucket",
+        "get-bucket-versioning",
+        "get-public-access-block",
+        "get-bucket-encryption",
+        "get-bucket-policy",
+        "list-objects-v2",
+        "list-object-versions",
+        "bundle_upload_status",
+        "NOT_ATTESTED",
+    ):
+        assert required in workflow
+
+
+def test_scope_is_exact_and_preserves_maturity_boundary() -> None:
+    scope = _json(SCOPE_PATH)
+    assert scope["schema_version"] == "tai.concurrent-scope.v1"
+    assert scope["branch"] == "agent/tai-ap-13b3f-s3-preflight"
+    assert (scope["program_issue"], scope["parent_issue"], scope["issue"]) == (
+        2726,
+        2835,
+        2954,
+    )
+    assert set(scope["allowed_paths"]) == {
+        ".github/workflows/tai-bundle-s3-preflight.yml",
+        "apps/tai/governance/scopes/ap-13b3f-s3-preflight-2954.json",
+        "apps/tai/model-artifacts/model-bundle-s3-preflight-requirements.v1.json",
+        "apps/tai/tai/model_bundle_s3_preflight.py",
+        "apps/tai/tai/model_bundle_s3_preflight_cli.py",
+        "apps/tai/tests/test_model_bundle_s3_preflight.py",
+    }
+    assert "production_operational_status remains NOT_ATTESTED" in scope["acceptance"]


### PR DESCRIPTION
Implements the owner-only exact-main read-only preflight for external immutable model-bundle storage.

The gate verifies dedicated `TAI_BUNDLE_S3_*` inputs, HTTPS endpoint safety, private public-access controls, bucket versioning, default encryption, global delete denial on the governed prefix and operator-confirmed capacity of at least 120 GB.

No object is written, uploaded, deleted or restored. No model bytes, GGUF, credentials, benchmark, admission or production-readiness claim are introduced. `production_operational_status` remains `NOT_ATTESTED`.

Refs #2954, #2835 and #2726.