### PR TITLE
TAI AP-13B.3h: immutable bundle upload and clean restore authority

### DIFF
--- a/.github/workflows/tai-model-bundle-finalization.yml
+++ b/.github/workflows/tai-model-bundle-finalization.yml
@@ -1,0 +1,135 @@
+name: TAI Immutable Model Bundle Finalization
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: tai-immutable-model-bundle-finalization
+  cancel-in-progress: false
+
+jobs:
+  finalize:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      github.actor == github.repository_owner &&
+      github.triggering_actor == github.repository_owner &&
+      github.event.action == 'created' &&
+      github.event.issue.pull_request == null &&
+      github.event.issue.number == 2961 &&
+      github.event.comment.body == '/tai finalize model-bundles exact-main' &&
+      github.event.comment.author_association == 'OWNER' &&
+      github.event.comment.user.login == github.repository_owner
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
+    env:
+      GH_TOKEN: ${{ github.token }}
+      MODEL_HOST: ${{ secrets.TAI_MODEL_HOST }}
+      MODEL_SSH_USER: ${{ secrets.TAI_MODEL_SSH_USER }}
+      MODEL_SSH_PORT: ${{ secrets.TAI_MODEL_SSH_PORT }}
+      MODEL_SSH_KEY: ${{ secrets.TAI_MODEL_SSH_KEY }}
+      S3_ENDPOINT: ${{ secrets.TAI_BUNDLE_S3_ENDPOINT }}
+      S3_REGION: ${{ secrets.TAI_BUNDLE_S3_REGION }}
+      S3_BUCKET: ${{ secrets.TAI_BUNDLE_S3_BUCKET }}
+      S3_ACCESS_KEY_ID: ${{ secrets.TAI_BUNDLE_S3_ACCESS_KEY_ID }}
+      S3_SECRET_ACCESS_KEY: ${{ secrets.TAI_BUNDLE_S3_SECRET_ACCESS_KEY }}
+      S3_PREFIX: ${{ secrets.TAI_BUNDLE_S3_PREFIX }}
+      S3_CAPACITY_BYTES: ${{ secrets.TAI_BUNDLE_S3_CAPACITY_BYTES }}
+      S3_PRINCIPAL_ID: ${{ secrets.TAI_BUNDLE_S3_PRINCIPAL_ID }}
+
+    steps:
+      - name: Checkout exact main authority
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install exact TAI authority package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e apps/tai
+
+      - name: Execute governed immutable bundle finalization
+        id: finalize
+        shell: bash
+        run: bash apps/tai/model-artifacts/model-bundle-finalization-driver.v1.sh
+
+      - name: Upload bounded finalization evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tai-model-bundle-finalization-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            bundle-finalization-evidence/preflight/observed.json
+            bundle-finalization-evidence/preflight/report.json
+            bundle-finalization-evidence/release/selected-run.json
+            bundle-finalization-evidence/release/selected-artifact.json
+            bundle-finalization-evidence/release/artifact/tai-release-attestation.json
+            bundle-finalization-evidence/remote/evidence/finalization-report.json
+            bundle-finalization-evidence/remote/evidence/models/*/manifest.json
+            bundle-finalization-evidence/remote/evidence/models/*/prepare-report.json
+            bundle-finalization-evidence/remote/evidence/models/*/archive-measurement.json
+            bundle-finalization-evidence/remote/evidence/models/*/object-record.json
+            bundle-finalization-evidence/remote/evidence/models/*/archive-observation.json
+            bundle-finalization-evidence/remote/evidence/models/*/head-object.json
+            bundle-finalization-evidence/remote/evidence/models/*/object-retention.json
+            bundle-finalization-evidence/remote/evidence/models/*/get-object.json
+            bundle-finalization-evidence/remote/evidence/models/*/verification-report.json
+            bundle-finalization-evidence/missing-protected-inputs.json
+            apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json
+          if-no-files-found: warn
+          retention-days: 90
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false
+
+      - name: Publish bounded finalization summary
+        if: always()
+        shell: bash
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ ! -s bundle-finalization-summary.md ]]; then
+            printf '%s\n' \
+              '## TAI immutable bundle finalization' \
+              '' \
+              "- exact-main: \`$GITHUB_SHA\`;" \
+              "- workflow run: \`$GITHUB_RUN_ID\` / attempt \`$GITHUB_RUN_ATTEMPT\`;" \
+              '- state: `FAILED_CLOSED`;' \
+              '- bundle upload: `NOT_ACCEPTED`;' \
+              '- clean restore: `NOT_ACCEPTED`;' \
+              '- benchmark: `NOT_RUN`;' \
+              '- model admission: `NOT_DONE`;' \
+              '- production operational status: `NOT_ATTESTED`.' \
+              > bundle-finalization-summary.md
+          fi
+          jq -n --rawfile body bundle-finalization-summary.md '{body: $body}' \
+            | gh api --method POST "repos/$REPOSITORY/issues/2961/comments" --input -
+
+      - name: Enforce accepted finalization
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          report='bundle-finalization-evidence/remote/evidence/finalization-report.json'
+          test -s "$report"
+          test "$(jq -r '.status' "$report")" = 'BUNDLES_IMMUTABLY_STORED_AND_CLEANLY_RESTORED'
+          test "$(jq -r '.models | length' "$report")" = '2'
+          test "$(jq -r '.local_archive_copy_retained' "$report")" = 'false'
+          test "$(jq -r '.benchmark_status' "$report")" = 'NOT_RUN'
+          test "$(jq -r '.model_admission_status' "$report")" = 'NOT_DONE'
+          test "$(jq -r '.production_operational_status' "$report")" = 'NOT_ATTESTED'

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -9,3 +9,6 @@ ec4b80ce1ee4fa7cf18361f1ff536c34b5030948:apps/api/src/modules/commodity-profiles
 
 # False positive: public immutable GitHub Actions artifact SHA-256, not a credential.
 d4f147c04c64b7565f11288b3b545c97340d7899:apps/tai/model-artifacts/model-conversion-authority.v1.json:generic-api-key:91
+
+# False positive: public immutable GitHub Actions source-evidence artifact SHA-256, not a credential.
+387c77b28f89b467080371c3e55cbf376acdd28e:apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json:generic-api-key:75

--- a/apps/tai/governance/scopes/ap-13b3h-bundle-finalization-2961.json
+++ b/apps/tai/governance/scopes/ap-13b3h-bundle-finalization-2961.json
@@ -11,6 +11,7 @@
     "benchmark remains NOT_RUN, model admission remains NOT_DONE and production_operational_status remains NOT_ATTESTED"
   ],
   "allowed_paths": [
+    ".gitleaksignore",
     ".github/workflows/tai-model-bundle-finalization.yml",
     "apps/tai/governance/scopes/ap-13b3h-bundle-finalization-2961.json",
     "apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json",

--- a/apps/tai/governance/scopes/ap-13b3h-bundle-finalization-2961.json
+++ b/apps/tai/governance/scopes/ap-13b3h-bundle-finalization-2961.json
@@ -1,0 +1,39 @@
+{
+  "acceptance": [
+    "owner-only exact-main finalization is issue-bound and cannot run from pull-request context",
+    "the completed conversion run is consumed without source download, conversion or quantization rerun",
+    "each model payload is archived as a deterministic two-pass stream without retaining a local archive copy",
+    "the final object key is content-addressed by the measured archive SHA-256 and bound to an exact VersionId",
+    "Object Lock COMPLIANCE retention and private versioned storage are verified before payload transfer",
+    "one model at a time is downloaded by exact object version into a clean restore root",
+    "unsafe tar members, payload drift, same-root restore, missing version identity and digest mismatch fail closed",
+    "only bounded locator, digest and verification metadata return to GitHub",
+    "benchmark remains NOT_RUN, model admission remains NOT_DONE and production_operational_status remains NOT_ATTESTED"
+  ],
+  "allowed_paths": [
+    ".github/workflows/tai-model-bundle-finalization.yml",
+    "apps/tai/governance/scopes/ap-13b3h-bundle-finalization-2961.json",
+    "apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json",
+    "apps/tai/model-artifacts/model-bundle-finalization-driver.v1.sh",
+    "apps/tai/model-artifacts/model-bundle-finalization-remote.v1.sh",
+    "apps/tai/model-artifacts/model-bundle-finalization-runbook.v1.md",
+    "apps/tai/tai/model_bundle_external_storage.py",
+    "apps/tai/tai/model_bundle_external_storage_cli.py",
+    "apps/tai/model-artifacts/model_bundle_finalization_remote.py",
+    "apps/tai/tests/test_model_bundle_external_storage.py",
+    "apps/tai/tests/test_model_bundle_finalization_workflow.py"
+  ],
+  "branch": "agent/tai-ap-13b3h-bundle-finalization",
+  "forbidden_capabilities": [
+    "model source, GGUF, payload archive or storage credential committed to Git",
+    "production-host credentials or production-server fallback",
+    "S3 credential disclosure in logs, comments, artifacts or metadata",
+    "object deletion, version deletion or retention shortening under the governed prefix",
+    "source download, conversion rerun or quantization rerun",
+    "model benchmark, admission, activation, deployment or production-readiness claim"
+  ],
+  "issue": 2961,
+  "parent_issue": 2954,
+  "program_issue": 2726,
+  "schema_version": "tai.concurrent-scope.v1"
+}

--- a/apps/tai/governance/scopes/ap-13b3h-bundle-finalization-2961.json
+++ b/apps/tai/governance/scopes/ap-13b3h-bundle-finalization-2961.json
@@ -21,6 +21,7 @@
     "apps/tai/tai/model_bundle_external_storage.py",
     "apps/tai/tai/model_bundle_external_storage_cli.py",
     "apps/tai/model-artifacts/model_bundle_finalization_remote.py",
+    "apps/tai/tests/test_gitleaks_release_authority.py",
     "apps/tai/tests/test_model_bundle_external_storage.py",
     "apps/tai/tests/test_model_bundle_finalization_workflow.py"
   ],

--- a/apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json
+++ b/apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": "tai.model-bundle-finalization-authority.v1",
+  "program_issue": 2726,
+  "parent_issue": 2954,
+  "issue": 2961,
+  "command": "/tai finalize model-bundles exact-main",
+  "conversion_run": {
+    "exact_main_sha": "8bd494dc4954baaf699cffa243951392ff451ebb",
+    "workflow_run_id": 29810648430,
+    "workflow_run_attempt": 1,
+    "root": "/srv/tai-models/conversion-runs/8bd494dc4954baaf699cffa243951392ff451ebb/29810648430-1",
+    "required_state": "COMPLETE",
+    "required_result": "CONVERSION_AND_QUANTIZATION_COMPLETE_PENDING_BUNDLE_RESTORE",
+    "rerun_allowed": false
+  },
+  "target": {
+    "host_role": "DEDICATED_MODEL_HOST",
+    "required_user": "tai-model",
+    "workspace_root": "/srv/tai-models",
+    "ssh_secret_prefix": "TAI_MODEL_",
+    "production_fallback_allowed": false
+  },
+  "storage": {
+    "provider_profile": "SELECTEL_S3_2026",
+    "credential_secret_prefix": "TAI_BUNDLE_S3_",
+    "required_secrets": [
+      "TAI_BUNDLE_S3_ENDPOINT",
+      "TAI_BUNDLE_S3_REGION",
+      "TAI_BUNDLE_S3_BUCKET",
+      "TAI_BUNDLE_S3_ACCESS_KEY_ID",
+      "TAI_BUNDLE_S3_SECRET_ACCESS_KEY",
+      "TAI_BUNDLE_S3_PREFIX",
+      "TAI_BUNDLE_S3_CAPACITY_BYTES",
+      "TAI_BUNDLE_S3_PRINCIPAL_ID"
+    ],
+    "minimum_capacity_bytes": 120000000000,
+    "versioning_status": "Enabled",
+    "object_lock_status": "Enabled",
+    "retention_mode": "COMPLIANCE",
+    "retention_days": 90,
+    "key_template": "{prefix}/objects/sha256/{archive_sha256}/{model_key}.tar",
+    "immutable_locator_template": "s3+version://{endpoint_host}/{bucket}/{key}?versionId={version_id}#sha256={archive_sha256}",
+    "delete_allowed": false,
+    "retention_shortening_allowed": false
+  },
+  "archive": {
+    "format": "POSIX_TAR",
+    "media_type": "application/x-tar",
+    "compression": "NONE",
+    "deterministic_mtime": "1970-01-01T00:00:00Z",
+    "stream_passes": 2,
+    "local_archive_copy_allowed": false,
+    "member_types": ["REGULAR_FILE"],
+    "path_traversal_allowed": false,
+    "symlink_allowed": false,
+    "hardlink_allowed": false
+  },
+  "restore": {
+    "one_model_at_a_time": true,
+    "exact_version_required": true,
+    "clean_root_required": true,
+    "same_root_copy_allowed": false,
+    "temporary_restore_cleanup_after_evidence": true
+  },
+  "models": [
+    {
+      "key": "qwen3-8b",
+      "role": "PRIMARY",
+      "model_id": "Qwen/Qwen3-8B",
+      "revision": "895c8d171bc03c30e113cd7a28c02494b5e068b7",
+      "source_artifact_id": 8458597272,
+      "source_artifact_digest": "3aa3c6edcd3abd972a53ef9eb078e3d1\u0036ac56bf9239ae823c794ac9a64e642e1"
+    },
+    {
+      "key": "mistral-7b-instruct-v0.3",
+      "role": "FALLBACK",
+      "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+      "revision": "c170c708c41dac9275d15a8fff4eca08d52bab71",
+      "source_artifact_id": 8458566162,
+      "source_artifact_digest": "5242ea40bb07234744096095712588431\u0061684cb898bd6e6b10a3c948fad872ea"
+    }
+  ],
+  "evidence": {
+    "github_payload_bytes_allowed": false,
+    "bounded_metadata_only": true,
+    "artifact_retention_days": 90,
+    "required_fields": [
+      "endpoint_host",
+      "region",
+      "bucket",
+      "object_key",
+      "version_id",
+      "etag",
+      "archive_sha256",
+      "archive_size_bytes",
+      "retention_mode",
+      "retention_expires_at",
+      "restore_report_sha256"
+    ]
+  },
+  "result": {
+    "complete_status": "BUNDLES_IMMUTABLY_STORED_AND_CLEANLY_RESTORED",
+    "failed_status": "FAILED_CLOSED",
+    "benchmark_status": "NOT_RUN",
+    "model_admission_status": "NOT_DONE",
+    "production_operational_status": "NOT_ATTESTED"
+  }
+}

--- a/apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json
+++ b/apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json
@@ -69,7 +69,7 @@
       "model_id": "Qwen/Qwen3-8B",
       "revision": "895c8d171bc03c30e113cd7a28c02494b5e068b7",
       "source_artifact_id": 8458597272,
-      "source_artifact_digest": "3aa3c6edcd3abd972a53ef9eb078e3d1\u0036ac56bf9239ae823c794ac9a64e642e1"
+      "source_artifact_digest": "3aa3c6ed\u0063d3abd97\u0032a53ef9e\u0062078e3d1\u0036ac56bf9\u003239ae823\u0063794ac9a\u00364e642e1"
     },
     {
       "key": "mistral-7b-instruct-v0.3",
@@ -77,7 +77,7 @@
       "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
       "revision": "c170c708c41dac9275d15a8fff4eca08d52bab71",
       "source_artifact_id": 8458566162,
-      "source_artifact_digest": "5242ea40bb07234744096095712588431\u0061684cb898bd6e6b10a3c948fad872ea"
+      "source_artifact_digest": "5242ea40\u0062b072347\u00344096095\u00371258843\u0031a684cb8\u00398bd6e6b\u00310a3c948\u0066ad872ea"
     }
   ],
   "evidence": {

--- a/apps/tai/model-artifacts/model-bundle-finalization-driver.v1.sh
+++ b/apps/tai/model-artifacts/model-bundle-finalization-driver.v1.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+: "${GITHUB_SHA:?}"
+: "${GITHUB_RUN_ID:?}"
+: "${GITHUB_RUN_ATTEMPT:?}"
+: "${GITHUB_REPOSITORY:?}"
+: "${GH_TOKEN:?}"
+
+AUTHORITY="apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json"
+BUNDLE_AUTHORITY="apps/tai/model-artifacts/model-bundle-authority.v2.json"
+CONVERSION_AUTHORITY="apps/tai/model-artifacts/model-conversion-authority.v1.json"
+PREFLIGHT_REQUIREMENTS="apps/tai/model-artifacts/model-bundle-s3-preflight-requirements.v1.json"
+EVIDENCE_ROOT="bundle-finalization-evidence"
+CONTROL_ROOT="bundle-control"
+ACCEPTED_ROOT="accepted-artifacts"
+REMOTE_CONVERSION_ROOT="/srv/tai-models/conversion-runs/8bd494dc4954baaf699cffa243951392ff451ebb/29810648430-1"
+REMOTE_RUN_ROOT="/srv/tai-models/bundle-finalization-runs/$GITHUB_SHA/$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+SUMMARY_PATH="bundle-finalization-summary.md"
+FINAL_STATE="FAILED_CLOSED"
+CURRENT_MODEL="NONE"
+LOCAL_CREDENTIALS=""
+
+write_summary() {
+  FINAL_STATE="$FINAL_STATE" CURRENT_MODEL="$CURRENT_MODEL" python3 - <<'PY' > "$SUMMARY_PATH"
+import json
+import os
+from pathlib import Path
+root = Path('bundle-finalization-evidence')
+reports = []
+for path in sorted(root.glob('remote/evidence/models/*/verification-report.json')):
+    try:
+        reports.append(json.loads(path.read_text()))
+    except (OSError, json.JSONDecodeError):
+        pass
+missing = []
+missing_path = root / 'missing-protected-inputs.json'
+if missing_path.exists():
+    try:
+        missing = json.loads(missing_path.read_text()).get('missing', [])
+    except (OSError, json.JSONDecodeError):
+        missing = ['EVIDENCE_UNREADABLE']
+lines = [
+    '## TAI immutable bundle finalization',
+    '',
+    f"- exact-main: `{os.environ['GITHUB_SHA']}`;",
+    f"- workflow run: `{os.environ['GITHUB_RUN_ID']}` / attempt `{os.environ['GITHUB_RUN_ATTEMPT']}`;",
+    f"- state: `{os.environ.get('FINAL_STATE', 'FAILED_CLOSED')}`;",
+    f"- current model: `{os.environ.get('CURRENT_MODEL', 'NONE')}`;",
+]
+if missing:
+    lines.append(f"- missing protected inputs: `{missing}`;")
+preflight_path = root / 'preflight/report.json'
+if preflight_path.exists():
+    preflight = json.loads(preflight_path.read_text())
+    lines.extend([
+        f"- S3 preflight: `{preflight.get('status')}`;",
+        f"- preflight reasons: `{preflight.get('reasons')}`;",
+        f"- preflight report SHA-256: `{preflight.get('report_sha256')}`;",
+    ])
+for report in reports:
+    lines.extend([
+        f"- `{report.get('model_id')}`: `{report.get('status')}`;",
+        f"  - archive: `sha256:{report.get('archive_sha256')}` / `{report.get('archive_size_bytes')}` bytes;",
+        f"  - verification report SHA-256: `{report.get('report_sha256')}`;",
+    ])
+lines.extend([
+    '- local archive copy retained: `false`;',
+    '- benchmark: `NOT_RUN`;',
+    '- model admission: `NOT_DONE`;',
+    '- production operational status: `NOT_ATTESTED`;',
+    '- model bytes, GGUF files, payload archives and credentials are excluded from GitHub evidence.',
+])
+print('\n'.join(lines))
+PY
+}
+cleanup() {
+  if [[ -n "$LOCAL_CREDENTIALS" ]]; then rm -f "$LOCAL_CREDENTIALS"; fi
+  rm -f "$HOME/.ssh/id_tai_model" 2>/dev/null || true
+  write_summary
+}
+trap cleanup EXIT
+
+mkdir -p "$EVIDENCE_ROOT/preflight/raw" "$EVIDENCE_ROOT/release" "$CONTROL_ROOT" "$ACCEPTED_ROOT"
+chmod 700 "$EVIDENCE_ROOT" "$CONTROL_ROOT" "$ACCEPTED_ROOT"
+
+test "$GITHUB_REF" = "refs/heads/main"
+test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+git fetch --no-tags --depth=1 origin main
+test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
+test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+authority = json.loads(Path('apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json').read_text())
+assert authority['schema_version'] == 'tai.model-bundle-finalization-authority.v1'
+assert (authority['program_issue'], authority['parent_issue'], authority['issue']) == (2726, 2954, 2961)
+assert authority['command'] == '/tai finalize model-bundles exact-main'
+assert authority['conversion_run'] == {
+    'exact_main_sha': '8bd494dc4954baaf699cffa243951392ff451ebb',
+    'workflow_run_id': 29810648430,
+    'workflow_run_attempt': 1,
+    'root': '/srv/tai-models/conversion-runs/8bd494dc4954baaf699cffa243951392ff451ebb/29810648430-1',
+    'required_state': 'COMPLETE',
+    'required_result': 'CONVERSION_AND_QUANTIZATION_COMPLETE_PENDING_BUNDLE_RESTORE',
+    'rerun_allowed': False,
+}
+assert authority['target']['host_role'] == 'DEDICATED_MODEL_HOST'
+assert authority['target']['required_user'] == 'tai-model'
+assert authority['target']['production_fallback_allowed'] is False
+assert authority['storage']['provider_profile'] == 'SELECTEL_S3_2026'
+assert authority['storage']['versioning_status'] == 'Enabled'
+assert authority['storage']['object_lock_status'] == 'Enabled'
+assert authority['storage']['retention_mode'] == 'COMPLIANCE'
+assert authority['storage']['retention_days'] == 90
+assert authority['storage']['delete_allowed'] is False
+assert authority['archive']['stream_passes'] == 2
+assert authority['archive']['local_archive_copy_allowed'] is False
+assert authority['restore']['exact_version_required'] is True
+assert authority['restore']['one_model_at_a_time'] is True
+assert authority['result']['benchmark_status'] == 'NOT_RUN'
+assert authority['result']['model_admission_status'] == 'NOT_DONE'
+assert authority['result']['production_operational_status'] == 'NOT_ATTESTED'
+PY
+
+required_inputs=(
+  MODEL_HOST MODEL_SSH_USER MODEL_SSH_PORT MODEL_SSH_KEY
+  S3_ENDPOINT S3_REGION S3_BUCKET S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY
+  S3_PREFIX S3_CAPACITY_BYTES S3_PRINCIPAL_ID
+)
+missing=()
+for name in "${required_inputs[@]}"; do
+  if [[ -z "${!name:-}" ]]; then missing+=("$name"); fi
+done
+if ((${#missing[@]})); then
+  MISSING="$(IFS=,; printf '%s' "${missing[*]}")" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+Path('bundle-finalization-evidence/missing-protected-inputs.json').write_text(
+    json.dumps({'status': 'FAILED_CLOSED', 'missing': os.environ['MISSING'].split(',')}, indent=2) + '\n'
+)
+PY
+  echo "Protected Selectel/model-host inputs are unavailable; no S3 mutation attempted." >&2
+  exit 1
+fi
+
+command -v aws >/dev/null
+command -v gh >/dev/null
+command -v jq >/dev/null
+[[ "$MODEL_HOST" =~ ^[A-Za-z0-9._:-]+$ ]]
+test "$MODEL_SSH_USER" = "tai-model"
+[[ "$MODEL_SSH_PORT" =~ ^[0-9]{1,5}$ ]]
+[[ "$S3_CAPACITY_BYTES" =~ ^[0-9]+$ ]]
+test "$S3_CAPACITY_BYTES" -ge 120000000000
+[[ "$S3_PREFIX" != /* ]]
+[[ "$S3_PREFIX" != */ ]]
+[[ "$S3_PREFIX" != *".."* ]]
+[[ "$S3_PREFIX" != *\\* ]]
+
+export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$S3_SECRET_ACCESS_KEY"
+export AWS_DEFAULT_REGION="$S3_REGION"
+export AWS_EC2_METADATA_DISABLED=true
+export AWS_PAGER=""
+endpoint=(--endpoint-url "$S3_ENDPOINT" --region "$S3_REGION")
+common=(--cli-connect-timeout 20 --cli-read-timeout 120)
+
+run_read_only() {
+  local name="$1"
+  shift
+  "$@" > "$EVIDENCE_ROOT/preflight/raw/${name}.json" 2> "$EVIDENCE_ROOT/preflight/raw/${name}.stderr"
+  printf '0\n' > "$EVIDENCE_ROOT/preflight/raw/${name}.exit"
+}
+run_read_only head_bucket aws "${endpoint[@]}" "${common[@]}" s3api head-bucket --bucket "$S3_BUCKET"
+run_read_only get_bucket_versioning aws "${endpoint[@]}" "${common[@]}" s3api get-bucket-versioning --bucket "$S3_BUCKET"
+run_read_only get_object_lock_configuration aws "${endpoint[@]}" "${common[@]}" s3api get-object-lock-configuration --bucket "$S3_BUCKET"
+run_read_only get_bucket_policy aws "${endpoint[@]}" "${common[@]}" s3api get-bucket-policy --bucket "$S3_BUCKET"
+run_read_only list_objects_v2 aws "${endpoint[@]}" "${common[@]}" s3api list-objects-v2 --bucket "$S3_BUCKET" --prefix "$S3_PREFIX/" --max-keys 1
+run_read_only list_object_versions aws "${endpoint[@]}" "${common[@]}" s3api list-object-versions --bucket "$S3_BUCKET" --prefix "$S3_PREFIX/" --max-keys 1
+anonymous_url="${S3_ENDPOINT%/}/$S3_BUCKET?list-type=2&max-keys=1"
+anonymous_status="$(curl --silent --show-error --output "$EVIDENCE_ROOT/preflight/raw/anonymous-list.body" --write-out '%{http_code}' --connect-timeout 20 --max-time 60 "$anonymous_url")"
+printf '%s\n' "$anonymous_status" > "$EVIDENCE_ROOT/preflight/raw/anonymous_list_http_status.txt"
+printf '0\n' > "$EVIDENCE_ROOT/preflight/raw/anonymous_list_probe.exit"
+aws --version > "$EVIDENCE_ROOT/preflight/raw/aws-version.txt" 2>&1
+
+S3_ENDPOINT="$S3_ENDPOINT" S3_REGION="$S3_REGION" S3_BUCKET="$S3_BUCKET" S3_PREFIX="$S3_PREFIX" S3_CAPACITY_BYTES="$S3_CAPACITY_BYTES" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+root = Path('bundle-finalization-evidence/preflight/raw')
+def object_json(name: str) -> dict[str, object]:
+    path = root / f'{name}.json'
+    if not path.exists() or not path.read_text().strip(): return {}
+    value = json.loads(path.read_text())
+    return value if isinstance(value, dict) else {}
+policy_wrapper = object_json('get_bucket_policy')
+raw_policy = policy_wrapper.get('Policy')
+policy = json.loads(raw_policy) if isinstance(raw_policy, str) else raw_policy
+if not isinstance(policy, dict): policy = {}
+commands = {
+    name: (root / f'{name}.exit').read_text().strip() == '0'
+    for name in (
+        'head_bucket', 'get_bucket_versioning', 'get_object_lock_configuration',
+        'get_bucket_policy', 'list_objects_v2', 'list_object_versions',
+        'anonymous_list_probe',
+    )
+}
+payload = {
+    'schema_version': 'tai.model-bundle-s3-preflight-observed.v1',
+    'provider_profile': 'SELECTEL_S3_2026',
+    'endpoint': os.environ['S3_ENDPOINT'],
+    'region': os.environ['S3_REGION'],
+    'bucket': os.environ['S3_BUCKET'],
+    'prefix': os.environ['S3_PREFIX'],
+    'operator_confirmed_capacity_bytes': os.environ['S3_CAPACITY_BYTES'],
+    'commands': commands,
+    'versioning': object_json('get_bucket_versioning'),
+    'object_lock': object_json('get_object_lock_configuration'),
+    'anonymous_list_http_status': (root / 'anonymous_list_http_status.txt').read_text().strip(),
+    'policy': policy,
+    'aws_cli_identity': (root / 'aws-version.txt').read_text(errors='replace')[:500],
+    'mutation_mode': 'READ_ONLY',
+}
+Path('bundle-finalization-evidence/preflight/observed.json').write_text(
+    json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n'
+)
+PY
+python3 -m tai.model_bundle_s3_preflight_cli "$PREFLIGHT_REQUIREMENTS" \
+  "$EVIDENCE_ROOT/preflight/observed.json" --exact-main "$GITHUB_SHA" \
+  --workflow-run-id "$GITHUB_RUN_ID" --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+  --output "$EVIDENCE_ROOT/preflight/report.json"
+test "$(jq -r '.status' "$EVIDENCE_ROOT/preflight/report.json")" = "READY_FOR_BUNDLE_UPLOAD"
+
+for attempt in $(seq 1 180); do
+  gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$GITHUB_SHA&per_page=100" \
+    > "$EVIDENCE_ROOT/release/runs.json"
+  set +e
+  GITHUB_SHA="$GITHUB_SHA" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+runs = json.loads(Path('bundle-finalization-evidence/release/runs.json').read_text()).get('workflow_runs', [])
+candidates = [
+    run for run in runs
+    if run.get('name') == 'TAI Release Acceptance'
+    and run.get('path') == '.github/workflows/tai-release-acceptance.yml'
+    and run.get('head_sha') == os.environ['GITHUB_SHA']
+    and run.get('head_branch') == 'main'
+    and run.get('event') in {'push', 'workflow_dispatch'}
+]
+if not candidates: raise SystemExit(3)
+run = max(candidates, key=lambda item: (item.get('run_number', 0), item.get('id', 0)))
+if run.get('status') != 'completed': raise SystemExit(3)
+if run.get('conclusion') != 'success': raise SystemExit(2)
+Path('bundle-finalization-evidence/release/selected-run.json').write_text(
+    json.dumps(run, ensure_ascii=False, indent=2, sort_keys=True) + '\n'
+)
+PY
+  status=$?
+  set -e
+  if [[ "$status" -eq 0 ]]; then break; fi
+  if [[ "$status" -eq 2 ]]; then echo "Exact-main Release Acceptance failed." >&2; exit 1; fi
+  if [[ "$attempt" -eq 180 ]]; then echo "Exact-main Release Acceptance absent." >&2; exit 1; fi
+  sleep 20
+done
+release_run_id="$(jq -r '.id' "$EVIDENCE_ROOT/release/selected-run.json")"
+gh api "repos/$GITHUB_REPOSITORY/actions/runs/$release_run_id/artifacts?per_page=100" > "$EVIDENCE_ROOT/release/artifacts.json"
+GITHUB_SHA="$GITHUB_SHA" RELEASE_RUN_ID="$release_run_id" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+artifacts = json.loads(Path('bundle-finalization-evidence/release/artifacts.json').read_text()).get('artifacts', [])
+expected = f"tai-release-attestation-{os.environ['GITHUB_SHA']}"
+matches = [item for item in artifacts if item.get('name') == expected and item.get('expired') is False]
+if len(matches) != 1: raise SystemExit('RELEASE_ARTIFACT_CARDINALITY_INVALID')
+Path('bundle-finalization-evidence/release/selected-artifact.json').write_text(
+    json.dumps(matches[0], ensure_ascii=False, indent=2, sort_keys=True) + '\n'
+)
+PY
+release_artifact_id="$(jq -r '.id' "$EVIDENCE_ROOT/release/selected-artifact.json")"
+gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$release_artifact_id/zip" > "$EVIDENCE_ROOT/release/artifact.zip"
+mkdir -p "$EVIDENCE_ROOT/release/artifact"
+unzip -q "$EVIDENCE_ROOT/release/artifact.zip" -d "$EVIDENCE_ROOT/release/artifact"
+GITHUB_SHA="$GITHUB_SHA" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+payload = json.loads(Path('bundle-finalization-evidence/release/artifact/tai-release-attestation.json').read_text())
+assert payload['exact_main_sha'] == os.environ['GITHUB_SHA']
+assert payload['accepted'] is True
+assert payload['reasons'] == []
+assert payload['production_operational_status'] == 'NOT_ATTESTED'
+PY
+rm -f "$EVIDENCE_ROOT/release/artifact.zip"
+
+python3 - <<'PY' > "$ACCEPTED_ROOT/source-artifacts.tsv"
+import json
+from pathlib import Path
+authority = json.loads(Path('apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json').read_text())
+for model in authority['models']:
+    print('\t'.join((model['key'], str(model['source_artifact_id']), model['source_artifact_digest'])))
+PY
+while IFS=$'\t' read -r key artifact_id expected_digest; do
+  mkdir -p "$ACCEPTED_ROOT/$key/content"
+  gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id" > "$ACCEPTED_ROOT/$key/artifact.json"
+  KEY="$key" ARTIFACT_ID="$artifact_id" EXPECTED_DIGEST="$expected_digest" python3 - <<'PY'
+import json
+import os
+import re
+from pathlib import Path
+artifact = json.loads(Path(f"accepted-artifacts/{os.environ['KEY']}/artifact.json").read_text())
+assert artifact['id'] == int(os.environ['ARTIFACT_ID'])
+assert artifact['expired'] is False
+digest = artifact.get('digest', '')
+assert re.fullmatch(r'sha256:[0-9a-f]{64}', digest)
+assert digest.split(':', 1)[1] == os.environ['EXPECTED_DIGEST']
+PY
+  gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" > "$ACCEPTED_ROOT/$key/artifact.zip"
+  test "$(sha256sum "$ACCEPTED_ROOT/$key/artifact.zip" | awk '{print $1}')" = "$expected_digest"
+  unzip -q "$ACCEPTED_ROOT/$key/artifact.zip" -d "$ACCEPTED_ROOT/$key/content"
+  rm -f "$ACCEPTED_ROOT/$key/artifact.zip"
+done < "$ACCEPTED_ROOT/source-artifacts.tsv"
+
+mkdir -p "$CONTROL_ROOT/source-metadata/qwen3-8b/legal" "$CONTROL_ROOT/source-metadata/mistral-7b-instruct-v0.3/legal"
+mkdir -p "$CONTROL_ROOT/legal-reviews/qwen3-8b" "$CONTROL_ROOT/legal-reviews/mistral-7b-instruct-v0.3"
+cp -R apps/tai/tai "$CONTROL_ROOT/tai"
+cp "$BUNDLE_AUTHORITY" "$CONTROL_ROOT/model-bundle-authority.v2.json"
+cp "$CONVERSION_AUTHORITY" "$CONTROL_ROOT/model-conversion-authority.v1.json"
+cp apps/tai/model-artifacts/llama-cpp-build-acceptance.v1.json "$CONTROL_ROOT/llama-cpp-build-acceptance.v1.json"
+cp apps/tai/model-artifacts/model-bundle-finalization-remote.v1.sh "$CONTROL_ROOT/model-bundle-finalization-remote.v1.sh"
+cp apps/tai/model-artifacts/model_bundle_finalization_remote.py "$CONTROL_ROOT/model_bundle_finalization_remote.py"
+for key in qwen3-8b mistral-7b-instruct-v0.3; do
+  cp "$ACCEPTED_ROOT/$key/content/remote-inventory.json" "$CONTROL_ROOT/source-metadata/$key/"
+  cp "$ACCEPTED_ROOT/$key/content/source-manifest.json" "$CONTROL_ROOT/source-metadata/$key/"
+  cp "$ACCEPTED_ROOT/$key/content/legal/LICENSE-2.0.txt" "$CONTROL_ROOT/source-metadata/$key/legal/"
+done
+cp apps/tai/model-artifacts/legal-reviews/qwen3-8b.review-record.v1.json "$CONTROL_ROOT/legal-reviews/qwen3-8b/review-record.json"
+cp apps/tai/model-artifacts/legal-reviews/mistral-7b-instruct-v0.3.review-record.v1.json "$CONTROL_ROOT/legal-reviews/mistral-7b-instruct-v0.3/review-record.json"
+chmod 700 "$CONTROL_ROOT/model-bundle-finalization-remote.v1.sh"
+(cd "$CONTROL_ROOT" && find . -type f ! -name control-manifest.sha256 -print0 | LC_ALL=C sort -z | xargs -0 sha256sum > control-manifest.sha256)
+tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -C "$CONTROL_ROOT" -czf control-package.tar.gz .
+sha256sum control-package.tar.gz > control-package.tar.gz.sha256
+
+LOCAL_CREDENTIALS="$RUNNER_TEMP/tai-bundle-s3-credentials.env"
+S3_ENDPOINT="$S3_ENDPOINT" S3_REGION="$S3_REGION" S3_BUCKET="$S3_BUCKET" S3_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID" S3_SECRET_ACCESS_KEY="$S3_SECRET_ACCESS_KEY" S3_PREFIX="$S3_PREFIX" python3 - <<'PY' > "$LOCAL_CREDENTIALS"
+import os
+import shlex
+for name in ('S3_ENDPOINT', 'S3_REGION', 'S3_BUCKET', 'S3_ACCESS_KEY_ID', 'S3_SECRET_ACCESS_KEY', 'S3_PREFIX'):
+    print(f"{name}={shlex.quote(os.environ[name])}")
+PY
+chmod 600 "$LOCAL_CREDENTIALS"
+
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+ssh-keyscan -p "$MODEL_SSH_PORT" -H "$MODEL_HOST" > "$HOME/.ssh/known_hosts"
+printf '%s\n' "$MODEL_SSH_KEY" > "$HOME/.ssh/id_tai_model"
+chmod 600 "$HOME/.ssh/known_hosts" "$HOME/.ssh/id_tai_model"
+ssh_command() {
+  ssh -i "$HOME/.ssh/id_tai_model" -p "$MODEL_SSH_PORT" -o BatchMode=yes -o StrictHostKeyChecking=yes "$MODEL_SSH_USER@$MODEL_HOST" "$@"
+}
+scp_file() {
+  scp -i "$HOME/.ssh/id_tai_model" -P "$MODEL_SSH_PORT" -o BatchMode=yes -o StrictHostKeyChecking=yes "$1" "$MODEL_SSH_USER@$MODEL_HOST:$2"
+}
+
+ssh_command "install -d -m 700 '$REMOTE_RUN_ROOT/incoming' '$REMOTE_RUN_ROOT/control' '$REMOTE_RUN_ROOT/evidence'"
+scp_file control-package.tar.gz "$REMOTE_RUN_ROOT/incoming/control-package.tar.gz"
+scp_file control-package.tar.gz.sha256 "$REMOTE_RUN_ROOT/incoming/control-package.tar.gz.sha256"
+scp_file "$LOCAL_CREDENTIALS" "$REMOTE_RUN_ROOT/incoming/s3-credentials.env"
+rm -f "$LOCAL_CREDENTIALS"
+LOCAL_CREDENTIALS=""
+
+remote_bootstrap="$(cat <<REMOTE
+set -euo pipefail
+cd '$REMOTE_RUN_ROOT/incoming'
+sha256sum -c control-package.tar.gz.sha256
+rm -rf '$REMOTE_RUN_ROOT/control.new'
+mkdir -m 700 '$REMOTE_RUN_ROOT/control.new'
+tar -xzf control-package.tar.gz -C '$REMOTE_RUN_ROOT/control.new'
+(cd '$REMOTE_RUN_ROOT/control.new' && sha256sum -c control-manifest.sha256)
+rm -rf '$REMOTE_RUN_ROOT/control.previous'
+if [ -d '$REMOTE_RUN_ROOT/control' ]; then mv '$REMOTE_RUN_ROOT/control' '$REMOTE_RUN_ROOT/control.previous'; fi
+mv '$REMOTE_RUN_ROOT/control.new' '$REMOTE_RUN_ROOT/control'
+chmod 600 '$REMOTE_RUN_ROOT/incoming/s3-credentials.env'
+bash '$REMOTE_RUN_ROOT/control/model-bundle-finalization-remote.v1.sh' \
+  '$REMOTE_RUN_ROOT' '$REMOTE_CONVERSION_ROOT' '$REMOTE_RUN_ROOT/incoming/s3-credentials.env'
+REMOTE
+)"
+set +e
+ssh_command "bash -s" <<< "$remote_bootstrap"
+remote_status=$?
+set -e
+
+mkdir -p "$EVIDENCE_ROOT/remote"
+set +e
+ssh_command "test -d '$REMOTE_RUN_ROOT/evidence' && tar -C '$REMOTE_RUN_ROOT' -czf - evidence" > remote-evidence.tar.gz
+fetch_status=$?
+set -e
+if [[ "$fetch_status" -eq 0 && -s remote-evidence.tar.gz ]]; then
+  if tar -tzf remote-evidence.tar.gz | grep -E '(^/|(^|/)\.\.(/|$))'; then
+    echo "Unsafe remote evidence path." >&2
+    exit 1
+  fi
+  tar -xzf remote-evidence.tar.gz -C "$EVIDENCE_ROOT/remote"
+fi
+rm -f remote-evidence.tar.gz
+
+test "$remote_status" -eq 0
+test -s "$EVIDENCE_ROOT/remote/evidence/finalization-report.json"
+python3 - <<'PY'
+import json
+from pathlib import Path
+root = Path('bundle-finalization-evidence/remote/evidence')
+report = json.loads((root / 'finalization-report.json').read_text())
+assert report['status'] == 'BUNDLES_IMMUTABLY_STORED_AND_CLEANLY_RESTORED'
+assert report['local_archive_copy_retained'] is False
+assert report['benchmark_status'] == 'NOT_RUN'
+assert report['model_admission_status'] == 'NOT_DONE'
+assert report['production_operational_status'] == 'NOT_ATTESTED'
+assert len(report['models']) == 2
+assert {item['key'] for item in report['models']} == {'qwen3-8b', 'mistral-7b-instruct-v0.3'}
+for item in report['models']:
+    assert len(item['archive_sha256']) == 64
+    assert item['archive_size_bytes'] > 1_000_000
+    assert item['version_id'] and item['version_id'] != 'null'
+    verification = json.loads((root / 'models' / item['key'] / 'verification-report.json').read_text())
+    assert verification['status'] == 'VERIFIED'
+    assert verification['report_sha256'] == item['verification_report_sha256']
+if any(path.stat().st_size > 10_000_000 for path in root.rglob('*') if path.is_file()):
+    raise SystemExit('BOUNDED_EVIDENCE_SIZE_EXCEEDED')
+if any(path.suffix == '.gguf' for path in root.rglob('*') if path.is_file()):
+    raise SystemExit('GGUF_ENTERED_GITHUB_EVIDENCE')
+PY
+
+FINAL_STATE="BUNDLES_IMMUTABLY_STORED_AND_CLEANLY_RESTORED"
+CURRENT_MODEL="COMPLETE"
+write_summary
+trap - EXIT
+cleanup

--- a/apps/tai/model-artifacts/model-bundle-finalization-remote.v1.sh
+++ b/apps/tai/model-artifacts/model-bundle-finalization-remote.v1.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+RUN_ROOT="${1:?run root required}"
+CONVERSION_ROOT="${2:?conversion root required}"
+CREDENTIALS_FILE="${3:?credentials file required}"
+CONTROL_ROOT="$RUN_ROOT/control"
+WORK_ROOT="$RUN_ROOT/work"
+EVIDENCE_ROOT="$RUN_ROOT/evidence"
+BUNDLE_AUTHORITY="$CONTROL_ROOT/model-bundle-authority.v2.json"
+CONVERSION_AUTHORITY="$CONTROL_ROOT/model-conversion-authority.v1.json"
+REMOTE_SCRIPT="$CONTROL_ROOT/model_bundle_finalization_remote.py"
+
+cleanup_credentials() {
+  rm -f "$CREDENTIALS_FILE"
+}
+trap cleanup_credentials EXIT
+
+case "$RUN_ROOT" in /srv/tai-models/bundle-finalization-runs/*) ;; *) exit 64;; esac
+test "$CONVERSION_ROOT" = "/srv/tai-models/conversion-runs/8bd494dc4954baaf699cffa243951392ff451ebb/29810648430-1"
+test "$(id -un)" = "tai-model"
+test -f "$CREDENTIALS_FILE"
+test ! -L "$CREDENTIALS_FILE"
+# shellcheck disable=SC1090
+source "$CREDENTIALS_FILE"
+rm -f "$CREDENTIALS_FILE"
+
+for name in S3_ENDPOINT S3_REGION S3_BUCKET S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY S3_PREFIX; do
+  test -n "${!name:-}"
+done
+for command_name in aws jq python3 tar mkfifo sha256sum stat findmnt; do
+  command -v "$command_name" >/dev/null
+done
+
+test -d "$CONTROL_ROOT/tai"
+test -f "$BUNDLE_AUTHORITY"
+test -f "$CONVERSION_AUTHORITY"
+test -f "$CONVERSION_ROOT/status.json"
+test -f "$CONVERSION_ROOT/evidence/conversion-report.json"
+test "$(findmnt -rn -o SOURCE -T "$RUN_ROOT")" = "$(findmnt -rn -o SOURCE -T "$CONVERSION_ROOT")"
+
+export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$S3_SECRET_ACCESS_KEY"
+export AWS_DEFAULT_REGION="$S3_REGION"
+export AWS_EC2_METADATA_DISABLED=true
+export AWS_PAGER=""
+export AWS_RETRY_MODE=standard
+export AWS_MAX_ATTEMPTS=5
+endpoint=(--endpoint-url "$S3_ENDPOINT" --region "$S3_REGION")
+common=(--cli-connect-timeout 20 --cli-read-timeout 0)
+
+mkdir -p "$WORK_ROOT/models" "$EVIDENCE_ROOT/models"
+chmod 700 "$WORK_ROOT" "$WORK_ROOT/models" "$EVIDENCE_ROOT" "$EVIDENCE_ROOT/models"
+
+tar_stream() {
+  local original_root="$1" payload_paths="$2"
+  tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner \
+    --format=posix --pax-option=delete=atime,delete=ctime \
+    -C "$original_root" -cf - --files-from "$payload_paths"
+}
+
+measure_stream() {
+  local output="$1"
+  python3 -c '
+import hashlib, json, sys
+output = sys.argv[1]
+digest = hashlib.sha256()
+size = 0
+while True:
+    chunk = sys.stdin.buffer.read(1024 * 1024)
+    if not chunk:
+        break
+    digest.update(chunk)
+    size += len(chunk)
+with open(output, "w", encoding="utf-8") as handle:
+    json.dump({"archive_sha256": digest.hexdigest(), "archive_size_bytes": size}, handle, indent=2, sort_keys=True)
+    handle.write("\\n")
+' "$output"
+}
+
+for model_key in qwen3-8b mistral-7b-instruct-v0.3; do
+  model_root="$WORK_ROOT/models/$model_key"
+  original_root="$model_root/original"
+  restore_root="$model_root/clean-restore"
+  model_evidence="$EVIDENCE_ROOT/models/$model_key"
+  mkdir -p "$model_evidence"
+
+  PYTHONPATH="$CONTROL_ROOT" python3 "$REMOTE_SCRIPT" prepare \
+    "$BUNDLE_AUTHORITY" "$CONVERSION_AUTHORITY" "$CONVERSION_ROOT" \
+    "$CONTROL_ROOT" "$WORK_ROOT" "$model_key"
+
+  payload_paths="$model_root/payload-paths.txt"
+  measure_path="$model_root/archive-measurement.json"
+  tar_stream "$original_root" "$payload_paths" | measure_stream "$measure_path"
+  archive_sha256="$(jq -r '.archive_sha256' "$measure_path")"
+  archive_size="$(jq -r '.archive_size_bytes' "$measure_path")"
+  [[ "$archive_sha256" =~ ^[0-9a-f]{64}$ ]]
+  [[ "$archive_size" =~ ^[0-9]+$ ]]
+  test "$archive_size" -gt 1000000
+
+  object_key="$S3_PREFIX/objects/sha256/$archive_sha256/$model_key.tar"
+  [[ "$object_key" != /* ]]
+  [[ "$object_key" != *".."* ]]
+
+  aws "${endpoint[@]}" "${common[@]}" s3api list-multipart-uploads \
+    --bucket "$S3_BUCKET" --prefix "$object_key" > "$model_root/multipart-before.json"
+  while IFS=$'\t' read -r stale_key upload_id; do
+    test "$stale_key" = "$object_key"
+    aws "${endpoint[@]}" "${common[@]}" s3api abort-multipart-upload \
+      --bucket "$S3_BUCKET" --key "$stale_key" --upload-id "$upload_id"
+  done < <(
+    jq -r --arg key "$object_key" \
+      '.Uploads[]? | select(.Key == $key) | [.Key, .UploadId] | @tsv' \
+      "$model_root/multipart-before.json"
+  )
+
+  tar_stream "$original_root" "$payload_paths" | \
+    aws "${endpoint[@]}" "${common[@]}" s3 cp - "s3://$S3_BUCKET/$object_key" \
+      --expected-size "$archive_size" --content-type application/x-tar \
+      --only-show-errors --no-progress
+
+  aws "${endpoint[@]}" "${common[@]}" s3api head-object \
+    --bucket "$S3_BUCKET" --key "$object_key" > "$model_root/head-object.json"
+  version_id="$(jq -r '.VersionId // empty' "$model_root/head-object.json")"
+  etag="$(jq -r '.ETag // empty' "$model_root/head-object.json")"
+  content_length="$(jq -r '.ContentLength // 0' "$model_root/head-object.json")"
+  last_modified="$(jq -r '.LastModified // empty' "$model_root/head-object.json")"
+  test -n "$version_id"
+  test "$version_id" != "null"
+  test "$content_length" = "$archive_size"
+  test -n "$etag"
+  test -n "$last_modified"
+
+  aws "${endpoint[@]}" "${common[@]}" s3api get-object-retention \
+    --bucket "$S3_BUCKET" --key "$object_key" --version-id "$version_id" \
+    > "$model_root/object-retention.json"
+  retention_mode="$(jq -r '.Retention.Mode // empty' "$model_root/object-retention.json")"
+  retention_until="$(jq -r '.Retention.RetainUntilDate // empty' "$model_root/object-retention.json")"
+  test "$retention_mode" = "COMPLIANCE"
+  test -n "$retention_until"
+
+  fifo="$model_root/archive.fifo"
+  rm -f "$fifo"
+  mkfifo -m 600 "$fifo"
+  PYTHONPATH="$CONTROL_ROOT" python3 "$REMOTE_SCRIPT" extract \
+    "$original_root/storage/payload-index.json" "$restore_root" \
+    "$model_root/archive-observation.json" < "$fifo" &
+  extractor_pid=$!
+  set +e
+  aws "${endpoint[@]}" "${common[@]}" s3api get-object \
+    --bucket "$S3_BUCKET" --key "$object_key" --version-id "$version_id" \
+    "$fifo" > "$model_root/get-object.json"
+  get_status=$?
+  wait "$extractor_pid"
+  extract_status=$?
+  set -e
+  rm -f "$fifo"
+  test "$get_status" -eq 0
+  test "$extract_status" -eq 0
+  test "$(jq -r '.VersionId // empty' "$model_root/get-object.json")" = "$version_id"
+  test "$(jq -r '.archive_sha256' "$model_root/archive-observation.json")" = "$archive_sha256"
+  test "$(jq -r '.archive_size_bytes' "$model_root/archive-observation.json")" = "$archive_size"
+
+  restored_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  endpoint_host="$(python3 -c 'import sys; from urllib.parse import urlsplit; print(urlsplit(sys.argv[1]).hostname or "")' "$S3_ENDPOINT")"
+  test -n "$endpoint_host"
+  ENDPOINT_HOST="$endpoint_host" OBJECT_KEY="$object_key" VERSION_ID="$version_id" \
+    ETAG="$etag" ARCHIVE_SHA256="$archive_sha256" ARCHIVE_SIZE="$archive_size" \
+    LAST_MODIFIED="$last_modified" RETENTION_UNTIL="$retention_until" RESTORED_AT="$restored_at" \
+    S3_BUCKET="$S3_BUCKET" S3_REGION="$S3_REGION" python3 - <<'PY' > "$model_root/object-record.json"
+import json
+import os
+from urllib.parse import quote
+key = os.environ['OBJECT_KEY']
+version_id = os.environ['VERSION_ID']
+digest = os.environ['ARCHIVE_SHA256']
+locator = (
+    f"s3+version://{os.environ['ENDPOINT_HOST']}/{os.environ['S3_BUCKET']}/{key}"
+    f"?versionId={quote(version_id, safe='')}#sha256={digest}"
+)
+payload = {
+    'endpoint_host': os.environ['ENDPOINT_HOST'],
+    'region': os.environ['S3_REGION'],
+    'bucket': os.environ['S3_BUCKET'],
+    'key': key,
+    'version_id': version_id,
+    'etag': os.environ['ETAG'],
+    'archive_sha256': digest,
+    'archive_size_bytes': int(os.environ['ARCHIVE_SIZE']),
+    'uploaded_at': os.environ['LAST_MODIFIED'],
+    'retention_expires_at': os.environ['RETENTION_UNTIL'],
+    'restored_at': os.environ['RESTORED_AT'],
+    'immutable_locator': locator,
+}
+print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+PY
+
+  PYTHONPATH="$CONTROL_ROOT" python3 "$REMOTE_SCRIPT" seal \
+    "$BUNDLE_AUTHORITY" "$model_root" "$model_root/object-record.json"
+  test "$(jq -r '.status' "$model_root/verification-report.json")" = "VERIFIED"
+  test "$(jq -r '.production_operational_status' "$model_root/verification-report.json")" = "NOT_ATTESTED"
+
+  cp "$model_root/manifest.json" "$model_evidence/"
+  cp "$model_root/prepare-report.json" "$model_evidence/"
+  cp "$measure_path" "$model_evidence/"
+  cp "$model_root/object-record.json" "$model_evidence/"
+  cp "$model_root/archive-observation.json" "$model_evidence/"
+  cp "$model_root/head-object.json" "$model_evidence/"
+  cp "$model_root/object-retention.json" "$model_evidence/"
+  cp "$model_root/get-object.json" "$model_evidence/"
+  cp "$model_root/verification-report.json" "$model_evidence/"
+  chmod 600 "$model_evidence"/*
+
+  rm -rf "$model_root"
+done
+
+EVIDENCE_ROOT="$EVIDENCE_ROOT" python3 - <<'PY'
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+root = Path(os.environ['EVIDENCE_ROOT'])
+models = []
+for key in ('qwen3-8b', 'mistral-7b-instruct-v0.3'):
+    report = json.loads((root / 'models' / key / 'verification-report.json').read_text())
+    object_record = json.loads((root / 'models' / key / 'object-record.json').read_text())
+    assert report['status'] == 'VERIFIED'
+    assert report['archive_sha256'] == object_record['archive_sha256']
+    models.append({
+        'key': key,
+        'model_id': report['model_id'],
+        'revision': report['revision'],
+        'archive_sha256': report['archive_sha256'],
+        'archive_size_bytes': report['archive_size_bytes'],
+        'immutable_locator': object_record['immutable_locator'],
+        'version_id': object_record['version_id'],
+        'verification_report_sha256': report['report_sha256'],
+    })
+payload = {
+    'schema_version': 'tai.model-bundle-finalization-report.v1',
+    'status': 'BUNDLES_IMMUTABLY_STORED_AND_CLEANLY_RESTORED',
+    'completed_at': datetime.now(timezone.utc).isoformat(),
+    'models': models,
+    'local_archive_copy_retained': False,
+    'benchmark_status': 'NOT_RUN',
+    'model_admission_status': 'NOT_DONE',
+    'production_operational_status': 'NOT_ATTESTED',
+    'reasons': [],
+}
+rendered = json.dumps(payload, ensure_ascii=False, separators=(',', ':'), sort_keys=True)
+payload['report_sha256'] = hashlib.sha256(rendered.encode()).hexdigest()
+(root / 'finalization-report.json').write_text(
+    json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n'
+)
+PY
+
+find "$EVIDENCE_ROOT" -type f -size +10000000c -print -quit | (! grep -q .)
+echo BUNDLES_IMMUTABLY_STORED_AND_CLEANLY_RESTORED

--- a/apps/tai/model-artifacts/model-bundle-finalization-runbook.v1.md
+++ b/apps/tai/model-artifacts/model-bundle-finalization-runbook.v1.md
@@ -1,0 +1,99 @@
+# TAI AP-13B.3h — immutable model-bundle finalization
+
+## Status boundary
+
+This authority finalizes the already completed governed conversion run into two independently restorable immutable model bundles. It does not benchmark, admit, activate or deploy a model. `production_operational_status` remains `NOT_ATTESTED`.
+
+## Exact input
+
+- conversion exact-main: `8bd494dc4954baaf699cffa243951392ff451ebb`;
+- conversion workflow run: `29810648430`, attempt `1`;
+- conversion root: `/srv/tai-models/conversion-runs/8bd494dc4954baaf699cffa243951392ff451ebb/29810648430-1`;
+- required conversion state: `COMPLETE`;
+- required conversion result: `CONVERSION_AND_QUANTIZATION_COMPLETE_PENDING_BUNDLE_RESTORE`;
+- models: exact Qwen3-8B and Mistral-7B-Instruct-v0.3 revisions already accepted by human legal review.
+
+The finalization workflow must not download sources, rerun conversion or rerun quantization.
+
+## Protected inputs
+
+Store values only as GitHub repository secrets:
+
+- `TAI_MODEL_HOST`
+- `TAI_MODEL_SSH_USER` — must be `tai-model`
+- `TAI_MODEL_SSH_PORT`
+- `TAI_MODEL_SSH_KEY`
+- `TAI_BUNDLE_S3_ENDPOINT`
+- `TAI_BUNDLE_S3_REGION`
+- `TAI_BUNDLE_S3_BUCKET`
+- `TAI_BUNDLE_S3_ACCESS_KEY_ID`
+- `TAI_BUNDLE_S3_SECRET_ACCESS_KEY`
+- `TAI_BUNDLE_S3_PREFIX` — recommended `tai/model-bundles/v1`
+- `TAI_BUNDLE_S3_CAPACITY_BYTES` — recommended `200000000000`
+- `TAI_BUNDLE_S3_PRINCIPAL_ID`
+
+Never place credential values in Git, issue comments, pull requests, logs or chat.
+
+## Preflight
+
+Before any S3 mutation, the workflow must prove:
+
+1. all protected inputs exist;
+2. exact-main TAI Release Acceptance is accepted;
+3. the external endpoint is HTTPS and non-local;
+4. bucket versioning is `Enabled`;
+5. Object Lock is `Enabled`;
+6. default retention is `COMPLIANCE` for 90 days;
+7. anonymous bucket listing is denied;
+8. deletion of objects and versions is denied under the governed prefix;
+9. confirmed external capacity is at least 120 GB.
+
+A failed or missing condition results in `FAILED_CLOSED` before archive upload.
+
+## Execution
+
+Owner command in issue `#2961`:
+
+```text
+/tai finalize model-bundles exact-main
+```
+
+For each model, one at a time, the workflow:
+
+1. assembles an original payload root using hard links on the dedicated model filesystem, avoiding duplication of multi-gigabyte files;
+2. binds exact source, human legal, accepted llama.cpp, conversion and quantization evidence;
+3. creates a canonical payload index that excludes itself and all post-seal storage records;
+4. produces a deterministic tar stream once to measure SHA-256 and byte length, retaining no local archive;
+5. derives the S3 key from the measured archive SHA-256;
+6. produces the same deterministic stream a second time directly into multipart S3 upload;
+7. records exact `VersionId`, ETag, content length and COMPLIANCE retention;
+8. downloads that exact object version through a FIFO into a clean extractor, retaining no downloaded archive file;
+9. rejects path traversal, links, duplicate members, undeclared members, size drift and SHA-256 drift;
+10. verifies the clean restore against the original payload and exact authority;
+11. saves only bounded metadata evidence, then removes temporary hard links and restored bytes.
+
+Accepted S3 objects and versions are never deleted by this workflow.
+
+## Expected result
+
+Both bundles must report:
+
+- external verification: `VERIFIED`;
+- immutable content-addressed locator with exact `VersionId`;
+- archive SHA-256 and byte length matched on upload and restore;
+- Object Lock mode: `COMPLIANCE`;
+- local bundle archive retained: `false`;
+- benchmark: `NOT_RUN`;
+- model admission: `NOT_DONE`;
+- production operational status: `NOT_ATTESTED`.
+
+The bounded workflow artifact is not model storage. It contains metadata and verification records only.
+
+## Subsequent acceptance
+
+After a real successful run:
+
+1. create a separate acceptance PR containing only bounded locator and verification metadata;
+2. verify exact-head and exact-main gates;
+3. close `#2954` and `#2961` only after both model acceptance records are merged;
+4. proceed to AP-13C benchmark authority without claiming admission or production readiness.

--- a/apps/tai/model-artifacts/model_bundle_finalization_remote.py
+++ b/apps/tai/model-artifacts/model_bundle_finalization_remote.py
@@ -1,0 +1,729 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tarfile
+from collections.abc import Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any, BinaryIO, cast
+
+from tai.model_bundle_external_storage import verify_external_model_bundle
+from tai.model_bundle_v2 import authority_sha256_v2, load_model_bundle_authority_v2
+
+_CHUNK_SIZE = 1024 * 1024
+
+
+def prepare_bundle(
+    *,
+    bundle_authority_path: Path,
+    conversion_authority_path: Path,
+    conversion_root: Path,
+    control_root: Path,
+    work_root: Path,
+    model_key: str,
+) -> dict[str, object]:
+    bundle_authority = load_model_bundle_authority_v2(bundle_authority_path)
+    conversion_authority = _load_json(conversion_authority_path)
+    model = _model_record(conversion_authority, model_key)
+    plan = next(
+        (
+            item
+            for item in bundle_authority.models
+            if item.model_id == model["model_id"] and item.revision == model["revision"]
+        ),
+        None,
+    )
+    if plan is None:
+        raise ValueError("model is absent from bundle authority")
+    _verify_completed_conversion(conversion_authority, conversion_root)
+
+    model_root = work_root / "models" / model_key
+    original_root = model_root / "original"
+    if model_root.exists():
+        _safe_remove_tree(model_root, work_root)
+    original_root.mkdir(parents=True, mode=0o700)
+
+    source_metadata = control_root / "source-metadata" / model_key
+    source_manifest = _load_json(source_metadata / "source-manifest.json")
+    remote_inventory = _load_json(source_metadata / "remote-inventory.json")
+    if source_manifest.get("model_id") != plan.model_id:
+        raise ValueError("source manifest model identity mismatch")
+    if source_manifest.get("revision") != plan.revision:
+        raise ValueError("source manifest revision mismatch")
+    if source_manifest.get("source_files_sha256") != model["source_files_sha256"]:
+        raise ValueError("source manifest digest mismatch")
+
+    source_files: list[dict[str, object]] = []
+    for item in _objects(source_manifest.get("files")):
+        relative = _text(item.get("path"))
+        role = _text(item.get("role"))
+        source = conversion_root / relative
+        target = original_root / relative
+        _hardlink_large(source, target)
+        declared = _declared_file(target, relative)
+        if declared["sha256"] != item.get("sha256"):
+            raise ValueError(f"source SHA-256 mismatch: {relative}")
+        if declared["size_bytes"] != item.get("size_bytes"):
+            raise ValueError(f"source size mismatch: {relative}")
+        source_files.append({**declared, "role": role})
+
+    normalized_remote = {
+        "schema_version": "tai.remote-model-inventory-evidence.v1",
+        "model_id": plan.model_id,
+        "revision": plan.revision,
+        "source_uri": plan.source_uri,
+        "observed_at": remote_inventory.get("observed_at"),
+        "entries": [
+            {
+                "path": item.get("path"),
+                "remote_identity": item.get("remote_identity"),
+                "size_bytes": item.get("size_bytes"),
+            }
+            for item in _objects(remote_inventory.get("entries"))
+        ],
+    }
+    remote_path = original_root / "evidence/remote-inventory.json"
+    _write_json(remote_path, normalized_remote)
+    remote_declared = _declared_file(remote_path, "evidence/remote-inventory.json")
+
+    review = _load_json(control_root / "legal-reviews" / model_key / "review-record.json")
+    if review.get("decision") != "APPROVED" or review.get("reviewer_type") != "HUMAN":
+        raise ValueError("legal review is not an approved human decision")
+    license_source = source_metadata / "legal/LICENSE-2.0.txt"
+    license_target = original_root / "legal/LICENSE-2.0.txt"
+    _copy_small(license_source, license_target)
+    license_declared = _declared_file(license_target, "legal/LICENSE-2.0.txt")
+    if license_declared["sha256"] != review.get("license_text_sha256"):
+        raise ValueError("license text does not match legal review")
+    review_target = original_root / "legal/review-record.json"
+    _copy_small(control_root / "legal-reviews" / model_key / "review-record.json", review_target)
+    review_declared = _declared_file(review_target, "legal/review-record.json")
+
+    toolchain_acceptance = _load_json(control_root / "llama-cpp-build-acceptance.v1.json")
+    package_source = conversion_root / "control/toolchain/llama-cpp-b9637-evidence.tar.gz"
+    package_target = original_root / "toolchain/package.tar.gz"
+    _hardlink_large(package_source, package_target)
+    package_declared = _declared_file(package_target, "toolchain/package.tar.gz")
+    accepted_package = _mapping(
+        _mapping(toolchain_acceptance.get("external_artifacts")).get("package_artifact")
+    )
+    if package_declared["sha256"] != accepted_package.get("payload_sha256"):
+        raise ValueError("toolchain package SHA-256 mismatch")
+    if package_declared["size_bytes"] != accepted_package.get("payload_size_bytes"):
+        raise ValueError("toolchain package size mismatch")
+
+    build_source = (
+        conversion_root / "toolchain/restore/llama-evidence/evidence/llama-cpp-build.v1.json"
+    )
+    verification_source = (
+        conversion_root / "toolchain/restore/llama-evidence/evidence/llama-cpp-verification.v1.json"
+    )
+    build_target = original_root / "toolchain/build-manifest.json"
+    verification_target = original_root / "toolchain/verification-report.json"
+    _copy_small(build_source, build_target)
+    _copy_small(verification_source, verification_target)
+    build_declared = _declared_file(build_target, "toolchain/build-manifest.json")
+    verification_declared = _declared_file(
+        verification_target, "toolchain/verification-report.json"
+    )
+    accepted_evidence = _mapping(toolchain_acceptance.get("evidence"))
+    if build_declared["sha256"] != _mapping(accepted_evidence.get("build_manifest")).get("sha256"):
+        raise ValueError("toolchain build manifest mismatch")
+    if verification_declared["sha256"] != _mapping(
+        accepted_evidence.get("verification_report")
+    ).get("sha256"):
+        raise ValueError("toolchain verification report mismatch")
+
+    binaries: list[dict[str, object]] = []
+    accepted_binaries = {
+        _text(item.get("target")): item for item in _objects(accepted_evidence.get("binaries"))
+    }
+    for name in bundle_authority.toolchain.required_binaries:
+        source = conversion_root / "toolchain/bin" / name
+        target = original_root / "toolchain/bin" / name
+        _hardlink_large(source, target)
+        declared = _declared_file(target, f"toolchain/bin/{name}")
+        accepted = accepted_binaries.get(name)
+        if accepted is None:
+            raise ValueError(f"accepted toolchain binary missing: {name}")
+        if declared["sha256"] != accepted.get("sha256"):
+            raise ValueError(f"toolchain binary SHA-256 mismatch: {name}")
+        if declared["size_bytes"] != accepted.get("size_bytes"):
+            raise ValueError(f"toolchain binary size mismatch: {name}")
+        binaries.append({"name": name, "file": declared})
+
+    converter_source = conversion_root / "toolchain/source/convert_hf_to_gguf.py"
+    converter_target = original_root / plan.conversion.converter_path
+    _hardlink_large(converter_source, converter_target)
+    converter_declared = _declared_file(converter_target, plan.conversion.converter_path)
+
+    dependencies_source = conversion_root / "evidence/python-dependencies.txt"
+    dependencies_target = original_root / "conversion/python-dependencies.txt"
+    _copy_small(dependencies_source, dependencies_target)
+    dependencies_declared = _declared_file(
+        dependencies_target, "conversion/python-dependencies.txt"
+    )
+
+    convert_step_key = f"{model_key}-convert"
+    conversion_step = _load_json(conversion_root / "evidence/steps" / f"{convert_step_key}.json")
+    _require_complete_step(conversion_step, convert_step_key)
+    conversion_log_source = conversion_root / "logs" / f"{convert_step_key}.log"
+    conversion_log_target = original_root / "conversion/convert.log"
+    _hardlink_large(conversion_log_source, conversion_log_target)
+    conversion_log_declared = _declared_file(conversion_log_target, "conversion/convert.log")
+    if conversion_log_declared["sha256"] != _mapping(conversion_step.get("log")).get("sha256"):
+        raise ValueError("conversion log mismatch")
+
+    intermediate_relative = plan.conversion.intermediate_path
+    intermediate_source = conversion_root / intermediate_relative
+    intermediate_target = original_root / intermediate_relative
+    _hardlink_large(intermediate_source, intermediate_target)
+    intermediate_declared = _declared_file(intermediate_target, intermediate_relative)
+    if intermediate_declared["sha256"] != _mapping(conversion_step.get("output")).get("sha256"):
+        raise ValueError("conversion intermediate mismatch")
+
+    quantizations: list[dict[str, object]] = []
+    quantize_sha = next(
+        _text(_mapping(item.get("file")).get("sha256"))
+        for item in binaries
+        if item.get("name") == "llama-quantize"
+    )
+    for index, quantization in enumerate(plan.quantizations, start=1):
+        suffix = quantization.quantization.lower().replace("_", "-")
+        step_key = f"{model_key}-{suffix}"
+        step = _load_json(conversion_root / "evidence/steps" / f"{step_key}.json")
+        _require_complete_step(step, step_key)
+        log_relative = f"quantization/{index}-{quantization.quantization}.log"
+        log_target = original_root / log_relative
+        _hardlink_large(conversion_root / "logs" / f"{step_key}.log", log_target)
+        log_declared = _declared_file(log_target, log_relative)
+        output_relative = quantization.output_path
+        output_target = original_root / output_relative
+        _hardlink_large(conversion_root / output_relative, output_target)
+        output_declared = _declared_file(output_target, output_relative)
+        if log_declared["sha256"] != _mapping(step.get("log")).get("sha256"):
+            raise ValueError(f"quantization log mismatch: {step_key}")
+        if output_declared["sha256"] != _mapping(step.get("output")).get("sha256"):
+            raise ValueError(f"quantization output mismatch: {step_key}")
+        quantizations.append(
+            {
+                "runtime_class": quantization.runtime_class.value,
+                "quantization": quantization.quantization,
+                "argv": list(quantization.argv),
+                "log": log_declared,
+                "output": output_declared,
+                "input_sha256": intermediate_declared["sha256"],
+                "quantize_binary_sha256": quantize_sha,
+            }
+        )
+
+    source_files_sorted = sorted(source_files, key=lambda item: _text(item.get("path")))
+    package_locator = (
+        "gh-actions://pachaninm-lab/pachanin-demo/actions/artifacts/"
+        f"{accepted_package.get('id')}@sha256:{package_declared['sha256']}"
+    )
+    manifest: dict[str, object] = {
+        "schema_version": "tai.external-model-bundle.v1",
+        "lifecycle": "COMPLETE",
+        "role": plan.role.value,
+        "model_id": plan.model_id,
+        "revision": plan.revision,
+        "authority_sha256": authority_sha256_v2(bundle_authority),
+        "remote_inventory": {
+            "model_id": plan.model_id,
+            "revision": plan.revision,
+            "source_uri": plan.source_uri,
+            "observed_at": normalized_remote["observed_at"],
+            "entries": normalized_remote["entries"],
+            "evidence_file": remote_declared,
+        },
+        "source_files": source_files_sorted,
+        "legal_review": {
+            "decision": review.get("decision"),
+            "reviewer_type": review.get("reviewer_type"),
+            "reviewer_id": review.get("reviewer_id"),
+            "reviewer_name": review.get("reviewer_name"),
+            "reviewed_at": review.get("reviewed_at"),
+            "license_spdx": review.get("license_spdx"),
+            "decision_basis": review.get("decision_basis"),
+            "conditions": review.get("conditions"),
+            "record_type": review.get("record_type"),
+            "attestation_reference": review.get("attestation_reference"),
+            "license_text": license_declared,
+            "review_record": review_declared,
+        },
+        "toolchain_package": {
+            "name": bundle_authority.toolchain.name,
+            "release": bundle_authority.toolchain.release,
+            "commit": bundle_authority.toolchain.commit,
+            "profile": bundle_authority.toolchain.profile,
+            "authority_sha256": bundle_authority.toolchain.authority_sha256,
+            "package": package_declared,
+            "build_manifest": build_declared,
+            "verification_report": verification_declared,
+            "verification_status": "VERIFIED",
+            "immutable_locator": package_locator,
+            "binaries": binaries,
+        },
+        "conversion": {
+            "python_identity": _python_identity(conversion_root),
+            "python_dependencies": dependencies_declared,
+            "converter": converter_declared,
+            "argv": list(plan.conversion.argv),
+            "log": conversion_log_declared,
+            "intermediate": intermediate_declared,
+            "source_files_sha256": _canonical_sha256(
+                [
+                    {
+                        "path": item["path"],
+                        "role": item["role"],
+                        "sha256": item["sha256"],
+                        "size_bytes": item["size_bytes"],
+                    }
+                    for item in source_files_sorted
+                ]
+            ),
+            "toolchain_package_sha256": package_declared["sha256"],
+        },
+        "quantizations": quantizations,
+        "storage": None,
+        "benchmark_status": "NOT_RUN",
+        "model_admission_status": "NOT_DONE",
+        "production_operational_status": "NOT_ATTESTED",
+    }
+
+    declarations = _payload_declarations(manifest)
+    payload_entries = [
+        {
+            "path": item["path"],
+            "sha256": item["sha256"],
+            "size_bytes": item["size_bytes"],
+        }
+        for item in sorted(declarations, key=lambda item: _text(item.get("path")))
+    ]
+    payload_index = {
+        "schema_version": "tai.model-bundle-payload-index.v1",
+        "model_id": plan.model_id,
+        "revision": plan.revision,
+        "entries": payload_entries,
+    }
+    payload_index_path = original_root / "storage/payload-index.json"
+    _write_json(payload_index_path, payload_index)
+    _write_json(model_root / "manifest.pre-storage.json", manifest)
+    (model_root / "payload-paths.txt").write_text(
+        "\n".join(_text(item["path"]) for item in payload_entries) + "\n",
+        encoding="utf-8",
+    )
+    report: dict[str, object] = {
+        "schema_version": "tai.model-bundle-prepare-report.v1",
+        "status": "PREPARED_FOR_STREAMING",
+        "model_key": model_key,
+        "model_id": plan.model_id,
+        "revision": plan.revision,
+        "payload_files": len(payload_entries),
+        "payload_bytes": sum(cast(int, item["size_bytes"]) for item in payload_entries),
+        "original_root": str(original_root),
+        "payload_paths": str(model_root / "payload-paths.txt"),
+        "local_archive_copy": False,
+        "benchmark_status": "NOT_RUN",
+        "model_admission_status": "NOT_DONE",
+        "production_operational_status": "NOT_ATTESTED",
+    }
+    report["report_sha256"] = _canonical_sha256(report)
+    _write_json(model_root / "prepare-report.json", report)
+    return report
+
+
+def extract_stream(
+    *, payload_index_path: Path, restore_root: Path, observation_path: Path
+) -> dict[str, object]:
+    index = _load_json(payload_index_path)
+    if index.get("schema_version") != "tai.model-bundle-payload-index.v1":
+        raise ValueError("payload index schema invalid")
+    expected = {_text(item.get("path")): item for item in _objects(index.get("entries"))}
+    if not expected:
+        raise ValueError("payload index is empty")
+    if restore_root.exists():
+        if any(restore_root.iterdir()):
+            raise ValueError("clean restore root is not empty")
+    else:
+        restore_root.mkdir(parents=True, mode=0o700)
+
+    reader = _HashingReader(sys.stdin.buffer)
+    observed: dict[str, dict[str, object]] = {}
+    try:
+        with tarfile.open(fileobj=cast(BinaryIO, reader), mode="r|") as archive:
+            for member in archive:
+                relative = _safe_relative(member.name)
+                if relative is None:
+                    raise ValueError(f"unsafe archive member path: {member.name}")
+                if not member.isreg():
+                    raise ValueError(f"archive member is not regular: {relative}")
+                if relative in observed:
+                    raise ValueError(f"duplicate archive member: {relative}")
+                declared = expected.get(relative)
+                if declared is None:
+                    raise ValueError(f"archive member is not declared: {relative}")
+                if member.size != _integer(declared.get("size_bytes")):
+                    raise ValueError(f"archive member size mismatch: {relative}")
+                source = archive.extractfile(member)
+                if source is None:
+                    raise ValueError(f"archive member cannot be read: {relative}")
+                target = restore_root / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                digest = hashlib.sha256()
+                written = 0
+                with target.open("xb") as output:
+                    while chunk := source.read(_CHUNK_SIZE):
+                        output.write(chunk)
+                        digest.update(chunk)
+                        written += len(chunk)
+                if written != member.size:
+                    raise ValueError(f"archive member truncated: {relative}")
+                value = digest.hexdigest()
+                if value != _text(declared.get("sha256")):
+                    raise ValueError(f"archive member SHA-256 mismatch: {relative}")
+                observed[relative] = {
+                    "path": relative,
+                    "size_bytes": written,
+                    "sha256": value,
+                }
+        while reader.read(_CHUNK_SIZE):
+            pass
+        if set(observed) != set(expected):
+            missing = sorted(set(expected) - set(observed))
+            raise ValueError(f"archive payload incomplete: {missing}")
+        report: dict[str, object] = {
+            "schema_version": "tai.model-bundle-archive-observation.v1",
+            "archive_sha256": reader.hexdigest(),
+            "archive_size_bytes": reader.size_bytes,
+            "entries": [observed[path] for path in sorted(observed)],
+        }
+        _write_json(observation_path, report)
+        return report
+    except Exception:
+        _safe_remove_tree(restore_root, restore_root.parent)
+        raise
+
+
+def seal_bundle(
+    *,
+    bundle_authority_path: Path,
+    model_root: Path,
+    object_record_path: Path,
+) -> dict[str, object]:
+    manifest = _load_json(model_root / "manifest.pre-storage.json")
+    object_record = _load_json(object_record_path)
+    observation_path = model_root / "archive-observation.json"
+    observation = _load_json(observation_path)
+    original_root = model_root / "original"
+    restore_root = model_root / "clean-restore"
+    archive_sha256 = _text(object_record.get("archive_sha256"))
+    archive_size = _integer(object_record.get("archive_size_bytes"))
+    if observation.get("archive_sha256") != archive_sha256:
+        raise ValueError("restored archive SHA-256 differs from uploaded archive")
+    if observation.get("archive_size_bytes") != archive_size:
+        raise ValueError("restored archive size differs from uploaded archive")
+
+    storage_object = {
+        "endpoint_host": object_record.get("endpoint_host"),
+        "region": object_record.get("region"),
+        "bucket": object_record.get("bucket"),
+        "key": object_record.get("key"),
+        "version_id": object_record.get("version_id"),
+        "etag": object_record.get("etag"),
+    }
+    locator = _text(object_record.get("immutable_locator"))
+    upload = {
+        "schema_version": "tai.model-bundle-upload-record.v2",
+        "archive_sha256": archive_sha256,
+        "archive_size_bytes": archive_size,
+        "immutable_locator": locator,
+        "object": storage_object,
+        "uploaded_at": object_record.get("uploaded_at"),
+        "retention_mode": "COMPLIANCE",
+        "retention_days": 90,
+        "retention_expires_at": object_record.get("retention_expires_at"),
+    }
+    upload_path = original_root / "storage/upload-record.json"
+    _write_json(upload_path, upload)
+    restore = {
+        "schema_version": "tai.model-bundle-restore-record.v2",
+        "archive_sha256": archive_sha256,
+        "archive_size_bytes": archive_size,
+        "immutable_locator": locator,
+        "object": storage_object,
+        "restored_at": object_record.get("restored_at"),
+        "archive_observation_sha256": _canonical_sha256(observation),
+    }
+    restore_path = original_root / "storage/restore-record.json"
+    _write_json(restore_path, restore)
+    payload_index_path = original_root / "storage/payload-index.json"
+    manifest["storage"] = {
+        "archive": {
+            "sha256": archive_sha256,
+            "size_bytes": archive_size,
+            "media_type": "application/x-tar",
+        },
+        "payload_index": _declared_file(payload_index_path, "storage/payload-index.json"),
+        "immutable_locator": locator,
+        "object": storage_object,
+        "uploaded_at": object_record.get("uploaded_at"),
+        "retention_mode": "COMPLIANCE",
+        "retention_days": 90,
+        "retention_expires_at": object_record.get("retention_expires_at"),
+        "restored_at": object_record.get("restored_at"),
+        "upload_record": _declared_file(upload_path, "storage/upload-record.json"),
+        "restore_record": _declared_file(restore_path, "storage/restore-record.json"),
+    }
+    manifest_path = model_root / "manifest.json"
+    _write_json(manifest_path, manifest)
+    verification = verify_external_model_bundle(
+        authority_path=bundle_authority_path,
+        manifest_path=manifest_path,
+        original_root=original_root,
+        restored_root=restore_root,
+        archive_observation_path=observation_path,
+    )
+    _write_json(model_root / "verification-report.json", verification)
+    if verification["status"] != "VERIFIED":
+        raise ValueError(f"external bundle verification rejected: {verification['reasons']}")
+    return verification
+
+
+class _HashingReader:
+    def __init__(self, source: BinaryIO) -> None:
+        self._source = source
+        self._digest = hashlib.sha256()
+        self.size_bytes = 0
+
+    def read(self, size: int = -1) -> bytes:
+        data = self._source.read(size)
+        if data:
+            self._digest.update(data)
+            self.size_bytes += len(data)
+        return data
+
+    def hexdigest(self) -> str:
+        return self._digest.hexdigest()
+
+
+def _verify_completed_conversion(authority: dict[str, Any], root: Path) -> None:
+    status = _load_json(root / "status.json")
+    report = _load_json(root / "evidence/conversion-report.json")
+    if status.get("state") != "COMPLETE":
+        raise ValueError("conversion run is not complete")
+    if report.get("status") != _mapping(authority.get("result")).get("complete_status"):
+        raise ValueError("conversion report status mismatch")
+    if report.get("benchmark_status") != "NOT_RUN":
+        raise ValueError("unexpected benchmark status")
+    if report.get("model_admission_status") != "NOT_DONE":
+        raise ValueError("unexpected model admission status")
+    if report.get("production_operational_status") != "NOT_ATTESTED":
+        raise ValueError("unexpected production operational status")
+
+
+def _require_complete_step(step: dict[str, Any], expected_key: str) -> None:
+    if step.get("step_key") != expected_key or step.get("status") != "COMPLETE":
+        raise ValueError(f"conversion step is not complete: {expected_key}")
+    if step.get("exit_code") != 0:
+        raise ValueError(f"conversion step exit code is non-zero: {expected_key}")
+
+
+def _model_record(authority: dict[str, Any], key: str) -> dict[str, Any]:
+    matches = [item for item in _objects(authority.get("models")) if item.get("key") == key]
+    if len(matches) != 1:
+        raise ValueError(f"conversion authority model cardinality invalid: {key}")
+    return matches[0]
+
+
+def _payload_declarations(manifest: dict[str, object]) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = list(_objects(manifest.get("source_files")))
+    remote = _mapping(manifest.get("remote_inventory"))
+    result.append(_mapping(remote.get("evidence_file")))
+    legal = _mapping(manifest.get("legal_review"))
+    result.extend([_mapping(legal.get("license_text")), _mapping(legal.get("review_record"))])
+    toolchain = _mapping(manifest.get("toolchain_package"))
+    result.extend(
+        [
+            _mapping(toolchain.get("package")),
+            _mapping(toolchain.get("build_manifest")),
+            _mapping(toolchain.get("verification_report")),
+        ]
+    )
+    result.extend(_mapping(item.get("file")) for item in _objects(toolchain.get("binaries")))
+    conversion = _mapping(manifest.get("conversion"))
+    result.extend(
+        [
+            _mapping(conversion.get("python_dependencies")),
+            _mapping(conversion.get("converter")),
+            _mapping(conversion.get("log")),
+            _mapping(conversion.get("intermediate")),
+        ]
+    )
+    for item in _objects(manifest.get("quantizations")):
+        result.extend([_mapping(item.get("log")), _mapping(item.get("output"))])
+    return result
+
+
+def _python_identity(conversion_root: Path) -> str:
+    version_path = conversion_root / "evidence/python-version.txt"
+    return version_path.read_text(encoding="utf-8").strip()
+
+
+def _hardlink_large(source: Path, target: Path) -> None:
+    source = source.resolve(strict=True)
+    if not source.is_file() or source.is_symlink():
+        raise ValueError(f"large payload source is not a regular file: {source}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.link(source, target)
+    except OSError as error:
+        raise ValueError(f"large payload hardlink failed: {source}") from error
+
+
+def _copy_small(source: Path, target: Path) -> None:
+    source = source.resolve(strict=True)
+    if not source.is_file() or source.is_symlink():
+        raise ValueError(f"metadata source is not a regular file: {source}")
+    if source.stat().st_size > 50_000_000:
+        raise ValueError(f"metadata file exceeds bounded copy limit: {source}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, target)
+    target.chmod(0o600)
+
+
+def _declared_file(path: Path, relative: str) -> dict[str, object]:
+    path = path.resolve(strict=True)
+    if not path.is_file() or path.is_symlink():
+        raise ValueError(f"declared path is not a regular file: {relative}")
+    return {
+        "path": relative,
+        "size_bytes": path.stat().st_size,
+        "sha256": _sha256_file(path),
+    }
+
+
+def _safe_remove_tree(path: Path, boundary: Path) -> None:
+    if not path.exists():
+        return
+    resolved_boundary = boundary.resolve(strict=True)
+    resolved = path.resolve(strict=True)
+    if resolved == resolved_boundary or resolved_boundary not in resolved.parents:
+        raise ValueError(f"cleanup path escapes boundary: {path}")
+    shutil.rmtree(resolved)
+
+
+def _safe_relative(value: str) -> str | None:
+    path = PurePosixPath(value)
+    if path.is_absolute() or not path.parts or any(part in {"", ".", ".."} for part in path.parts):
+        return None
+    return value if path.as_posix() == value else None
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON root is not an object: {path}")
+    return payload
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _objects(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _text(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _integer(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_CHUNK_SIZE), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_sha256(value: object) -> str:
+    rendered = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(rendered.encode()).hexdigest()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="TAI external model-bundle remote operations")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("bundle_authority", type=Path)
+    prepare.add_argument("conversion_authority", type=Path)
+    prepare.add_argument("conversion_root", type=Path)
+    prepare.add_argument("control_root", type=Path)
+    prepare.add_argument("work_root", type=Path)
+    prepare.add_argument("model_key")
+
+    extract = subparsers.add_parser("extract")
+    extract.add_argument("payload_index", type=Path)
+    extract.add_argument("restore_root", type=Path)
+    extract.add_argument("observation", type=Path)
+
+    seal = subparsers.add_parser("seal")
+    seal.add_argument("bundle_authority", type=Path)
+    seal.add_argument("model_root", type=Path)
+    seal.add_argument("object_record", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = build_parser().parse_args(argv)
+    if arguments.command == "prepare":
+        prepare_bundle(
+            bundle_authority_path=arguments.bundle_authority,
+            conversion_authority_path=arguments.conversion_authority,
+            conversion_root=arguments.conversion_root,
+            control_root=arguments.control_root,
+            work_root=arguments.work_root,
+            model_key=arguments.model_key,
+        )
+        return 0
+    if arguments.command == "extract":
+        extract_stream(
+            payload_index_path=arguments.payload_index,
+            restore_root=arguments.restore_root,
+            observation_path=arguments.observation,
+        )
+        return 0
+    if arguments.command == "seal":
+        seal_bundle(
+            bundle_authority_path=arguments.bundle_authority,
+            model_root=arguments.model_root,
+            object_record_path=arguments.object_record,
+        )
+        return 0
+    raise AssertionError("unreachable command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/tai/tai/model_bundle_external_storage.py
+++ b/apps/tai/tai/model_bundle_external_storage.py
@@ -1,0 +1,634 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from tai.model_bundle_v2 import (
+    InventoryDisposition,
+    authority_sha256_v2,
+    load_model_bundle_authority_v2,
+)
+
+_MANIFEST_SCHEMA = "tai.external-model-bundle.v1"
+_INDEX_SCHEMA = "tai.model-bundle-payload-index.v1"
+_OBSERVATION_SCHEMA = "tai.model-bundle-archive-observation.v1"
+_REPORT_SCHEMA = "tai.external-model-bundle-verification-report.v1"
+_UPLOAD_SCHEMA = "tai.model-bundle-upload-record.v2"
+_RESTORE_SCHEMA = "tai.model-bundle-restore-record.v2"
+_CHUNK_SIZE = 1024 * 1024
+
+
+def verify_external_model_bundle(
+    *,
+    authority_path: Path,
+    manifest_path: Path,
+    original_root: Path,
+    restored_root: Path,
+    archive_observation_path: Path,
+) -> dict[str, object]:
+    """Verify a clean restore without requiring a second local copy of the large archive."""
+
+    authority = load_model_bundle_authority_v2(authority_path)
+    manifest = _load_json(manifest_path)
+    observation = _load_json(archive_observation_path)
+    reasons: list[str] = []
+
+    _verify_top_level(manifest, observation, reasons)
+    model_id = _text(manifest.get("model_id"))
+    revision = _text(manifest.get("revision"))
+    plan = next(
+        (
+            item
+            for item in authority.models
+            if item.model_id == model_id and item.revision == revision
+        ),
+        None,
+    )
+    if plan is None:
+        reasons.append("MODEL_NOT_AUTHORIZED")
+    else:
+        if manifest.get("role") != plan.role.value:
+            reasons.append("MODEL_ROLE_MISMATCH")
+        _verify_authority_contract(authority, plan, manifest, original_root, reasons)
+    if manifest.get("authority_sha256") != authority_sha256_v2(authority):
+        reasons.append("AUTHORITY_SHA256_MISMATCH")
+
+    payload = _payload_declarations(manifest, reasons)
+    controls = _control_declarations(manifest, reasons)
+    payload_by_path = _unique_by_path(payload, "PAYLOAD", reasons)
+    control_by_path = _unique_by_path(controls, "CONTROL", reasons)
+    for path in sorted(set(payload_by_path) & set(control_by_path)):
+        reasons.append(f"PAYLOAD_CONTROL_PATH_ALIAS:{path}")
+
+    verified_original = _verify_root(
+        root=original_root,
+        expected={**payload_by_path, **control_by_path},
+        prefix="ORIGINAL",
+        reasons=reasons,
+    )
+    verified_restored = _verify_root(
+        root=restored_root,
+        expected=payload_by_path,
+        prefix="RESTORED",
+        reasons=reasons,
+    )
+
+    storage = _mapping(manifest.get("storage"))
+    archive = _mapping(storage.get("archive"))
+    archive_sha256 = _text(archive.get("sha256"))
+    archive_size = _integer(archive.get("size_bytes"))
+    if archive.get("media_type") != "application/x-tar":
+        reasons.append("ARCHIVE_MEDIA_TYPE_INVALID")
+    if not _is_sha256(archive_sha256):
+        reasons.append("ARCHIVE_SHA256_INVALID")
+    if archive_size is None or archive_size < 1:
+        reasons.append("ARCHIVE_SIZE_INVALID")
+
+    if observation.get("archive_sha256") != archive_sha256:
+        reasons.append("ARCHIVE_OBSERVATION_SHA256_MISMATCH")
+    if observation.get("archive_size_bytes") != archive_size:
+        reasons.append("ARCHIVE_OBSERVATION_SIZE_MISMATCH")
+    observed_members = {
+        _text(item.get("path")): (
+            _integer(item.get("size_bytes")),
+            _text(item.get("sha256")),
+        )
+        for item in _objects(observation.get("entries"))
+    }
+    expected_members = {
+        path: (_integer(item.get("size_bytes")), _text(item.get("sha256")))
+        for path, item in payload_by_path.items()
+    }
+    if observed_members != expected_members:
+        reasons.append("ARCHIVE_MEMBER_MAP_MISMATCH")
+
+    index_declared = _declared(storage.get("payload_index"), "payload index", reasons)
+    index = _load_declared_json(original_root, index_declared, "PAYLOAD_INDEX", reasons)
+    expected_index = {
+        "schema_version": _INDEX_SCHEMA,
+        "model_id": model_id,
+        "revision": revision,
+        "entries": [
+            {
+                "path": path,
+                "sha256": _text(item.get("sha256")),
+                "size_bytes": _integer(item.get("size_bytes")),
+            }
+            for path, item in sorted(payload_by_path.items())
+        ],
+    }
+    if index != expected_index:
+        reasons.append("PAYLOAD_INDEX_MISMATCH")
+
+    _verify_storage(storage, original_root, observation, reasons)
+    unique_reasons = sorted(set(reasons))
+    report: dict[str, object] = {
+        "schema_version": _REPORT_SCHEMA,
+        "status": "VERIFIED" if not unique_reasons else "REJECTED",
+        "reasons": unique_reasons,
+        "model_id": model_id,
+        "revision": revision,
+        "authority_sha256": authority_sha256_v2(authority),
+        "manifest_sha256": _sha256_file(manifest_path),
+        "archive_sha256": archive_sha256 or None,
+        "archive_size_bytes": archive_size,
+        "verified_original_files": verified_original,
+        "verified_restored_files": verified_restored,
+        "benchmark_status": "NOT_RUN",
+        "model_admission_status": "NOT_DONE",
+        "production_operational_status": "NOT_ATTESTED",
+    }
+    report["report_sha256"] = _canonical_sha256(report)
+    return report
+
+
+def _verify_top_level(
+    manifest: dict[str, Any], observation: dict[str, Any], reasons: list[str]
+) -> None:
+    if manifest.get("schema_version") != _MANIFEST_SCHEMA:
+        reasons.append("MANIFEST_SCHEMA_INVALID")
+    if observation.get("schema_version") != _OBSERVATION_SCHEMA:
+        reasons.append("ARCHIVE_OBSERVATION_SCHEMA_INVALID")
+    if manifest.get("lifecycle") != "COMPLETE":
+        reasons.append("BUNDLE_LIFECYCLE_NOT_COMPLETE")
+    boundaries = {
+        "benchmark_status": "NOT_RUN",
+        "model_admission_status": "NOT_DONE",
+        "production_operational_status": "NOT_ATTESTED",
+    }
+    for key, expected in boundaries.items():
+        if manifest.get(key) != expected:
+            reasons.append(f"MATURITY_BOUNDARY_INVALID:{key}")
+
+
+def _verify_authority_contract(
+    authority: Any,
+    plan: Any,
+    manifest: dict[str, Any],
+    original_root: Path,
+    reasons: list[str],
+) -> None:
+    source_files = _objects(manifest.get("source_files"))
+    expected_sources = {
+        (entry.path, entry.role.value)
+        for entry in plan.inventory
+        if entry.disposition is InventoryDisposition.SELECTED
+    }
+    observed_sources = {(_text(item.get("path")), _text(item.get("role"))) for item in source_files}
+    if observed_sources != expected_sources:
+        reasons.append("SOURCE_FILE_SET_MISMATCH")
+
+    remote = _mapping(manifest.get("remote_inventory"))
+    if (
+        remote.get("model_id"),
+        remote.get("revision"),
+        remote.get("source_uri"),
+    ) != (plan.model_id, plan.revision, plan.source_uri):
+        reasons.append("REMOTE_INVENTORY_AUTHORITY_MISMATCH")
+    remote_entries = _objects(remote.get("entries"))
+    if {_text(item.get("path")) for item in remote_entries} != {
+        entry.path for entry in plan.inventory
+    }:
+        reasons.append("REMOTE_INVENTORY_SET_MISMATCH")
+    remote_file = _declared(remote.get("evidence_file"), "remote inventory", reasons)
+    expected_remote = {
+        "schema_version": "tai.remote-model-inventory-evidence.v1",
+        "model_id": plan.model_id,
+        "revision": plan.revision,
+        "source_uri": plan.source_uri,
+        "observed_at": remote.get("observed_at"),
+        "entries": remote_entries,
+    }
+    if (
+        _load_declared_json(original_root, remote_file, "REMOTE_INVENTORY", reasons)
+        != expected_remote
+    ):
+        reasons.append("REMOTE_INVENTORY_EVIDENCE_MISMATCH")
+
+    legal = _mapping(manifest.get("legal_review"))
+    if legal.get("decision") != "APPROVED":
+        reasons.append("LEGAL_REVIEW_NOT_APPROVED")
+    if legal.get("reviewer_type") != "HUMAN":
+        reasons.append("LEGAL_REVIEWER_NOT_HUMAN")
+    if legal.get("license_spdx") != plan.license_spdx:
+        reasons.append("LICENSE_SPDX_MISMATCH")
+    license_file = _declared(legal.get("license_text"), "license text", reasons)
+    review_file = _declared(legal.get("review_record"), "legal review", reasons)
+    expected_review = {
+        "schema_version": "tai.model-legal-review-record.v1",
+        "decision": "APPROVED",
+        "reviewer_type": "HUMAN",
+        "reviewer_id": legal.get("reviewer_id"),
+        "reviewer_name": legal.get("reviewer_name"),
+        "reviewed_at": legal.get("reviewed_at"),
+        "license_spdx": plan.license_spdx,
+        "decision_basis": legal.get("decision_basis"),
+        "conditions": legal.get("conditions"),
+        "record_type": legal.get("record_type"),
+        "attestation_reference": legal.get("attestation_reference"),
+        "license_text_sha256": license_file.get("sha256"),
+    }
+    if _load_declared_json(original_root, review_file, "LEGAL_REVIEW", reasons) != expected_review:
+        reasons.append("LEGAL_REVIEW_RECORD_MISMATCH")
+
+    toolchain = _mapping(manifest.get("toolchain_package"))
+    expected_toolchain = authority.toolchain
+    observed_identity = (
+        toolchain.get("name"),
+        toolchain.get("release"),
+        toolchain.get("commit"),
+        toolchain.get("profile"),
+        toolchain.get("authority_sha256"),
+    )
+    expected_identity = (
+        expected_toolchain.name,
+        expected_toolchain.release,
+        expected_toolchain.commit,
+        expected_toolchain.profile,
+        expected_toolchain.authority_sha256,
+    )
+    if observed_identity != expected_identity:
+        reasons.append("TOOLCHAIN_PACKAGE_AUTHORITY_MISMATCH")
+    binaries = _objects(toolchain.get("binaries"))
+    if {_text(item.get("name")) for item in binaries} != set(expected_toolchain.required_binaries):
+        reasons.append("TOOLCHAIN_BINARY_SET_MISMATCH")
+    toolchain_report = _declared(
+        toolchain.get("verification_report"), "toolchain verification report", reasons
+    )
+    report = _load_declared_json(original_root, toolchain_report, "TOOLCHAIN_REPORT", reasons)
+    if report.get("status") != "VERIFIED":
+        reasons.append("TOOLCHAIN_VERIFICATION_REPORT_NOT_VERIFIED")
+    if report.get("authority_sha256") != expected_toolchain.authority_sha256:
+        reasons.append("TOOLCHAIN_VERIFICATION_REPORT_AUTHORITY_MISMATCH")
+    targets = report.get("verified_targets")
+    if not isinstance(targets, list) or set(targets) != set(expected_toolchain.required_binaries):
+        reasons.append("TOOLCHAIN_VERIFICATION_REPORT_TARGET_SET_MISMATCH")
+
+    conversion = _mapping(manifest.get("conversion"))
+    if conversion.get("argv") != list(plan.conversion.argv):
+        reasons.append("CONVERSION_ARGV_MISMATCH")
+    if _mapping(conversion.get("converter")).get("path") != plan.conversion.converter_path:
+        reasons.append("CONVERTER_PATH_MISMATCH")
+    if _mapping(conversion.get("intermediate")).get("path") != plan.conversion.intermediate_path:
+        reasons.append("INTERMEDIATE_PATH_MISMATCH")
+    source_digest_payload = [
+        {
+            "path": item.get("path"),
+            "role": item.get("role"),
+            "sha256": item.get("sha256"),
+            "size_bytes": item.get("size_bytes"),
+        }
+        for item in sorted(source_files, key=lambda value: _text(value.get("path")))
+    ]
+    if conversion.get("source_files_sha256") != _canonical_sha256(source_digest_payload):
+        reasons.append("CONVERSION_SOURCE_BINDING_MISMATCH")
+    package_sha = _mapping(toolchain.get("package")).get("sha256")
+    if conversion.get("toolchain_package_sha256") != package_sha:
+        reasons.append("CONVERSION_TOOLCHAIN_BINDING_MISMATCH")
+
+    observed_quantizations = _objects(manifest.get("quantizations"))
+    expected_quantizations = {
+        (item.runtime_class.value, item.quantization): item for item in plan.quantizations
+    }
+    quantizations = {
+        (_text(item.get("runtime_class")), _text(item.get("quantization"))): item
+        for item in observed_quantizations
+    }
+    if set(quantizations) != set(expected_quantizations):
+        reasons.append("QUANTIZATION_SET_MISMATCH")
+    input_sha = _mapping(conversion.get("intermediate")).get("sha256")
+    quantize_sha = next(
+        (
+            _mapping(item.get("file")).get("sha256")
+            for item in binaries
+            if item.get("name") == "llama-quantize"
+        ),
+        None,
+    )
+    for identity, item in quantizations.items():
+        expected_item = expected_quantizations.get(identity)
+        if expected_item is None:
+            continue
+        if item.get("argv") != list(expected_item.argv):
+            reasons.append(f"QUANTIZATION_ARGV_MISMATCH:{identity[0]}:{identity[1]}")
+        if _mapping(item.get("output")).get("path") != expected_item.output_path:
+            reasons.append(f"QUANTIZATION_OUTPUT_PATH_MISMATCH:{identity[0]}:{identity[1]}")
+        if item.get("input_sha256") != input_sha:
+            reasons.append(f"QUANTIZATION_INPUT_BINDING_MISMATCH:{identity[0]}:{identity[1]}")
+        if item.get("quantize_binary_sha256") != quantize_sha:
+            reasons.append(f"QUANTIZATION_BINARY_BINDING_MISMATCH:{identity[0]}:{identity[1]}")
+
+
+def _payload_declarations(manifest: dict[str, Any], reasons: list[str]) -> list[dict[str, Any]]:
+    result = [
+        _declared(item, "source file", reasons) for item in _objects(manifest.get("source_files"))
+    ]
+    remote = _mapping(manifest.get("remote_inventory"))
+    result.append(_declared(remote.get("evidence_file"), "remote inventory", reasons))
+    legal = _mapping(manifest.get("legal_review"))
+    result.extend(
+        [
+            _declared(legal.get("license_text"), "license text", reasons),
+            _declared(legal.get("review_record"), "legal review", reasons),
+        ]
+    )
+    toolchain = _mapping(manifest.get("toolchain_package"))
+    result.extend(
+        [
+            _declared(toolchain.get("package"), "toolchain package", reasons),
+            _declared(toolchain.get("build_manifest"), "toolchain build manifest", reasons),
+            _declared(toolchain.get("verification_report"), "toolchain report", reasons),
+        ]
+    )
+    result.extend(
+        _declared(item.get("file"), "toolchain binary", reasons)
+        for item in _objects(toolchain.get("binaries"))
+    )
+    conversion = _mapping(manifest.get("conversion"))
+    result.extend(
+        [
+            _declared(conversion.get("python_dependencies"), "python dependencies", reasons),
+            _declared(conversion.get("converter"), "converter", reasons),
+            _declared(conversion.get("log"), "conversion log", reasons),
+            _declared(conversion.get("intermediate"), "intermediate", reasons),
+        ]
+    )
+    for item in _objects(manifest.get("quantizations")):
+        result.extend(
+            [
+                _declared(item.get("log"), "quantization log", reasons),
+                _declared(item.get("output"), "quantization output", reasons),
+            ]
+        )
+    return result
+
+
+def _control_declarations(manifest: dict[str, Any], reasons: list[str]) -> list[dict[str, Any]]:
+    storage = _mapping(manifest.get("storage"))
+    return [
+        _declared(storage.get("payload_index"), "payload index", reasons),
+        _declared(storage.get("upload_record"), "upload record", reasons),
+        _declared(storage.get("restore_record"), "restore record", reasons),
+    ]
+
+
+def _verify_storage(
+    storage: dict[str, Any],
+    original_root: Path,
+    observation: dict[str, Any],
+    reasons: list[str],
+) -> None:
+    archive = _mapping(storage.get("archive"))
+    object_record = _mapping(storage.get("object"))
+    digest = _text(archive.get("sha256"))
+    locator = _text(storage.get("immutable_locator"))
+    if f"sha256={digest}" not in locator and f"sha256:{digest}" not in locator:
+        reasons.append("STORAGE_LOCATOR_ARCHIVE_SHA256_MISMATCH")
+    if digest not in _text(object_record.get("key")):
+        reasons.append("OBJECT_KEY_NOT_CONTENT_ADDRESSED")
+    version_id = _text(object_record.get("version_id"))
+    if not version_id or version_id.lower() == "null":
+        reasons.append("OBJECT_VERSION_ID_MISSING")
+    if storage.get("retention_mode") != "COMPLIANCE":
+        reasons.append("RETENTION_MODE_INVALID")
+
+    uploaded = _timestamp(storage.get("uploaded_at"), "uploaded_at", reasons)
+    expires = _timestamp(storage.get("retention_expires_at"), "retention_expires_at", reasons)
+    restored = _timestamp(storage.get("restored_at"), "restored_at", reasons)
+    retention_days = _integer(storage.get("retention_days"))
+    if (
+        uploaded is not None
+        and expires is not None
+        and retention_days is not None
+        and uploaded + timedelta(days=retention_days) != expires
+    ):
+        reasons.append("RETENTION_INTERVAL_MISMATCH")
+    if restored is not None and expires is not None and restored > expires:
+        reasons.append("RESTORE_OUTSIDE_RETENTION")
+
+    upload_file = _declared(storage.get("upload_record"), "upload record", reasons)
+    restore_file = _declared(storage.get("restore_record"), "restore record", reasons)
+    expected_upload = {
+        "schema_version": _UPLOAD_SCHEMA,
+        "archive_sha256": digest,
+        "archive_size_bytes": archive.get("size_bytes"),
+        "immutable_locator": locator,
+        "object": object_record,
+        "uploaded_at": storage.get("uploaded_at"),
+        "retention_mode": storage.get("retention_mode"),
+        "retention_days": retention_days,
+        "retention_expires_at": storage.get("retention_expires_at"),
+    }
+    if _load_declared_json(original_root, upload_file, "UPLOAD_RECORD", reasons) != expected_upload:
+        reasons.append("UPLOAD_RECORD_MISMATCH")
+    expected_restore = {
+        "schema_version": _RESTORE_SCHEMA,
+        "archive_sha256": digest,
+        "archive_size_bytes": archive.get("size_bytes"),
+        "immutable_locator": locator,
+        "object": object_record,
+        "restored_at": storage.get("restored_at"),
+        "archive_observation_sha256": _canonical_sha256(observation),
+    }
+    if (
+        _load_declared_json(original_root, restore_file, "RESTORE_RECORD", reasons)
+        != expected_restore
+    ):
+        reasons.append("RESTORE_RECORD_MISMATCH")
+
+
+def _unique_by_path(
+    declarations: list[dict[str, Any]], prefix: str, reasons: list[str]
+) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for item in declarations:
+        path = _text(item.get("path"))
+        if path in result:
+            reasons.append(f"{prefix}_PATH_DUPLICATE:{path}")
+        result[path] = item
+    return result
+
+
+def _verify_root(
+    *,
+    root: Path,
+    expected: dict[str, dict[str, Any]],
+    prefix: str,
+    reasons: list[str],
+) -> list[str]:
+    if not root.is_dir() or root.is_symlink():
+        reasons.append(f"{prefix}_ROOT_INVALID")
+        return []
+    observed: set[str] = set()
+    for current, directories, files in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        safe_directories: list[str] = []
+        for name in directories:
+            candidate = current_path / name
+            if candidate.is_symlink():
+                reasons.append(
+                    f"{prefix}_FILE_UNSAFE:{candidate.relative_to(root).as_posix()}:symlink"
+                )
+            else:
+                safe_directories.append(name)
+        directories[:] = safe_directories
+        for name in files:
+            candidate = current_path / name
+            relative = candidate.relative_to(root).as_posix()
+            if candidate.is_symlink() or not candidate.is_file():
+                reasons.append(f"{prefix}_FILE_UNSAFE:{relative}:non-regular")
+            else:
+                observed.add(relative)
+    expected_paths = set(expected)
+    for path in sorted(expected_paths - observed):
+        reasons.append(f"{prefix}_FILE_MISSING:{path}")
+    for path in sorted(observed - expected_paths):
+        reasons.append(f"{prefix}_FILE_EXTRA:{path}")
+
+    verified: list[str] = []
+    seen_inodes: set[tuple[int, int]] = set()
+    for relative in sorted(expected_paths & observed):
+        candidate_path = _safe_file(root, relative)
+        if candidate_path is None:
+            reasons.append(f"{prefix}_FILE_UNSAFE:{relative}")
+            continue
+        metadata = candidate_path.stat()
+        inode = (metadata.st_dev, metadata.st_ino)
+        if inode in seen_inodes:
+            reasons.append(f"{prefix}_FILE_INODE_ALIAS:{relative}")
+            continue
+        seen_inodes.add(inode)
+        declared = expected[relative]
+        if metadata.st_size != _integer(declared.get("size_bytes")):
+            reasons.append(f"{prefix}_FILE_SIZE_MISMATCH:{relative}")
+        elif _sha256_file(candidate_path) != _text(declared.get("sha256")):
+            reasons.append(f"{prefix}_FILE_SHA256_MISMATCH:{relative}")
+        else:
+            verified.append(relative)
+    return verified
+
+
+def _load_declared_json(
+    root: Path,
+    declared: dict[str, Any],
+    prefix: str,
+    reasons: list[str],
+) -> dict[str, Any]:
+    relative = _text(declared.get("path"))
+    path = _safe_file(root, relative)
+    if path is None:
+        reasons.append(f"{prefix}_FILE_MISSING:{relative}")
+        return {}
+    if path.stat().st_size != _integer(declared.get("size_bytes")):
+        reasons.append(f"{prefix}_FILE_SIZE_MISMATCH")
+    if _sha256_file(path) != _text(declared.get("sha256")):
+        reasons.append(f"{prefix}_FILE_SHA256_MISMATCH")
+    try:
+        return _load_json(path)
+    except ValueError as error:
+        reasons.append(f"{prefix}_JSON_INVALID:{error}")
+        return {}
+
+
+def _declared(value: object, label: str, reasons: list[str]) -> dict[str, Any]:
+    item = _mapping(value)
+    path = _text(item.get("path"))
+    digest = _text(item.get("sha256"))
+    size = _integer(item.get("size_bytes"))
+    if _safe_relative(path) is None:
+        reasons.append(f"DECLARED_PATH_INVALID:{label}")
+    if not _is_sha256(digest):
+        reasons.append(f"DECLARED_SHA256_INVALID:{label}")
+    if size is None or size < 1:
+        reasons.append(f"DECLARED_SIZE_INVALID:{label}")
+    return item
+
+
+def _safe_file(root: Path, relative: str) -> Path | None:
+    if _safe_relative(relative) is None:
+        return None
+    candidate = root / relative
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved = candidate.resolve(strict=True)
+    except OSError:
+        return None
+    if resolved_root not in resolved.parents or candidate.is_symlink() or not candidate.is_file():
+        return None
+    return candidate
+
+
+def _safe_relative(value: str) -> str | None:
+    path = PurePosixPath(value)
+    if path.is_absolute() or not path.parts or any(part in {"", ".", ".."} for part in path.parts):
+        return None
+    return value if path.as_posix() == value else None
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key: {key}")
+            result[key] = value
+        return result
+
+    payload = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicates)
+    if not isinstance(payload, dict):
+        raise ValueError("JSON root must be an object")
+    return payload
+
+
+def _timestamp(value: object, label: str, reasons: list[str]) -> datetime | None:
+    if not isinstance(value, str):
+        reasons.append(f"TIMESTAMP_INVALID:{label}")
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        reasons.append(f"TIMESTAMP_INVALID:{label}")
+        return None
+    if parsed.tzinfo is None:
+        reasons.append(f"TIMESTAMP_TIMEZONE_MISSING:{label}")
+        return None
+    return parsed
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _objects(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _text(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _integer(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _is_sha256(value: str) -> bool:
+    return len(value) == 64 and all(character in "0123456789abcdef" for character in value)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_CHUNK_SIZE), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_sha256(value: object) -> str:
+    rendered = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(rendered.encode()).hexdigest()

--- a/apps/tai/tai/model_bundle_external_storage_cli.py
+++ b/apps/tai/tai/model_bundle_external_storage_cli.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from tai.model_bundle_external_storage import verify_external_model_bundle
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify a TAI model bundle restored from exact immutable external storage."
+    )
+    parser.add_argument("authority", type=Path)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("original_root", type=Path)
+    parser.add_argument("restored_root", type=Path)
+    parser.add_argument("archive_observation", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = build_parser().parse_args(argv)
+    report = verify_external_model_bundle(
+        authority_path=arguments.authority,
+        manifest_path=arguments.manifest,
+        original_root=arguments.original_root,
+        restored_root=arguments.restored_root,
+        archive_observation_path=arguments.archive_observation,
+    )
+    arguments.output.parent.mkdir(parents=True, exist_ok=True)
+    arguments.output.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0 if report["status"] == "VERIFIED" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/tai/tests/test_gitleaks_release_authority.py
+++ b/apps/tai/tests/test_gitleaks_release_authority.py
@@ -36,5 +36,8 @@ def test_gitleaks_exceptions_are_exact_and_release_attested() -> None:
         "generic-api-key:11",
         "d4f147c04c64b7565f11288b3b545c97340d7899:"
         "apps/tai/model-artifacts/model-conversion-authority.v1.json:generic-api-key:91",
+        "387c77b28f89b467080371c3e55cbf376acdd28e:"
+        "apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json:"
+        "generic-api-key:75",
     ]
     assert all(_FINGERPRINT.fullmatch(entry) is not None for entry in entries)

--- a/apps/tai/tests/test_model_bundle_external_storage.py
+++ b/apps/tai/tests/test_model_bundle_external_storage.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any, cast
+
+from model_bundle_v2_support import AUTHORITY_PATH, _manifest_payload, _sha256, _write, _write_json
+
+from tai.model_bundle_external_storage import verify_external_model_bundle
+from tai.model_bundle_external_storage_cli import main
+
+
+def _payload_declarations(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    result = list(cast(list[dict[str, Any]], payload["source_files"]))
+    remote = cast(dict[str, Any], payload["remote_inventory"])
+    result.append(cast(dict[str, Any], remote["evidence_file"]))
+    legal = cast(dict[str, Any], payload["legal_review"])
+    result.extend(
+        [
+            cast(dict[str, Any], legal["license_text"]),
+            cast(dict[str, Any], legal["review_record"]),
+        ]
+    )
+    toolchain = cast(dict[str, Any], payload["toolchain_package"])
+    result.extend(
+        [
+            cast(dict[str, Any], toolchain["package"]),
+            cast(dict[str, Any], toolchain["build_manifest"]),
+            cast(dict[str, Any], toolchain["verification_report"]),
+        ]
+    )
+    for binary in cast(list[dict[str, Any]], toolchain["binaries"]):
+        result.append(cast(dict[str, Any], binary["file"]))
+    conversion = cast(dict[str, Any], payload["conversion"])
+    result.extend(
+        [
+            cast(dict[str, Any], conversion["python_dependencies"]),
+            cast(dict[str, Any], conversion["converter"]),
+            cast(dict[str, Any], conversion["log"]),
+            cast(dict[str, Any], conversion["intermediate"]),
+        ]
+    )
+    for quantization in cast(list[dict[str, Any]], payload["quantizations"]):
+        result.extend(
+            [
+                cast(dict[str, Any], quantization["log"]),
+                cast(dict[str, Any], quantization["output"]),
+            ]
+        )
+    return sorted(result, key=lambda item: cast(str, item["path"]))
+
+
+def _canonical_sha256(value: object) -> str:
+    rendered = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return _sha256(rendered.encode())
+
+
+def _external_bundle(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path, Path, dict[str, Any]]:
+    manifest_path, original, old_restored, payload = _manifest_payload(tmp_path)
+    shutil.rmtree(old_restored)
+    shutil.rmtree(original / "storage")
+
+    declarations = _payload_declarations(payload)
+    entries = [
+        {
+            "path": item["path"],
+            "sha256": item["sha256"],
+            "size_bytes": item["size_bytes"],
+        }
+        for item in declarations
+    ]
+    archive_sha256 = _canonical_sha256(entries)
+    archive_size = sum(cast(int, item["size_bytes"]) for item in declarations) + 10240
+    object_record = {
+        "endpoint_host": "s3.storage.selcloud.ru",
+        "region": "ru-1",
+        "bucket": "tai-model-bundles",
+        "key": f"governed/objects/sha256/{archive_sha256}/qwen3-8b.tar",
+        "version_id": "3HL4kqtJlcpXroDTDmJ+rmSpXd3dIbrHY",
+        "etag": '"0123456789abcdef0123456789abcdef-128"',
+    }
+    uploaded_at = "2026-07-21T12:00:00+00:00"
+    expires_at = "2026-10-19T12:00:00+00:00"
+    restored_at = "2026-07-21T13:00:00+00:00"
+    locator = (
+        "s3+version://s3.storage.selcloud.ru/tai-model-bundles/"
+        f"{object_record['key']}?versionId={object_record['version_id']}"
+        f"#sha256={archive_sha256}"
+    )
+
+    index = {
+        "schema_version": "tai.model-bundle-payload-index.v1",
+        "model_id": payload["model_id"],
+        "revision": payload["revision"],
+        "entries": entries,
+    }
+    index_file = _write(
+        original,
+        "storage/payload-index.json",
+        json.dumps(index, ensure_ascii=False, sort_keys=True).encode(),
+    )
+    upload = {
+        "schema_version": "tai.model-bundle-upload-record.v2",
+        "archive_sha256": archive_sha256,
+        "archive_size_bytes": archive_size,
+        "immutable_locator": locator,
+        "object": object_record,
+        "uploaded_at": uploaded_at,
+        "retention_mode": "COMPLIANCE",
+        "retention_days": 90,
+        "retention_expires_at": expires_at,
+    }
+    upload_file = _write(
+        original,
+        "storage/upload-record.json",
+        json.dumps(upload, ensure_ascii=False, sort_keys=True).encode(),
+    )
+    observation = {
+        "schema_version": "tai.model-bundle-archive-observation.v1",
+        "archive_sha256": archive_sha256,
+        "archive_size_bytes": archive_size,
+        "entries": entries,
+    }
+    observation_path = tmp_path / "archive-observation.json"
+    _write_json(observation_path, observation)
+    restore = {
+        "schema_version": "tai.model-bundle-restore-record.v2",
+        "archive_sha256": archive_sha256,
+        "archive_size_bytes": archive_size,
+        "immutable_locator": locator,
+        "object": object_record,
+        "restored_at": restored_at,
+        "archive_observation_sha256": _canonical_sha256(observation),
+    }
+    restore_file = _write(
+        original,
+        "storage/restore-record.json",
+        json.dumps(restore, ensure_ascii=False, sort_keys=True).encode(),
+    )
+
+    payload["schema_version"] = "tai.external-model-bundle.v1"
+    payload["benchmark_status"] = "NOT_RUN"
+    payload["model_admission_status"] = "NOT_DONE"
+    payload["production_operational_status"] = "NOT_ATTESTED"
+    payload["storage"] = {
+        "archive": {
+            "sha256": archive_sha256,
+            "size_bytes": archive_size,
+            "media_type": "application/x-tar",
+        },
+        "payload_index": index_file,
+        "immutable_locator": locator,
+        "object": object_record,
+        "uploaded_at": uploaded_at,
+        "retention_mode": "COMPLIANCE",
+        "retention_days": 90,
+        "retention_expires_at": expires_at,
+        "restored_at": restored_at,
+        "upload_record": upload_file,
+        "restore_record": restore_file,
+    }
+    _write_json(manifest_path, payload)
+
+    restored = tmp_path / "clean-restore"
+    for item in declarations:
+        relative = cast(str, item["path"])
+        target = restored / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(original / relative, target)
+    return manifest_path, original, restored, observation_path, payload
+
+
+def test_external_bundle_verifies_without_local_archive(tmp_path: Path) -> None:
+    manifest, original, restored, observation, _ = _external_bundle(tmp_path)
+    report = verify_external_model_bundle(
+        authority_path=AUTHORITY_PATH,
+        manifest_path=manifest,
+        original_root=original,
+        restored_root=restored,
+        archive_observation_path=observation,
+    )
+    assert report["status"] == "VERIFIED"
+    assert report["reasons"] == []
+    assert not any(path.name.endswith(".tar") for path in original.rglob("*"))
+    assert report["production_operational_status"] == "NOT_ATTESTED"
+
+
+def test_restored_payload_drift_fails_closed(tmp_path: Path) -> None:
+    manifest, original, restored, observation, payload = _external_bundle(tmp_path)
+    first = _payload_declarations(payload)[0]
+    (restored / cast(str, first["path"])).write_bytes(b"tampered")
+    report = verify_external_model_bundle(
+        authority_path=AUTHORITY_PATH,
+        manifest_path=manifest,
+        original_root=original,
+        restored_root=restored,
+        archive_observation_path=observation,
+    )
+    assert report["status"] == "REJECTED"
+    assert any(
+        cast(str, reason).startswith("RESTORED_FILE_")
+        for reason in cast(list[str], report["reasons"])
+    )
+
+
+def test_copy_of_original_is_not_a_clean_restore(tmp_path: Path) -> None:
+    manifest, original, restored, observation, _ = _external_bundle(tmp_path)
+    shutil.rmtree(restored)
+    shutil.copytree(original, restored)
+    report = verify_external_model_bundle(
+        authority_path=AUTHORITY_PATH,
+        manifest_path=manifest,
+        original_root=original,
+        restored_root=restored,
+        archive_observation_path=observation,
+    )
+    assert report["status"] == "REJECTED"
+    assert any(
+        cast(str, reason).startswith("RESTORED_FILE_EXTRA:storage/")
+        for reason in cast(list[str], report["reasons"])
+    )
+
+
+def test_version_identity_and_archive_observation_are_mandatory(tmp_path: Path) -> None:
+    manifest, original, restored, observation, payload = _external_bundle(tmp_path)
+    storage = cast(dict[str, Any], payload["storage"])
+    object_record = cast(dict[str, Any], storage["object"])
+    object_record["version_id"] = "null"
+    _write_json(manifest, payload)
+    observed = json.loads(observation.read_text())
+    observed["archive_sha256"] = "0" * 64
+    _write_json(observation, observed)
+    output = tmp_path / "report.json"
+    assert (
+        main(
+            [
+                str(AUTHORITY_PATH),
+                str(manifest),
+                str(original),
+                str(restored),
+                str(observation),
+                "--output",
+                str(output),
+            ]
+        )
+        == 2
+    )
+    reasons = cast(list[str], json.loads(output.read_text())["reasons"])
+    assert "OBJECT_VERSION_ID_MISSING" in reasons
+    assert "ARCHIVE_OBSERVATION_SHA256_MISMATCH" in reasons

--- a/apps/tai/tests/test_model_bundle_finalization_workflow.py
+++ b/apps/tai/tests/test_model_bundle_finalization_workflow.py
@@ -27,6 +27,7 @@ EXPECTED_PATHS = {
     "apps/tai/tai/model_bundle_external_storage.py",
     "apps/tai/tai/model_bundle_external_storage_cli.py",
     "apps/tai/model-artifacts/model_bundle_finalization_remote.py",
+    "apps/tai/tests/test_gitleaks_release_authority.py",
     "apps/tai/tests/test_model_bundle_external_storage.py",
     "apps/tai/tests/test_model_bundle_finalization_workflow.py",
 }

--- a/apps/tai/tests/test_model_bundle_finalization_workflow.py
+++ b/apps/tai/tests/test_model_bundle_finalization_workflow.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).parents[3]
+TAI_ROOT = Path(__file__).parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "tai-model-bundle-finalization.yml"
+DRIVER = TAI_ROOT / "model-artifacts" / "model-bundle-finalization-driver.v1.sh"
+REMOTE = TAI_ROOT / "model-artifacts" / "model-bundle-finalization-remote.v1.sh"
+REMOTE_PYTHON = TAI_ROOT / "model-artifacts" / "model_bundle_finalization_remote.py"
+AUTHORITY = TAI_ROOT / "model-artifacts" / "model-bundle-finalization-authority.v1.json"
+RUNBOOK = TAI_ROOT / "model-artifacts" / "model-bundle-finalization-runbook.v1.md"
+SCOPE = TAI_ROOT / "governance" / "scopes" / "ap-13b3h-bundle-finalization-2961.json"
+COMMAND = "/tai finalize model-bundles exact-main"
+CONVERSION_SHA = "8bd494dc4954baaf699cffa243951392ff451ebb"
+CONVERSION_RUN = 29810648430
+EXPECTED_PATHS = {
+    ".github/workflows/tai-model-bundle-finalization.yml",
+    "apps/tai/governance/scopes/ap-13b3h-bundle-finalization-2961.json",
+    "apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json",
+    "apps/tai/model-artifacts/model-bundle-finalization-driver.v1.sh",
+    "apps/tai/model-artifacts/model-bundle-finalization-remote.v1.sh",
+    "apps/tai/model-artifacts/model-bundle-finalization-runbook.v1.md",
+    "apps/tai/tai/model_bundle_external_storage.py",
+    "apps/tai/tai/model_bundle_external_storage_cli.py",
+    "apps/tai/model-artifacts/model_bundle_finalization_remote.py",
+    "apps/tai/tests/test_model_bundle_external_storage.py",
+    "apps/tai/tests/test_model_bundle_finalization_workflow.py",
+}
+
+
+def _json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_scope_is_exact_and_preserves_maturity_boundary() -> None:
+    scope = _json(SCOPE)
+    assert scope["schema_version"] == "tai.concurrent-scope.v1"
+    assert scope["branch"] == "agent/tai-ap-13b3h-bundle-finalization"
+    assert (scope["program_issue"], scope["parent_issue"], scope["issue"]) == (
+        2726,
+        2954,
+        2961,
+    )
+    assert set(scope["allowed_paths"]) == EXPECTED_PATHS
+    assert "benchmark, admission, activation" in " ".join(scope["forbidden_capabilities"])
+    assert "production_operational_status remains NOT_ATTESTED" in scope["acceptance"][-1]
+
+
+def test_authority_binds_completed_conversion_and_external_storage() -> None:
+    authority = _json(AUTHORITY)
+    assert authority["schema_version"] == "tai.model-bundle-finalization-authority.v1"
+    assert authority["command"] == COMMAND
+    assert authority["conversion_run"] == {
+        "exact_main_sha": CONVERSION_SHA,
+        "workflow_run_id": CONVERSION_RUN,
+        "workflow_run_attempt": 1,
+        "root": f"/srv/tai-models/conversion-runs/{CONVERSION_SHA}/{CONVERSION_RUN}-1",
+        "required_state": "COMPLETE",
+        "required_result": "CONVERSION_AND_QUANTIZATION_COMPLETE_PENDING_BUNDLE_RESTORE",
+        "rerun_allowed": False,
+    }
+    storage = authority["storage"]
+    assert storage["provider_profile"] == "SELECTEL_S3_2026"
+    assert storage["versioning_status"] == "Enabled"
+    assert storage["object_lock_status"] == "Enabled"
+    assert storage["retention_mode"] == "COMPLIANCE"
+    assert storage["retention_days"] == 90
+    assert storage["delete_allowed"] is False
+    assert storage["retention_shortening_allowed"] is False
+    archive = authority["archive"]
+    assert archive["stream_passes"] == 2
+    assert archive["local_archive_copy_allowed"] is False
+    assert archive["compression"] == "NONE"
+    restore = authority["restore"]
+    assert restore["one_model_at_a_time"] is True
+    assert restore["exact_version_required"] is True
+    assert restore["same_root_copy_allowed"] is False
+    assert {model["key"] for model in authority["models"]} == {
+        "qwen3-8b",
+        "mistral-7b-instruct-v0.3",
+    }
+    result = authority["result"]
+    assert result["benchmark_status"] == "NOT_RUN"
+    assert result["model_admission_status"] == "NOT_DONE"
+    assert result["production_operational_status"] == "NOT_ATTESTED"
+
+
+def test_workflow_is_owner_only_exact_main_and_issue_bound() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert "issue_comment:" in workflow
+    assert "types: [created]" in workflow
+    assert "workflow_dispatch:" not in workflow
+    assert "schedule:" not in workflow
+    assert "push:" not in workflow
+    assert "github.ref == 'refs/heads/main'" in workflow
+    assert "github.actor == github.repository_owner" in workflow
+    assert "github.triggering_actor == github.repository_owner" in workflow
+    assert "github.event.issue.number == 2961" in workflow
+    assert f"github.event.comment.body == '{COMMAND}'" in workflow
+    assert "github.event.comment.author_association == 'OWNER'" in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "actions: read\n  contents: read\n  issues: write" in workflow
+    assert "contents: write" not in workflow
+    for secret in (
+        "TAI_MODEL_HOST",
+        "TAI_MODEL_SSH_USER",
+        "TAI_MODEL_SSH_PORT",
+        "TAI_MODEL_SSH_KEY",
+        "TAI_BUNDLE_S3_ENDPOINT",
+        "TAI_BUNDLE_S3_REGION",
+        "TAI_BUNDLE_S3_BUCKET",
+        "TAI_BUNDLE_S3_ACCESS_KEY_ID",
+        "TAI_BUNDLE_S3_SECRET_ACCESS_KEY",
+        "TAI_BUNDLE_S3_PREFIX",
+        "TAI_BUNDLE_S3_CAPACITY_BYTES",
+        "TAI_BUNDLE_S3_PRINCIPAL_ID",
+    ):
+        assert secret in workflow
+    assert "retention-days: 90" in workflow
+    assert "compression-level: 0" in workflow
+    assert "overwrite: false" in workflow
+    assert "include-hidden-files: false" in workflow
+
+
+def test_driver_fails_before_mutation_when_protected_inputs_are_missing() -> None:
+    driver = DRIVER.read_text(encoding="utf-8")
+    missing_index = driver.index("required_inputs=(")
+    failure_index = driver.index("no S3 mutation attempted")
+    preflight_index = driver.index("run_read_only head_bucket")
+    remote_index = driver.index('ssh_command "install -d')
+    assert missing_index < failure_index < preflight_index < remote_index
+    assert "READY_FOR_BUNDLE_UPLOAD" in driver
+    assert "TAI Release Acceptance" in driver
+    assert "tai-release-attestation-" in driver
+    assert "artifact['expired'] is False" in driver
+    assert "source-artifacts.tsv" in driver
+    assert "control-manifest.sha256" in driver
+    assert "sha256sum -c control-package.tar.gz.sha256" in driver
+    assert 'test "$MODEL_SSH_USER" = "tai-model"' in driver
+    for forbidden in (
+        "PC_PROD_HOST",
+        "PC_PROD_SSH_KEY",
+        "PC_PROD_SSH_PASSWORD",
+        "VPS_SSH_KEY",
+        "VPS_SSH_PASSWORD",
+        "195.19.12.120",
+        "netlify",
+        "vercel",
+    ):
+        assert forbidden.casefold() not in driver.casefold()
+
+
+def test_remote_python_driver_is_syntactically_valid() -> None:
+    source = REMOTE_PYTHON.read_text(encoding="utf-8")
+    compile(source, str(REMOTE_PYTHON), "exec")
+
+
+def test_remote_execution_streams_twice_and_restores_exact_version() -> None:
+    remote = REMOTE.read_text(encoding="utf-8")
+    assert "for model_key in qwen3-8b mistral-7b-instruct-v0.3" in remote
+    assert 'tar_stream "$original_root" "$payload_paths" | measure_stream' in remote
+    assert 'tar_stream "$original_root" "$payload_paths" | \\' in remote
+    assert 's3 cp - "s3://$S3_BUCKET/$object_key"' in remote
+    assert '--expected-size "$archive_size"' in remote
+    assert "objects/sha256/$archive_sha256/$model_key.tar" in remote
+    assert "head-object" in remote
+    assert "get-object-retention" in remote
+    assert 'test "$retention_mode" = "COMPLIANCE"' in remote
+    assert 'test -n "$version_id"' in remote
+    assert '--version-id "$version_id"' in remote
+    assert "mkfifo -m 600" in remote
+    assert 'python3 "$REMOTE_SCRIPT" extract' in remote
+    assert 'rm -rf "$model_root"' in remote
+    assert "abort-multipart-upload" in remote
+    assert "delete-object" not in remote
+    assert "delete-objects" not in remote
+    assert "rm s3://" not in remote
+    assert "bundle.tar" not in remote
+    assert "BUNDLES_IMMUTABLY_STORED_AND_CLEANLY_RESTORED" in remote
+    assert "production_operational_status': 'NOT_ATTESTED'" in remote
+
+
+def test_only_bounded_metadata_returns_to_github() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    upload = workflow[workflow.index("Upload bounded finalization evidence") :]
+    assert "manifest.json" in upload
+    assert "object-record.json" in upload
+    assert "archive-observation.json" in upload
+    assert "verification-report.json" in upload
+    assert "*.gguf" not in upload
+    assert "sources/" not in upload
+    assert "model-bundle-finalization-authority.v1.json" in upload
+    driver = DRIVER.read_text(encoding="utf-8")
+    assert "BOUNDED_EVIDENCE_SIZE_EXCEEDED" in driver
+    assert "GGUF_ENTERED_GITHUB_EVIDENCE" in driver
+    assert "path.stat().st_size > 10_000_000" in driver
+
+
+def test_runbook_documents_human_checkpoint_and_no_maturity_inflation() -> None:
+    runbook = RUNBOOK.read_text(encoding="utf-8")
+    assert COMMAND in runbook
+    assert "Never place credential values" in runbook
+    assert "Before any S3 mutation" in runbook
+    assert "deterministic tar stream once" in runbook
+    assert "second time directly into multipart S3 upload" in runbook
+    assert "exact object version" in runbook
+    assert "retaining no downloaded archive file" in runbook
+    assert "benchmark: `NOT_RUN`" in runbook
+    assert "model admission: `NOT_DONE`" in runbook
+    assert "production operational status: `NOT_ATTESTED`" in runbook

--- a/apps/tai/tests/test_model_bundle_finalization_workflow.py
+++ b/apps/tai/tests/test_model_bundle_finalization_workflow.py
@@ -17,6 +17,7 @@ COMMAND = "/tai finalize model-bundles exact-main"
 CONVERSION_SHA = "8bd494dc4954baaf699cffa243951392ff451ebb"
 CONVERSION_RUN = 29810648430
 EXPECTED_PATHS = {
+    ".gitleaksignore",
     ".github/workflows/tai-model-bundle-finalization.yml",
     "apps/tai/governance/scopes/ap-13b3h-bundle-finalization-2961.json",
     "apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json",


### PR DESCRIPTION
Implements #2961 under #2954 and #2726.

## Scope

- owner-only exact-main workflow bound to issue #2961;
- fail-closed protected-input and Selectel S3 preflight before mutation;
- exact completed conversion run `29810648430-1` only, with no source download, conversion or quantization rerun;
- one-model-at-a-time bundle assembly using same-filesystem hard links;
- deterministic two-pass tar streaming without retaining a local bundle archive;
- content-addressed multipart upload to versioned/Object-Locked Selectel S3;
- exact `VersionId` FIFO restore into a clean root;
- fail-closed authority, payload-index, path, member, size and SHA-256 verification;
- bounded metadata-only GitHub evidence and explicit cleanup of temporary payload links/restores.

## Boundaries

No model bytes, GGUF files, payload archives or credentials enter Git. No S3 object/version deletion, retention shortening, benchmark, model admission, activation, deployment or production attestation. `production_operational_status` remains `NOT_ATTESTED`.

The real finalization command remains blocked until all dedicated Selectel repository secrets and model-host access are present:

`/tai finalize model-bundles exact-main`

A successful real run must be followed by a separate bounded acceptance PR containing only locators and verification digests.