### PR TITLE
Fix VPS deploy trigger for merge actor

### DIFF
--- a/.github/release-triggers/tai-p0-web-24277e0.md
+++ b/.github/release-triggers/tai-p0-web-24277e0.md
@@ -9,5 +9,6 @@
 - Required acceptance: running OCI revision, live manifest, public home, TAI passport, dock, interactions, WCAG and 320–1440 px browser checks
 - Rollback: previous immutable web image restored automatically if post-deploy acceptance fails
 - TAI operational status after release: `NOT_ATTESTED`
+- Release attempt: `2` — protected `push/main`, independent of merge actor identity
 
 This file is a one-release trigger. It authorizes no API, database, Caddy, Compose, environment, volume, network or non-web service mutation.

--- a/.github/workflows/deploy-ai-web-vps-c21eec0.yml
+++ b/.github/workflows/deploy-ai-web-vps-c21eec0.yml
@@ -70,8 +70,7 @@ jobs:
     name: Key-only targeted VPS web deployment and exact live verification
     if: >-
       github.event_name == 'push' &&
-      github.ref == 'refs/heads/main' &&
-      github.actor == github.repository_owner
+      github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
## Причина

Первый post-merge запуск не опубликовал VPS evidence. Production не был подтверждён. Лишнее условие `github.actor == github.repository_owner` блокирует trusted `push/main`, когда squash-merge выполнен GitHub App от имени владельца.

## Изменение

- удалена только проверка имени actor;
- сохранены обязательные условия `push` и `refs/heads/main`;
- сохранены exact target/image, key-only SSH, DNS authority, web-only Compose update, OCI revision check, live markers и rollback;
- одноразовый trigger переведён на attempt 2.

## Scope

Два файла, четыре строки net-diff:
- `.github/workflows/deploy-ai-web-vps-c21eec0.yml`;
- `.github/release-triggers/tai-p0-web-24277e0.md`.

Production до merge не изменяется. TAI остаётся `NOT_ATTESTED`.