### PR TITLE
TAI AP-13C.1b: fix exact-main authority workflow ordering

### DIFF
--- a/.github/workflows/tai-cpu-benchmark-execution-authority.yml
+++ b/.github/workflows/tai-cpu-benchmark-execution-authority.yml
@@ -38,6 +38,16 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Assert exact-main immutable checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = 'refs/heads/main'
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git fetch --no-tags --depth=1 origin main
+          test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -49,16 +59,6 @@ jobs:
           set -euo pipefail
           python -m pip install --upgrade pip
           python -m pip install -e apps/tai
-
-      - name: Assert exact-main immutable checkout
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$GITHUB_REF" = 'refs/heads/main'
-          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-          git fetch --no-tags --depth=1 origin main
-          test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
-          test -z "$(git status --porcelain=v1 --untracked-files=all)"
 
       - name: Validate CPU benchmark execution authority
         shell: bash

--- a/apps/tai/governance/scopes/ap-13c1b-exact-main-workflow-fix-2981.json
+++ b/apps/tai/governance/scopes/ap-13c1b-exact-main-workflow-fix-2981.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "tai.concurrent-scope.v1",
+  "program_issue": 2726,
+  "parent_issue": 2977,
+  "issue": 2981,
+  "branch": "agent/tai-ap-13c1b-exact-main-workflow-fix",
+  "allowed_paths": [
+    ".github/workflows/tai-cpu-benchmark-execution-authority.yml",
+    "apps/tai/governance/scopes/ap-13c1b-exact-main-workflow-fix-2981.json",
+    "apps/tai/tests/test_cpu_benchmark_execution_workflow.py"
+  ],
+  "acceptance": [
+    "exact-main SHA and clean-tree checks execute immediately after checkout",
+    "editable package installation cannot invalidate the immutable checkout assertion",
+    "AP-14C authority validation and prerequisite readiness evaluation execute on current main",
+    "current external blockers are reported explicitly instead of READINESS_REPORT_ABSENT",
+    "no model host, model payload, benchmark measurement, admission or production state is touched",
+    "benchmark remains PENDING_BENCHMARK, model admission remains PENDING_ADMISSION and production_operational_status remains NOT_ATTESTED"
+  ],
+  "forbidden_capabilities": [
+    "weakening or removing exact-main SHA or clean-tree checks",
+    "treating editable-install metadata as repository evidence",
+    "starting model inference, SSH, S3 mutation or benchmark execution",
+    "fabricating AP-14C acceptance, immutable bundles or readiness evidence",
+    "model admission, activation, deployment or production attestation"
+  ]
+}

--- a/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
+++ b/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
@@ -15,6 +15,12 @@ SCOPE = (
     / "scopes"
     / "ap-13c1a-cpu-benchmark-authority-2977.json"
 )
+RUNTIME_FIX_SCOPE = (
+    TAI_ROOT
+    / "governance"
+    / "scopes"
+    / "ap-13c1b-exact-main-workflow-fix-2981.json"
+)
 COMMAND = "/tai benchmark cpu-fallback exact-main"
 EXPECTED_PATHS = {
     ".gitleaksignore",
@@ -28,6 +34,11 @@ EXPECTED_PATHS = {
     "apps/tai/tests/test_cpu_benchmark_execution_cli.py",
     "apps/tai/tests/test_cpu_benchmark_execution_workflow.py",
     "apps/tai/tests/test_gitleaks_release_authority.py",
+}
+RUNTIME_FIX_PATHS = {
+    ".github/workflows/tai-cpu-benchmark-execution-authority.yml",
+    "apps/tai/governance/scopes/ap-13c1b-exact-main-workflow-fix-2981.json",
+    "apps/tai/tests/test_cpu_benchmark_execution_workflow.py",
 }
 
 
@@ -56,6 +67,22 @@ def test_scope_is_exact_and_preserves_maturity_boundary() -> None:
     assert "production_operational_status remains NOT_ATTESTED" in scope["acceptance"][-1]
 
 
+def test_runtime_fix_scope_is_bounded_and_preserves_maturity() -> None:
+    scope = _json(RUNTIME_FIX_SCOPE)
+    assert scope["schema_version"] == "tai.concurrent-scope.v1"
+    assert scope["branch"] == "agent/tai-ap-13c1b-exact-main-workflow-fix"
+    assert (scope["program_issue"], scope["parent_issue"], scope["issue"]) == (
+        2726,
+        2977,
+        2981,
+    )
+    assert set(scope["allowed_paths"]) == RUNTIME_FIX_PATHS
+    assert "weakening or removing exact-main SHA" in " ".join(
+        scope["forbidden_capabilities"]
+    )
+    assert "production_operational_status remains NOT_ATTESTED" in scope["acceptance"][-1]
+
+
 def test_workflow_is_owner_only_exact_main_and_issue_bound() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     assert "issue_comment:" in workflow
@@ -73,6 +100,21 @@ def test_workflow_is_owner_only_exact_main_and_issue_bound() -> None:
     assert "actions: read\n  contents: read\n  issues: write" in workflow
     assert "contents: write" not in workflow
     assert "timeout-minutes: 30" in workflow
+
+
+def test_exact_main_is_asserted_before_any_editable_install_mutation() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    checkout = workflow.index("- name: Checkout exact main authority")
+    exact_main = workflow.index("- name: Assert exact-main immutable checkout")
+    setup = workflow.index("- name: Setup Python")
+    install = workflow.index("- name: Install exact TAI authority package")
+    validate = workflow.index("- name: Validate CPU benchmark execution authority")
+    assert checkout < exact_main < setup < install < validate
+    exact_block = workflow[exact_main:setup]
+    assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in exact_block
+    assert 'test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"' in exact_block
+    assert 'test -z "$(git status --porcelain=v1 --untracked-files=all)"' in exact_block
+    assert "pip install" not in exact_block
 
 
 def test_workflow_validates_only_readiness_and_never_touches_model_host() -> None:


### PR DESCRIPTION
## What changed

- moves exact-main SHA, remote-main equality and clean-tree assertions immediately after checkout;
- performs Python setup and editable TAI installation only after the immutable checkout is accepted;
- adds the bounded AP-13C.1b scope for issue #2981;
- adds a regression test that enforces checkout → exact-main assertion → setup → install → validation ordering.

## Why

Exact-main owner-command runs `29846311261` and `29846313256` failed before readiness evaluation because `pip install -e apps/tai` created untracked editable-install metadata before the clean-tree check. The workflow therefore emitted `READINESS_REPORT_ABSENT` instead of the real external blockers.

## Maturity boundary

No inference, S3 mutation, SSH, model payload, benchmark measurement, admission, activation or production state is touched.

- benchmark: `PENDING_BENCHMARK`;
- model admission: `PENDING_ADMISSION`;
- production operational status: `NOT_ATTESTED`.

After merge, rerun `/tai benchmark cpu-fallback exact-main` in #2977. The expected result is a precise bounded `BLOCKED` report for immutable bundles and AP-14C expert review, not a runtime-control failure.

Refs #2981, #2977, #2971 and #2726.