### PR TITLE
TAI AP-13C.1a: governed CPU benchmark execution authority

### DIFF
--- a/.github/workflows/tai-cpu-benchmark-execution-authority.yml
+++ b/.github/workflows/tai-cpu-benchmark-execution-authority.yml
@@ -69,6 +69,19 @@ jobs:
             apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json \
             --output cpu-benchmark-authority-evidence/authority-validation.json
 
+      - name: Validate exact AP-14C corpus and review assessment
+        shell: bash
+        run: |
+          set -euo pipefail
+          node docs/platform-v7/autopilot/tai-ap-14c/gold-set-authority.mjs \
+            > cpu-benchmark-authority-evidence/gold-authority-validation.json
+          report='cpu-benchmark-authority-evidence/gold-authority-validation.json'
+          test "$(jq -r '.schema_version' "$report")" = 'tai.gold-set-assessment.v1'
+          test "$(jq -r '.counts.total_cases' "$report")" = '58'
+          test "$(jq -r '.counts.critical_cases' "$report")" = '23'
+          [[ "$(jq -r '.assessment_sha256' "$report")" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$(jq -r '.corpus_sha256' "$report")" =~ ^[0-9a-f]{64}$ ]]
+
       - name: Evaluate exact-main benchmark prerequisites
         id: readiness
         continue-on-error: true
@@ -96,6 +109,7 @@ jobs:
           name: tai-cpu-benchmark-authority-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             cpu-benchmark-authority-evidence/authority-validation.json
+            cpu-benchmark-authority-evidence/gold-authority-validation.json
             cpu-benchmark-authority-evidence/prerequisite-report.json
             cpu-benchmark-authority-evidence/readiness.json
             apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json
@@ -118,6 +132,7 @@ jobs:
           from pathlib import Path
 
           readiness_path = Path('cpu-benchmark-authority-evidence/readiness.json')
+          gold_path = Path('cpu-benchmark-authority-evidence/gold-authority-validation.json')
           if readiness_path.exists():
               value = json.loads(readiness_path.read_text(encoding='utf-8'))
           else:
@@ -129,11 +144,17 @@ jobs:
                   'model_admission_status': 'PENDING_ADMISSION',
                   'production_operational_status': 'NOT_ATTESTED',
               }
+          if gold_path.exists():
+              gold = json.loads(gold_path.read_text(encoding='utf-8'))
+          else:
+              gold = {'status': 'INVALID', 'accepted': False, 'assessment_sha256': None}
 
           print('## TAI CPU/fallback benchmark execution authority')
           print()
           print(f"- exact-main: `{os.environ['GITHUB_SHA']}`;")
           print(f"- workflow run: `{os.environ['GITHUB_RUN_ID']}` / attempt `{os.environ['GITHUB_RUN_ATTEMPT']}`;")
+          print(f"- AP-14C authority: `{gold.get('status')}` / accepted `{gold.get('accepted')}`;")
+          print(f"- AP-14C assessment SHA-256: `{gold.get('assessment_sha256')}`;")
           print(f"- readiness: `{value.get('status')}`;")
           print(f"- ready: `{value.get('ready')}`;")
           print(f"- blockers: `{value.get('reasons', [])}`;")
@@ -151,8 +172,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          gold='cpu-benchmark-authority-evidence/gold-authority-validation.json'
           report='cpu-benchmark-authority-evidence/readiness.json'
+          test -s "$gold"
           test -s "$report"
+          test "$(jq -r '.accepted' "$gold")" = 'true'
+          test "$(jq -r '.status' "$gold")" = 'ACCEPTED'
+          test "$(jq -r '.counts.reviewed_cases' "$gold")" = '58'
+          test "$(jq -r '.counts.unreviewed_cases' "$gold")" = '0'
           test "$(jq -r '.status' "$report")" = 'READY_FOR_EXTERNAL_EXECUTION'
           test "$(jq -r '.ready' "$report")" = 'true'
           test "$(jq -r '.reasons | length' "$report")" = '0'

--- a/.github/workflows/tai-cpu-benchmark-execution-authority.yml
+++ b/.github/workflows/tai-cpu-benchmark-execution-authority.yml
@@ -1,0 +1,161 @@
+name: TAI CPU Benchmark Execution Authority
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: tai-cpu-benchmark-execution-authority
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      github.actor == github.repository_owner &&
+      github.triggering_actor == github.repository_owner &&
+      github.event.action == 'created' &&
+      github.event.issue.pull_request == null &&
+      github.event.issue.number == 2977 &&
+      github.event.comment.body == '/tai benchmark cpu-fallback exact-main' &&
+      github.event.comment.author_association == 'OWNER' &&
+      github.event.comment.user.login == github.repository_owner
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout exact main authority
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install exact TAI authority package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e apps/tai
+
+      - name: Assert exact-main immutable checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = 'refs/heads/main'
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git fetch --no-tags --depth=1 origin main
+          test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+      - name: Validate CPU benchmark execution authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p cpu-benchmark-authority-evidence
+          python -m tai.cpu_benchmark_execution_cli validate-authority \
+            apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json \
+            --output cpu-benchmark-authority-evidence/authority-validation.json
+
+      - name: Evaluate exact-main benchmark prerequisites
+        id: readiness
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          evaluated_at="$(date --utc +'%Y-%m-%dT%H:%M:%S+00:00')"
+          python -m tai.benchmark_prerequisite_matrix_cli \
+            apps/tai/model-artifacts/benchmark-prerequisite-authority.v1.json \
+            apps/tai/model-artifacts/benchmark-prerequisite-baseline.v1.json \
+            --evaluated-at "$evaluated_at" \
+            --output cpu-benchmark-authority-evidence/prerequisite-report.json || true
+          python -m tai.cpu_benchmark_execution_cli evaluate-readiness \
+            apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json \
+            cpu-benchmark-authority-evidence/prerequisite-report.json \
+            docs/platform-v7/autopilot/tai-ap-14c/baseline-assessment.v1.json \
+            --exact-main "$GITHUB_SHA" \
+            --evaluated-at "$evaluated_at" \
+            --output cpu-benchmark-authority-evidence/readiness.json
+
+      - name: Upload bounded readiness evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tai-cpu-benchmark-authority-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            cpu-benchmark-authority-evidence/authority-validation.json
+            cpu-benchmark-authority-evidence/prerequisite-report.json
+            cpu-benchmark-authority-evidence/readiness.json
+            apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json
+          if-no-files-found: warn
+          retention-days: 90
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false
+
+      - name: Publish bounded readiness summary
+        if: always()
+        shell: bash
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' > cpu-benchmark-authority-summary.md
+          import json
+          import os
+          from pathlib import Path
+
+          readiness_path = Path('cpu-benchmark-authority-evidence/readiness.json')
+          if readiness_path.exists():
+              value = json.loads(readiness_path.read_text(encoding='utf-8'))
+          else:
+              value = {
+                  'status': 'BLOCKED',
+                  'ready': False,
+                  'reasons': ['READINESS_REPORT_ABSENT'],
+                  'benchmark_status': 'PENDING_BENCHMARK',
+                  'model_admission_status': 'PENDING_ADMISSION',
+                  'production_operational_status': 'NOT_ATTESTED',
+              }
+
+          print('## TAI CPU/fallback benchmark execution authority')
+          print()
+          print(f"- exact-main: `{os.environ['GITHUB_SHA']}`;")
+          print(f"- workflow run: `{os.environ['GITHUB_RUN_ID']}` / attempt `{os.environ['GITHUB_RUN_ATTEMPT']}`;")
+          print(f"- readiness: `{value.get('status')}`;")
+          print(f"- ready: `{value.get('ready')}`;")
+          print(f"- blockers: `{value.get('reasons', [])}`;")
+          print("- real CPU benchmark: `NOT_RUN`;")
+          print("- GPU benchmark: `NOT_RUN`;")
+          print(f"- benchmark status: `{value.get('benchmark_status', 'PENDING_BENCHMARK')}`;")
+          print(f"- model admission: `{value.get('model_admission_status', 'PENDING_ADMISSION')}`;")
+          print(f"- production operational status: `{value.get('production_operational_status', 'NOT_ATTESTED')}`.")
+          PY
+          jq -n --rawfile body cpu-benchmark-authority-summary.md '{body: $body}' \
+            | gh api --method POST "repos/$REPOSITORY/issues/2977/comments" --input -
+
+      - name: Enforce external execution readiness
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          report='cpu-benchmark-authority-evidence/readiness.json'
+          test -s "$report"
+          test "$(jq -r '.status' "$report")" = 'READY_FOR_EXTERNAL_EXECUTION'
+          test "$(jq -r '.ready' "$report")" = 'true'
+          test "$(jq -r '.reasons | length' "$report")" = '0'
+          test "$(jq -r '.benchmark_status' "$report")" = 'PENDING_BENCHMARK'
+          test "$(jq -r '.model_admission_status' "$report")" = 'PENDING_ADMISSION'
+          test "$(jq -r '.production_operational_status' "$report")" = 'NOT_ATTESTED'

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -12,3 +12,9 @@ d4f147c04c64b7565f11288b3b545c97340d7899:apps/tai/model-artifacts/model-conversi
 
 # False positive: public immutable GitHub Actions source-evidence artifact SHA-256, not a credential.
 387c77b28f89b467080371c3e55cbf376acdd28e:apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json:generic-api-key:75
+
+# False positive: public immutable Mistral model revision, not an API key.
+d84b7faadf1b430e549850ccc5cce82a03d52d99:apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json:generic-api-key:67
+
+# False positive: public immutable Mistral model revision asserted by the fail-closed authority validator.
+ecdc1130ca1bc424f3ccecb072115e304722c971:apps/tai/tai/cpu_benchmark_execution.py:generic-api-key:413

--- a/apps/tai/governance/scopes/ap-13c1a-cpu-benchmark-authority-2977.json
+++ b/apps/tai/governance/scopes/ap-13c1a-cpu-benchmark-authority-2977.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "tai.concurrent-scope.v1",
+  "program_issue": 2726,
+  "parent_issue": 2971,
+  "issue": 2977,
+  "branch": "agent/tai-ap-13c1a-cpu-benchmark-authority",
+  "allowed_paths": [
+    ".github/workflows/tai-cpu-benchmark-execution-authority.yml",
+    "apps/tai/governance/scopes/ap-13c1a-cpu-benchmark-authority-2977.json",
+    "apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json",
+    "apps/tai/model-artifacts/cpu-benchmark-execution-runbook.v1.md",
+    "apps/tai/tai/cpu_benchmark_execution.py",
+    "apps/tai/tai/cpu_benchmark_execution_cli.py",
+    "apps/tai/tests/test_cpu_benchmark_execution.py",
+    "apps/tai/tests/test_cpu_benchmark_execution_workflow.py"
+  ],
+  "acceptance": [
+    "owner-only exact-main command validates the CPU/fallback execution gate",
+    "stale, simulated, pending, incomplete or maturity-inflated evidence is rejected",
+    "the exact Qwen and Mistral CPU profiles, llama.cpp toolchain and 58-case suite are pinned",
+    "current missing immutable bundles and expert review remain visible blockers",
+    "no model inference, benchmark measurement, admission, activation or deployment is claimed",
+    "production_operational_status remains NOT_ATTESTED"
+  ],
+  "forbidden_capabilities": [
+    "model weights, GGUF files, bundle archives, benchmark payloads or credentials in Git",
+    "automatic acceptance of Selectel storage, expert reviews or external execution",
+    "execution on the production web, API or PostgreSQL host",
+    "GPU benchmark, joint model admission, activation, deployment or production attestation"
+  ]
+}

--- a/apps/tai/governance/scopes/ap-13c1a-cpu-benchmark-authority-2977.json
+++ b/apps/tai/governance/scopes/ap-13c1a-cpu-benchmark-authority-2977.json
@@ -12,6 +12,7 @@
     "apps/tai/tai/cpu_benchmark_execution.py",
     "apps/tai/tai/cpu_benchmark_execution_cli.py",
     "apps/tai/tests/test_cpu_benchmark_execution.py",
+    "apps/tai/tests/test_cpu_benchmark_execution_cli.py",
     "apps/tai/tests/test_cpu_benchmark_execution_workflow.py"
   ],
   "acceptance": [

--- a/apps/tai/governance/scopes/ap-13c1a-cpu-benchmark-authority-2977.json
+++ b/apps/tai/governance/scopes/ap-13c1a-cpu-benchmark-authority-2977.json
@@ -5,26 +5,30 @@
   "issue": 2977,
   "branch": "agent/tai-ap-13c1a-cpu-benchmark-authority",
   "allowed_paths": [
+    ".gitleaksignore",
     ".github/workflows/tai-cpu-benchmark-execution-authority.yml",
     "apps/tai/governance/scopes/ap-13c1a-cpu-benchmark-authority-2977.json",
     "apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json",
     "apps/tai/model-artifacts/cpu-benchmark-execution-runbook.v1.md",
     "apps/tai/tai/cpu_benchmark_execution.py",
-    "apps/tai/tai/cpu_benchmark_execution_cli.py",
     "apps/tai/tests/test_cpu_benchmark_execution.py",
     "apps/tai/tests/test_cpu_benchmark_execution_cli.py",
-    "apps/tai/tests/test_cpu_benchmark_execution_workflow.py"
+    "apps/tai/tests/test_cpu_benchmark_execution_workflow.py",
+    "apps/tai/tests/test_gitleaks_release_authority.py",
+    "apps/tai/tai/cpu_benchmark_execution_cli.py"
   ],
   "acceptance": [
     "owner-only exact-main command validates the CPU/fallback execution gate",
     "stale, simulated, pending, incomplete or maturity-inflated evidence is rejected",
     "the exact Qwen and Mistral CPU profiles, llama.cpp toolchain and 58-case suite are pinned",
+    "public immutable model revisions use only exact fingerprint-bound Gitleaks exceptions",
     "current missing immutable bundles and expert review remain visible blockers",
     "no model inference, benchmark measurement, admission, activation or deployment is claimed",
     "production_operational_status remains NOT_ATTESTED"
   ],
   "forbidden_capabilities": [
     "model weights, GGUF files, bundle archives, benchmark payloads or credentials in Git",
+    "broad secret-scanner suppression or unbound Gitleaks exceptions",
     "automatic acceptance of Selectel storage, expert reviews or external execution",
     "execution on the production web, API or PostgreSQL host",
     "GPU benchmark, joint model admission, activation, deployment or production attestation"

--- a/apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json
+++ b/apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": "tai.cpu-benchmark-execution-authority.v1",
+  "program_issue": 2726,
+  "parent_issue": 2971,
+  "issue": 2977,
+  "command": "/tai benchmark cpu-fallback exact-main",
+  "prerequisite_gate": {
+    "authority_schema": "tai.benchmark-prerequisite-authority.v1",
+    "report_schema": "tai.benchmark-prerequisite-report.v1",
+    "slice_id": "cpu-fallback-execution",
+    "required_status": "READY_FOR_CPU_FALLBACK_BENCHMARK",
+    "maximum_report_age_hours": 24
+  },
+  "benchmark_authority": {
+    "schema_version": "tai.model-benchmark-admission-authority.v2",
+    "issue": 2862,
+    "suite_id": "tai-platform-agro-58-v1",
+    "required_profiles": [
+      "qwen3-8b-cpu-q4-k-m",
+      "mistral-7b-fallback-cpu-q4-k-m"
+    ]
+  },
+  "bundle_authority": {
+    "schema_version": "tai.model-bundle-authority.v2",
+    "finalization_issue": 2961,
+    "required_finalization_status": "BUNDLES_IMMUTABLY_STORED_AND_CLEANLY_RESTORED",
+    "verification_status": "VERIFIED",
+    "exact_version_restore_required": true,
+    "independent_restore_roots_required": true
+  },
+  "toolchain": {
+    "name": "ggml-org/llama.cpp",
+    "release": "b9637",
+    "commit": "aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3",
+    "profile": "linux-x86_64-cpu-release-static-v1",
+    "required_binaries": [
+      "llama-cli",
+      "llama-server",
+      "llama-bench"
+    ]
+  },
+  "target": {
+    "host_role": "DEDICATED_MODEL_HOST",
+    "required_user": "tai-model",
+    "workspace_root": "/srv/tai-models/benchmark-runs",
+    "ssh_secret_prefix": "TAI_MODEL_",
+    "production_fallback_allowed": false,
+    "network_egress": "S3_EXACT_VERSION_ONLY"
+  },
+  "models": [
+    {
+      "key": "qwen3-8b",
+      "role": "PRIMARY",
+      "model_id": "Qwen/Qwen3-8B",
+      "revision": "895c8d171bc03c30e113cd7a28c02494b5e068b7",
+      "runtime_profile_id": "qwen3-8b-cpu-q4-k-m",
+      "runtime_class": "CPU",
+      "quantization": "Q4_K_M",
+      "artifact_path": "artifacts/qwen3-8b-q4-k-m.gguf",
+      "required_concurrency_levels": [
+        1,
+        2,
+        4
+      ]
+    },
+    {
+      "key": "mistral-7b-instruct-v0.3",
+      "role": "FALLBACK",
+      "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+      "revision": "c170c708c41dac9275d15a8fff4eca08d52bab71",
+      "runtime_profile_id": "mistral-7b-fallback-cpu-q4-k-m",
+      "runtime_class": "CPU",
+      "quantization": "Q4_K_M",
+      "artifact_path": "artifacts/mistral-7b-instruct-v0.3-q4-k-m.gguf",
+      "required_concurrency_levels": [
+        1,
+        2,
+        4
+      ]
+    }
+  ],
+  "evaluation": {
+    "suite_id": "tai-platform-agro-58-v1",
+    "assessment_schema": "tai.gold-set-assessment.v1",
+    "required_status": "ACCEPTED",
+    "required_accepted": true,
+    "required_total_cases": 58,
+    "required_critical_cases": 23,
+    "maximum_unreviewed_cases": 0,
+    "source_root": "docs/platform-v7/autopilot/tai-ap-14c",
+    "materializer": "docs/platform-v7/autopilot/tai-ap-14c/gold-set-authority.mjs"
+  },
+  "measurements": {
+    "minimum_sample_count": 100,
+    "metrics": [
+      "prompt_tokens_per_second",
+      "generation_tokens_per_second",
+      "p50_latency_ms",
+      "p95_latency_ms",
+      "p99_latency_ms",
+      "error_rate",
+      "peak_ram_mb",
+      "cold_start_ms",
+      "warmup_ms",
+      "operating_cost_inputs"
+    ],
+    "concurrency_levels": [
+      1,
+      2,
+      4
+    ],
+    "deterministic_seed": 13001,
+    "temperature_milli": 0,
+    "maximum_output_tokens": 512
+  },
+  "fallback": {
+    "minimum_trigger_count": 100,
+    "forced_primary_failure_required": true,
+    "maximum_failed_transitions": 0,
+    "maximum_continuity_violations": 0,
+    "maximum_critical_unsupported_facts": 0
+  },
+  "soak": {
+    "minimum_duration_seconds": 3600,
+    "minimum_request_count": 1000,
+    "maximum_failed_requests": 10,
+    "maximum_critical_failures": 0,
+    "maximum_memory_drift_mb": 512
+  },
+  "evidence": {
+    "bounded_metadata_only": true,
+    "maximum_github_file_bytes": 10000000,
+    "forbidden_suffixes": [
+      ".gguf",
+      ".safetensors",
+      ".tar",
+      ".bin"
+    ],
+    "forbidden_path_fragments": [
+      "sources/",
+      "artifacts/",
+      "payload/"
+    ],
+    "artifact_retention_days": 90,
+    "independent_restore_required": true
+  },
+  "maturity_boundary": {
+    "benchmark_status": "PENDING_BENCHMARK",
+    "model_admission_status": "PENDING_ADMISSION",
+    "production_operational_status": "NOT_ATTESTED"
+  }
+}

--- a/apps/tai/model-artifacts/cpu-benchmark-execution-runbook.v1.md
+++ b/apps/tai/model-artifacts/cpu-benchmark-execution-runbook.v1.md
@@ -1,0 +1,95 @@
+# TAI AP-13C.1a CPU/fallback benchmark execution authority
+
+## Purpose
+
+This slice establishes the exact owner-only gate for the real AP-13C.1 CPU benchmark. It does not execute model inference, generate benchmark numbers, accept expert reviews, admit a model or change production status.
+
+Coordinator: issue `#2977`  
+Parent execution issue: `#2971`  
+Command: `/tai benchmark cpu-fallback exact-main`
+
+## What is pinned
+
+The authority binds:
+
+- Qwen/Qwen3-8B revision `895c8d171bc03c30e113cd7a28c02494b5e068b7`, CPU `Q4_K_M`, profile `qwen3-8b-cpu-q4-k-m`;
+- mistralai/Mistral-7B-Instruct-v0.3 revision `c170c708c41dac9275d15a8fff4eca08d52bab71`, CPU `Q4_K_M`, profile `mistral-7b-fallback-cpu-q4-k-m`;
+- llama.cpp release `b9637`, commit `aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3`;
+- AP-14C suite `tai-platform-agro-58-v1`: 58 total cases and 23 critical cases;
+- concurrency levels `1`, `2`, `4`;
+- at least 100 samples per runtime profile;
+- deterministic generation with temperature `0`;
+- one-hour soak with at least 1,000 requests;
+- at least 100 forced primary-to-fallback transitions;
+- zero critical unsupported facts, safety failures, failed fallback transitions or continuity violations.
+
+## Current state
+
+The committed prerequisite observation is intentionally blocked:
+
+- immutable model bundles have not yet been accepted in external storage;
+- Selectel S3 external evidence storage is not accepted;
+- the AP-14C corpus remains `PENDING_REVIEW`;
+- CPU/fallback benchmark is `NOT_RUN`.
+
+Therefore the command currently exits fail-closed after publishing bounded readiness metadata. It must not start inference, download model payloads or contact the production VPS.
+
+## Owner-only exact-main check
+
+After all external prerequisites are accepted on `main`, the repository owner posts this exact comment to issue `#2977`:
+
+```text
+/tai benchmark cpu-fallback exact-main
+```
+
+The workflow accepts no `workflow_dispatch`, schedule, push trigger, alternate issue, alternate actor or mutable branch input. It validates that the checkout equals current `main`.
+
+The authority workflow produces only:
+
+- authority validation;
+- AP-13C prerequisite report;
+- CPU/fallback readiness report;
+- a bounded issue summary.
+
+It deliberately contains no model, GGUF, source-weight, bundle archive, prompt/response payload or credential transfer.
+
+## Readiness conditions
+
+`READY_FOR_EXTERNAL_EXECUTION` requires all of the following at the same time:
+
+1. the prerequisite report schema is exact and no more than 24 hours old;
+2. `cpu-fallback-execution.status` is `READY_FOR_CPU_FALLBACK_BENCHMARK`;
+3. `cpu-fallback-execution.ready=true`;
+4. the blocker list is empty;
+5. benchmark maturity remains `PENDING_BENCHMARK`;
+6. model admission remains `PENDING_ADMISSION`;
+7. production operational status remains `NOT_ATTESTED`;
+8. AP-14C assessment status is `ACCEPTED`;
+9. `accepted=true`, total cases `58`, critical cases `23`, unreviewed cases `0`;
+10. the assessment has no blocking reasons and carries valid corpus/assessment SHA-256 values.
+
+A stale report, future timestamp, simulated evidence, pending review, missing bundle, incomplete counts or maturity inflation blocks execution.
+
+## Next governed slice
+
+After this authority is accepted and all external prerequisites are real, AP-13C.1b must execute on the dedicated `tai-model` host:
+
+- independently restore exact immutable Qwen and Mistral object versions;
+- validate bundle and toolchain digests;
+- materialize the accepted AP-14C corpus;
+- measure CPU profiles and concurrency;
+- exercise forced fallback;
+- complete one-hour soak;
+- store full evidence externally with exact-version restore;
+- return only bounded metadata;
+- verify both model reports through `tai.model-benchmark-evidence.v2`.
+
+No CPU result can satisfy the separate Qwen GPU/shared Q8_0 profile. Joint model admission remains blocked until AP-13C.2 GPU evidence is independently verified.
+
+## Maturity boundary
+
+Until real external benchmark evidence verifies successfully:
+
+- benchmark status: `PENDING_BENCHMARK`;
+- model admission: `PENDING_ADMISSION`;
+- production operational status: `NOT_ATTESTED`.

--- a/apps/tai/tai/cpu_benchmark_execution.py
+++ b/apps/tai/tai/cpu_benchmark_execution.py
@@ -1,0 +1,992 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+_IDENTITY = re.compile(r"^[A-Za-z0-9._:/+-]{1,200}$")
+
+_EXPECTED_MATURITY = {
+    "benchmark_status": "PENDING_BENCHMARK",
+    "model_admission_status": "PENDING_ADMISSION",
+    "production_operational_status": "NOT_ATTESTED",
+}
+
+
+class ExecutionContractError(ValueError):
+    pass
+
+
+def _reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in output:
+            raise ExecutionContractError(f"duplicate JSON key: {key}")
+        output[key] = value
+    return output
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"), object_pairs_hook=_reject_duplicates
+        )
+    except (OSError, json.JSONDecodeError, ExecutionContractError) as exc:
+        raise ExecutionContractError(f"invalid JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ExecutionContractError(f"JSON root must be an object: {path}")
+    return value
+
+
+def canonical_sha256(value: object) -> str:
+    rendered = json.dumps(
+        value, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
+    return hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+
+
+def _require_keys(value: dict[str, Any], expected: set[str], name: str) -> None:
+    observed = set(value)
+    missing = sorted(expected - observed)
+    unknown = sorted(observed - expected)
+    if missing or unknown:
+        raise ExecutionContractError(
+            f"{name} keys invalid; missing={missing!r}, unknown={unknown!r}"
+        )
+
+
+def _object(value: object, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ExecutionContractError(f"{name} must be an object")
+    return value
+
+
+def _array(value: object, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ExecutionContractError(f"{name} must be an array")
+    return value
+
+
+def _text(value: object, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ExecutionContractError(f"{name} must be a non-blank string")
+    return value
+
+
+def _boolean(value: object, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ExecutionContractError(f"{name} must be a boolean")
+    return value
+
+
+def _integer(value: object, name: str, *, minimum: int = 0) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        raise ExecutionContractError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _sha256(value: object, name: str) -> str:
+    text = _text(value, name)
+    if _SHA256.fullmatch(text) is None:
+        raise ExecutionContractError(f"{name} must be a lowercase SHA-256")
+    return text
+
+
+def _commit(value: object, name: str) -> str:
+    text = _text(value, name)
+    if _COMMIT.fullmatch(text) is None:
+        raise ExecutionContractError(f"{name} must be an exact lowercase Git commit")
+    return text
+
+
+def _identity(value: object, name: str) -> str:
+    text = _text(value, name)
+    if _IDENTITY.fullmatch(text) is None:
+        raise ExecutionContractError(f"{name} must be a portable bounded identity")
+    return text
+
+
+def _timestamp(value: object, name: str) -> datetime:
+    text = _text(value, name)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ExecutionContractError(f"{name} must be an ISO-8601 timestamp") from exc
+    if parsed.utcoffset() is None:
+        raise ExecutionContractError(f"{name} must be timezone-aware")
+    return parsed.astimezone(UTC)
+
+
+def _string_array(value: object, name: str, *, non_empty: bool = True) -> list[str]:
+    items = [
+        _text(item, f"{name}[{index}]")
+        for index, item in enumerate(_array(value, name))
+    ]
+    if non_empty and not items:
+        raise ExecutionContractError(f"{name} must be non-empty")
+    if len(items) != len(set(items)):
+        raise ExecutionContractError(f"{name} must contain unique values")
+    return items
+
+
+def _integer_array(value: object, name: str) -> list[int]:
+    items = [
+        _integer(item, f"{name}[{index}]", minimum=1)
+        for index, item in enumerate(_array(value, name))
+    ]
+    if not items or items != sorted(set(items)):
+        raise ExecutionContractError(f"{name} must be non-empty sorted unique")
+    return items
+
+
+def load_execution_authority(path: Path) -> dict[str, Any]:
+    raw = load_json(path)
+    _require_keys(
+        raw,
+        {
+            "schema_version",
+            "program_issue",
+            "parent_issue",
+            "issue",
+            "command",
+            "prerequisite_gate",
+            "benchmark_authority",
+            "bundle_authority",
+            "toolchain",
+            "target",
+            "models",
+            "evaluation",
+            "measurements",
+            "fallback",
+            "soak",
+            "evidence",
+            "maturity_boundary",
+        },
+        "execution authority",
+    )
+    if raw["schema_version"] != "tai.cpu-benchmark-execution-authority.v1":
+        raise ExecutionContractError("unsupported execution authority schema_version")
+    if (
+        _integer(raw["program_issue"], "execution authority.program_issue", minimum=1),
+        _integer(raw["parent_issue"], "execution authority.parent_issue", minimum=1),
+        _integer(raw["issue"], "execution authority.issue", minimum=1),
+    ) != (2726, 2971, 2977):
+        raise ExecutionContractError("execution authority issue binding mismatch")
+    if raw["command"] != "/tai benchmark cpu-fallback exact-main":
+        raise ExecutionContractError("execution authority command mismatch")
+
+    prerequisite = _object(raw["prerequisite_gate"], "prerequisite_gate")
+    _require_keys(
+        prerequisite,
+        {
+            "authority_schema",
+            "report_schema",
+            "slice_id",
+            "required_status",
+            "maximum_report_age_hours",
+        },
+        "prerequisite_gate",
+    )
+    parsed_prerequisite = {
+        "authority_schema": _text(
+            prerequisite["authority_schema"], "prerequisite_gate.authority_schema"
+        ),
+        "report_schema": _text(
+            prerequisite["report_schema"], "prerequisite_gate.report_schema"
+        ),
+        "slice_id": _identity(prerequisite["slice_id"], "prerequisite_gate.slice_id"),
+        "required_status": _text(
+            prerequisite["required_status"], "prerequisite_gate.required_status"
+        ),
+        "maximum_report_age_hours": _integer(
+            prerequisite["maximum_report_age_hours"],
+            "prerequisite_gate.maximum_report_age_hours",
+            minimum=1,
+        ),
+    }
+    if parsed_prerequisite != {
+        "authority_schema": "tai.benchmark-prerequisite-authority.v1",
+        "report_schema": "tai.benchmark-prerequisite-report.v1",
+        "slice_id": "cpu-fallback-execution",
+        "required_status": "READY_FOR_CPU_FALLBACK_BENCHMARK",
+        "maximum_report_age_hours": 24,
+    }:
+        raise ExecutionContractError("prerequisite gate weakens the exact CPU slice")
+
+    benchmark = _object(raw["benchmark_authority"], "benchmark_authority")
+    _require_keys(
+        benchmark,
+        {"schema_version", "issue", "suite_id", "required_profiles"},
+        "benchmark_authority",
+    )
+    parsed_benchmark = {
+        "schema_version": _text(
+            benchmark["schema_version"], "benchmark_authority.schema_version"
+        ),
+        "issue": _integer(benchmark["issue"], "benchmark_authority.issue", minimum=1),
+        "suite_id": _identity(
+            benchmark["suite_id"], "benchmark_authority.suite_id"
+        ),
+        "required_profiles": _string_array(
+            benchmark["required_profiles"], "benchmark_authority.required_profiles"
+        ),
+    }
+    if parsed_benchmark != {
+        "schema_version": "tai.model-benchmark-admission-authority.v2",
+        "issue": 2862,
+        "suite_id": "tai-platform-agro-58-v1",
+        "required_profiles": [
+            "qwen3-8b-cpu-q4-k-m",
+            "mistral-7b-fallback-cpu-q4-k-m",
+        ],
+    }:
+        raise ExecutionContractError("benchmark authority binding mismatch")
+
+    bundle = _object(raw["bundle_authority"], "bundle_authority")
+    _require_keys(
+        bundle,
+        {
+            "schema_version",
+            "finalization_issue",
+            "required_finalization_status",
+            "verification_status",
+            "exact_version_restore_required",
+            "independent_restore_roots_required",
+        },
+        "bundle_authority",
+    )
+    parsed_bundle = {
+        "schema_version": _text(
+            bundle["schema_version"], "bundle_authority.schema_version"
+        ),
+        "finalization_issue": _integer(
+            bundle["finalization_issue"],
+            "bundle_authority.finalization_issue",
+            minimum=1,
+        ),
+        "required_finalization_status": _text(
+            bundle["required_finalization_status"],
+            "bundle_authority.required_finalization_status",
+        ),
+        "verification_status": _text(
+            bundle["verification_status"], "bundle_authority.verification_status"
+        ),
+        "exact_version_restore_required": _boolean(
+            bundle["exact_version_restore_required"],
+            "bundle_authority.exact_version_restore_required",
+        ),
+        "independent_restore_roots_required": _boolean(
+            bundle["independent_restore_roots_required"],
+            "bundle_authority.independent_restore_roots_required",
+        ),
+    }
+    if parsed_bundle != {
+        "schema_version": "tai.model-bundle-authority.v2",
+        "finalization_issue": 2961,
+        "required_finalization_status": "BUNDLES_IMMUTABLY_STORED_AND_CLEANLY_RESTORED",
+        "verification_status": "VERIFIED",
+        "exact_version_restore_required": True,
+        "independent_restore_roots_required": True,
+    }:
+        raise ExecutionContractError("bundle authority binding mismatch")
+
+    toolchain = _object(raw["toolchain"], "toolchain")
+    _require_keys(
+        toolchain,
+        {"name", "release", "commit", "profile", "required_binaries"},
+        "toolchain",
+    )
+    parsed_toolchain = {
+        "name": _text(toolchain["name"], "toolchain.name"),
+        "release": _text(toolchain["release"], "toolchain.release"),
+        "commit": _commit(toolchain["commit"], "toolchain.commit"),
+        "profile": _identity(toolchain["profile"], "toolchain.profile"),
+        "required_binaries": _string_array(
+            toolchain["required_binaries"], "toolchain.required_binaries"
+        ),
+    }
+    if parsed_toolchain != {
+        "name": "ggml-org/llama.cpp",
+        "release": "b9637",
+        "commit": "aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3",
+        "profile": "linux-x86_64-cpu-release-static-v1",
+        "required_binaries": ["llama-cli", "llama-server", "llama-bench"],
+    }:
+        raise ExecutionContractError("toolchain binding mismatch")
+
+    target = _object(raw["target"], "target")
+    _require_keys(
+        target,
+        {
+            "host_role",
+            "required_user",
+            "workspace_root",
+            "ssh_secret_prefix",
+            "production_fallback_allowed",
+            "network_egress",
+        },
+        "target",
+    )
+    parsed_target = {
+        "host_role": _text(target["host_role"], "target.host_role"),
+        "required_user": _text(target["required_user"], "target.required_user"),
+        "workspace_root": _text(target["workspace_root"], "target.workspace_root"),
+        "ssh_secret_prefix": _text(
+            target["ssh_secret_prefix"], "target.ssh_secret_prefix"
+        ),
+        "production_fallback_allowed": _boolean(
+            target["production_fallback_allowed"], "target.production_fallback_allowed"
+        ),
+        "network_egress": _text(target["network_egress"], "target.network_egress"),
+    }
+    if parsed_target != {
+        "host_role": "DEDICATED_MODEL_HOST",
+        "required_user": "tai-model",
+        "workspace_root": "/srv/tai-models/benchmark-runs",
+        "ssh_secret_prefix": "TAI_MODEL_",
+        "production_fallback_allowed": False,
+        "network_egress": "S3_EXACT_VERSION_ONLY",
+    }:
+        raise ExecutionContractError("target boundary mismatch")
+
+    models: list[dict[str, Any]] = []
+    for index, raw_model in enumerate(_array(raw["models"], "models")):
+        name = f"models[{index}]"
+        model = _object(raw_model, name)
+        _require_keys(
+            model,
+            {
+                "key",
+                "role",
+                "model_id",
+                "revision",
+                "runtime_profile_id",
+                "runtime_class",
+                "quantization",
+                "artifact_path",
+                "required_concurrency_levels",
+            },
+            name,
+        )
+        models.append(
+            {
+                "key": _identity(model["key"], f"{name}.key"),
+                "role": _text(model["role"], f"{name}.role"),
+                "model_id": _identity(model["model_id"], f"{name}.model_id"),
+                "revision": _commit(model["revision"], f"{name}.revision"),
+                "runtime_profile_id": _identity(
+                    model["runtime_profile_id"], f"{name}.runtime_profile_id"
+                ),
+                "runtime_class": _text(
+                    model["runtime_class"], f"{name}.runtime_class"
+                ),
+                "quantization": _identity(
+                    model["quantization"], f"{name}.quantization"
+                ),
+                "artifact_path": _text(
+                    model["artifact_path"], f"{name}.artifact_path"
+                ),
+                "required_concurrency_levels": _integer_array(
+                    model["required_concurrency_levels"],
+                    f"{name}.required_concurrency_levels",
+                ),
+            }
+        )
+    expected_models = [
+        {
+            "key": "qwen3-8b",
+            "role": "PRIMARY",
+            "model_id": "Qwen/Qwen3-8B",
+            "revision": "895c8d171bc03c30e113cd7a28c02494b5e068b7",
+            "runtime_profile_id": "qwen3-8b-cpu-q4-k-m",
+            "runtime_class": "CPU",
+            "quantization": "Q4_K_M",
+            "artifact_path": "artifacts/qwen3-8b-q4-k-m.gguf",
+            "required_concurrency_levels": [1, 2, 4],
+        },
+        {
+            "key": "mistral-7b-instruct-v0.3",
+            "role": "FALLBACK",
+            "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+            "revision": "c170c708c41dac9275d15a8fff4eca08d52bab71",
+            "runtime_profile_id": "mistral-7b-fallback-cpu-q4-k-m",
+            "runtime_class": "CPU",
+            "quantization": "Q4_K_M",
+            "artifact_path": "artifacts/mistral-7b-instruct-v0.3-q4-k-m.gguf",
+            "required_concurrency_levels": [1, 2, 4],
+        },
+    ]
+    if models != expected_models:
+        raise ExecutionContractError("model execution set mismatch")
+
+    evaluation = _object(raw["evaluation"], "evaluation")
+    _require_keys(
+        evaluation,
+        {
+            "suite_id",
+            "assessment_schema",
+            "required_status",
+            "required_accepted",
+            "required_total_cases",
+            "required_critical_cases",
+            "maximum_unreviewed_cases",
+            "source_root",
+            "materializer",
+        },
+        "evaluation",
+    )
+    parsed_evaluation = {
+        "suite_id": _identity(evaluation["suite_id"], "evaluation.suite_id"),
+        "assessment_schema": _text(
+            evaluation["assessment_schema"], "evaluation.assessment_schema"
+        ),
+        "required_status": _text(
+            evaluation["required_status"], "evaluation.required_status"
+        ),
+        "required_accepted": _boolean(
+            evaluation["required_accepted"], "evaluation.required_accepted"
+        ),
+        "required_total_cases": _integer(
+            evaluation["required_total_cases"],
+            "evaluation.required_total_cases",
+            minimum=1,
+        ),
+        "required_critical_cases": _integer(
+            evaluation["required_critical_cases"],
+            "evaluation.required_critical_cases",
+            minimum=1,
+        ),
+        "maximum_unreviewed_cases": _integer(
+            evaluation["maximum_unreviewed_cases"],
+            "evaluation.maximum_unreviewed_cases",
+        ),
+        "source_root": _text(evaluation["source_root"], "evaluation.source_root"),
+        "materializer": _text(evaluation["materializer"], "evaluation.materializer"),
+    }
+    if parsed_evaluation != {
+        "suite_id": "tai-platform-agro-58-v1",
+        "assessment_schema": "tai.gold-set-assessment.v1",
+        "required_status": "ACCEPTED",
+        "required_accepted": True,
+        "required_total_cases": 58,
+        "required_critical_cases": 23,
+        "maximum_unreviewed_cases": 0,
+        "source_root": "docs/platform-v7/autopilot/tai-ap-14c",
+        "materializer": "docs/platform-v7/autopilot/tai-ap-14c/gold-set-authority.mjs",
+    }:
+        raise ExecutionContractError("evaluation authority binding mismatch")
+
+    measurements = _object(raw["measurements"], "measurements")
+    _require_keys(
+        measurements,
+        {
+            "minimum_sample_count",
+            "metrics",
+            "concurrency_levels",
+            "deterministic_seed",
+            "temperature_milli",
+            "maximum_output_tokens",
+        },
+        "measurements",
+    )
+    parsed_measurements = {
+        "minimum_sample_count": _integer(
+            measurements["minimum_sample_count"],
+            "measurements.minimum_sample_count",
+            minimum=1,
+        ),
+        "metrics": _string_array(measurements["metrics"], "measurements.metrics"),
+        "concurrency_levels": _integer_array(
+            measurements["concurrency_levels"], "measurements.concurrency_levels"
+        ),
+        "deterministic_seed": _integer(
+            measurements["deterministic_seed"], "measurements.deterministic_seed"
+        ),
+        "temperature_milli": _integer(
+            measurements["temperature_milli"], "measurements.temperature_milli"
+        ),
+        "maximum_output_tokens": _integer(
+            measurements["maximum_output_tokens"],
+            "measurements.maximum_output_tokens",
+            minimum=1,
+        ),
+    }
+    expected_metrics = [
+        "prompt_tokens_per_second",
+        "generation_tokens_per_second",
+        "p50_latency_ms",
+        "p95_latency_ms",
+        "p99_latency_ms",
+        "error_rate",
+        "peak_ram_mb",
+        "cold_start_ms",
+        "warmup_ms",
+        "operating_cost_inputs",
+    ]
+    if parsed_measurements != {
+        "minimum_sample_count": 100,
+        "metrics": expected_metrics,
+        "concurrency_levels": [1, 2, 4],
+        "deterministic_seed": 13001,
+        "temperature_milli": 0,
+        "maximum_output_tokens": 512,
+    }:
+        raise ExecutionContractError("measurement policy mismatch")
+
+    fallback = _object(raw["fallback"], "fallback")
+    _require_keys(
+        fallback,
+        {
+            "minimum_trigger_count",
+            "forced_primary_failure_required",
+            "maximum_failed_transitions",
+            "maximum_continuity_violations",
+            "maximum_critical_unsupported_facts",
+        },
+        "fallback",
+    )
+    parsed_fallback = {
+        "minimum_trigger_count": _integer(
+            fallback["minimum_trigger_count"],
+            "fallback.minimum_trigger_count",
+            minimum=1,
+        ),
+        "forced_primary_failure_required": _boolean(
+            fallback["forced_primary_failure_required"],
+            "fallback.forced_primary_failure_required",
+        ),
+        "maximum_failed_transitions": _integer(
+            fallback["maximum_failed_transitions"],
+            "fallback.maximum_failed_transitions",
+        ),
+        "maximum_continuity_violations": _integer(
+            fallback["maximum_continuity_violations"],
+            "fallback.maximum_continuity_violations",
+        ),
+        "maximum_critical_unsupported_facts": _integer(
+            fallback["maximum_critical_unsupported_facts"],
+            "fallback.maximum_critical_unsupported_facts",
+        ),
+    }
+    if parsed_fallback != {
+        "minimum_trigger_count": 100,
+        "forced_primary_failure_required": True,
+        "maximum_failed_transitions": 0,
+        "maximum_continuity_violations": 0,
+        "maximum_critical_unsupported_facts": 0,
+    }:
+        raise ExecutionContractError("fallback policy mismatch")
+
+    soak = _object(raw["soak"], "soak")
+    _require_keys(
+        soak,
+        {
+            "minimum_duration_seconds",
+            "minimum_request_count",
+            "maximum_failed_requests",
+            "maximum_critical_failures",
+            "maximum_memory_drift_mb",
+        },
+        "soak",
+    )
+    parsed_soak = {
+        key: _integer(soak[key], f"soak.{key}", minimum=0)
+        for key in {
+            "minimum_duration_seconds",
+            "minimum_request_count",
+            "maximum_failed_requests",
+            "maximum_critical_failures",
+            "maximum_memory_drift_mb",
+        }
+    }
+    if parsed_soak != {
+        "minimum_duration_seconds": 3600,
+        "minimum_request_count": 1000,
+        "maximum_failed_requests": 10,
+        "maximum_critical_failures": 0,
+        "maximum_memory_drift_mb": 512,
+    }:
+        raise ExecutionContractError("soak policy mismatch")
+
+    evidence = _object(raw["evidence"], "evidence")
+    _require_keys(
+        evidence,
+        {
+            "bounded_metadata_only",
+            "maximum_github_file_bytes",
+            "forbidden_suffixes",
+            "forbidden_path_fragments",
+            "artifact_retention_days",
+            "independent_restore_required",
+        },
+        "evidence",
+    )
+    parsed_evidence = {
+        "bounded_metadata_only": _boolean(
+            evidence["bounded_metadata_only"], "evidence.bounded_metadata_only"
+        ),
+        "maximum_github_file_bytes": _integer(
+            evidence["maximum_github_file_bytes"],
+            "evidence.maximum_github_file_bytes",
+            minimum=1,
+        ),
+        "forbidden_suffixes": _string_array(
+            evidence["forbidden_suffixes"], "evidence.forbidden_suffixes"
+        ),
+        "forbidden_path_fragments": _string_array(
+            evidence["forbidden_path_fragments"],
+            "evidence.forbidden_path_fragments",
+        ),
+        "artifact_retention_days": _integer(
+            evidence["artifact_retention_days"],
+            "evidence.artifact_retention_days",
+            minimum=1,
+        ),
+        "independent_restore_required": _boolean(
+            evidence["independent_restore_required"],
+            "evidence.independent_restore_required",
+        ),
+    }
+    if parsed_evidence != {
+        "bounded_metadata_only": True,
+        "maximum_github_file_bytes": 10_000_000,
+        "forbidden_suffixes": [".gguf", ".safetensors", ".tar", ".bin"],
+        "forbidden_path_fragments": ["sources/", "artifacts/", "payload/"],
+        "artifact_retention_days": 90,
+        "independent_restore_required": True,
+    }:
+        raise ExecutionContractError("evidence boundary mismatch")
+
+    maturity = _object(raw["maturity_boundary"], "maturity_boundary")
+    if maturity != _EXPECTED_MATURITY:
+        raise ExecutionContractError("maturity boundary is invalid")
+
+    authority: dict[str, Any] = {
+        "schema_version": raw["schema_version"],
+        "program_issue": 2726,
+        "parent_issue": 2971,
+        "issue": 2977,
+        "command": raw["command"],
+        "prerequisite_gate": parsed_prerequisite,
+        "benchmark_authority": parsed_benchmark,
+        "bundle_authority": parsed_bundle,
+        "toolchain": parsed_toolchain,
+        "target": parsed_target,
+        "models": models,
+        "evaluation": parsed_evaluation,
+        "measurements": parsed_measurements,
+        "fallback": parsed_fallback,
+        "soak": parsed_soak,
+        "evidence": parsed_evidence,
+        "maturity_boundary": maturity,
+    }
+    authority["authority_sha256"] = canonical_sha256(authority)
+    return authority
+
+
+def _load_prerequisite_report(path: Path) -> dict[str, Any]:
+    raw = load_json(path)
+    _require_keys(
+        raw,
+        {
+            "schema_version",
+            "status",
+            "authority_sha256",
+            "observation_sha256",
+            "observed_at",
+            "evaluated_at",
+            "stale",
+            "prerequisites",
+            "slices",
+            "reasons",
+            "benchmark_status",
+            "model_admission_status",
+            "production_operational_status",
+            "report_sha256",
+        },
+        "prerequisite report",
+    )
+    if raw["schema_version"] != "tai.benchmark-prerequisite-report.v1":
+        raise ExecutionContractError("unsupported prerequisite report schema_version")
+    _sha256(raw["authority_sha256"], "prerequisite report.authority_sha256")
+    _sha256(raw["observation_sha256"], "prerequisite report.observation_sha256")
+    _sha256(raw["report_sha256"], "prerequisite report.report_sha256")
+    observed_at = _timestamp(raw["observed_at"], "prerequisite report.observed_at")
+    evaluated_at = _timestamp(raw["evaluated_at"], "prerequisite report.evaluated_at")
+    stale = _boolean(raw["stale"], "prerequisite report.stale")
+    prerequisites = _object(raw["prerequisites"], "prerequisite report.prerequisites")
+    slices = _object(raw["slices"], "prerequisite report.slices")
+    reasons = [
+        _text(item, f"prerequisite report.reasons[{index}]")
+        for index, item in enumerate(
+            _array(raw["reasons"], "prerequisite report.reasons")
+        )
+    ]
+    maturity = {
+        "benchmark_status": raw["benchmark_status"],
+        "model_admission_status": raw["model_admission_status"],
+        "production_operational_status": raw["production_operational_status"],
+    }
+    if maturity != _EXPECTED_MATURITY:
+        raise ExecutionContractError("prerequisite report maturity boundary is invalid")
+    expected_digest = canonical_sha256(
+        {key: value for key, value in raw.items() if key != "report_sha256"}
+    )
+    if raw["report_sha256"] != expected_digest:
+        raise ExecutionContractError("prerequisite report digest mismatch")
+    return {
+        **raw,
+        "observed_at_parsed": observed_at,
+        "evaluated_at_parsed": evaluated_at,
+        "stale": stale,
+        "prerequisites": prerequisites,
+        "slices": slices,
+        "reasons": reasons,
+    }
+
+
+def _load_gold_assessment(path: Path) -> dict[str, Any]:
+    raw = load_json(path)
+    _require_keys(
+        raw,
+        {
+            "schema_version",
+            "version",
+            "accepted",
+            "status",
+            "corpus_sha256",
+            "component_sha256",
+            "counts",
+            "quality_targets",
+            "blocking_reasons",
+            "missing_review_case_ids",
+            "assessment_sha256",
+        },
+        "gold assessment",
+    )
+    if raw["schema_version"] != "tai.gold-set-assessment.v1":
+        raise ExecutionContractError("unsupported gold assessment schema_version")
+    _text(raw["version"], "gold assessment.version")
+    _boolean(raw["accepted"], "gold assessment.accepted")
+    _text(raw["status"], "gold assessment.status")
+    _sha256(raw["corpus_sha256"], "gold assessment.corpus_sha256")
+    components = _object(raw["component_sha256"], "gold assessment.component_sha256")
+    _require_keys(
+        components,
+        {"platform_sha256", "agro_sha256", "coverage_sha256", "reviews_sha256"},
+        "gold assessment.component_sha256",
+    )
+    for key, value in components.items():
+        _sha256(value, f"gold assessment.component_sha256.{key}")
+    counts = _object(raw["counts"], "gold assessment.counts")
+    _require_keys(
+        counts,
+        {
+            "platform_cases",
+            "agro_cases",
+            "total_cases",
+            "critical_cases",
+            "reviewed_cases",
+            "unreviewed_cases",
+            "platform_roles",
+            "deal_states",
+            "agro_topics",
+            "locales",
+        },
+        "gold assessment.counts",
+    )
+    parsed_counts = {
+        key: _integer(value, f"gold assessment.counts.{key}")
+        for key, value in counts.items()
+    }
+    targets = _object(raw["quality_targets"], "gold assessment.quality_targets")
+    _require_keys(
+        targets,
+        {
+            "platform_accuracy_minimum",
+            "agro_accuracy_minimum",
+            "critical_unsupported_facts_maximum",
+            "citation_validity_minimum",
+        },
+        "gold assessment.quality_targets",
+    )
+    for key, value in targets.items():
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise ExecutionContractError(
+                f"gold assessment.quality_targets.{key} must be numeric"
+            )
+    blockers = [
+        _text(item, f"gold assessment.blocking_reasons[{index}]")
+        for index, item in enumerate(
+            _array(raw["blocking_reasons"], "gold assessment.blocking_reasons")
+        )
+    ]
+    missing = [
+        _text(item, f"gold assessment.missing_review_case_ids[{index}]")
+        for index, item in enumerate(
+            _array(
+                raw["missing_review_case_ids"],
+                "gold assessment.missing_review_case_ids",
+            )
+        )
+    ]
+    _sha256(raw["assessment_sha256"], "gold assessment.assessment_sha256")
+    return {
+        **raw,
+        "counts": parsed_counts,
+        "blocking_reasons": blockers,
+        "missing_review_case_ids": missing,
+    }
+
+
+def evaluate_readiness(
+    authority_path: Path,
+    prerequisite_report_path: Path,
+    gold_assessment_path: Path,
+    *,
+    exact_main: str,
+    evaluated_at: str,
+) -> dict[str, object]:
+    authority = load_execution_authority(authority_path)
+    prerequisite = _load_prerequisite_report(prerequisite_report_path)
+    assessment = _load_gold_assessment(gold_assessment_path)
+    exact_commit = _commit(exact_main, "exact_main")
+    now = _timestamp(evaluated_at, "evaluated_at")
+
+    reasons: list[str] = []
+    report_time = prerequisite["evaluated_at_parsed"]
+    observed_time = prerequisite["observed_at_parsed"]
+    if not isinstance(report_time, datetime) or not isinstance(observed_time, datetime):
+        raise ExecutionContractError("prerequisite report timestamp type is invalid")
+    if report_time > now + timedelta(minutes=5):
+        reasons.append("PREREQUISITE_REPORT_FROM_FUTURE")
+    if observed_time > now + timedelta(minutes=5):
+        reasons.append("PREREQUISITE_OBSERVATION_FROM_FUTURE")
+    maximum_age = timedelta(
+        hours=int(authority["prerequisite_gate"]["maximum_report_age_hours"])
+    )
+    if now - report_time > maximum_age:
+        reasons.append("PREREQUISITE_REPORT_STALE")
+    if prerequisite["stale"] is not False:
+        reasons.append("PREREQUISITE_MATRIX_STALE")
+
+    slice_id = str(authority["prerequisite_gate"]["slice_id"])
+    slice_value = prerequisite["slices"].get(slice_id)
+    if not isinstance(slice_value, dict):
+        reasons.append("CPU_FALLBACK_SLICE_ABSENT")
+        slice_status = None
+        slice_ready = False
+        slice_blockers: list[str] = []
+    else:
+        _require_keys(
+            slice_value, {"status", "ready", "blockers"}, f"slices.{slice_id}"
+        )
+        slice_status = _text(slice_value["status"], f"slices.{slice_id}.status")
+        slice_ready = _boolean(slice_value["ready"], f"slices.{slice_id}.ready")
+        slice_blockers = [
+            _text(item, f"slices.{slice_id}.blockers[{index}]")
+            for index, item in enumerate(
+                _array(slice_value["blockers"], f"slices.{slice_id}.blockers")
+            )
+        ]
+    if slice_status != authority["prerequisite_gate"]["required_status"]:
+        reasons.append("CPU_FALLBACK_SLICE_STATUS_NOT_READY")
+    if not slice_ready:
+        reasons.append("CPU_FALLBACK_SLICE_NOT_READY")
+    if slice_blockers:
+        reasons.extend(
+            f"CPU_FALLBACK_BLOCKER:{item}" for item in sorted(set(slice_blockers))
+        )
+
+    required_prerequisite_ids = {
+        "benchmark-authority-v2",
+        "immutable-model-bundles",
+        "external-evidence-storage",
+        "expert-reviewed-58-case-suite",
+        "dedicated-cpu-host",
+    }
+    observed_prerequisite_ids = set(prerequisite["prerequisites"])
+    missing_prerequisites = sorted(
+        required_prerequisite_ids - observed_prerequisite_ids
+    )
+    reasons.extend(
+        f"PREREQUISITE_ABSENT:{item}" for item in missing_prerequisites
+    )
+    for prerequisite_id in sorted(
+        required_prerequisite_ids & observed_prerequisite_ids
+    ):
+        item = prerequisite["prerequisites"][prerequisite_id]
+        if not isinstance(item, dict):
+            reasons.append(f"PREREQUISITE_INVALID:{prerequisite_id}")
+            continue
+        _require_keys(
+            item,
+            {
+                "satisfied",
+                "required_status",
+                "observed_status",
+                "owner_issue",
+                "kind",
+                "evidence_ref",
+                "exact_commit",
+                "simulated",
+            },
+            f"prerequisites.{prerequisite_id}",
+        )
+        if _boolean(
+            item["simulated"], f"prerequisites.{prerequisite_id}.simulated"
+        ):
+            reasons.append(f"SIMULATED_PREREQUISITE:{prerequisite_id}")
+        if not _boolean(
+            item["satisfied"], f"prerequisites.{prerequisite_id}.satisfied"
+        ):
+            reasons.append(f"UNSATISFIED_PREREQUISITE:{prerequisite_id}")
+
+    if assessment["status"] != authority["evaluation"]["required_status"]:
+        reasons.append("GOLD_SET_STATUS_NOT_ACCEPTED")
+    if assessment["accepted"] is not authority["evaluation"]["required_accepted"]:
+        reasons.append("GOLD_SET_NOT_ACCEPTED")
+    counts = assessment["counts"]
+    if counts["total_cases"] != authority["evaluation"]["required_total_cases"]:
+        reasons.append("GOLD_SET_TOTAL_CASE_COUNT_MISMATCH")
+    if counts["critical_cases"] != authority["evaluation"]["required_critical_cases"]:
+        reasons.append("GOLD_SET_CRITICAL_CASE_COUNT_MISMATCH")
+    if counts["unreviewed_cases"] > authority["evaluation"]["maximum_unreviewed_cases"]:
+        reasons.append("GOLD_SET_UNREVIEWED_CASES_PRESENT")
+    if counts["reviewed_cases"] != counts["total_cases"]:
+        reasons.append("GOLD_SET_REVIEW_COVERAGE_INCOMPLETE")
+    if assessment["blocking_reasons"]:
+        reasons.append("GOLD_SET_BLOCKING_REASONS_PRESENT")
+    if assessment["missing_review_case_ids"]:
+        reasons.append("GOLD_SET_MISSING_REVIEW_CASES_PRESENT")
+
+    ready = not reasons
+    report: dict[str, object] = {
+        "schema_version": "tai.cpu-benchmark-execution-readiness.v1",
+        "status": "READY_FOR_EXTERNAL_EXECUTION" if ready else "BLOCKED",
+        "ready": ready,
+        "exact_main": exact_commit,
+        "evaluated_at": now.isoformat(),
+        "authority_sha256": authority["authority_sha256"],
+        "prerequisite_report_sha256": prerequisite["report_sha256"],
+        "gold_corpus_sha256": assessment["corpus_sha256"],
+        "gold_assessment_sha256": assessment["assessment_sha256"],
+        "required_profiles": authority["benchmark_authority"]["required_profiles"],
+        "reasons": sorted(set(reasons)),
+        **_EXPECTED_MATURITY,
+    }
+    report["report_sha256"] = canonical_sha256(report)
+    return report
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/apps/tai/tai/cpu_benchmark_execution_cli.py
+++ b/apps/tai/tai/cpu_benchmark_execution_cli.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from tai import cpu_benchmark_execution as execution
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate AP-13C.1a CPU benchmark execution readiness."
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    validate = commands.add_parser("validate-authority")
+    validate.add_argument("authority", type=Path)
+    validate.add_argument("--output", type=Path)
+
+    readiness = commands.add_parser("evaluate-readiness")
+    readiness.add_argument("authority", type=Path)
+    readiness.add_argument("prerequisite_report", type=Path)
+    readiness.add_argument("gold_assessment", type=Path)
+    readiness.add_argument("--exact-main", required=True)
+    readiness.add_argument("--evaluated-at", required=True)
+    readiness.add_argument("--output", type=Path)
+    return parser
+
+
+def _emit(value: dict[str, object], output: Path | None) -> None:
+    if output is not None:
+        execution.write_json(output, value)
+    print(json.dumps(value, ensure_ascii=False, sort_keys=True))
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        if args.command == "validate-authority":
+            authority = execution.load_execution_authority(args.authority)
+            result: dict[str, object] = {
+                "schema_version": "tai.cpu-benchmark-execution-authority-validation.v1",
+                "status": "VALID",
+                "authority_sha256": authority["authority_sha256"],
+                "required_profiles": authority["benchmark_authority"][
+                    "required_profiles"
+                ],
+                "benchmark_status": "PENDING_BENCHMARK",
+                "model_admission_status": "PENDING_ADMISSION",
+                "production_operational_status": "NOT_ATTESTED",
+            }
+            _emit(result, args.output)
+            return 0
+
+        report = execution.evaluate_readiness(
+            args.authority,
+            args.prerequisite_report,
+            args.gold_assessment,
+            exact_main=args.exact_main,
+            evaluated_at=args.evaluated_at,
+        )
+        _emit(report, args.output)
+        return 0 if report["status"] == "READY_FOR_EXTERNAL_EXECUTION" else 2
+    except execution.ExecutionContractError as exc:
+        result = {
+            "schema_version": "tai.cpu-benchmark-execution-cli-error.v1",
+            "status": "REJECTED",
+            "reason": f"CONTRACT_INVALID:{exc}",
+            "benchmark_status": "PENDING_BENCHMARK",
+            "model_admission_status": "PENDING_ADMISSION",
+            "production_operational_status": "NOT_ATTESTED",
+        }
+        _emit(result, getattr(args, "output", None))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/tai/tests/test_cpu_benchmark_execution.py
+++ b/apps/tai/tests/test_cpu_benchmark_execution.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tai.benchmark_prerequisite_matrix import evaluate_matrix, write_json
+from tai.cpu_benchmark_execution import (
+    ExecutionContractError,
+    canonical_sha256,
+    evaluate_readiness,
+    load_execution_authority,
+)
+
+ROOT = Path(__file__).parents[1]
+ARTIFACTS = ROOT / "model-artifacts"
+AUTHORITY = ARTIFACTS / "cpu-benchmark-execution-authority.v1.json"
+PREREQUISITE_AUTHORITY = ARTIFACTS / "benchmark-prerequisite-authority.v1.json"
+PREREQUISITE_BASELINE = ARTIFACTS / "benchmark-prerequisite-baseline.v1.json"
+GOLD_BASELINE = (
+    ROOT.parents[1]
+    / "docs"
+    / "platform-v7"
+    / "autopilot"
+    / "tai-ap-14c"
+    / "baseline-assessment.v1.json"
+)
+EXACT_MAIN = "4cc19710e070441081a031fd30efae3b0ba91ab0"
+
+
+def _json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _write(path: Path, value: object) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _blocked_prerequisite_report(tmp_path: Path) -> Path:
+    report = evaluate_matrix(
+        PREREQUISITE_AUTHORITY,
+        PREREQUISITE_BASELINE,
+        evaluated_at=datetime(2026, 7, 21, 14, 20, tzinfo=UTC),
+    )
+    path = tmp_path / "prerequisite-report.json"
+    write_json(path, report)
+    return path
+
+
+def _accepted_prerequisite_report(tmp_path: Path) -> Path:
+    source = _blocked_prerequisite_report(tmp_path)
+    report = _json(source)
+    required = {
+        "benchmark-authority-v2",
+        "immutable-model-bundles",
+        "external-evidence-storage",
+        "expert-reviewed-58-case-suite",
+        "dedicated-cpu-host",
+    }
+    for prerequisite_id in required:
+        item = report["prerequisites"][prerequisite_id]
+        item["satisfied"] = True
+        item["observed_status"] = item["required_status"]
+        item["simulated"] = False
+    report["slices"]["cpu-fallback-execution"] = {
+        "status": "READY_FOR_CPU_FALLBACK_BENCHMARK",
+        "ready": True,
+        "blockers": [],
+    }
+    report["reasons"] = [
+        item
+        for item in report["reasons"]
+        if not item.startswith("cpu-fallback-execution:")
+    ]
+    report["report_sha256"] = canonical_sha256(
+        {key: value for key, value in report.items() if key != "report_sha256"}
+    )
+    path = tmp_path / "accepted-prerequisite-report.json"
+    _write(path, report)
+    return path
+
+
+def _accepted_gold_assessment(tmp_path: Path) -> Path:
+    assessment = _json(GOLD_BASELINE)
+    assessment["accepted"] = True
+    assessment["status"] = "ACCEPTED"
+    assessment["counts"]["reviewed_cases"] = 58
+    assessment["counts"]["unreviewed_cases"] = 0
+    assessment["blocking_reasons"] = []
+    assessment["missing_review_case_ids"] = []
+    assessment["component_sha256"]["reviews_sha256"] = "f" * 64
+    assessment["assessment_sha256"] = canonical_sha256(
+        {key: value for key, value in assessment.items() if key != "assessment_sha256"}
+    )
+    path = tmp_path / "accepted-gold-assessment.json"
+    _write(path, assessment)
+    return path
+
+
+def test_authority_pins_exact_cpu_execution_boundary() -> None:
+    authority = load_execution_authority(AUTHORITY)
+
+    assert authority["issue"] == 2977
+    assert authority["command"] == "/tai benchmark cpu-fallback exact-main"
+    assert authority["toolchain"]["commit"] == (
+        "aedb2a5e9ca3d4064148bbb919e0ddc0c1b70ab3"
+    )
+    assert authority["benchmark_authority"]["required_profiles"] == [
+        "qwen3-8b-cpu-q4-k-m",
+        "mistral-7b-fallback-cpu-q4-k-m",
+    ]
+    assert authority["measurements"]["concurrency_levels"] == [1, 2, 4]
+    assert authority["fallback"]["minimum_trigger_count"] == 100
+    assert authority["soak"]["minimum_duration_seconds"] == 3600
+    assert authority["target"]["production_fallback_allowed"] is False
+    assert authority["maturity_boundary"]["production_operational_status"] == (
+        "NOT_ATTESTED"
+    )
+    assert authority["authority_sha256"]
+
+
+def test_current_external_state_remains_blocked(tmp_path: Path) -> None:
+    report = evaluate_readiness(
+        AUTHORITY,
+        _blocked_prerequisite_report(tmp_path),
+        GOLD_BASELINE,
+        exact_main=EXACT_MAIN,
+        evaluated_at="2026-07-21T14:21:00+00:00",
+    )
+
+    assert report["status"] == "BLOCKED"
+    assert report["ready"] is False
+    reasons = set(report["reasons"])
+    assert "CPU_FALLBACK_SLICE_NOT_READY" in reasons
+    assert "UNSATISFIED_PREREQUISITE:immutable-model-bundles" in reasons
+    assert "UNSATISFIED_PREREQUISITE:external-evidence-storage" in reasons
+    assert "UNSATISFIED_PREREQUISITE:expert-reviewed-58-case-suite" in reasons
+    assert "GOLD_SET_NOT_ACCEPTED" in reasons
+    assert "GOLD_SET_UNREVIEWED_CASES_PRESENT" in reasons
+    assert report["benchmark_status"] == "PENDING_BENCHMARK"
+    assert report["model_admission_status"] == "PENDING_ADMISSION"
+    assert report["production_operational_status"] == "NOT_ATTESTED"
+
+
+def test_all_real_prerequisites_open_only_external_execution_gate(
+    tmp_path: Path,
+) -> None:
+    report = evaluate_readiness(
+        AUTHORITY,
+        _accepted_prerequisite_report(tmp_path),
+        _accepted_gold_assessment(tmp_path),
+        exact_main=EXACT_MAIN,
+        evaluated_at="2026-07-21T14:21:00+00:00",
+    )
+
+    assert report["status"] == "READY_FOR_EXTERNAL_EXECUTION"
+    assert report["ready"] is True
+    assert report["reasons"] == []
+    assert report["required_profiles"] == [
+        "qwen3-8b-cpu-q4-k-m",
+        "mistral-7b-fallback-cpu-q4-k-m",
+    ]
+    assert report["benchmark_status"] == "PENDING_BENCHMARK"
+    assert report["model_admission_status"] == "PENDING_ADMISSION"
+    assert report["production_operational_status"] == "NOT_ATTESTED"
+
+
+def test_stale_future_and_simulated_evidence_fail_closed(tmp_path: Path) -> None:
+    prerequisite_path = _accepted_prerequisite_report(tmp_path)
+    assessment_path = _accepted_gold_assessment(tmp_path)
+
+    stale = evaluate_readiness(
+        AUTHORITY,
+        prerequisite_path,
+        assessment_path,
+        exact_main=EXACT_MAIN,
+        evaluated_at="2026-07-23T14:21:00+00:00",
+    )
+    assert "PREREQUISITE_REPORT_STALE" in stale["reasons"]
+
+    prerequisite = _json(prerequisite_path)
+    future = datetime(2026, 7, 22, 14, 21, tzinfo=UTC)
+    prerequisite["evaluated_at"] = future.isoformat()
+    prerequisite["observed_at"] = future.isoformat()
+    prerequisite["prerequisites"]["dedicated-cpu-host"]["simulated"] = True
+    prerequisite["report_sha256"] = canonical_sha256(
+        {key: value for key, value in prerequisite.items() if key != "report_sha256"}
+    )
+    _write(prerequisite_path, prerequisite)
+
+    rejected = evaluate_readiness(
+        AUTHORITY,
+        prerequisite_path,
+        assessment_path,
+        exact_main=EXACT_MAIN,
+        evaluated_at="2026-07-21T14:21:00+00:00",
+    )
+    reasons = set(rejected["reasons"])
+    assert "PREREQUISITE_REPORT_FROM_FUTURE" in reasons
+    assert "PREREQUISITE_OBSERVATION_FROM_FUTURE" in reasons
+    assert "SIMULATED_PREREQUISITE:dedicated-cpu-host" in reasons
+
+
+def test_maturity_inflation_and_authority_weakening_are_rejected(
+    tmp_path: Path,
+) -> None:
+    authority = _json(AUTHORITY)
+    authority["target"]["production_fallback_allowed"] = True
+    weakened = tmp_path / "weakened-authority.json"
+    _write(weakened, authority)
+    with pytest.raises(ExecutionContractError, match="target boundary mismatch"):
+        load_execution_authority(weakened)
+
+    prerequisite = _json(_accepted_prerequisite_report(tmp_path))
+    prerequisite["benchmark_status"] = "VERIFIED"
+    prerequisite["report_sha256"] = canonical_sha256(
+        {key: value for key, value in prerequisite.items() if key != "report_sha256"}
+    )
+    inflated = tmp_path / "inflated-prerequisite.json"
+    _write(inflated, prerequisite)
+    with pytest.raises(ExecutionContractError, match="maturity boundary"):
+        evaluate_readiness(
+            AUTHORITY,
+            inflated,
+            _accepted_gold_assessment(tmp_path),
+            exact_main=EXACT_MAIN,
+            evaluated_at="2026-07-21T14:21:00+00:00",
+        )
+
+
+def test_duplicate_and_unknown_authority_keys_are_rejected(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text(
+        '{"schema_version":"x","schema_version":"y"}', encoding="utf-8"
+    )
+    with pytest.raises(ExecutionContractError, match="duplicate JSON key"):
+        load_execution_authority(duplicate)
+
+    authority = _json(AUTHORITY)
+    authority["unknown"] = True
+    unknown = tmp_path / "unknown.json"
+    _write(unknown, authority)
+    with pytest.raises(ExecutionContractError, match="unknown=\['unknown'\]"):
+        load_execution_authority(unknown)

--- a/apps/tai/tests/test_cpu_benchmark_execution.py
+++ b/apps/tai/tests/test_cpu_benchmark_execution.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 

--- a/apps/tai/tests/test_cpu_benchmark_execution_cli.py
+++ b/apps/tai/tests/test_cpu_benchmark_execution_cli.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tai import cpu_benchmark_execution_cli as execution_cli
+from tai.benchmark_prerequisite_matrix import evaluate_matrix, write_json
+from tai.cpu_benchmark_execution import (
+    ExecutionContractError,
+    canonical_sha256,
+    evaluate_readiness,
+    load_execution_authority,
+)
+
+ROOT = Path(__file__).parents[1]
+ARTIFACTS = ROOT / "model-artifacts"
+AUTHORITY = ARTIFACTS / "cpu-benchmark-execution-authority.v1.json"
+PREREQUISITE_AUTHORITY = ARTIFACTS / "benchmark-prerequisite-authority.v1.json"
+PREREQUISITE_BASELINE = ARTIFACTS / "benchmark-prerequisite-baseline.v1.json"
+GOLD_BASELINE = (
+    ROOT.parents[1]
+    / "docs"
+    / "platform-v7"
+    / "autopilot"
+    / "tai-ap-14c"
+    / "baseline-assessment.v1.json"
+)
+EXACT_MAIN = "4cc19710e070441081a031fd30efae3b0ba91ab0"
+
+
+def _json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _write(path: Path, value: object) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _blocked_report(tmp_path: Path) -> Path:
+    report = evaluate_matrix(
+        PREREQUISITE_AUTHORITY,
+        PREREQUISITE_BASELINE,
+        evaluated_at=datetime(2026, 7, 21, 14, 20, tzinfo=UTC),
+    )
+    path = tmp_path / "prerequisite-report.json"
+    write_json(path, report)
+    return path
+
+
+def _accepted_report(tmp_path: Path) -> Path:
+    path = _blocked_report(tmp_path)
+    report = _json(path)
+    required = {
+        "benchmark-authority-v2",
+        "immutable-model-bundles",
+        "external-evidence-storage",
+        "expert-reviewed-58-case-suite",
+        "dedicated-cpu-host",
+    }
+    for prerequisite_id in required:
+        item = report["prerequisites"][prerequisite_id]
+        item["satisfied"] = True
+        item["observed_status"] = item["required_status"]
+        item["simulated"] = False
+    report["slices"]["cpu-fallback-execution"] = {
+        "status": "READY_FOR_CPU_FALLBACK_BENCHMARK",
+        "ready": True,
+        "blockers": [],
+    }
+    report["reasons"] = [
+        item
+        for item in report["reasons"]
+        if not item.startswith("cpu-fallback-execution:")
+    ]
+    report["report_sha256"] = canonical_sha256(
+        {key: value for key, value in report.items() if key != "report_sha256"}
+    )
+    _write(path, report)
+    return path
+
+
+def _accepted_gold(tmp_path: Path) -> Path:
+    assessment = _json(GOLD_BASELINE)
+    assessment["accepted"] = True
+    assessment["status"] = "ACCEPTED"
+    assessment["counts"]["reviewed_cases"] = 58
+    assessment["counts"]["unreviewed_cases"] = 0
+    assessment["blocking_reasons"] = []
+    assessment["missing_review_case_ids"] = []
+    assessment["component_sha256"]["reviews_sha256"] = "f" * 64
+    assessment["assessment_sha256"] = canonical_sha256(
+        {key: value for key, value in assessment.items() if key != "assessment_sha256"}
+    )
+    path = tmp_path / "accepted-gold.json"
+    _write(path, assessment)
+    return path
+
+
+def test_cli_validates_authority_and_writes_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "authority-validation.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cpu-benchmark-execution",
+            "validate-authority",
+            str(AUTHORITY),
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert execution_cli.main() == 0
+    emitted = json.loads(capsys.readouterr().out)
+    assert emitted["status"] == "VALID"
+    assert _json(output)["production_operational_status"] == "NOT_ATTESTED"
+
+
+def test_cli_returns_two_for_current_blocked_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cpu-benchmark-execution",
+            "evaluate-readiness",
+            str(AUTHORITY),
+            str(_blocked_report(tmp_path)),
+            str(GOLD_BASELINE),
+            "--exact-main",
+            EXACT_MAIN,
+            "--evaluated-at",
+            "2026-07-21T14:21:00+00:00",
+        ],
+    )
+
+    assert execution_cli.main() == 2
+    emitted = json.loads(capsys.readouterr().out)
+    assert emitted["status"] == "BLOCKED"
+    assert emitted["benchmark_status"] == "PENDING_BENCHMARK"
+
+
+def test_cli_opens_only_external_execution_gate_when_all_inputs_are_real(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cpu-benchmark-execution",
+            "evaluate-readiness",
+            str(AUTHORITY),
+            str(_accepted_report(tmp_path)),
+            str(_accepted_gold(tmp_path)),
+            "--exact-main",
+            EXACT_MAIN,
+            "--evaluated-at",
+            "2026-07-21T14:21:00+00:00",
+        ],
+    )
+
+    assert execution_cli.main() == 0
+    emitted = json.loads(capsys.readouterr().out)
+    assert emitted["status"] == "READY_FOR_EXTERNAL_EXECUTION"
+    assert emitted["model_admission_status"] == "PENDING_ADMISSION"
+
+
+def test_cli_contract_error_preserves_maturity_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cpu-benchmark-execution",
+            "evaluate-readiness",
+            str(AUTHORITY),
+            str(_accepted_report(tmp_path)),
+            str(_accepted_gold(tmp_path)),
+            "--exact-main",
+            "main",
+            "--evaluated-at",
+            "2026-07-21T14:21:00+00:00",
+        ],
+    )
+
+    assert execution_cli.main() == 2
+    emitted = json.loads(capsys.readouterr().out)
+    assert emitted["status"] == "REJECTED"
+    assert emitted["reason"].startswith("CONTRACT_INVALID:")
+    assert emitted["production_operational_status"] == "NOT_ATTESTED"
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        ("prerequisite-not-object", "must be an object"),
+        ("models-not-array", "must be an array"),
+        ("blank-toolchain-name", "non-blank string"),
+        ("bad-toolchain-commit", "exact lowercase Git commit"),
+        ("bad-toolchain-profile", "portable bounded identity"),
+        ("duplicate-binaries", "unique values"),
+        ("unsorted-concurrency", "sorted unique"),
+        ("non-boolean-review", "must be a boolean"),
+        ("negative-soak", "integer >= 0"),
+        ("empty-suffixes", "must be non-empty"),
+    ],
+)
+def test_authority_scalar_and_collection_guards_fail_closed(
+    tmp_path: Path,
+    mutation: str,
+    match: str,
+) -> None:
+    authority = _json(AUTHORITY)
+    if mutation == "prerequisite-not-object":
+        authority["prerequisite_gate"] = []
+    elif mutation == "models-not-array":
+        authority["models"] = {}
+    elif mutation == "blank-toolchain-name":
+        authority["toolchain"]["name"] = ""
+    elif mutation == "bad-toolchain-commit":
+        authority["toolchain"]["commit"] = "main"
+    elif mutation == "bad-toolchain-profile":
+        authority["toolchain"]["profile"] = "bad profile"
+    elif mutation == "duplicate-binaries":
+        authority["toolchain"]["required_binaries"] = ["llama-cli", "llama-cli"]
+    elif mutation == "unsorted-concurrency":
+        authority["models"][0]["required_concurrency_levels"] = [2, 1]
+    elif mutation == "non-boolean-review":
+        authority["evaluation"]["required_accepted"] = 1
+    elif mutation == "negative-soak":
+        authority["soak"]["maximum_failed_requests"] = -1
+    elif mutation == "empty-suffixes":
+        authority["evidence"]["forbidden_suffixes"] = []
+    path = tmp_path / f"{mutation}.json"
+    _write(path, authority)
+
+    with pytest.raises(ExecutionContractError, match=match):
+        load_execution_authority(path)
+
+
+def test_json_root_and_integer_boolean_are_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "array-root.json"
+    root.write_text("[]", encoding="utf-8")
+    with pytest.raises(ExecutionContractError, match="root must be an object"):
+        load_execution_authority(root)
+
+    authority = _json(AUTHORITY)
+    authority["program_issue"] = True
+    boolean_integer = tmp_path / "boolean-integer.json"
+    _write(boolean_integer, authority)
+    with pytest.raises(ExecutionContractError, match="integer >= 1"):
+        load_execution_authority(boolean_integer)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        ("schema", "unsupported prerequisite report"),
+        ("sha", "lowercase SHA-256"),
+        ("invalid-time", "ISO-8601"),
+        ("naive-time", "timezone-aware"),
+        ("unknown", "unknown=\['unknown'\]"),
+        ("digest", "digest mismatch"),
+    ],
+)
+def test_prerequisite_report_contract_rejects_tampering(
+    tmp_path: Path,
+    mutation: str,
+    match: str,
+) -> None:
+    report_path = _accepted_report(tmp_path)
+    report = _json(report_path)
+    if mutation == "schema":
+        report["schema_version"] = "wrong"
+    elif mutation == "sha":
+        report["authority_sha256"] = "bad"
+    elif mutation == "invalid-time":
+        report["evaluated_at"] = "not-a-time"
+    elif mutation == "naive-time":
+        report["evaluated_at"] = "2026-07-21T14:20:00"
+    elif mutation == "unknown":
+        report["unknown"] = True
+    elif mutation == "digest":
+        report["status"] = "READY"
+    if mutation != "digest":
+        report["report_sha256"] = canonical_sha256(
+            {key: value for key, value in report.items() if key != "report_sha256"}
+        )
+    _write(report_path, report)
+
+    with pytest.raises(ExecutionContractError, match=match):
+        evaluate_readiness(
+            AUTHORITY,
+            report_path,
+            _accepted_gold(tmp_path),
+            exact_main=EXACT_MAIN,
+            evaluated_at="2026-07-21T14:21:00+00:00",
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        ("accepted-type", "must be a boolean"),
+        ("component-sha", "lowercase SHA-256"),
+        ("counts-object", "must be an object"),
+        ("target-number", "must be numeric"),
+        ("blockers-array", "must be an array"),
+    ],
+)
+def test_gold_assessment_contract_rejects_invalid_evidence(
+    tmp_path: Path,
+    mutation: str,
+    match: str,
+) -> None:
+    assessment_path = _accepted_gold(tmp_path)
+    assessment = _json(assessment_path)
+    if mutation == "accepted-type":
+        assessment["accepted"] = "yes"
+    elif mutation == "component-sha":
+        assessment["component_sha256"]["platform_sha256"] = "bad"
+    elif mutation == "counts-object":
+        assessment["counts"] = []
+    elif mutation == "target-number":
+        assessment["quality_targets"]["platform_accuracy_minimum"] = "0.95"
+    elif mutation == "blockers-array":
+        assessment["blocking_reasons"] = {}
+    _write(assessment_path, assessment)
+
+    with pytest.raises(ExecutionContractError, match=match):
+        evaluate_readiness(
+            AUTHORITY,
+            _accepted_report(tmp_path),
+            assessment_path,
+            exact_main=EXACT_MAIN,
+            evaluated_at="2026-07-21T14:21:00+00:00",
+        )

--- a/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
+++ b/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
@@ -78,12 +78,16 @@ def test_workflow_is_owner_only_exact_main_and_issue_bound() -> None:
 def test_workflow_validates_only_readiness_and_never_touches_model_host() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     assert "validate-authority" in workflow
+    assert "gold-set-authority.mjs" in workflow
+    assert "gold-authority-validation.json" in workflow
     assert "benchmark_prerequisite_matrix_cli" in workflow
     assert "evaluate-readiness" in workflow
     assert "READY_FOR_EXTERNAL_EXECUTION" in workflow
     assert "PENDING_BENCHMARK" in workflow
     assert "PENDING_ADMISSION" in workflow
     assert "NOT_ATTESTED" in workflow
+    assert "test \"$(jq -r '.accepted' \"$gold\")\" = 'true'" in workflow
+    assert "test \"$(jq -r '.counts.reviewed_cases' \"$gold\")\" = '58'" in workflow
     for forbidden in (
         "TAI_MODEL_HOST",
         "TAI_MODEL_SSH_KEY",
@@ -105,6 +109,7 @@ def test_only_bounded_metadata_can_enter_github_artifacts() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     upload = workflow[workflow.index("Upload bounded readiness evidence") :]
     assert "authority-validation.json" in upload
+    assert "gold-authority-validation.json" in upload
     assert "prerequisite-report.json" in upload
     assert "readiness.json" in upload
     assert "cpu-benchmark-execution-authority.v1.json" in upload

--- a/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
+++ b/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).parents[3]
+TAI_ROOT = Path(__file__).parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "tai-cpu-benchmark-execution-authority.yml"
+AUTHORITY = TAI_ROOT / "model-artifacts" / "cpu-benchmark-execution-authority.v1.json"
+RUNBOOK = TAI_ROOT / "model-artifacts" / "cpu-benchmark-execution-runbook.v1.md"
+SCOPE = (
+    TAI_ROOT
+    / "governance"
+    / "scopes"
+    / "ap-13c1a-cpu-benchmark-authority-2977.json"
+)
+COMMAND = "/tai benchmark cpu-fallback exact-main"
+EXPECTED_PATHS = {
+    ".github/workflows/tai-cpu-benchmark-execution-authority.yml",
+    "apps/tai/governance/scopes/ap-13c1a-cpu-benchmark-authority-2977.json",
+    "apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json",
+    "apps/tai/model-artifacts/cpu-benchmark-execution-runbook.v1.md",
+    "apps/tai/tai/cpu_benchmark_execution.py",
+    "apps/tai/tai/cpu_benchmark_execution_cli.py",
+    "apps/tai/tests/test_cpu_benchmark_execution.py",
+    "apps/tai/tests/test_cpu_benchmark_execution_workflow.py",
+}
+
+
+def _json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_scope_is_exact_and_preserves_maturity_boundary() -> None:
+    scope = _json(SCOPE)
+    assert scope["schema_version"] == "tai.concurrent-scope.v1"
+    assert scope["branch"] == "agent/tai-ap-13c1a-cpu-benchmark-authority"
+    assert (scope["program_issue"], scope["parent_issue"], scope["issue"]) == (
+        2726,
+        2971,
+        2977,
+    )
+    assert set(scope["allowed_paths"]) == EXPECTED_PATHS
+    assert "model weights" in " ".join(scope["forbidden_capabilities"])
+    assert "production_operational_status remains NOT_ATTESTED" in scope["acceptance"][-1]
+
+
+def test_workflow_is_owner_only_exact_main_and_issue_bound() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert "issue_comment:" in workflow
+    assert "types: [created]" in workflow
+    assert "workflow_dispatch:" not in workflow
+    assert "schedule:" not in workflow
+    assert "push:" not in workflow
+    assert "github.ref == 'refs/heads/main'" in workflow
+    assert "github.actor == github.repository_owner" in workflow
+    assert "github.triggering_actor == github.repository_owner" in workflow
+    assert "github.event.issue.number == 2977" in workflow
+    assert f"github.event.comment.body == '{COMMAND}'" in workflow
+    assert "github.event.comment.author_association == 'OWNER'" in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "actions: read\n  contents: read\n  issues: write" in workflow
+    assert "contents: write" not in workflow
+    assert "timeout-minutes: 30" in workflow
+
+
+def test_workflow_validates_only_readiness_and_never_touches_model_host() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert "validate-authority" in workflow
+    assert "benchmark_prerequisite_matrix_cli" in workflow
+    assert "evaluate-readiness" in workflow
+    assert "READY_FOR_EXTERNAL_EXECUTION" in workflow
+    assert "PENDING_BENCHMARK" in workflow
+    assert "PENDING_ADMISSION" in workflow
+    assert "NOT_ATTESTED" in workflow
+    for forbidden in (
+        "TAI_MODEL_HOST",
+        "TAI_MODEL_SSH_KEY",
+        "TAI_BUNDLE_S3_SECRET_ACCESS_KEY",
+        "ssh ",
+        "scp ",
+        "aws s3",
+        "llama-cli",
+        "llama-server",
+        "llama-bench",
+        "195.19.12.120",
+        "netlify",
+        "vercel",
+    ):
+        assert forbidden.casefold() not in workflow.casefold()
+
+
+def test_only_bounded_metadata_can_enter_github_artifacts() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    upload = workflow[workflow.index("Upload bounded readiness evidence") :]
+    assert "authority-validation.json" in upload
+    assert "prerequisite-report.json" in upload
+    assert "readiness.json" in upload
+    assert "cpu-benchmark-execution-authority.v1.json" in upload
+    assert "retention-days: 90" in upload
+    assert "compression-level: 0" in upload
+    assert "overwrite: false" in upload
+    assert "include-hidden-files: false" in upload
+    for forbidden in ("*.gguf", ".safetensors", ".tar", "sources/", "payload/"):
+        assert forbidden not in upload
+
+
+def test_runbook_documents_blockers_and_no_maturity_inflation() -> None:
+    runbook = RUNBOOK.read_text(encoding="utf-8")
+    assert COMMAND in runbook
+    assert "immutable model bundles have not yet been accepted" in runbook
+    assert "AP-14C corpus remains `PENDING_REVIEW`" in runbook
+    assert "must not start inference" in runbook
+    assert "dedicated `tai-model` host" in runbook
+    assert "one-hour soak" in runbook
+    assert "CPU result can satisfy" not in runbook
+    assert "benchmark status: `PENDING_BENCHMARK`" in runbook
+    assert "model admission: `PENDING_ADMISSION`" in runbook
+    assert "production operational status: `NOT_ATTESTED`" in runbook
+
+
+def test_authority_excludes_production_and_gpu_execution() -> None:
+    authority = _json(AUTHORITY)
+    assert authority["target"]["host_role"] == "DEDICATED_MODEL_HOST"
+    assert authority["target"]["required_user"] == "tai-model"
+    assert authority["target"]["production_fallback_allowed"] is False
+    assert authority["target"]["network_egress"] == "S3_EXACT_VERSION_ONLY"
+    assert {model["runtime_class"] for model in authority["models"]} == {"CPU"}
+    assert {model["quantization"] for model in authority["models"]} == {"Q4_K_M"}
+    assert authority["maturity_boundary"] == {
+        "benchmark_status": "PENDING_BENCHMARK",
+        "model_admission_status": "PENDING_ADMISSION",
+        "production_operational_status": "NOT_ATTESTED",
+    }

--- a/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
+++ b/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
@@ -47,6 +47,11 @@ def test_scope_is_exact_and_preserves_maturity_boundary() -> None:
         2977,
     )
     assert set(scope["allowed_paths"]) == EXPECTED_PATHS
+    assert ".gitleaksignore" in scope["allowed_paths"]
+    assert "apps/tai/tests/test_gitleaks_release_authority.py" in scope["allowed_paths"]
+    assert "broad secret-scanner suppression" in " ".join(
+        scope["forbidden_capabilities"]
+    )
     assert "model weights" in " ".join(scope["forbidden_capabilities"])
     assert "production_operational_status remains NOT_ATTESTED" in scope["acceptance"][-1]
 

--- a/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
+++ b/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
@@ -17,6 +17,7 @@ SCOPE = (
 )
 COMMAND = "/tai benchmark cpu-fallback exact-main"
 EXPECTED_PATHS = {
+    ".gitleaksignore",
     ".github/workflows/tai-cpu-benchmark-execution-authority.yml",
     "apps/tai/governance/scopes/ap-13c1a-cpu-benchmark-authority-2977.json",
     "apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json",
@@ -26,6 +27,7 @@ EXPECTED_PATHS = {
     "apps/tai/tests/test_cpu_benchmark_execution.py",
     "apps/tai/tests/test_cpu_benchmark_execution_cli.py",
     "apps/tai/tests/test_cpu_benchmark_execution_workflow.py",
+    "apps/tai/tests/test_gitleaks_release_authority.py",
 }
 
 

--- a/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
+++ b/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
@@ -116,7 +116,7 @@ def test_runbook_documents_blockers_and_no_maturity_inflation() -> None:
     assert "must not start inference" in runbook
     assert "dedicated `tai-model` host" in runbook
     assert "one-hour soak" in runbook
-    assert "CPU result can satisfy" not in runbook
+    assert "No CPU result can satisfy the separate Qwen GPU/shared Q8_0 profile" in runbook
     assert "benchmark status: `PENDING_BENCHMARK`" in runbook
     assert "model admission: `PENDING_ADMISSION`" in runbook
     assert "production operational status: `NOT_ATTESTED`" in runbook

--- a/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
+++ b/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
@@ -24,6 +24,7 @@ EXPECTED_PATHS = {
     "apps/tai/tai/cpu_benchmark_execution.py",
     "apps/tai/tai/cpu_benchmark_execution_cli.py",
     "apps/tai/tests/test_cpu_benchmark_execution.py",
+    "apps/tai/tests/test_cpu_benchmark_execution_cli.py",
     "apps/tai/tests/test_cpu_benchmark_execution_workflow.py",
 }
 

--- a/apps/tai/tests/test_gitleaks_release_authority.py
+++ b/apps/tai/tests/test_gitleaks_release_authority.py
@@ -39,5 +39,10 @@ def test_gitleaks_exceptions_are_exact_and_release_attested() -> None:
         "387c77b28f89b467080371c3e55cbf376acdd28e:"
         "apps/tai/model-artifacts/model-bundle-finalization-authority.v1.json:"
         "generic-api-key:75",
+        "d84b7faadf1b430e549850ccc5cce82a03d52d99:"
+        "apps/tai/model-artifacts/cpu-benchmark-execution-authority.v1.json:"
+        "generic-api-key:67",
+        "ecdc1130ca1bc424f3ccecb072115e304722c971:"
+        "apps/tai/tai/cpu_benchmark_execution.py:generic-api-key:413",
     ]
     assert all(_FINGERPRINT.fullmatch(entry) is not None for entry in entries)


### PR DESCRIPTION
## What changed

- adds the exact AP-13C.1a concurrent scope for issue #2977;
- pins the Qwen3-8B and Mistral-7B CPU Q4_K_M execution profiles, llama.cpp b9637 toolchain, 58-case AP-14C suite, concurrency, fallback and soak requirements;
- adds a strict fail-closed readiness evaluator and CLI;
- adds an owner-only exact-main issue-comment workflow for `/tai benchmark cpu-fallback exact-main`;
- adds positive and negative tests for stale, future, simulated, incomplete and maturity-inflated evidence;
- documents the current real blockers: immutable Selectel S3 bundles and 58/58 expert review acceptance.

## Why

The existing AP-13C v2 verifier can reject or accept completed benchmark manifests, but there was no bounded execution gate preventing a benchmark from starting before immutable bundle restore and expert corpus acceptance. This slice closes that control-plane gap without fabricating measurements.

## Maturity boundary

This PR does **not** execute inference, produce benchmark numbers, accept expert reviews, provision external storage, run the GPU profile, admit models, activate runtime composition or attest production.

- benchmark: `PENDING_BENCHMARK`;
- model admission: `PENDING_ADMISSION`;
- production operational status: `NOT_ATTESTED`.

## Validation

Expected repository gates:

- Ruff;
- strict mypy;
- full pytest/coverage;
- scope, dependency, security and runtime-context checks.

Refs #2977, #2971, #2974, #2961, #2954, #2973, #2861 and #2726.