### PR TITLE
TAI AP-13C.0: benchmark prerequisite matrix

### DIFF
--- a/apps/tai/governance/scopes/ap-13c0-benchmark-prerequisites-2974.json
+++ b/apps/tai/governance/scopes/ap-13c0-benchmark-prerequisites-2974.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "tai.concurrent-scope.v1",
+  "program_issue": 2726,
+  "issue": 2974,
+  "branch": "agent/tai-ap-13c0-benchmark-prerequisites",
+  "allowed_paths": [
+    "apps/tai/governance/scopes/ap-13c0-benchmark-prerequisites-2974.json",
+    "apps/tai/model-artifacts/benchmark-prerequisite-authority.v1.json",
+    "apps/tai/model-artifacts/benchmark-prerequisite-baseline.v1.json",
+    "apps/tai/model-artifacts/benchmark-prerequisite-runbook.v1.md",
+    "apps/tai/tai/benchmark_prerequisite_matrix.py",
+    "apps/tai/tai/benchmark_prerequisite_matrix_cli.py",
+    "apps/tai/tests/test_benchmark_prerequisite_matrix.py"
+  ],
+  "acceptance": [
+    "all AP-13C prerequisites are explicit and machine-readable",
+    "CPU/fallback readiness and joint-admission readiness are evaluated separately",
+    "code-only, simulated, pending or stale evidence cannot close an external prerequisite",
+    "the current baseline remains BLOCKED while bundle storage, expert review and GPU evidence are absent",
+    "no benchmark, admission, deployment or production-readiness claim is created",
+    "production_operational_status remains NOT_ATTESTED"
+  ],
+  "forbidden_capabilities": [
+    "fabricated model bundle, expert review, benchmark, hardware or storage evidence",
+    "model weights, GGUF files, benchmark payloads or credentials in Git",
+    "automatic closure of human, account, storage or GPU checkpoints",
+    "model admission, activation, deployment or production attestation"
+  ]
+}

--- a/apps/tai/model-artifacts/benchmark-prerequisite-authority.v1.json
+++ b/apps/tai/model-artifacts/benchmark-prerequisite-authority.v1.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "tai.benchmark-prerequisite-authority.v1",
+  "program_issue": 2726,
+  "issue": 2974,
+  "benchmark_authority_issue": 2862,
+  "maximum_evidence_age_days": 30,
+  "prerequisites": [
+    {
+      "id": "benchmark-authority-v2",
+      "owner_issue": 2862,
+      "kind": "CODE_AUTHORITY",
+      "required_status": "VALID"
+    },
+    {
+      "id": "immutable-model-bundles",
+      "owner_issue": 2961,
+      "kind": "EXTERNAL_EXECUTION",
+      "required_status": "BUNDLES_IMMUTABLY_STORED_AND_CLEANLY_RESTORED"
+    },
+    {
+      "id": "external-evidence-storage",
+      "owner_issue": 2954,
+      "kind": "EXTERNAL_ACCOUNT",
+      "required_status": "EXTERNAL_STORAGE_ACCEPTED"
+    },
+    {
+      "id": "expert-reviewed-58-case-suite",
+      "owner_issue": 2973,
+      "kind": "HUMAN_REVIEW",
+      "required_status": "ACCEPTED"
+    },
+    {
+      "id": "dedicated-cpu-host",
+      "owner_issue": 2861,
+      "kind": "EXTERNAL_INFRASTRUCTURE",
+      "required_status": "CPU_HOST_ACCEPTED"
+    },
+    {
+      "id": "dedicated-gpu-host",
+      "owner_issue": 2972,
+      "kind": "EXTERNAL_INFRASTRUCTURE",
+      "required_status": "GPU_HOST_ACCEPTED"
+    },
+    {
+      "id": "cpu-fallback-benchmark",
+      "owner_issue": 2971,
+      "kind": "EXTERNAL_EXECUTION",
+      "required_status": "CPU_FALLBACK_BENCHMARK_VERIFIED"
+    },
+    {
+      "id": "gpu-benchmark",
+      "owner_issue": 2972,
+      "kind": "EXTERNAL_EXECUTION",
+      "required_status": "GPU_BENCHMARK_VERIFIED"
+    }
+  ],
+  "slices": [
+    {
+      "id": "cpu-fallback-execution",
+      "required_prerequisites": [
+        "benchmark-authority-v2",
+        "immutable-model-bundles",
+        "external-evidence-storage",
+        "expert-reviewed-58-case-suite",
+        "dedicated-cpu-host"
+      ],
+      "ready_status": "READY_FOR_CPU_FALLBACK_BENCHMARK"
+    },
+    {
+      "id": "gpu-execution",
+      "required_prerequisites": [
+        "benchmark-authority-v2",
+        "immutable-model-bundles",
+        "external-evidence-storage",
+        "expert-reviewed-58-case-suite",
+        "dedicated-gpu-host"
+      ],
+      "ready_status": "READY_FOR_GPU_BENCHMARK"
+    },
+    {
+      "id": "joint-model-admission",
+      "required_prerequisites": [
+        "benchmark-authority-v2",
+        "immutable-model-bundles",
+        "external-evidence-storage",
+        "expert-reviewed-58-case-suite",
+        "cpu-fallback-benchmark",
+        "gpu-benchmark"
+      ],
+      "ready_status": "READY_FOR_JOINT_MODEL_ADMISSION"
+    }
+  ],
+  "evidence_policy": {
+    "exact_commit_required_for_code_authority": true,
+    "external_evidence_reference_required": true,
+    "timezone_aware_observed_at_required": true,
+    "simulation_accepted": false,
+    "pending_accepted": false,
+    "self_attestation_accepted_for_human_review": false
+  },
+  "maturity_boundary": {
+    "benchmark_status": "PENDING_BENCHMARK",
+    "model_admission_status": "PENDING_ADMISSION",
+    "production_operational_status": "NOT_ATTESTED"
+  }
+}

--- a/apps/tai/model-artifacts/benchmark-prerequisite-baseline.v1.json
+++ b/apps/tai/model-artifacts/benchmark-prerequisite-baseline.v1.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "tai.benchmark-prerequisite-observation.v1",
+  "observed_at": "2026-07-21T14:15:00+00:00",
+  "observations": [
+    {
+      "id": "benchmark-authority-v2",
+      "owner_issue": 2862,
+      "status": "VALID",
+      "evidence_ref": "repo://pachaninm-lab/pachanin-demo@bdf901dbdd4660ed87d25e40c6459b4698e424a9/apps/tai/model-artifacts/model-benchmark-admission-authority.v2.json",
+      "exact_commit": "bdf901dbdd4660ed87d25e40c6459b4698e424a9",
+      "simulated": false
+    },
+    {
+      "id": "immutable-model-bundles",
+      "owner_issue": 2961,
+      "status": "FAILED_CLOSED",
+      "evidence_ref": "https://github.com/pachaninm-lab/pachanin-demo/issues/2961#issuecomment-5034662678",
+      "exact_commit": "1183eab316d287407e29cac79cf88a599e682906",
+      "simulated": false
+    },
+    {
+      "id": "external-evidence-storage",
+      "owner_issue": 2954,
+      "status": "MISSING_SELECTEL_S3_INPUTS",
+      "evidence_ref": "https://github.com/pachaninm-lab/pachanin-demo/issues/2958#issuecomment-5033324335",
+      "exact_commit": "1183eab316d287407e29cac79cf88a599e682906",
+      "simulated": false
+    },
+    {
+      "id": "expert-reviewed-58-case-suite",
+      "owner_issue": 2973,
+      "status": "PENDING_REVIEW",
+      "evidence_ref": "repo://pachaninm-lab/pachanin-demo@bdf901dbdd4660ed87d25e40c6459b4698e424a9/docs/platform-v7/autopilot/tai-ap-14c/baseline-assessment.v1.json",
+      "exact_commit": "bdf901dbdd4660ed87d25e40c6459b4698e424a9",
+      "simulated": false
+    },
+    {
+      "id": "dedicated-cpu-host",
+      "owner_issue": 2861,
+      "status": "CPU_HOST_ACCEPTED",
+      "evidence_ref": "https://github.com/pachaninm-lab/pachanin-demo/issues/2861#issuecomment-5030432350",
+      "exact_commit": "b09bcb2f43a3de96bfd5e2f02f10efbc12f345dc",
+      "simulated": false
+    },
+    {
+      "id": "dedicated-gpu-host",
+      "owner_issue": 2972,
+      "status": "NOT_PROVISIONED",
+      "evidence_ref": "https://github.com/pachaninm-lab/pachanin-demo/issues/2972",
+      "exact_commit": null,
+      "simulated": false
+    },
+    {
+      "id": "cpu-fallback-benchmark",
+      "owner_issue": 2971,
+      "status": "NOT_RUN",
+      "evidence_ref": "https://github.com/pachaninm-lab/pachanin-demo/issues/2971",
+      "exact_commit": null,
+      "simulated": false
+    },
+    {
+      "id": "gpu-benchmark",
+      "owner_issue": 2972,
+      "status": "NOT_RUN",
+      "evidence_ref": "https://github.com/pachaninm-lab/pachanin-demo/issues/2972",
+      "exact_commit": null,
+      "simulated": false
+    }
+  ],
+  "benchmark_status": "PENDING_BENCHMARK",
+  "model_admission_status": "PENDING_ADMISSION",
+  "production_operational_status": "NOT_ATTESTED"
+}

--- a/apps/tai/model-artifacts/benchmark-prerequisite-runbook.v1.md
+++ b/apps/tai/model-artifacts/benchmark-prerequisite-runbook.v1.md
@@ -1,0 +1,78 @@
+# TAI AP-13C.0 benchmark prerequisite closure
+
+## Purpose
+
+This contour makes every dependency of real model benchmarking explicit. It does not execute inference, accept a human review, provision external accounts, create a GPU host, admit a model or change production readiness.
+
+Authority: `benchmark-prerequisite-authority.v1.json`  
+Current observation: `benchmark-prerequisite-baseline.v1.json`  
+Coordinator: issue `#2974`
+
+## Current exact baseline
+
+The current machine-readable assessment is intentionally `BLOCKED`:
+
+- AP-13C/AP-13D v2 benchmark authority exists and is valid;
+- the dedicated CPU host has been provisioned;
+- immutable Selectel S3 storage inputs are absent;
+- both model bundles remain `FAILED_CLOSED` before external storage mutation;
+- the 58-case / 23-critical-case AP-14C corpus remains `PENDING_REVIEW`;
+- no dedicated GPU host has been accepted;
+- CPU/fallback and GPU benchmarks are `NOT_RUN`.
+
+`production_operational_status` remains `NOT_ATTESTED`.
+
+## Evaluate the matrix
+
+```bash
+cd apps/tai
+python -m tai.benchmark_prerequisite_matrix_cli \
+  model-artifacts/benchmark-prerequisite-authority.v1.json \
+  model-artifacts/benchmark-prerequisite-baseline.v1.json \
+  --evaluated-at 2026-07-21T14:20:00+00:00 \
+  --output /tmp/tai-benchmark-prerequisites.json
+```
+
+Exit code `2` is expected while any prerequisite is missing, pending, stale or simulated. Exit code `0` is reserved for `READY_FOR_JOINT_MODEL_ADMISSION`.
+
+## CPU/fallback execution gate
+
+Issue `#2971` can start only when all of these are accepted:
+
+1. AP-13C/AP-13D v2 authority;
+2. both exact model bundles stored externally, bound to exact object versions and independently restored;
+3. external evidence storage accepted;
+4. all 58 AP-14C cases accepted under the governed independent-review policy;
+5. dedicated CPU host accepted.
+
+The CPU slice does not satisfy the Qwen GPU/shared profile and cannot produce joint model admission.
+
+## GPU execution gate
+
+Issue `#2972` additionally requires a dedicated GPU execution environment with exact hardware/runtime evidence. CPU measurements, model-card numbers or third-party benchmarks cannot substitute for this requirement.
+
+## Human-review gate
+
+Issue `#2973` closes only when:
+
+```bash
+node docs/platform-v7/autopilot/tai-ap-14c/gold-set-authority.mjs --require-accepted
+```
+
+returns exit code `0` on exact-main. Review records must remain attributable, independent, digest-bound and current for the exact case SHA-256 values.
+
+## External S3 gate
+
+The owner must create the Selectel service-user S3 key and store all required values only in GitHub repository secrets. The governed storage workflow then proves versioning, Object Lock COMPLIANCE retention, private access, exact object-version restore and digest equality. Code-only or same-host copies do not satisfy this gate.
+
+## Updating observations
+
+A prerequisite may be changed to its required status only from real evidence referenced by an immutable repository commit or a concrete GitHub issue/workflow evidence locator. Every update must preserve:
+
+- exact owner issue;
+- timezone-aware observation time;
+- `simulated=false`;
+- exact commit for code authority;
+- no model files, benchmark payloads or credentials in Git.
+
+Observations older than 30 days are treated as stale and block every slice.

--- a/apps/tai/tai/benchmark_prerequisite_matrix.py
+++ b/apps/tai/tai/benchmark_prerequisite_matrix.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+_IDENTITY = re.compile(r"^[a-z0-9][a-z0-9.-]{1,79}$")
+_ALLOWED_KINDS = {
+    "CODE_AUTHORITY",
+    "EXTERNAL_EXECUTION",
+    "EXTERNAL_ACCOUNT",
+    "HUMAN_REVIEW",
+    "EXTERNAL_INFRASTRUCTURE",
+}
+
+
+class MatrixError(ValueError):
+    pass
+
+
+def _reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in output:
+            raise MatrixError(f"duplicate JSON key: {key}")
+        output[key] = value
+    return output
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"), object_pairs_hook=_reject_duplicates
+        )
+    except (OSError, json.JSONDecodeError, MatrixError) as exc:
+        raise MatrixError(f"invalid JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise MatrixError(f"JSON root must be an object: {path}")
+    return value
+
+
+def canonical_sha256(value: object) -> str:
+    rendered = json.dumps(
+        value, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
+    return hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+
+
+def _require_keys(value: dict[str, Any], expected: set[str], name: str) -> None:
+    observed = set(value)
+    missing = sorted(expected - observed)
+    unknown = sorted(observed - expected)
+    if missing or unknown:
+        raise MatrixError(
+            f"{name} keys invalid; missing={missing!r}, unknown={unknown!r}"
+        )
+
+
+def _object(value: object, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MatrixError(f"{name} must be an object")
+    return value
+
+
+def _array(value: object, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise MatrixError(f"{name} must be an array")
+    return value
+
+
+def _text(value: object, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise MatrixError(f"{name} must be a non-blank string")
+    return value
+
+
+def _integer(value: object, name: str, *, minimum: int = 0) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        raise MatrixError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _boolean(value: object, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise MatrixError(f"{name} must be a boolean")
+    return value
+
+
+def _identity(value: object, name: str) -> str:
+    text = _text(value, name)
+    if _IDENTITY.fullmatch(text) is None:
+        raise MatrixError(f"{name} must be a portable lowercase identity")
+    return text
+
+
+def _timestamp(value: object, name: str) -> datetime:
+    text = _text(value, name)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise MatrixError(f"{name} must be an ISO-8601 timestamp") from exc
+    if parsed.utcoffset() is None:
+        raise MatrixError(f"{name} must be timezone-aware")
+    return parsed.astimezone(UTC)
+
+
+def _optional_commit(value: object, name: str) -> str | None:
+    if value is None:
+        return None
+    text = _text(value, name)
+    if _COMMIT.fullmatch(text) is None:
+        raise MatrixError(f"{name} must be an exact lowercase Git commit")
+    return text
+
+
+def _evidence_ref(value: object, name: str) -> str:
+    text = _text(value, name)
+    valid = (
+        text.startswith("https://github.com/pachaninm-lab/pachanin-demo/issues/")
+        or text.startswith("repo://pachaninm-lab/pachanin-demo@")
+    )
+    if not valid or " " in text or "\n" in text:
+        raise MatrixError(f"{name} must be a bounded governed evidence reference")
+    if text.startswith("repo://"):
+        prefix = "repo://pachaninm-lab/pachanin-demo@"
+        remainder = text.removeprefix(prefix)
+        commit, separator, path = remainder.partition("/")
+        if not separator or _COMMIT.fullmatch(commit) is None or not path:
+            raise MatrixError(f"{name} repository reference must bind an exact commit")
+    return text
+
+
+def load_authority(path: Path) -> dict[str, Any]:
+    raw = load_json(path)
+    _require_keys(
+        raw,
+        {
+            "schema_version",
+            "program_issue",
+            "issue",
+            "benchmark_authority_issue",
+            "maximum_evidence_age_days",
+            "prerequisites",
+            "slices",
+            "evidence_policy",
+            "maturity_boundary",
+        },
+        "authority",
+    )
+    if raw["schema_version"] != "tai.benchmark-prerequisite-authority.v1":
+        raise MatrixError("unsupported authority schema_version")
+    if _integer(raw["program_issue"], "authority.program_issue", minimum=1) != 2726:
+        raise MatrixError("authority program issue mismatch")
+    if _integer(raw["issue"], "authority.issue", minimum=1) != 2974:
+        raise MatrixError("authority issue mismatch")
+    if (
+        _integer(
+            raw["benchmark_authority_issue"],
+            "authority.benchmark_authority_issue",
+            minimum=1,
+        )
+        != 2862
+    ):
+        raise MatrixError("benchmark authority issue mismatch")
+    maximum_age = _integer(
+        raw["maximum_evidence_age_days"],
+        "authority.maximum_evidence_age_days",
+        minimum=1,
+    )
+
+    prerequisites: list[dict[str, Any]] = []
+    prerequisite_ids: set[str] = set()
+    for index, raw_item in enumerate(_array(raw["prerequisites"], "prerequisites")):
+        name = f"prerequisites[{index}]"
+        item = _object(raw_item, name)
+        _require_keys(item, {"id", "owner_issue", "kind", "required_status"}, name)
+        prerequisite_id = _identity(item["id"], f"{name}.id")
+        if prerequisite_id in prerequisite_ids:
+            raise MatrixError("prerequisite ids must be unique")
+        prerequisite_ids.add(prerequisite_id)
+        kind = _text(item["kind"], f"{name}.kind")
+        if kind not in _ALLOWED_KINDS:
+            raise MatrixError(f"{name}.kind is unsupported")
+        prerequisites.append(
+            {
+                "id": prerequisite_id,
+                "owner_issue": _integer(
+                    item["owner_issue"], f"{name}.owner_issue", minimum=1
+                ),
+                "kind": kind,
+                "required_status": _text(
+                    item["required_status"], f"{name}.required_status"
+                ),
+            }
+        )
+
+    slices: list[dict[str, Any]] = []
+    slice_ids: set[str] = set()
+    for index, raw_item in enumerate(_array(raw["slices"], "slices")):
+        name = f"slices[{index}]"
+        item = _object(raw_item, name)
+        _require_keys(
+            item, {"id", "required_prerequisites", "ready_status"}, name
+        )
+        slice_id = _identity(item["id"], f"{name}.id")
+        if slice_id in slice_ids:
+            raise MatrixError("slice ids must be unique")
+        slice_ids.add(slice_id)
+        required = [
+            _identity(value, f"{name}.required_prerequisites")
+            for value in _array(
+                item["required_prerequisites"], f"{name}.required_prerequisites"
+            )
+        ]
+        if not required or len(required) != len(set(required)):
+            raise MatrixError(f"{name}.required_prerequisites must be non-empty unique")
+        unknown = sorted(set(required) - prerequisite_ids)
+        if unknown:
+            raise MatrixError(f"{name} references unknown prerequisites: {unknown!r}")
+        slices.append(
+            {
+                "id": slice_id,
+                "required_prerequisites": required,
+                "ready_status": _text(item["ready_status"], f"{name}.ready_status"),
+            }
+        )
+
+    policy = _object(raw["evidence_policy"], "evidence_policy")
+    _require_keys(
+        policy,
+        {
+            "exact_commit_required_for_code_authority",
+            "external_evidence_reference_required",
+            "timezone_aware_observed_at_required",
+            "simulation_accepted",
+            "pending_accepted",
+            "self_attestation_accepted_for_human_review",
+        },
+        "evidence_policy",
+    )
+    parsed_policy = {key: _boolean(policy[key], f"evidence_policy.{key}") for key in policy}
+    expected_policy = {
+        "exact_commit_required_for_code_authority": True,
+        "external_evidence_reference_required": True,
+        "timezone_aware_observed_at_required": True,
+        "simulation_accepted": False,
+        "pending_accepted": False,
+        "self_attestation_accepted_for_human_review": False,
+    }
+    if parsed_policy != expected_policy:
+        raise MatrixError("evidence policy weakens the fail-closed boundary")
+
+    maturity = _object(raw["maturity_boundary"], "maturity_boundary")
+    expected_maturity = {
+        "benchmark_status": "PENDING_BENCHMARK",
+        "model_admission_status": "PENDING_ADMISSION",
+        "production_operational_status": "NOT_ATTESTED",
+    }
+    if maturity != expected_maturity:
+        raise MatrixError("maturity boundary is invalid")
+
+    authority: dict[str, Any] = {
+        "schema_version": raw["schema_version"],
+        "program_issue": 2726,
+        "issue": 2974,
+        "benchmark_authority_issue": 2862,
+        "maximum_evidence_age_days": maximum_age,
+        "prerequisites": prerequisites,
+        "slices": slices,
+        "evidence_policy": parsed_policy,
+        "maturity_boundary": maturity,
+    }
+    authority["authority_sha256"] = canonical_sha256(authority)
+    return authority
+
+
+def load_observation(path: Path) -> dict[str, Any]:
+    raw = load_json(path)
+    _require_keys(
+        raw,
+        {
+            "schema_version",
+            "observed_at",
+            "observations",
+            "benchmark_status",
+            "model_admission_status",
+            "production_operational_status",
+        },
+        "observation",
+    )
+    if raw["schema_version"] != "tai.benchmark-prerequisite-observation.v1":
+        raise MatrixError("unsupported observation schema_version")
+    observations: list[dict[str, Any]] = []
+    observed_ids: set[str] = set()
+    for index, raw_item in enumerate(_array(raw["observations"], "observations")):
+        name = f"observations[{index}]"
+        item = _object(raw_item, name)
+        _require_keys(
+            item,
+            {"id", "owner_issue", "status", "evidence_ref", "exact_commit", "simulated"},
+            name,
+        )
+        item_id = _identity(item["id"], f"{name}.id")
+        if item_id in observed_ids:
+            raise MatrixError("observation ids must be unique")
+        observed_ids.add(item_id)
+        observations.append(
+            {
+                "id": item_id,
+                "owner_issue": _integer(
+                    item["owner_issue"], f"{name}.owner_issue", minimum=1
+                ),
+                "status": _text(item["status"], f"{name}.status"),
+                "evidence_ref": _evidence_ref(
+                    item["evidence_ref"], f"{name}.evidence_ref"
+                ),
+                "exact_commit": _optional_commit(
+                    item["exact_commit"], f"{name}.exact_commit"
+                ),
+                "simulated": _boolean(item["simulated"], f"{name}.simulated"),
+            }
+        )
+    maturity = {
+        "benchmark_status": raw["benchmark_status"],
+        "model_admission_status": raw["model_admission_status"],
+        "production_operational_status": raw["production_operational_status"],
+    }
+    expected_maturity = {
+        "benchmark_status": "PENDING_BENCHMARK",
+        "model_admission_status": "PENDING_ADMISSION",
+        "production_operational_status": "NOT_ATTESTED",
+    }
+    if maturity != expected_maturity:
+        raise MatrixError("observation maturity boundary is invalid")
+    return {
+        "schema_version": raw["schema_version"],
+        "observed_at": _timestamp(raw["observed_at"], "observation.observed_at"),
+        "observations": observations,
+        **maturity,
+    }
+
+
+def evaluate_matrix(
+    authority_path: Path,
+    observation_path: Path,
+    *,
+    evaluated_at: datetime | None = None,
+) -> dict[str, object]:
+    authority = load_authority(authority_path)
+    observation = load_observation(observation_path)
+    now = (evaluated_at or datetime.now(UTC)).astimezone(UTC)
+    observed_at = observation["observed_at"]
+    if not isinstance(observed_at, datetime):
+        raise MatrixError("observation timestamp type is invalid")
+    if observed_at > now + timedelta(minutes=5):
+        raise MatrixError("observation timestamp is in the future")
+    stale = now - observed_at > timedelta(days=authority["maximum_evidence_age_days"])
+
+    plans = {item["id"]: item for item in authority["prerequisites"]}
+    observed = {item["id"]: item for item in observation["observations"]}
+    if set(plans) != set(observed):
+        missing = sorted(set(plans) - set(observed))
+        unknown = sorted(set(observed) - set(plans))
+        raise MatrixError(
+            f"observation coverage invalid; missing={missing!r}, unknown={unknown!r}"
+        )
+
+    prerequisite_results: dict[str, dict[str, object]] = {}
+    for prerequisite_id, plan in plans.items():
+        value = observed[prerequisite_id]
+        if value["owner_issue"] != plan["owner_issue"]:
+            raise MatrixError(f"owner issue mismatch for {prerequisite_id}")
+        if plan["kind"] == "CODE_AUTHORITY" and value["exact_commit"] is None:
+            raise MatrixError(f"exact commit missing for {prerequisite_id}")
+        satisfied = (
+            not stale
+            and value["simulated"] is False
+            and value["status"] == plan["required_status"]
+        )
+        prerequisite_results[prerequisite_id] = {
+            "satisfied": satisfied,
+            "required_status": plan["required_status"],
+            "observed_status": value["status"],
+            "owner_issue": plan["owner_issue"],
+            "kind": plan["kind"],
+            "evidence_ref": value["evidence_ref"],
+            "exact_commit": value["exact_commit"],
+            "simulated": value["simulated"],
+        }
+
+    slice_results: dict[str, dict[str, object]] = {}
+    reasons: list[str] = []
+    for slice_plan in authority["slices"]:
+        blockers = [
+            prerequisite_id
+            for prerequisite_id in slice_plan["required_prerequisites"]
+            if not prerequisite_results[prerequisite_id]["satisfied"]
+        ]
+        ready = not blockers
+        slice_results[slice_plan["id"]] = {
+            "status": slice_plan["ready_status"] if ready else "BLOCKED",
+            "ready": ready,
+            "blockers": blockers,
+        }
+        for prerequisite_id in blockers:
+            result = prerequisite_results[prerequisite_id]
+            reasons.append(
+                f"{slice_plan['id']}:{prerequisite_id}:"
+                f"expected={result['required_status']}:observed={result['observed_status']}"
+            )
+
+    joint_ready = bool(slice_results["joint-model-admission"]["ready"])
+    report: dict[str, object] = {
+        "schema_version": "tai.benchmark-prerequisite-report.v1",
+        "status": "READY_FOR_JOINT_MODEL_ADMISSION" if joint_ready else "BLOCKED",
+        "authority_sha256": authority["authority_sha256"],
+        "observation_sha256": canonical_sha256(
+            {
+                **observation,
+                "observed_at": observed_at.isoformat(),
+            }
+        ),
+        "observed_at": observed_at.isoformat(),
+        "evaluated_at": now.isoformat(),
+        "stale": stale,
+        "prerequisites": prerequisite_results,
+        "slices": slice_results,
+        "reasons": sorted(set(reasons)),
+        "benchmark_status": "PENDING_BENCHMARK",
+        "model_admission_status": "PENDING_ADMISSION",
+        "production_operational_status": "NOT_ATTESTED",
+    }
+    report["report_sha256"] = canonical_sha256(report)
+    return report
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/apps/tai/tai/benchmark_prerequisite_matrix_cli.py
+++ b/apps/tai/tai/benchmark_prerequisite_matrix_cli.py
@@ -27,13 +27,15 @@ def main() -> int:
             if arguments.evaluated_at
             else None
         )
+        if evaluated_at is not None and evaluated_at.utcoffset() is None:
+            raise ValueError("--evaluated-at must be timezone-aware")
         report = evaluate_matrix(
             arguments.authority,
             arguments.observation,
             evaluated_at=evaluated_at,
         )
     except (MatrixError, ValueError) as exc:
-        report: dict[str, object] = {
+        report = {
             "schema_version": "tai.benchmark-prerequisite-cli-error.v1",
             "status": "REJECTED",
             "reason": f"CONTRACT_INVALID:{exc}",

--- a/apps/tai/tai/benchmark_prerequisite_matrix_cli.py
+++ b/apps/tai/tai/benchmark_prerequisite_matrix_cli.py
@@ -21,6 +21,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     arguments = build_parser().parse_args()
+    report: dict[str, object]
     try:
         evaluated_at = (
             datetime.fromisoformat(arguments.evaluated_at.replace("Z", "+00:00"))

--- a/apps/tai/tai/benchmark_prerequisite_matrix_cli.py
+++ b/apps/tai/tai/benchmark_prerequisite_matrix_cli.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+from tai.benchmark_prerequisite_matrix import MatrixError, evaluate_matrix, write_json
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Evaluate AP-13C benchmark prerequisites without maturity inflation."
+    )
+    parser.add_argument("authority", type=Path)
+    parser.add_argument("observation", type=Path)
+    parser.add_argument("--evaluated-at")
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main() -> int:
+    arguments = build_parser().parse_args()
+    try:
+        evaluated_at = (
+            datetime.fromisoformat(arguments.evaluated_at.replace("Z", "+00:00"))
+            if arguments.evaluated_at
+            else None
+        )
+        report = evaluate_matrix(
+            arguments.authority,
+            arguments.observation,
+            evaluated_at=evaluated_at,
+        )
+    except (MatrixError, ValueError) as exc:
+        report: dict[str, object] = {
+            "schema_version": "tai.benchmark-prerequisite-cli-error.v1",
+            "status": "REJECTED",
+            "reason": f"CONTRACT_INVALID:{exc}",
+            "benchmark_status": "PENDING_BENCHMARK",
+            "model_admission_status": "PENDING_ADMISSION",
+            "production_operational_status": "NOT_ATTESTED",
+        }
+    if arguments.output is not None:
+        write_json(arguments.output, report)
+    print(json.dumps(report, ensure_ascii=False, sort_keys=True))
+    return 0 if report["status"] == "READY_FOR_JOINT_MODEL_ADMISSION" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/tai/tests/test_benchmark_prerequisite_matrix.py
+++ b/apps/tai/tests/test_benchmark_prerequisite_matrix.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from tai.benchmark_prerequisite_matrix import MatrixError, evaluate_matrix, load_authority
+
+MODEL_ARTIFACTS = Path(__file__).resolve().parents[1] / "model-artifacts"
+AUTHORITY = MODEL_ARTIFACTS / "benchmark-prerequisite-authority.v1.json"
+BASELINE = MODEL_ARTIFACTS / "benchmark-prerequisite-baseline.v1.json"
+EVALUATED_AT = datetime(2026, 7, 21, 14, 20, tzinfo=UTC)
+
+
+def _write_json(path: Path, value: object) -> Path:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _baseline() -> dict[str, Any]:
+    value = json.loads(BASELINE.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _ready_observation(tmp_path: Path) -> Path:
+    authority = load_authority(AUTHORITY)
+    value = _baseline()
+    plans = {item["id"]: item for item in authority["prerequisites"]}
+    for observation in cast(list[dict[str, Any]], value["observations"]):
+        plan = plans[observation["id"]]
+        observation["status"] = plan["required_status"]
+        observation["simulated"] = False
+        if plan["kind"] == "CODE_AUTHORITY" and observation["exact_commit"] is None:
+            observation["exact_commit"] = "1" * 40
+    return _write_json(tmp_path / "ready.json", value)
+
+
+def test_committed_baseline_is_honestly_blocked() -> None:
+    report = evaluate_matrix(AUTHORITY, BASELINE, evaluated_at=EVALUATED_AT)
+    assert report["status"] == "BLOCKED"
+    assert report["stale"] is False
+    slices = cast(dict[str, dict[str, Any]], report["slices"])
+    assert slices["cpu-fallback-execution"] == {
+        "status": "BLOCKED",
+        "ready": False,
+        "blockers": [
+            "immutable-model-bundles",
+            "external-evidence-storage",
+            "expert-reviewed-58-case-suite",
+        ],
+    }
+    assert slices["gpu-execution"]["blockers"] == [
+        "immutable-model-bundles",
+        "external-evidence-storage",
+        "expert-reviewed-58-case-suite",
+        "dedicated-gpu-host",
+    ]
+    assert slices["joint-model-admission"]["blockers"] == [
+        "immutable-model-bundles",
+        "external-evidence-storage",
+        "expert-reviewed-58-case-suite",
+        "cpu-fallback-benchmark",
+        "gpu-benchmark",
+    ]
+    assert report["benchmark_status"] == "PENDING_BENCHMARK"
+    assert report["model_admission_status"] == "PENDING_ADMISSION"
+    assert report["production_operational_status"] == "NOT_ATTESTED"
+    assert isinstance(report["report_sha256"], str)
+    assert len(cast(str, report["report_sha256"])) == 64
+
+
+def test_all_real_prerequisites_enable_joint_admission_readiness(tmp_path: Path) -> None:
+    report = evaluate_matrix(
+        AUTHORITY, _ready_observation(tmp_path), evaluated_at=EVALUATED_AT
+    )
+    assert report["status"] == "READY_FOR_JOINT_MODEL_ADMISSION"
+    assert report["reasons"] == []
+    slices = cast(dict[str, dict[str, Any]], report["slices"])
+    assert all(item["ready"] is True for item in slices.values())
+    assert slices["cpu-fallback-execution"]["status"] == (
+        "READY_FOR_CPU_FALLBACK_BENCHMARK"
+    )
+    assert slices["gpu-execution"]["status"] == "READY_FOR_GPU_BENCHMARK"
+
+
+def test_simulated_evidence_never_satisfies_prerequisite(tmp_path: Path) -> None:
+    path = _ready_observation(tmp_path)
+    value = json.loads(path.read_text(encoding="utf-8"))
+    observations = cast(list[dict[str, Any]], value["observations"])
+    next(item for item in observations if item["id"] == "immutable-model-bundles")[
+        "simulated"
+    ] = True
+    _write_json(path, value)
+    report = evaluate_matrix(AUTHORITY, path, evaluated_at=EVALUATED_AT)
+    prerequisite = cast(dict[str, dict[str, Any]], report["prerequisites"])[
+        "immutable-model-bundles"
+    ]
+    assert prerequisite["satisfied"] is False
+    assert report["status"] == "BLOCKED"
+
+
+def test_stale_observation_blocks_every_slice(tmp_path: Path) -> None:
+    path = _ready_observation(tmp_path)
+    value = json.loads(path.read_text(encoding="utf-8"))
+    value["observed_at"] = (EVALUATED_AT - timedelta(days=31)).isoformat()
+    _write_json(path, value)
+    report = evaluate_matrix(AUTHORITY, path, evaluated_at=EVALUATED_AT)
+    assert report["stale"] is True
+    slices = cast(dict[str, dict[str, Any]], report["slices"])
+    assert all(item["ready"] is False for item in slices.values())
+
+
+def test_future_observation_is_rejected(tmp_path: Path) -> None:
+    value = _baseline()
+    value["observed_at"] = (EVALUATED_AT + timedelta(minutes=6)).isoformat()
+    path = _write_json(tmp_path / "future.json", value)
+    with pytest.raises(MatrixError, match="in the future"):
+        evaluate_matrix(AUTHORITY, path, evaluated_at=EVALUATED_AT)
+
+
+def test_missing_code_commit_is_rejected(tmp_path: Path) -> None:
+    value = _baseline()
+    observations = cast(list[dict[str, Any]], value["observations"])
+    next(item for item in observations if item["id"] == "benchmark-authority-v2")[
+        "exact_commit"
+    ] = None
+    path = _write_json(tmp_path / "missing-commit.json", value)
+    with pytest.raises(MatrixError, match="exact commit missing"):
+        evaluate_matrix(AUTHORITY, path, evaluated_at=EVALUATED_AT)
+
+
+def test_observation_must_cover_exact_prerequisite_set(tmp_path: Path) -> None:
+    value = _baseline()
+    cast(list[dict[str, Any]], value["observations"]).pop()
+    path = _write_json(tmp_path / "missing.json", value)
+    with pytest.raises(MatrixError, match="observation coverage invalid"):
+        evaluate_matrix(AUTHORITY, path, evaluated_at=EVALUATED_AT)
+
+
+def test_duplicate_json_keys_are_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text(
+        '{"schema_version":"x","schema_version":"y"}\n', encoding="utf-8"
+    )
+    with pytest.raises(MatrixError, match="duplicate JSON key"):
+        evaluate_matrix(AUTHORITY, path, evaluated_at=EVALUATED_AT)
+
+
+def test_authority_rejects_unknown_prerequisite_kind(tmp_path: Path) -> None:
+    value = json.loads(AUTHORITY.read_text(encoding="utf-8"))
+    cast(list[dict[str, Any]], value["prerequisites"])[0]["kind"] = "SIMULATION"
+    path = _write_json(tmp_path / "weak-authority.json", value)
+    with pytest.raises(MatrixError, match="kind is unsupported"):
+        load_authority(path)


### PR DESCRIPTION
Implements #2974.

Adds a strict fail-closed matrix for CPU/fallback benchmark readiness, GPU benchmark readiness and joint model-admission readiness. The current baseline remains BLOCKED while external storage, verified model bundles, expert review and GPU evidence are incomplete. No model files or maturity claim are added; status remains NOT_ATTESTED.