### PR TITLE
TAI AP-13C.1a.1: harden exact-main issue-comment probe

### DIFF
--- a/.github/workflows/tai-cpu-benchmark-execution-authority.yml
+++ b/.github/workflows/tai-cpu-benchmark-execution-authority.yml
@@ -40,13 +40,9 @@ jobs:
 
       - name: Assert exact-main immutable checkout
         shell: bash
-        run: |
-          set -euo pipefail
-          test "$GITHUB_REF" = 'refs/heads/main'
-          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-          git fetch --no-tags --depth=1 origin main
-          test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"
-          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+        env:
+          EXACT_MAIN_PROBE_REPORT: cpu-benchmark-authority-evidence/exact-main-probe.json
+        run: bash apps/tai/model-artifacts/exact-main-probe.v1.sh
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -108,6 +104,7 @@ jobs:
         with:
           name: tai-cpu-benchmark-authority-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
+            cpu-benchmark-authority-evidence/exact-main-probe.json
             cpu-benchmark-authority-evidence/authority-validation.json
             cpu-benchmark-authority-evidence/gold-authority-validation.json
             cpu-benchmark-authority-evidence/prerequisite-report.json
@@ -131,8 +128,13 @@ jobs:
           import os
           from pathlib import Path
 
+          probe_path = Path('cpu-benchmark-authority-evidence/exact-main-probe.json')
           readiness_path = Path('cpu-benchmark-authority-evidence/readiness.json')
           gold_path = Path('cpu-benchmark-authority-evidence/gold-authority-validation.json')
+          if probe_path.exists():
+              probe = json.loads(probe_path.read_text(encoding='utf-8'))
+          else:
+              probe = {'status': 'REJECTED', 'report_sha256': None}
           if readiness_path.exists():
               value = json.loads(readiness_path.read_text(encoding='utf-8'))
           else:
@@ -153,6 +155,8 @@ jobs:
           print()
           print(f"- exact-main: `{os.environ['GITHUB_SHA']}`;")
           print(f"- workflow run: `{os.environ['GITHUB_RUN_ID']}` / attempt `{os.environ['GITHUB_RUN_ATTEMPT']}`;")
+          print(f"- exact-main probe: `{probe.get('status')}`;")
+          print(f"- exact-main report SHA-256: `{probe.get('report_sha256')}`;")
           print(f"- AP-14C authority: `{gold.get('status')}` / accepted `{gold.get('accepted')}`;")
           print(f"- AP-14C assessment SHA-256: `{gold.get('assessment_sha256')}`;")
           print(f"- readiness: `{value.get('status')}`;")
@@ -172,10 +176,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          probe='cpu-benchmark-authority-evidence/exact-main-probe.json'
           gold='cpu-benchmark-authority-evidence/gold-authority-validation.json'
           report='cpu-benchmark-authority-evidence/readiness.json'
+          test -s "$probe"
           test -s "$gold"
           test -s "$report"
+          test "$(jq -r '.status' "$probe")" = 'EXACT_MAIN_CONFIRMED'
+          test "$(jq -r '.event_sha' "$probe")" = "$GITHUB_SHA"
+          test "$(jq -r '.remote_main_sha' "$probe")" = "$GITHUB_SHA"
           test "$(jq -r '.accepted' "$gold")" = 'true'
           test "$(jq -r '.status' "$gold")" = 'ACCEPTED'
           test "$(jq -r '.counts.reviewed_cases' "$gold")" = '58'

--- a/apps/tai/governance/scopes/ap-13c1a1-exact-main-probe-2982.json
+++ b/apps/tai/governance/scopes/ap-13c1a1-exact-main-probe-2982.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "tai.concurrent-scope.v1",
+  "program_issue": 2726,
+  "parent_issue": 2977,
+  "issue": 2982,
+  "branch": "agent/tai-ap-13c1a1-exact-main-probe",
+  "allowed_paths": [
+    ".github/workflows/tai-cpu-benchmark-execution-authority.yml",
+    "apps/tai/governance/scopes/ap-13c1a1-exact-main-probe-2982.json",
+    "apps/tai/model-artifacts/exact-main-probe.v1.sh",
+    "apps/tai/tests/test_cpu_benchmark_exact_main_probe.py",
+    "apps/tai/tests/test_cpu_benchmark_execution_workflow.py"
+  ],
+  "acceptance": [
+    "the issue-comment checkout is bound to the live main branch head through git ls-remote",
+    "a missing, ambiguous, malformed or moved main branch fails closed",
+    "the checked-out HEAD, GITHUB_SHA and live main SHA must be identical",
+    "the clean-worktree assertion remains mandatory",
+    "the exact-main probe executes immediately after checkout and before editable installation",
+    "the exact-main probe has executable negative tests",
+    "no benchmark or external model operation is introduced",
+    "production_operational_status remains NOT_ATTESTED"
+  ],
+  "forbidden_capabilities": [
+    "mutable branch assumptions or unverified remote-tracking refs",
+    "moving exact-main verification after editable package installation",
+    "network mutation, model download, inference or benchmark execution",
+    "automatic acceptance of storage, bundles or expert review",
+    "model admission, activation, deployment or production attestation"
+  ]
+}

--- a/apps/tai/model-artifacts/exact-main-probe.v1.sh
+++ b/apps/tai/model-artifacts/exact-main-probe.v1.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+: "${GITHUB_REF:?}"
+: "${GITHUB_SHA:?}"
+
+REPORT_PATH="${EXACT_MAIN_PROBE_REPORT:-}"
+SHA_PATTERN='^[0-9a-f]{40}$'
+
+fail() {
+  printf 'EXACT_MAIN_REJECTED:%s\n' "$1" >&2
+  exit 2
+}
+
+[[ "$GITHUB_REF" == 'refs/heads/main' ]] || fail 'EVENT_REF_NOT_MAIN'
+[[ "$GITHUB_SHA" =~ $SHA_PATTERN ]] || fail 'EVENT_SHA_INVALID'
+
+checked_out_sha="$(git rev-parse --verify 'HEAD^{commit}' 2>/dev/null)" \
+  || fail 'CHECKED_OUT_HEAD_UNREADABLE'
+[[ "$checked_out_sha" =~ $SHA_PATTERN ]] || fail 'CHECKED_OUT_SHA_INVALID'
+[[ "$checked_out_sha" == "$GITHUB_SHA" ]] || fail 'CHECKED_OUT_SHA_MISMATCH'
+
+set +e
+remote_rows="$(git ls-remote --exit-code --heads origin refs/heads/main 2>/dev/null)"
+remote_status=$?
+set -e
+[[ "$remote_status" -eq 0 ]] || fail 'LIVE_MAIN_LOOKUP_FAILED'
+
+mapfile -t live_rows < <(printf '%s\n' "$remote_rows" | sed '/^[[:space:]]*$/d')
+[[ "${#live_rows[@]}" -eq 1 ]] || fail 'LIVE_MAIN_CARDINALITY_INVALID'
+
+IFS=$'\t ' read -r remote_main_sha remote_main_ref extra <<< "${live_rows[0]}"
+[[ -z "${extra:-}" ]] || fail 'LIVE_MAIN_ROW_INVALID'
+[[ "$remote_main_sha" =~ $SHA_PATTERN ]] || fail 'LIVE_MAIN_SHA_INVALID'
+[[ "$remote_main_ref" == 'refs/heads/main' ]] || fail 'LIVE_MAIN_REF_INVALID'
+[[ "$remote_main_sha" == "$GITHUB_SHA" ]] || fail 'LIVE_MAIN_MOVED'
+
+worktree_status="$(git status --porcelain=v1 --untracked-files=all)" \
+  || fail 'WORKTREE_STATUS_FAILED'
+[[ -z "$worktree_status" ]] || fail 'WORKTREE_DIRTY'
+
+if [[ -n "$REPORT_PATH" ]]; then
+  CHECKED_OUT_SHA="$checked_out_sha" \
+  REMOTE_MAIN_SHA="$remote_main_sha" \
+  REPORT_PATH="$REPORT_PATH" \
+  python3 - <<'PY'
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+payload: dict[str, object] = {
+    "schema_version": "tai.exact-main-probe-report.v1",
+    "status": "EXACT_MAIN_CONFIRMED",
+    "event_ref": os.environ["GITHUB_REF"],
+    "event_sha": os.environ["GITHUB_SHA"],
+    "checked_out_sha": os.environ["CHECKED_OUT_SHA"],
+    "remote_main_ref": "refs/heads/main",
+    "remote_main_sha": os.environ["REMOTE_MAIN_SHA"],
+    "clean_worktree": True,
+}
+canonical = json.dumps(
+    payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+).encode("utf-8")
+payload["report_sha256"] = hashlib.sha256(canonical).hexdigest()
+path = Path(os.environ["REPORT_PATH"])
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(
+    json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
+fi
+
+printf 'EXACT_MAIN_CONFIRMED:%s\n' "$GITHUB_SHA"

--- a/apps/tai/tests/test_cpu_benchmark_exact_main_probe.py
+++ b/apps/tai/tests/test_cpu_benchmark_exact_main_probe.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+TAI_ROOT = Path(__file__).parents[1]
+PROBE = TAI_ROOT / "model-artifacts" / "exact-main-probe.v1.sh"
+BASH = Path("/usr/bin/bash")
+SHA = "a08ea173ebfffd14dff7c9efdc4e39e9ff3c757f"
+OTHER_SHA = "b" * 40
+
+
+def _fake_git(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    git = bin_dir / "git"
+    git.write_text(
+        """#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  rev-parse)
+    exit_code="${FAKE_REV_PARSE_EXIT:-0}"
+    if [[ "$exit_code" != 0 ]]; then exit "$exit_code"; fi
+    printf '%s\n' "${FAKE_HEAD_SHA:-}"
+    ;;
+  ls-remote)
+    exit_code="${FAKE_LS_REMOTE_EXIT:-0}"
+    if [[ "$exit_code" != 0 ]]; then exit "$exit_code"; fi
+    printf '%s' "${FAKE_REMOTE_ROWS:-}"
+    ;;
+  status)
+    exit_code="${FAKE_STATUS_EXIT:-0}"
+    if [[ "$exit_code" != 0 ]]; then exit "$exit_code"; fi
+    printf '%s' "${FAKE_STATUS_OUTPUT:-}"
+    ;;
+  *)
+    printf 'unexpected fake git command: %s\n' "$*" >&2
+    exit 97
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    git.chmod(0o700)
+    return bin_dir
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    github_ref: str = "refs/heads/main",
+    github_sha: str = SHA,
+    head_sha: str = SHA,
+    remote_rows: str | None = None,
+    rev_parse_exit: int = 0,
+    ls_remote_exit: int = 0,
+    status_output: str = "",
+    status_exit: int = 0,
+    report: bool = True,
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    bin_dir = _fake_git(tmp_path)
+    report_path = tmp_path / "probe-report.json"
+    rows = remote_rows
+    if rows is None:
+        rows = f"{SHA}\trefs/heads/main\n"
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "GITHUB_REF": github_ref,
+        "GITHUB_SHA": github_sha,
+        "FAKE_HEAD_SHA": head_sha,
+        "FAKE_REMOTE_ROWS": rows,
+        "FAKE_REV_PARSE_EXIT": str(rev_parse_exit),
+        "FAKE_LS_REMOTE_EXIT": str(ls_remote_exit),
+        "FAKE_STATUS_OUTPUT": status_output,
+        "FAKE_STATUS_EXIT": str(status_exit),
+    }
+    if report:
+        env["EXACT_MAIN_PROBE_REPORT"] = str(report_path)
+    result = subprocess.run(  # noqa: S603 - controlled absolute Bash and repository script
+        [str(BASH), str(PROBE)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result, report_path
+
+
+def _json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_stable_live_main_is_confirmed_with_digest_bound_report(tmp_path: Path) -> None:
+    result, report_path = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == f"EXACT_MAIN_CONFIRMED:{SHA}\n"
+    assert result.stderr == ""
+    report = _json(report_path)
+    assert report == {
+        "schema_version": "tai.exact-main-probe-report.v1",
+        "status": "EXACT_MAIN_CONFIRMED",
+        "event_ref": "refs/heads/main",
+        "event_sha": SHA,
+        "checked_out_sha": SHA,
+        "remote_main_ref": "refs/heads/main",
+        "remote_main_sha": SHA,
+        "clean_worktree": True,
+        "report_sha256": report["report_sha256"],
+    }
+    unsigned = {key: value for key, value in report.items() if key != "report_sha256"}
+    expected = hashlib.sha256(
+        json.dumps(
+            unsigned,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    assert report["report_sha256"] == expected
+
+
+def test_report_is_optional_for_read_only_probe(tmp_path: Path) -> None:
+    result, report_path = _run(tmp_path, report=False)
+
+    assert result.returncode == 0
+    assert not report_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "reason"),
+    [
+        ({"github_ref": "refs/heads/develop"}, "EVENT_REF_NOT_MAIN"),
+        ({"github_sha": "main"}, "EVENT_SHA_INVALID"),
+        ({"rev_parse_exit": 1}, "CHECKED_OUT_HEAD_UNREADABLE"),
+        ({"head_sha": "bad"}, "CHECKED_OUT_SHA_INVALID"),
+        ({"head_sha": OTHER_SHA}, "CHECKED_OUT_SHA_MISMATCH"),
+        ({"ls_remote_exit": 2}, "LIVE_MAIN_LOOKUP_FAILED"),
+        ({"remote_rows": ""}, "LIVE_MAIN_CARDINALITY_INVALID"),
+        (
+            {
+                "remote_rows": (
+                    f"{SHA}\trefs/heads/main\n{SHA}\trefs/heads/main\n"
+                )
+            },
+            "LIVE_MAIN_CARDINALITY_INVALID",
+        ),
+        ({"remote_rows": "bad\trefs/heads/main\n"}, "LIVE_MAIN_SHA_INVALID"),
+        ({"remote_rows": f"{SHA}\trefs/heads/other\n"}, "LIVE_MAIN_REF_INVALID"),
+        ({"remote_rows": f"{OTHER_SHA}\trefs/heads/main\n"}, "LIVE_MAIN_MOVED"),
+        ({"status_output": "?? unexpected.txt\n"}, "WORKTREE_DIRTY"),
+        ({"status_exit": 3}, "WORKTREE_STATUS_FAILED"),
+    ],
+)
+def test_probe_rejects_ambiguous_or_changed_authority(
+    tmp_path: Path,
+    kwargs: dict[str, object],
+    reason: str,
+) -> None:
+    result, report_path = _run(tmp_path, **kwargs)  # type: ignore[arg-type]
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert f"EXACT_MAIN_REJECTED:{reason}" in result.stderr
+    assert not report_path.exists()
+
+
+def test_remote_row_with_extra_field_is_rejected(tmp_path: Path) -> None:
+    result, _ = _run(
+        tmp_path,
+        remote_rows=f"{SHA}\trefs/heads/main\textra\n",
+    )
+
+    assert result.returncode == 2
+    assert "EXACT_MAIN_REJECTED:LIVE_MAIN_ROW_INVALID" in result.stderr
+
+
+def test_probe_uses_only_read_only_live_branch_lookup() -> None:
+    source = PROBE.read_text(encoding="utf-8")
+
+    assert "git ls-remote --exit-code --heads origin refs/heads/main" in source
+    assert "git rev-parse --verify 'HEAD^{commit}'" in source
+    assert "git status --porcelain=v1 --untracked-files=all" in source
+    assert "refs/remotes/origin/main" not in source
+    for forbidden in ("git push", "git fetch", "git update-ref", "git reset", "git checkout"):
+        assert forbidden not in source

--- a/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
+++ b/apps/tai/tests/test_cpu_benchmark_execution_workflow.py
@@ -9,6 +9,7 @@ TAI_ROOT = Path(__file__).parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "tai-cpu-benchmark-execution-authority.yml"
 AUTHORITY = TAI_ROOT / "model-artifacts" / "cpu-benchmark-execution-authority.v1.json"
 RUNBOOK = TAI_ROOT / "model-artifacts" / "cpu-benchmark-execution-runbook.v1.md"
+PROBE = TAI_ROOT / "model-artifacts" / "exact-main-probe.v1.sh"
 SCOPE = (
     TAI_ROOT
     / "governance"
@@ -20,6 +21,12 @@ RUNTIME_FIX_SCOPE = (
     / "governance"
     / "scopes"
     / "ap-13c1b-exact-main-workflow-fix-2981.json"
+)
+PROBE_SCOPE = (
+    TAI_ROOT
+    / "governance"
+    / "scopes"
+    / "ap-13c1a1-exact-main-probe-2982.json"
 )
 COMMAND = "/tai benchmark cpu-fallback exact-main"
 EXPECTED_PATHS = {
@@ -38,6 +45,13 @@ EXPECTED_PATHS = {
 RUNTIME_FIX_PATHS = {
     ".github/workflows/tai-cpu-benchmark-execution-authority.yml",
     "apps/tai/governance/scopes/ap-13c1b-exact-main-workflow-fix-2981.json",
+    "apps/tai/tests/test_cpu_benchmark_execution_workflow.py",
+}
+PROBE_EXPECTED_PATHS = {
+    ".github/workflows/tai-cpu-benchmark-execution-authority.yml",
+    "apps/tai/governance/scopes/ap-13c1a1-exact-main-probe-2982.json",
+    "apps/tai/model-artifacts/exact-main-probe.v1.sh",
+    "apps/tai/tests/test_cpu_benchmark_exact_main_probe.py",
     "apps/tai/tests/test_cpu_benchmark_execution_workflow.py",
 }
 
@@ -83,6 +97,27 @@ def test_runtime_fix_scope_is_bounded_and_preserves_maturity() -> None:
     assert "production_operational_status remains NOT_ATTESTED" in scope["acceptance"][-1]
 
 
+def test_exact_main_probe_hardening_scope_is_exact() -> None:
+    scope = _json(PROBE_SCOPE)
+
+    assert scope["schema_version"] == "tai.concurrent-scope.v1"
+    assert scope["branch"] == "agent/tai-ap-13c1a1-exact-main-probe"
+    assert (scope["program_issue"], scope["parent_issue"], scope["issue"]) == (
+        2726,
+        2977,
+        2982,
+    )
+    assert set(scope["allowed_paths"]) == PROBE_EXPECTED_PATHS
+    assert "missing, ambiguous, malformed or moved main" in " ".join(
+        scope["acceptance"]
+    )
+    assert "before editable installation" in " ".join(scope["acceptance"])
+    assert "unverified remote-tracking refs" in " ".join(
+        scope["forbidden_capabilities"]
+    )
+    assert "production_operational_status remains NOT_ATTESTED" in scope["acceptance"][-1]
+
+
 def test_workflow_is_owner_only_exact_main_and_issue_bound() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     assert "issue_comment:" in workflow
@@ -111,10 +146,26 @@ def test_exact_main_is_asserted_before_any_editable_install_mutation() -> None:
     validate = workflow.index("- name: Validate CPU benchmark execution authority")
     assert checkout < exact_main < setup < install < validate
     exact_block = workflow[exact_main:setup]
-    assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in exact_block
-    assert 'test "$(git rev-parse refs/remotes/origin/main)" = "$GITHUB_SHA"' in exact_block
-    assert 'test -z "$(git status --porcelain=v1 --untracked-files=all)"' in exact_block
+    assert "EXACT_MAIN_PROBE_REPORT" in exact_block
+    assert "bash apps/tai/model-artifacts/exact-main-probe.v1.sh" in exact_block
     assert "pip install" not in exact_block
+    assert "refs/remotes/origin/main" not in exact_block
+
+
+def test_workflow_executes_governed_live_main_probe() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert (
+        "EXACT_MAIN_PROBE_REPORT: "
+        "cpu-benchmark-authority-evidence/exact-main-probe.json"
+    ) in workflow
+    assert "bash apps/tai/model-artifacts/exact-main-probe.v1.sh" in workflow
+    assert "exact-main-probe.json" in workflow
+    assert "EXACT_MAIN_CONFIRMED" in workflow
+    assert "test \"$(jq -r '.event_sha' \"$probe\")\" = \"$GITHUB_SHA\"" in workflow
+    assert "test \"$(jq -r '.remote_main_sha' \"$probe\")\" = \"$GITHUB_SHA\"" in workflow
+    assert "refs/remotes/origin/main" not in workflow
+    assert "git fetch --no-tags --depth=1 origin main" not in workflow
 
 
 def test_workflow_validates_only_readiness_and_never_touches_model_host() -> None:
@@ -150,6 +201,7 @@ def test_workflow_validates_only_readiness_and_never_touches_model_host() -> Non
 def test_only_bounded_metadata_can_enter_github_artifacts() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     upload = workflow[workflow.index("Upload bounded readiness evidence") :]
+    assert "exact-main-probe.json" in upload
     assert "authority-validation.json" in upload
     assert "gold-authority-validation.json" in upload
     assert "prerequisite-report.json" in upload
@@ -161,6 +213,21 @@ def test_only_bounded_metadata_can_enter_github_artifacts() -> None:
     assert "include-hidden-files: false" in upload
     for forbidden in ("*.gguf", ".safetensors", ".tar", "sources/", "payload/"):
         assert forbidden not in upload
+
+
+def test_exact_main_probe_is_read_only_and_fail_closed() -> None:
+    source = PROBE.read_text(encoding="utf-8")
+
+    assert "set -Eeuo pipefail" in source
+    assert "git ls-remote --exit-code --heads origin refs/heads/main" in source
+    assert "LIVE_MAIN_CARDINALITY_INVALID" in source
+    assert "LIVE_MAIN_MOVED" in source
+    assert "WORKTREE_DIRTY" in source
+    assert "tai.exact-main-probe-report.v1" in source
+    assert "EXACT_MAIN_CONFIRMED" in source
+    assert "refs/remotes/origin/main" not in source
+    for forbidden in ("git push", "git fetch", "git reset", "git update-ref"):
+        assert forbidden not in source
 
 
 def test_runbook_documents_blockers_and_no_maturity_inflation() -> None:


### PR DESCRIPTION
## What changed

- replaces the unreliable detached-checkout `refs/remotes/origin/main` assertion with a governed read-only `git ls-remote --heads` live-main probe;
- requires exactly one `refs/heads/main` row and equality between live main, `GITHUB_SHA` and checked-out HEAD;
- preserves the clean-worktree invariant;
- emits a bounded digest-bound `tai.exact-main-probe-report.v1` artifact;
- adds executable negative tests for missing, ambiguous, malformed, moved main, checkout mismatch and dirty worktree;
- binds the probe to a narrow concurrent scope.

## Confirmed defect

Exact-main owner-command runs `29846311261` and `29846313256` checked out main SHA `a08ea173ebfffd14dff7c9efdc4e39e9ff3c757f` but failed before authority evaluation because `git fetch origin main` did not reliably materialize `refs/remotes/origin/main` in the detached issue-comment checkout.

## Maturity boundary

No model inference, bundle mutation, benchmark measurement, expert acceptance, admission, activation, deployment or production attestation is added.

- benchmark: `PENDING_BENCHMARK`;
- model admission: `PENDING_ADMISSION`;
- production operational status: `NOT_ATTESTED`.

Refs #2982, #2977, #2971 and #2726.