### PR TITLE
TAI AP-14C.3: governed expert review submission intake

### DIFF
--- a/.github/workflows/tai-ap14c-review-submission-intake.yml
+++ b/.github/workflows/tai-ap14c-review-submission-intake.yml
@@ -86,7 +86,7 @@ jobs:
           name: tai-ap14c-review-intake-${{ github.sha }}
           path: tai-review-intake-evidence
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 90
           compression-level: 0
           overwrite: false
           include-hidden-files: false

--- a/.github/workflows/tai-ap14c-review-submission-intake.yml
+++ b/.github/workflows/tai-ap14c-review-submission-intake.yml
@@ -45,6 +45,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          node --check apps/tai/model-artifacts/expert-review-packet.mjs
           node --check apps/tai/model-artifacts/expert-review-submission-intake.mjs
           node --check apps/tai/tests/expert-review-submission-intake.test.mjs
           node --check apps/tai/tests/expert-review-submission-packet-authority.test.mjs
@@ -67,6 +68,7 @@ jobs:
           mkdir -p tai-review-intake-evidence
           printf '%s\n' "$GITHUB_SHA" > tai-review-intake-evidence/exact-head.txt
           sha256sum \
+            apps/tai/model-artifacts/expert-review-packet.mjs \
             apps/tai/model-artifacts/expert-review-submission-intake.mjs \
             apps/tai/tests/expert-review-submission-intake.test.mjs \
             apps/tai/tests/expert-review-submission-packet-authority.test.mjs \

--- a/.github/workflows/tai-ap14c-review-submission-intake.yml
+++ b/.github/workflows/tai-ap14c-review-submission-intake.yml
@@ -8,6 +8,7 @@ on:
       - 'apps/tai/model-artifacts/expert-review-packet.mjs'
       - 'apps/tai/model-artifacts/expert-review-submission-intake.mjs'
       - 'apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md'
+      - 'apps/tai/tests/expert-review-packet.test.mjs'
       - 'apps/tai/tests/expert-review-submission-intake.test.mjs'
       - 'apps/tai/tests/expert-review-submission-packet-authority.test.mjs'
       - 'docs/platform-v7/autopilot/tai-ap-14c/**'
@@ -19,6 +20,7 @@ on:
       - 'apps/tai/model-artifacts/expert-review-packet.mjs'
       - 'apps/tai/model-artifacts/expert-review-submission-intake.mjs'
       - 'apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md'
+      - 'apps/tai/tests/expert-review-packet.test.mjs'
       - 'apps/tai/tests/expert-review-submission-intake.test.mjs'
       - 'apps/tai/tests/expert-review-submission-packet-authority.test.mjs'
       - 'docs/platform-v7/autopilot/tai-ap-14c/**'
@@ -41,21 +43,23 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Validate intake module syntax
+      - name: Validate packet and intake syntax
         shell: bash
         run: |
           set -euo pipefail
           node --check apps/tai/model-artifacts/expert-review-packet.mjs
           node --check apps/tai/model-artifacts/expert-review-submission-intake.mjs
+          node --check apps/tai/tests/expert-review-packet.test.mjs
           node --check apps/tai/tests/expert-review-submission-intake.test.mjs
           node --check apps/tai/tests/expert-review-submission-packet-authority.test.mjs
 
-      - name: Run fail-closed intake regression suite
+      - name: Run fail-closed packet and intake regression suite
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p tai-review-intake-evidence
           {
+            node apps/tai/tests/expert-review-packet.test.mjs
             node apps/tai/tests/expert-review-submission-intake.test.mjs
             node apps/tai/tests/expert-review-submission-packet-authority.test.mjs
           } 2>&1 | tee tai-review-intake-evidence/test-output.txt
@@ -70,6 +74,7 @@ jobs:
           sha256sum \
             apps/tai/model-artifacts/expert-review-packet.mjs \
             apps/tai/model-artifacts/expert-review-submission-intake.mjs \
+            apps/tai/tests/expert-review-packet.test.mjs \
             apps/tai/tests/expert-review-submission-intake.test.mjs \
             apps/tai/tests/expert-review-submission-packet-authority.test.mjs \
             > tai-review-intake-evidence/files.sha256

--- a/.github/workflows/tai-ap14c-review-submission-intake.yml
+++ b/.github/workflows/tai-ap14c-review-submission-intake.yml
@@ -57,7 +57,7 @@ jobs:
           {
             node apps/tai/tests/expert-review-submission-intake.test.mjs
             node apps/tai/tests/expert-review-submission-packet-authority.test.mjs
-          } | tee tai-review-intake-evidence/test-output.txt
+          } 2>&1 | tee tai-review-intake-evidence/test-output.txt
 
       - name: Record exact-head evidence
         if: always()

--- a/.github/workflows/tai-ap14c-review-submission-intake.yml
+++ b/.github/workflows/tai-ap14c-review-submission-intake.yml
@@ -9,6 +9,7 @@ on:
       - 'apps/tai/model-artifacts/expert-review-submission-intake.mjs'
       - 'apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md'
       - 'apps/tai/tests/expert-review-submission-intake.test.mjs'
+      - 'apps/tai/tests/expert-review-submission-packet-authority.test.mjs'
       - 'docs/platform-v7/autopilot/tai-ap-14c/**'
   push:
     branches: [main]
@@ -19,6 +20,7 @@ on:
       - 'apps/tai/model-artifacts/expert-review-submission-intake.mjs'
       - 'apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md'
       - 'apps/tai/tests/expert-review-submission-intake.test.mjs'
+      - 'apps/tai/tests/expert-review-submission-packet-authority.test.mjs'
       - 'docs/platform-v7/autopilot/tai-ap-14c/**'
 
 permissions:
@@ -45,14 +47,17 @@ jobs:
           set -euo pipefail
           node --check apps/tai/model-artifacts/expert-review-submission-intake.mjs
           node --check apps/tai/tests/expert-review-submission-intake.test.mjs
+          node --check apps/tai/tests/expert-review-submission-packet-authority.test.mjs
 
       - name: Run fail-closed intake regression suite
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p tai-review-intake-evidence
-          node apps/tai/tests/expert-review-submission-intake.test.mjs \
-            | tee tai-review-intake-evidence/test-output.txt
+          {
+            node apps/tai/tests/expert-review-submission-intake.test.mjs
+            node apps/tai/tests/expert-review-submission-packet-authority.test.mjs
+          } | tee tai-review-intake-evidence/test-output.txt
 
       - name: Record exact-head evidence
         if: always()
@@ -64,6 +69,7 @@ jobs:
           sha256sum \
             apps/tai/model-artifacts/expert-review-submission-intake.mjs \
             apps/tai/tests/expert-review-submission-intake.test.mjs \
+            apps/tai/tests/expert-review-submission-packet-authority.test.mjs \
             > tai-review-intake-evidence/files.sha256
 
       - name: Upload bounded intake evidence

--- a/.github/workflows/tai-ap14c-review-submission-intake.yml
+++ b/.github/workflows/tai-ap14c-review-submission-intake.yml
@@ -1,0 +1,79 @@
+name: TAI AP-14C Review Submission Intake
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/tai-ap14c-review-submission-intake.yml'
+      - 'apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json'
+      - 'apps/tai/model-artifacts/expert-review-packet.mjs'
+      - 'apps/tai/model-artifacts/expert-review-submission-intake.mjs'
+      - 'apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md'
+      - 'apps/tai/tests/expert-review-submission-intake.test.mjs'
+      - 'docs/platform-v7/autopilot/tai-ap-14c/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/tai-ap14c-review-submission-intake.yml'
+      - 'apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json'
+      - 'apps/tai/model-artifacts/expert-review-packet.mjs'
+      - 'apps/tai/model-artifacts/expert-review-submission-intake.mjs'
+      - 'apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md'
+      - 'apps/tai/tests/expert-review-submission-intake.test.mjs'
+      - 'docs/platform-v7/autopilot/tai-ap-14c/**'
+
+permissions:
+  contents: read
+
+jobs:
+  intake-contract:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact head
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate intake module syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --check apps/tai/model-artifacts/expert-review-submission-intake.mjs
+          node --check apps/tai/tests/expert-review-submission-intake.test.mjs
+
+      - name: Run fail-closed intake regression suite
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tai-review-intake-evidence
+          node apps/tai/tests/expert-review-submission-intake.test.mjs \
+            | tee tai-review-intake-evidence/test-output.txt
+
+      - name: Record exact-head evidence
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tai-review-intake-evidence
+          printf '%s\n' "$GITHUB_SHA" > tai-review-intake-evidence/exact-head.txt
+          sha256sum \
+            apps/tai/model-artifacts/expert-review-submission-intake.mjs \
+            apps/tai/tests/expert-review-submission-intake.test.mjs \
+            > tai-review-intake-evidence/files.sha256
+
+      - name: Upload bounded intake evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tai-ap14c-review-intake-${{ github.sha }}
+          path: tai-review-intake-evidence
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false

--- a/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
+++ b/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "tai.concurrent-scope.v1",
+  "program_issue": 2726,
+  "parent_issue": 2973,
+  "issue": 2986,
+  "branch": "agent/tai-ap-14c3-review-submission-intake",
+  "allowed_paths": [
+    "apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json",
+    "apps/tai/model-artifacts/expert-review-submission-intake.mjs",
+    "apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md",
+    "apps/tai/tests/expert-review-submission-intake.test.mjs"
+  ],
+  "acceptance": [
+    "submission intake is offline and writes only caller-selected candidate files",
+    "every submission binds the exact review packet, corpus, exact-main and reviewer track",
+    "stale cases, wrong roles, future timestamps, invalid digests, unknown fields and duplicate or conflicting reviews are rejected",
+    "existing review records are never silently replaced",
+    "candidate reviews and assessment are deterministic and require human pull-request review",
+    "automation creates no expert decision and cannot close the human checkpoint",
+    "expert review remains PENDING_REVIEW until real external records satisfy policy",
+    "benchmark remains PENDING_BENCHMARK, model admission remains PENDING_ADMISSION and production_operational_status remains NOT_ATTESTED"
+  ],
+  "forbidden_capabilities": [
+    "automated APPROVED, REJECTED or NEEDS_CHANGES decisions",
+    "fabricated reviewer identity, evidence digest, timestamp, disagreement or review digest",
+    "direct update of GitHub issues, branches, pull requests or authority files",
+    "silent overwrite of an existing review ID or reviewer/case pair",
+    "model execution, benchmark, admission, activation, deployment or production attestation"
+  ]
+}

--- a/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
+++ b/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
@@ -16,14 +16,16 @@
   ],
   "acceptance": [
     "submission intake is offline and writes only caller-selected candidate files",
-    "every submission binds the exact review packet, corpus, exact-main and reviewer track",
+    "every submission binds the exact review packet, trusted packet digest, corpus, exact-main and reviewer track",
     "the packet must exactly match current governed case contracts, track assignments and review policy, not only its self-declared digest",
     "the packet generator can bind an explicit exact review-authority path for deterministic regression fixtures while production CLI remains bound to the repository authority",
     "packet materialization emits one track-bound intake envelope per reviewer track with all authority fields fixed and all human-only fields blank",
-    "stale cases, wrong roles, future timestamps, invalid digests, unknown fields and duplicate or conflicting reviews are rejected",
+    "duplicate JSON keys, stale cases, wrong roles, future or invalid timestamps, placeholder evidence digests, unknown fields and duplicate or conflicting reviews are rejected",
     "existing review records are never silently replaced",
+    "candidate reviews, assessment and report are committed as one rollback-capable local output transaction",
+    "candidate outputs cannot alias packet, submission or existing-review inputs",
     "candidate reviews and assessment are deterministic and require human pull-request review",
-    "the dedicated exact-head Node gate runs packet compatibility, syntax, fail-closed and forged-packet regression tests",
+    "the dedicated exact-head Node gate captures stdout and stderr and runs packet compatibility, syntax, fail-closed and forged-packet regression tests",
     "automation creates no expert decision and cannot close the human checkpoint",
     "expert review remains PENDING_REVIEW until real external records satisfy policy",
     "benchmark remains PENDING_BENCHMARK, model admission remains PENDING_ADMISSION and production_operational_status remains NOT_ATTESTED"
@@ -33,6 +35,7 @@
     "fabricated reviewer identity, evidence digest, timestamp, disagreement or review digest",
     "self-signed packet authority that can redefine reviewer tracks or case contracts",
     "production CLI selection of an arbitrary review authority path",
+    "partial candidate output publication after a failed transaction",
     "direct update of GitHub issues, branches, pull requests or authority files",
     "silent overwrite of an existing review ID or reviewer/case pair",
     "model execution, benchmark, admission, activation, deployment or production attestation"

--- a/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
+++ b/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
@@ -7,6 +7,7 @@
   "allowed_paths": [
     ".github/workflows/tai-ap14c-review-submission-intake.yml",
     "apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json",
+    "apps/tai/model-artifacts/expert-review-packet.mjs",
     "apps/tai/model-artifacts/expert-review-submission-intake.mjs",
     "apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md",
     "apps/tai/tests/expert-review-submission-intake.test.mjs",
@@ -16,6 +17,7 @@
     "submission intake is offline and writes only caller-selected candidate files",
     "every submission binds the exact review packet, corpus, exact-main and reviewer track",
     "the packet must exactly match current governed case contracts, track assignments and review policy, not only its self-declared digest",
+    "the packet generator can bind an explicit exact review-authority path for deterministic regression fixtures while production CLI remains bound to the repository authority",
     "stale cases, wrong roles, future timestamps, invalid digests, unknown fields and duplicate or conflicting reviews are rejected",
     "existing review records are never silently replaced",
     "candidate reviews and assessment are deterministic and require human pull-request review",
@@ -28,6 +30,7 @@
     "automated APPROVED, REJECTED or NEEDS_CHANGES decisions",
     "fabricated reviewer identity, evidence digest, timestamp, disagreement or review digest",
     "self-signed packet authority that can redefine reviewer tracks or case contracts",
+    "production CLI selection of an arbitrary review authority path",
     "direct update of GitHub issues, branches, pull requests or authority files",
     "silent overwrite of an existing review ID or reviewer/case pair",
     "model execution, benchmark, admission, activation, deployment or production attestation"

--- a/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
+++ b/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
@@ -9,15 +9,17 @@
     "apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json",
     "apps/tai/model-artifacts/expert-review-submission-intake.mjs",
     "apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md",
-    "apps/tai/tests/expert-review-submission-intake.test.mjs"
+    "apps/tai/tests/expert-review-submission-intake.test.mjs",
+    "apps/tai/tests/expert-review-submission-packet-authority.test.mjs"
   ],
   "acceptance": [
     "submission intake is offline and writes only caller-selected candidate files",
     "every submission binds the exact review packet, corpus, exact-main and reviewer track",
+    "the packet must exactly match current governed case contracts, track assignments and review policy, not only its self-declared digest",
     "stale cases, wrong roles, future timestamps, invalid digests, unknown fields and duplicate or conflicting reviews are rejected",
     "existing review records are never silently replaced",
     "candidate reviews and assessment are deterministic and require human pull-request review",
-    "the dedicated exact-head Node gate runs syntax and fail-closed regression tests",
+    "the dedicated exact-head Node gate runs syntax, fail-closed and forged-packet regression tests",
     "automation creates no expert decision and cannot close the human checkpoint",
     "expert review remains PENDING_REVIEW until real external records satisfy policy",
     "benchmark remains PENDING_BENCHMARK, model admission remains PENDING_ADMISSION and production_operational_status remains NOT_ATTESTED"
@@ -25,6 +27,7 @@
   "forbidden_capabilities": [
     "automated APPROVED, REJECTED or NEEDS_CHANGES decisions",
     "fabricated reviewer identity, evidence digest, timestamp, disagreement or review digest",
+    "self-signed packet authority that can redefine reviewer tracks or case contracts",
     "direct update of GitHub issues, branches, pull requests or authority files",
     "silent overwrite of an existing review ID or reviewer/case pair",
     "model execution, benchmark, admission, activation, deployment or production attestation"

--- a/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
+++ b/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
@@ -10,6 +10,7 @@
     "apps/tai/model-artifacts/expert-review-packet.mjs",
     "apps/tai/model-artifacts/expert-review-submission-intake.mjs",
     "apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md",
+    "apps/tai/tests/expert-review-packet.test.mjs",
     "apps/tai/tests/expert-review-submission-intake.test.mjs",
     "apps/tai/tests/expert-review-submission-packet-authority.test.mjs"
   ],
@@ -18,10 +19,11 @@
     "every submission binds the exact review packet, corpus, exact-main and reviewer track",
     "the packet must exactly match current governed case contracts, track assignments and review policy, not only its self-declared digest",
     "the packet generator can bind an explicit exact review-authority path for deterministic regression fixtures while production CLI remains bound to the repository authority",
+    "packet materialization emits one track-bound intake envelope per reviewer track with all authority fields fixed and all human-only fields blank",
     "stale cases, wrong roles, future timestamps, invalid digests, unknown fields and duplicate or conflicting reviews are rejected",
     "existing review records are never silently replaced",
     "candidate reviews and assessment are deterministic and require human pull-request review",
-    "the dedicated exact-head Node gate runs syntax, fail-closed and forged-packet regression tests",
+    "the dedicated exact-head Node gate runs packet compatibility, syntax, fail-closed and forged-packet regression tests",
     "automation creates no expert decision and cannot close the human checkpoint",
     "expert review remains PENDING_REVIEW until real external records satisfy policy",
     "benchmark remains PENDING_BENCHMARK, model admission remains PENDING_ADMISSION and production_operational_status remains NOT_ATTESTED"

--- a/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
+++ b/apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json
@@ -5,6 +5,7 @@
   "issue": 2986,
   "branch": "agent/tai-ap-14c3-review-submission-intake",
   "allowed_paths": [
+    ".github/workflows/tai-ap14c-review-submission-intake.yml",
     "apps/tai/governance/scopes/ap-14c3-review-submission-intake-2986.json",
     "apps/tai/model-artifacts/expert-review-submission-intake.mjs",
     "apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md",
@@ -16,6 +17,7 @@
     "stale cases, wrong roles, future timestamps, invalid digests, unknown fields and duplicate or conflicting reviews are rejected",
     "existing review records are never silently replaced",
     "candidate reviews and assessment are deterministic and require human pull-request review",
+    "the dedicated exact-head Node gate runs syntax and fail-closed regression tests",
     "automation creates no expert decision and cannot close the human checkpoint",
     "expert review remains PENDING_REVIEW until real external records satisfy policy",
     "benchmark remains PENDING_BENCHMARK, model admission remains PENDING_ADMISSION and production_operational_status remains NOT_ATTESTED"

--- a/apps/tai/model-artifacts/expert-review-packet.mjs
+++ b/apps/tai/model-artifacts/expert-review-packet.mjs
@@ -137,7 +137,11 @@ function trackCases(cases, track) {
   );
 }
 
-export function buildExpertReviewPacket({ exactMainSha, generatedAt }) {
+export function buildExpertReviewPacket({
+  exactMainSha,
+  generatedAt,
+  reviewsPath = REVIEWS_PATH,
+}) {
   invariant(
     typeof exactMainSha === 'string' && SHA1.test(exactMainSha),
     'exact_main_sha must be a full Git SHA',
@@ -146,7 +150,7 @@ export function buildExpertReviewPacket({ exactMainSha, generatedAt }) {
 
   const corpus = buildCorpus();
   const caseMap = validateCorpus(corpus);
-  const reviews = parseJson(REVIEWS_PATH);
+  const reviews = parseJson(reviewsPath);
   validateReviews(reviews, caseMap);
   const assessment = computeAssessment(corpus, reviews);
   const cases = [...corpus.platform.cases, ...corpus.agro.cases];

--- a/apps/tai/model-artifacts/expert-review-packet.mjs
+++ b/apps/tai/model-artifacts/expert-review-packet.mjs
@@ -229,6 +229,19 @@ function trackPacket(packet, track) {
   };
 }
 
+function intakeSubmissionTemplate(packet, track) {
+  return {
+    schema_version: 'tai.expert-review-submission.v1',
+    exact_main_sha: packet.exact_main_sha,
+    corpus_sha256: packet.corpus_sha256,
+    packet_sha256: packet.packet_sha256,
+    track_id: track.track_id,
+    submitter_id: null,
+    submitted_at: null,
+    reviews: [],
+  };
+}
+
 export function materializeExpertReviewPacket(packet, outputDirectory) {
   invariant(
     packet?.schema_version === 'tai.expert-review-packet.v1',
@@ -263,6 +276,17 @@ export function materializeExpertReviewPacket(packet, outputDirectory) {
       name: fileName,
       sha256: written.sha256,
       size_bytes: written.size_bytes,
+    });
+
+    const intakeName = `intake-submission-${track.track_id}.v1.json`;
+    const intake = writeJson(
+      resolve(outputDirectory, intakeName),
+      intakeSubmissionTemplate(packet, track),
+    );
+    files.push({
+      name: intakeName,
+      sha256: intake.sha256,
+      size_bytes: intake.size_bytes,
     });
   }
   const submissionTemplate = {

--- a/apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md
+++ b/apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md
@@ -13,9 +13,12 @@ Packet command: `/tai prepare expert-review-packet exact-main`
 Use the exact packet artifact published by the owner-only AP-14C packet workflow. The intake requires:
 
 - `expert-review-packet.v1.json` from that artifact;
+- the trusted canonical packet SHA-256 copied independently from the packet workflow summary or manifest;
 - one track-bound `intake-submission-<track-id>.v1.json` template from the same artifact;
 - the current `expert-reviews.v1.json` authority;
-- the packet's exact-main SHA and a timezone-aware evaluation timestamp.
+- the packet's exact-main SHA and a strict RFC3339 evaluation timestamp.
+
+Do not derive `--expected-packet-sha256` from the packet file being validated. That value is the external trust anchor which prevents a self-produced replacement packet from becoming authoritative merely because it is internally self-consistent.
 
 The packet materializes one intake template for each governed reviewer track. Exact-main, corpus SHA-256, packet SHA-256 and `track_id` are already fixed. The coordinator fills only `submitter_id`, `submitted_at` and the non-empty `reviews` array. The template has exactly these fields:
 
@@ -32,7 +35,7 @@ The packet materializes one intake template for each governed reviewer track. Ex
 }
 ```
 
-Each review must use the unchanged record contract from its corresponding `track-<track-id>.v1.json` template. Human-only fields must be completed by the reviewer. `review_sha256` is SHA-256 over canonical JSON of the complete review record excluding `review_sha256` itself.
+Each review must use the unchanged record contract from its corresponding `track-<track-id>.v1.json` template. Human-only fields must be completed by the reviewer. `evidence_sha256` must identify real external evidence and cannot be an all-zero or repeated-character placeholder. `review_sha256` is SHA-256 over canonical JSON of the complete review record excluding `review_sha256` itself.
 
 ## Governed reviewer tracks
 
@@ -51,32 +54,36 @@ node apps/tai/model-artifacts/expert-review-submission-intake.mjs \
   --submission /secure/packet/intake-submission-platform-primary.v1.json \
   --existing-reviews docs/platform-v7/autopilot/tai-ap-14c/expert-reviews.v1.json \
   --exact-main <packet-exact-main-sha> \
+  --expected-packet-sha256 <trusted-packet-sha256> \
   --evaluated-at 2026-07-21T12:10:00Z \
   --output-reviews /secure/candidate/expert-reviews.v1.json \
   --output-assessment /secure/candidate/baseline-assessment.v1.json \
   --output-report /secure/candidate/intake-report.v1.json
 ```
 
-Exit code `0` means only that candidate files were written. It does not accept the reviews. Any contract or provenance failure exits with code `2` before output files are written.
+Exit code `0` means only that candidate files were written. It does not accept the reviews. Any contract or provenance failure exits with code `2` before candidate output files are published.
 
 ## Fail-closed controls
 
 The intake rejects:
 
-- packet, corpus or exact-main drift;
+- packet, corpus, trusted packet digest or exact-main drift;
 - any self-signed packet that redefines case contracts, reviewer tracks or review policy;
+- duplicate JSON object keys at any nesting level;
 - stale `case_sha256` or a case outside the selected track;
 - reviewer roles that do not match the track;
-- placeholder reviewer or submitter identities;
-- timestamps before packet generation, after submission or in the future;
+- placeholder reviewer, submitter or evidence identities;
+- malformed calendar dates, invalid timezone offsets and timestamps before packet generation, after submission or after evaluation;
 - invalid evidence or review SHA-256 values;
 - unknown or missing fields;
 - duplicate review IDs or reviewer/case pairs;
 - attempted replacement of an existing review;
-- disagreement references to an unknown, different-case or same-reviewer record;
-- stale packets whose baseline assessment no longer matches current authority.
+- disagreement references to an unknown, different-case, same-reviewer or same-decision record;
+- stale packets whose baseline assessment no longer matches current authority;
+- candidate outputs which alias packet, submission or existing-review inputs;
+- symbolic-link or non-regular existing output destinations.
 
-Outputs are written atomically to three distinct caller-selected paths. Existing symbolic-link destinations are rejected.
+The three outputs are staged first and committed as one rollback-capable local transaction. If validation, staging or commit fails, the tool removes staged files and restores any pre-existing destinations rather than leaving a partial candidate set.
 
 ## Human acceptance remains mandatory
 

--- a/apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md
+++ b/apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md
@@ -13,11 +13,11 @@ Packet command: `/tai prepare expert-review-packet exact-main`
 Use the exact packet artifact published by the owner-only AP-14C packet workflow. The intake requires:
 
 - `expert-review-packet.v1.json` from that artifact;
-- one `tai.expert-review-submission.v1` envelope;
+- one track-bound `intake-submission-<track-id>.v1.json` template from the same artifact;
 - the current `expert-reviews.v1.json` authority;
 - the packet's exact-main SHA and a timezone-aware evaluation timestamp.
 
-The submission envelope has exactly these fields:
+The packet materializes one intake template for each governed reviewer track. Exact-main, corpus SHA-256, packet SHA-256 and `track_id` are already fixed. The coordinator fills only `submitter_id`, `submitted_at` and the non-empty `reviews` array. The template has exactly these fields:
 
 ```json
 {
@@ -32,7 +32,7 @@ The submission envelope has exactly these fields:
 }
 ```
 
-Each review must use the unchanged record contract from its track template. Human-only fields must be completed by the reviewer. `review_sha256` is SHA-256 over canonical JSON of the complete review record excluding `review_sha256` itself.
+Each review must use the unchanged record contract from its corresponding `track-<track-id>.v1.json` template. Human-only fields must be completed by the reviewer. `review_sha256` is SHA-256 over canonical JSON of the complete review record excluding `review_sha256` itself.
 
 ## Governed reviewer tracks
 
@@ -48,7 +48,7 @@ A submission may contain only cases assigned to its selected track. Partial subm
 ```bash
 node apps/tai/model-artifacts/expert-review-submission-intake.mjs \
   --packet /secure/packet/expert-review-packet.v1.json \
-  --submission /secure/submissions/platform-primary-01.json \
+  --submission /secure/packet/intake-submission-platform-primary.v1.json \
   --existing-reviews docs/platform-v7/autopilot/tai-ap-14c/expert-reviews.v1.json \
   --exact-main <packet-exact-main-sha> \
   --evaluated-at 2026-07-21T12:10:00Z \
@@ -64,6 +64,7 @@ Exit code `0` means only that candidate files were written. It does not accept t
 The intake rejects:
 
 - packet, corpus or exact-main drift;
+- any self-signed packet that redefines case contracts, reviewer tracks or review policy;
 - stale `case_sha256` or a case outside the selected track;
 - reviewer roles that do not match the track;
 - placeholder reviewer or submitter identities;

--- a/apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md
+++ b/apps/tai/model-artifacts/expert-review-submission-intake-runbook.v1.md
@@ -1,0 +1,89 @@
+# TAI AP-14C expert review submission intake
+
+## Purpose
+
+This offline contour validates review records completed by real external reviewers and writes candidate authority files for a separate human-reviewed pull request. It never creates, changes or approves an expert decision by itself.
+
+Authority issue: `#2986`  
+Parent checkpoint: `#2973`  
+Packet command: `/tai prepare expert-review-packet exact-main`
+
+## Inputs
+
+Use the exact packet artifact published by the owner-only AP-14C packet workflow. The intake requires:
+
+- `expert-review-packet.v1.json` from that artifact;
+- one `tai.expert-review-submission.v1` envelope;
+- the current `expert-reviews.v1.json` authority;
+- the packet's exact-main SHA and a timezone-aware evaluation timestamp.
+
+The submission envelope has exactly these fields:
+
+```json
+{
+  "schema_version": "tai.expert-review-submission.v1",
+  "exact_main_sha": "<40-character packet SHA>",
+  "corpus_sha256": "<packet corpus SHA-256>",
+  "packet_sha256": "<packet SHA-256>",
+  "track_id": "platform-primary",
+  "submitter_id": "<opaque non-placeholder coordinator identity>",
+  "submitted_at": "2026-07-21T12:00:00Z",
+  "reviews": []
+}
+```
+
+Each review must use the unchanged record contract from its track template. Human-only fields must be completed by the reviewer. `review_sha256` is SHA-256 over canonical JSON of the complete review record excluding `review_sha256` itself.
+
+## Governed reviewer tracks
+
+- `platform-primary` → `PLATFORM_OWNER`;
+- `agro-primary` → `DOMAIN_EXPERT`;
+- `critical-security` → `SECURITY_REVIEWER`;
+- `critical-legal-method` → `LEGAL_OR_METHOD_REVIEWER`.
+
+A submission may contain only cases assigned to its selected track. Partial submissions are allowed, but the reviews array must be non-empty.
+
+## Execute locally
+
+```bash
+node apps/tai/model-artifacts/expert-review-submission-intake.mjs \
+  --packet /secure/packet/expert-review-packet.v1.json \
+  --submission /secure/submissions/platform-primary-01.json \
+  --existing-reviews docs/platform-v7/autopilot/tai-ap-14c/expert-reviews.v1.json \
+  --exact-main <packet-exact-main-sha> \
+  --evaluated-at 2026-07-21T12:10:00Z \
+  --output-reviews /secure/candidate/expert-reviews.v1.json \
+  --output-assessment /secure/candidate/baseline-assessment.v1.json \
+  --output-report /secure/candidate/intake-report.v1.json
+```
+
+Exit code `0` means only that candidate files were written. It does not accept the reviews. Any contract or provenance failure exits with code `2` before output files are written.
+
+## Fail-closed controls
+
+The intake rejects:
+
+- packet, corpus or exact-main drift;
+- stale `case_sha256` or a case outside the selected track;
+- reviewer roles that do not match the track;
+- placeholder reviewer or submitter identities;
+- timestamps before packet generation, after submission or in the future;
+- invalid evidence or review SHA-256 values;
+- unknown or missing fields;
+- duplicate review IDs or reviewer/case pairs;
+- attempted replacement of an existing review;
+- disagreement references to an unknown, different-case or same-reviewer record;
+- stale packets whose baseline assessment no longer matches current authority.
+
+Outputs are written atomically to three distinct caller-selected paths. Existing symbolic-link destinations are rejected.
+
+## Human acceptance remains mandatory
+
+A human must inspect the candidate diff, verify reviewer identity and external evidence outside automation, and open a bounded pull request updating only the governed review and assessment files plus required provenance metadata. The normal AP-14C authority must then pass on exact-head.
+
+Until the real review policy is satisfied:
+
+- expert review: `PENDING_REVIEW`;
+- benchmark: `PENDING_BENCHMARK`;
+- model admission: `PENDING_ADMISSION`;
+- production operational status: `NOT_ATTESTED`.

--- a/apps/tai/model-artifacts/expert-review-submission-intake.mjs
+++ b/apps/tai/model-artifacts/expert-review-submission-intake.mjs
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildCorpus,
+  computeAssessment,
+  sha256,
+  validateCorpus,
+  validateReviews,
+} from '../../../docs/platform-v7/autopilot/tai-ap-14c/gold-set-authority.mjs';
+
+const SHA1 = /^[0-9a-f]{40}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const ALLOWED_DECISIONS = new Set(['APPROVED', 'REJECTED', 'NEEDS_CHANGES']);
+const ROOT_KEYS = new Set([
+  'schema_version',
+  'exact_main_sha',
+  'corpus_sha256',
+  'packet_sha256',
+  'track_id',
+  'submitter_id',
+  'submitted_at',
+  'reviews',
+]);
+const REVIEW_KEYS = new Set([
+  'review_id',
+  'case_id',
+  'case_sha256',
+  'reviewer_id',
+  'reviewer_role',
+  'decision',
+  'reviewed_at',
+  'evidence_sha256',
+  'disagreement_with_review_id',
+  'review_sha256',
+]);
+const PLACEHOLDERS = new Set([
+  'example',
+  'none',
+  'null',
+  'placeholder',
+  'reviewer',
+  'tbd',
+  'todo',
+  'unknown',
+]);
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function object(value, name) {
+  invariant(
+    value !== null && typeof value === 'object' && !Array.isArray(value),
+    `${name} must be an object`,
+  );
+  return value;
+}
+
+function exactKeys(value, expected, name) {
+  const observed = new Set(Object.keys(value));
+  const missing = [...expected].filter((key) => !observed.has(key)).sort();
+  const unknown = [...observed].filter((key) => !expected.has(key)).sort();
+  invariant(
+    missing.length === 0 && unknown.length === 0,
+    `${name} keys invalid; missing=${JSON.stringify(missing)}, unknown=${JSON.stringify(unknown)}`,
+  );
+}
+
+function parseJson(path, name) {
+  let value;
+  try {
+    value = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    throw new Error(`${name} is invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return object(value, name);
+}
+
+function fileSha256(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function timestamp(value, name) {
+  invariant(
+    typeof value === 'string'
+      && Number.isFinite(Date.parse(value))
+      && /(?:Z|[+-]\d{2}:\d{2})$/.test(value),
+    `${name} must be a timezone-aware timestamp`,
+  );
+  return Date.parse(value);
+}
+
+function portableId(value, name) {
+  invariant(typeof value === 'string' && ID.test(value), `${name} must be a portable ID`);
+  return value;
+}
+
+function humanId(value, name) {
+  const id = portableId(value, name);
+  const normalized = id.toLowerCase();
+  invariant(!PLACEHOLDERS.has(normalized), `${name} must not be a placeholder`);
+  invariant(!normalized.startsWith('example-'), `${name} must not be an example identity`);
+  return id;
+}
+
+function atomicJson(path, value) {
+  const target = resolve(path);
+  mkdirSync(dirname(target), { recursive: true });
+  try {
+    const stat = lstatSync(target);
+    invariant(!stat.isSymbolicLink(), `${target} must not be a symbolic link`);
+  } catch (error) {
+    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') throw error;
+  }
+  const temporary = `${target}.tmp-${process.pid}`;
+  const content = `${JSON.stringify(value, null, 2)}\n`;
+  try {
+    writeFileSync(temporary, content, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+    renameSync(temporary, target);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+}
+
+function validatePacket(packet, currentAssessment, caseMap, expectedExactMain) {
+  invariant(packet.schema_version === 'tai.expert-review-packet.v1', 'packet schema mismatch');
+  invariant(SHA1.test(packet.exact_main_sha), 'packet exact_main_sha is invalid');
+  invariant(packet.exact_main_sha === expectedExactMain, 'packet exact-main mismatch');
+  invariant(SHA256.test(packet.packet_sha256), 'packet SHA-256 is invalid');
+  const payload = { ...packet };
+  delete payload.packet_sha256;
+  invariant(packet.packet_sha256 === sha256(payload), 'packet digest mismatch');
+  invariant(packet.corpus_sha256 === currentAssessment.corpus_sha256, 'packet corpus is stale');
+  invariant(
+    packet.baseline_assessment_sha256 === currentAssessment.assessment_sha256,
+    'packet baseline assessment is stale',
+  );
+  invariant(packet.counts?.total_cases === 58, 'packet total case count mismatch');
+  invariant(packet.counts?.critical_cases === 23, 'packet critical case count mismatch');
+  invariant(Array.isArray(packet.cases) && packet.cases.length === caseMap.size, 'packet case coverage mismatch');
+  const packetCaseIds = new Set();
+  for (const packetCase of packet.cases) {
+    object(packetCase, 'packet case');
+    const caseValue = caseMap.get(packetCase.case_id);
+    invariant(caseValue, `packet contains unknown case ${packetCase.case_id}`);
+    invariant(!packetCaseIds.has(packetCase.case_id), `packet duplicates case ${packetCase.case_id}`);
+    packetCaseIds.add(packetCase.case_id);
+    invariant(packetCase.case_sha256 === caseValue.case_sha256, `${packetCase.case_id}: packet case digest mismatch`);
+    invariant(packetCase.prompt_sha256 === caseValue.prompt_sha256, `${packetCase.case_id}: packet prompt digest mismatch`);
+    invariant(packetCase.domain === caseValue.domain, `${packetCase.case_id}: packet domain mismatch`);
+    invariant(packetCase.criticality === caseValue.criticality, `${packetCase.case_id}: packet criticality mismatch`);
+  }
+  invariant(packetCaseIds.size === caseMap.size, 'packet does not exactly cover current corpus');
+  invariant(Array.isArray(packet.reviewer_tracks), 'packet reviewer_tracks must be an array');
+  const trackIds = new Set();
+  for (const track of packet.reviewer_tracks) {
+    object(track, 'reviewer track');
+    portableId(track.track_id, 'track_id');
+    invariant(!trackIds.has(track.track_id), `duplicate packet track ${track.track_id}`);
+    trackIds.add(track.track_id);
+    invariant(typeof track.reviewer_role === 'string', `${track.track_id}: reviewer role missing`);
+    invariant(Array.isArray(track.case_ids) && track.case_ids.length > 0, `${track.track_id}: case_ids missing`);
+    const trackCaseIds = new Set();
+    for (const caseId of track.case_ids) {
+      invariant(caseMap.has(caseId), `${track.track_id}: unknown case ${caseId}`);
+      invariant(!trackCaseIds.has(caseId), `${track.track_id}: duplicate case ${caseId}`);
+      trackCaseIds.add(caseId);
+    }
+    invariant(track.case_count === track.case_ids.length, `${track.track_id}: case_count mismatch`);
+  }
+  return timestamp(packet.generated_at, 'packet.generated_at');
+}
+
+function validateReviewRecord(review, index, context) {
+  const name = `submission.reviews[${index}]`;
+  object(review, name);
+  exactKeys(review, REVIEW_KEYS, name);
+  const reviewId = portableId(review.review_id, `${name}.review_id`);
+  const caseId = portableId(review.case_id, `${name}.case_id`);
+  const reviewerId = humanId(review.reviewer_id, `${name}.reviewer_id`);
+  invariant(context.allowedCases.has(caseId), `${reviewId}: case is outside reviewer track`);
+  const caseValue = context.caseMap.get(caseId);
+  invariant(review.case_sha256 === caseValue.case_sha256, `${reviewId}: stale case digest`);
+  invariant(review.reviewer_role === context.track.reviewer_role, `${reviewId}: reviewer role does not match track`);
+  invariant(ALLOWED_DECISIONS.has(review.decision), `${reviewId}: unsupported decision`);
+  invariant(SHA256.test(review.evidence_sha256), `${reviewId}: evidence SHA-256 is invalid`);
+  const reviewedAt = timestamp(review.reviewed_at, `${reviewId}.reviewed_at`);
+  invariant(reviewedAt >= context.packetGeneratedAt, `${reviewId}: review predates packet`);
+  invariant(reviewedAt <= context.submittedAt, `${reviewId}: review is after submission`);
+  invariant(reviewedAt <= context.latestAllowedTime, `${reviewId}: review is in the future`);
+  invariant(
+    review.disagreement_with_review_id === null
+      || (typeof review.disagreement_with_review_id === 'string'
+        && ID.test(review.disagreement_with_review_id)),
+    `${reviewId}: disagreement target is invalid`,
+  );
+  const payload = { ...review };
+  delete payload.review_sha256;
+  invariant(
+    SHA256.test(review.review_sha256) && review.review_sha256 === sha256(payload),
+    `${reviewId}: review digest mismatch`,
+  );
+  return { reviewId, caseId, reviewerId };
+}
+
+export function ingestExpertReviewSubmission({
+  packetPath,
+  submissionPath,
+  existingReviewsPath,
+  exactMainSha,
+  evaluatedAt,
+  outputReviewsPath,
+  outputAssessmentPath,
+  outputReportPath,
+}) {
+  invariant(SHA1.test(exactMainSha), 'exact-main must be a full Git SHA');
+  const evaluatedAtMs = timestamp(evaluatedAt, 'evaluated_at');
+  const latestAllowedTime = evaluatedAtMs + 5 * 60 * 1000;
+  const packet = parseJson(packetPath, 'packet');
+  const submission = parseJson(submissionPath, 'submission');
+  const existingReviews = parseJson(existingReviewsPath, 'existing reviews');
+
+  const corpus = buildCorpus();
+  const caseMap = validateCorpus(corpus);
+  validateReviews(existingReviews, caseMap);
+  const currentAssessment = computeAssessment(corpus, existingReviews);
+  const packetGeneratedAt = validatePacket(
+    packet,
+    currentAssessment,
+    caseMap,
+    exactMainSha,
+  );
+
+  exactKeys(submission, ROOT_KEYS, 'submission');
+  invariant(
+    submission.schema_version === 'tai.expert-review-submission.v1',
+    'submission schema mismatch',
+  );
+  invariant(submission.exact_main_sha === packet.exact_main_sha, 'submission exact-main mismatch');
+  invariant(submission.corpus_sha256 === packet.corpus_sha256, 'submission corpus mismatch');
+  invariant(submission.packet_sha256 === packet.packet_sha256, 'submission packet mismatch');
+  const submitterId = humanId(submission.submitter_id, 'submission.submitter_id');
+  const submittedAt = timestamp(submission.submitted_at, 'submission.submitted_at');
+  invariant(submittedAt >= packetGeneratedAt, 'submission predates packet');
+  invariant(submittedAt <= latestAllowedTime, 'submission timestamp is in the future');
+  invariant(Array.isArray(submission.reviews) && submission.reviews.length > 0, 'submission reviews must be non-empty');
+
+  const trackId = portableId(submission.track_id, 'submission.track_id');
+  const track = packet.reviewer_tracks.find((item) => item.track_id === trackId);
+  invariant(track, `unknown reviewer track ${trackId}`);
+  const allowedCases = new Set(track.case_ids);
+
+  const existingIds = new Set();
+  const existingPairs = new Set();
+  const allById = new Map();
+  for (const review of existingReviews.reviews) {
+    existingIds.add(review.review_id);
+    existingPairs.add(`${review.case_id}:${review.reviewer_id}`);
+    allById.set(review.review_id, review);
+  }
+  const submissionIds = new Set();
+  const submissionPairs = new Set();
+  const parsed = [];
+  const context = {
+    allowedCases,
+    caseMap,
+    latestAllowedTime,
+    packetGeneratedAt,
+    submittedAt,
+    track,
+  };
+  for (let index = 0; index < submission.reviews.length; index += 1) {
+    const review = submission.reviews[index];
+    const { reviewId, caseId, reviewerId } = validateReviewRecord(review, index, context);
+    const pair = `${caseId}:${reviewerId}`;
+    invariant(!existingIds.has(reviewId), `${reviewId}: review ID already exists`);
+    invariant(!existingPairs.has(pair), `${reviewId}: reviewer/case pair already exists`);
+    invariant(!submissionIds.has(reviewId), `${reviewId}: duplicate review ID in submission`);
+    invariant(!submissionPairs.has(pair), `${reviewId}: duplicate reviewer/case pair in submission`);
+    submissionIds.add(reviewId);
+    submissionPairs.add(pair);
+    allById.set(reviewId, review);
+    parsed.push(review);
+  }
+
+  for (const review of parsed) {
+    if (review.disagreement_with_review_id !== null) {
+      const target = allById.get(review.disagreement_with_review_id);
+      invariant(target, `${review.review_id}: disagreement target does not exist`);
+      invariant(target.case_id === review.case_id, `${review.review_id}: disagreement target must concern the same case`);
+      invariant(target.reviewer_id !== review.reviewer_id, `${review.review_id}: self-disagreement is forbidden`);
+    }
+  }
+
+  const candidateReviews = {
+    schema_version: existingReviews.schema_version,
+    version: existingReviews.version,
+    policy: existingReviews.policy,
+    reviews: [...existingReviews.reviews, ...parsed].sort((left, right) => {
+      const leftKey = `${left.case_id}\u0000${left.reviewer_role}\u0000${left.reviewer_id}\u0000${left.review_id}`;
+      const rightKey = `${right.case_id}\u0000${right.reviewer_role}\u0000${right.reviewer_id}\u0000${right.review_id}`;
+      return leftKey.localeCompare(rightKey);
+    }),
+  };
+  validateReviews(candidateReviews, caseMap);
+  const candidateAssessment = computeAssessment(corpus, candidateReviews);
+  const report = {
+    schema_version: 'tai.expert-review-intake-report.v1',
+    status: 'CANDIDATE_WRITTEN_FOR_HUMAN_PR_REVIEW',
+    exact_main_sha: exactMainSha,
+    evaluated_at: evaluatedAt,
+    packet_sha256: packet.packet_sha256,
+    corpus_sha256: packet.corpus_sha256,
+    track_id: trackId,
+    reviewer_role: track.reviewer_role,
+    submitter_id: submitterId,
+    submission_sha256: fileSha256(submissionPath),
+    existing_reviews_sha256: fileSha256(existingReviewsPath),
+    reviews_added: parsed.length,
+    candidate_review_count: candidateReviews.reviews.length,
+    candidate_reviews_sha256: sha256(candidateReviews),
+    candidate_assessment_sha256: candidateAssessment.assessment_sha256,
+    candidate_assessment_status: candidateAssessment.status,
+    candidate_accepted: candidateAssessment.accepted,
+    candidate_blocking_reasons: candidateAssessment.blocking_reasons,
+    candidate_unreviewed_cases: candidateAssessment.counts.unreviewed_cases,
+    automation_created_decisions: false,
+    requires_human_pull_request_review: true,
+    benchmark_status: 'PENDING_BENCHMARK',
+    model_admission_status: 'PENDING_ADMISSION',
+    production_operational_status: 'NOT_ATTESTED',
+  };
+  report.report_sha256 = sha256(report);
+
+  const outputs = [outputReviewsPath, outputAssessmentPath, outputReportPath].map((value) => resolve(value));
+  invariant(new Set(outputs).size === outputs.length, 'output paths must be distinct');
+  atomicJson(outputReviewsPath, candidateReviews);
+  atomicJson(outputAssessmentPath, candidateAssessment);
+  atomicJson(outputReportPath, report);
+  return report;
+}
+
+function parseArgs(argv) {
+  const result = {
+    packetPath: '',
+    submissionPath: '',
+    existingReviewsPath: '',
+    exactMainSha: '',
+    evaluatedAt: '',
+    outputReviewsPath: '',
+    outputAssessmentPath: '',
+    outputReportPath: '',
+  };
+  const mapping = {
+    '--packet': 'packetPath',
+    '--submission': 'submissionPath',
+    '--existing-reviews': 'existingReviewsPath',
+    '--exact-main': 'exactMainSha',
+    '--evaluated-at': 'evaluatedAt',
+    '--output-reviews': 'outputReviewsPath',
+    '--output-assessment': 'outputAssessmentPath',
+    '--output-report': 'outputReportPath',
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = mapping[argv[index]];
+    invariant(key, `unknown argument: ${argv[index]}`);
+    const value = argv[++index] ?? '';
+    invariant(value, `${argv[index - 1]} requires a value`);
+    result[key] = key.endsWith('Path') ? resolve(value) : value;
+  }
+  for (const [key, value] of Object.entries(result)) invariant(value, `${key} is required`);
+  return result;
+}
+
+function main() {
+  const report = ingestExpertReviewSubmission(parseArgs(process.argv.slice(2)));
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 2;
+  }
+}

--- a/apps/tai/model-artifacts/expert-review-submission-intake.mjs
+++ b/apps/tai/model-artifacts/expert-review-submission-intake.mjs
@@ -1,15 +1,17 @@
 #!/usr/bin/env node
 
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import {
+  existsSync,
   lstatSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -23,7 +25,10 @@ import { REVIEWER_TRACKS } from './expert-review-packet.mjs';
 
 const SHA1 = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
+const UNIFORM_SHA256 = /^([0-9a-f])\1{63}$/;
 const ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const NUMBER = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/;
+const RFC3339 = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|([+-])(\d{2}):(\d{2}))$/;
 const ALLOWED_DECISIONS = new Set(['APPROVED', 'REJECTED', 'NEEDS_CHANGES']);
 const ROOT_KEYS = new Set([
   'schema_version',
@@ -48,12 +53,19 @@ const REVIEW_KEYS = new Set([
   'review_sha256',
 ]);
 const PLACEHOLDERS = new Set([
+  'anonymous',
+  'automation',
+  'automated',
+  'bot',
   'example',
+  'fake',
   'none',
   'null',
   'placeholder',
   'reviewer',
+  'sample',
   'tbd',
+  'test',
   'todo',
   'unknown',
 ]);
@@ -80,28 +92,191 @@ function exactKeys(value, expected, name) {
   );
 }
 
-function parseJson(path, name) {
-  let value;
-  try {
-    value = JSON.parse(readFileSync(path, 'utf8'));
-  } catch (error) {
-    throw new Error(`${name} is invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+function parseStrictJson(text, name) {
+  let cursor = 0;
+
+  function fail(message) {
+    throw new Error(`${name} is invalid JSON: ${message} at offset ${cursor}`);
   }
-  return object(value, name);
+
+  function whitespace() {
+    while (cursor < text.length && /[\u0009\u000a\u000d\u0020]/.test(text[cursor])) {
+      cursor += 1;
+    }
+  }
+
+  function stringValue() {
+    const start = cursor;
+    invariant(text[cursor] === '"', `${name} JSON string parser state is invalid`);
+    cursor += 1;
+    while (cursor < text.length) {
+      const character = text[cursor];
+      if (character === '"') {
+        cursor += 1;
+        try {
+          return JSON.parse(text.slice(start, cursor));
+        } catch (error) {
+          fail(error instanceof Error ? error.message : String(error));
+        }
+      }
+      if (character === '\\') {
+        cursor += 1;
+        if (cursor >= text.length) fail('unterminated escape sequence');
+        const escape = text[cursor];
+        if (escape === 'u') {
+          const hex = text.slice(cursor + 1, cursor + 5);
+          if (!/^[0-9a-fA-F]{4}$/.test(hex)) fail('invalid Unicode escape');
+          cursor += 5;
+          continue;
+        }
+        if (!'"\\/bfnrt'.includes(escape)) fail('invalid escape sequence');
+        cursor += 1;
+        continue;
+      }
+      if (text.charCodeAt(cursor) < 0x20) fail('unescaped control character');
+      cursor += 1;
+    }
+    fail('unterminated string');
+  }
+
+  function value(path) {
+    whitespace();
+    const character = text[cursor];
+    if (character === '{') return objectValue(path);
+    if (character === '[') return arrayValue(path);
+    if (character === '"') {
+      stringValue();
+      return;
+    }
+    if (character === 't' && text.slice(cursor, cursor + 4) === 'true') {
+      cursor += 4;
+      return;
+    }
+    if (character === 'f' && text.slice(cursor, cursor + 5) === 'false') {
+      cursor += 5;
+      return;
+    }
+    if (character === 'n' && text.slice(cursor, cursor + 4) === 'null') {
+      cursor += 4;
+      return;
+    }
+    const match = NUMBER.exec(text.slice(cursor));
+    if (match) {
+      cursor += match[0].length;
+      return;
+    }
+    fail(`unexpected token in ${path}`);
+  }
+
+  function objectValue(path) {
+    cursor += 1;
+    whitespace();
+    const keys = new Set();
+    if (text[cursor] === '}') {
+      cursor += 1;
+      return;
+    }
+    while (cursor < text.length) {
+      whitespace();
+      if (text[cursor] !== '"') fail(`object key expected in ${path}`);
+      const key = stringValue();
+      invariant(
+        !keys.has(key),
+        `${name} contains duplicate JSON key ${JSON.stringify(key)} in ${path}`,
+      );
+      keys.add(key);
+      whitespace();
+      if (text[cursor] !== ':') fail(`colon expected after object key in ${path}`);
+      cursor += 1;
+      value(`${path}.${key}`);
+      whitespace();
+      if (text[cursor] === '}') {
+        cursor += 1;
+        return;
+      }
+      if (text[cursor] !== ',') fail(`comma expected in ${path}`);
+      cursor += 1;
+    }
+    fail(`unterminated object in ${path}`);
+  }
+
+  function arrayValue(path) {
+    cursor += 1;
+    whitespace();
+    if (text[cursor] === ']') {
+      cursor += 1;
+      return;
+    }
+    let index = 0;
+    while (cursor < text.length) {
+      value(`${path}[${index}]`);
+      index += 1;
+      whitespace();
+      if (text[cursor] === ']') {
+        cursor += 1;
+        return;
+      }
+      if (text[cursor] !== ',') fail(`comma expected in ${path}`);
+      cursor += 1;
+    }
+    fail(`unterminated array in ${path}`);
+  }
+
+  value('$');
+  whitespace();
+  if (cursor !== text.length) fail('trailing content');
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${name} is invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
-function fileSha256(path) {
-  return createHash('sha256').update(readFileSync(path)).digest('hex');
+function parseJsonDocument(path, name) {
+  const resolvedPath = resolve(path);
+  let content;
+  try {
+    content = readFileSync(resolvedPath, 'utf8');
+  } catch (error) {
+    throw new Error(
+      `${name} cannot be read: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return {
+    path: resolvedPath,
+    canonical_path: realpathSync(resolvedPath),
+    file_sha256: createHash('sha256').update(content).digest('hex'),
+    value: object(parseStrictJson(content, name), name),
+  };
 }
 
 function timestamp(value, name) {
-  invariant(
-    typeof value === 'string'
-      && Number.isFinite(Date.parse(value))
-      && /(?:Z|[+-]\d{2}:\d{2})$/.test(value),
-    `${name} must be a timezone-aware timestamp`,
-  );
-  return Date.parse(value);
+  invariant(typeof value === 'string', `${name} must be a timezone-aware timestamp`);
+  const match = RFC3339.exec(value);
+  invariant(match, `${name} must be a strict RFC3339 timestamp`);
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  invariant(month >= 1 && month <= 12, `${name} month is invalid`);
+  const maximumDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  invariant(day >= 1 && day <= maximumDay, `${name} day is invalid`);
+  invariant(hour <= 23 && minute <= 59 && second <= 59, `${name} clock time is invalid`);
+  if (match[8] !== 'Z') {
+    const offsetHour = Number(match[10]);
+    const offsetMinute = Number(match[11]);
+    invariant(
+      offsetHour <= 14 && offsetMinute <= 59 && !(offsetHour === 14 && offsetMinute !== 0),
+      `${name} timezone offset is invalid`,
+    );
+  }
+  const parsed = Date.parse(value);
+  invariant(Number.isFinite(parsed), `${name} must be a valid timestamp`);
+  return parsed;
 }
 
 function portableId(value, name) {
@@ -114,25 +289,140 @@ function humanId(value, name) {
   const normalized = id.toLowerCase();
   invariant(!PLACEHOLDERS.has(normalized), `${name} must not be a placeholder`);
   invariant(!normalized.startsWith('example-'), `${name} must not be an example identity`);
+  invariant(!normalized.startsWith('fake-'), `${name} must not be a fake identity`);
+  invariant(!normalized.startsWith('sample-'), `${name} must not be a sample identity`);
+  invariant(!normalized.startsWith('test-'), `${name} must not be a test identity`);
   return id;
 }
 
-function atomicJson(path, value) {
+function evidenceSha256(value, name) {
+  invariant(
+    typeof value === 'string' && SHA256.test(value) && !UNIFORM_SHA256.test(value),
+    `${name} must be a non-placeholder SHA-256`,
+  );
+  return value;
+}
+
+function canonicalProspectivePath(path) {
   const target = resolve(path);
-  mkdirSync(dirname(target), { recursive: true });
-  try {
-    const stat = lstatSync(target);
-    invariant(!stat.isSymbolicLink(), `${target} must not be a symbolic link`);
-  } catch (error) {
-    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') throw error;
+  let cursor = target;
+  const suffix = [];
+  while (!existsSync(cursor)) {
+    const parent = dirname(cursor);
+    invariant(parent !== cursor, `cannot resolve output path ${target}`);
+    suffix.unshift(basename(cursor));
+    cursor = parent;
   }
-  const temporary = `${target}.tmp-${process.pid}`;
-  const content = `${JSON.stringify(value, null, 2)}\n`;
+  return resolve(realpathSync(cursor), ...suffix);
+}
+
+function inspectOutputTarget(path) {
+  const target = resolve(path);
+  const canonicalPath = canonicalProspectivePath(target);
+  if (!existsSync(target)) {
+    return {
+      target,
+      canonical_path: canonicalPath,
+      exists: false,
+      existing_sha256: null,
+    };
+  }
+  const stat = lstatSync(target);
+  invariant(!stat.isSymbolicLink(), `${target} must not be a symbolic link`);
+  invariant(stat.isFile(), `${target} must be a regular file when it exists`);
+  return {
+    target,
+    canonical_path: canonicalPath,
+    exists: true,
+    existing_sha256: createHash('sha256').update(readFileSync(target)).digest('hex'),
+  };
+}
+
+function writeJsonTransaction(entries, inputCanonicalPaths) {
+  const inspected = entries.map((entry) => ({
+    ...entry,
+    ...inspectOutputTarget(entry.path),
+    content: `${JSON.stringify(entry.value, null, 2)}\n`,
+  }));
+  const outputCanonicalPaths = inspected.map((entry) => entry.canonical_path);
+  invariant(
+    new Set(outputCanonicalPaths).size === outputCanonicalPaths.length,
+    'output paths must be canonically distinct',
+  );
+  for (const outputPath of outputCanonicalPaths) {
+    invariant(!inputCanonicalPaths.has(outputPath), 'output path must not overlap an input');
+  }
+
+  const transactionId = `${process.pid}-${Date.now()}-${randomBytes(8).toString('hex')}`;
+  for (const entry of inspected) {
+    mkdirSync(dirname(entry.target), { recursive: true, mode: 0o700 });
+    entry.temporary = `${entry.target}.tmp-${transactionId}`;
+    entry.backup = `${entry.target}.bak-${transactionId}`;
+    invariant(!existsSync(entry.temporary), `temporary output already exists: ${entry.temporary}`);
+    invariant(!existsSync(entry.backup), `backup output already exists: ${entry.backup}`);
+  }
+
   try {
-    writeFileSync(temporary, content, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
-    renameSync(temporary, target);
+    for (const entry of inspected) {
+      writeFileSync(entry.temporary, entry.content, {
+        encoding: 'utf8',
+        mode: 0o600,
+        flag: 'wx',
+      });
+    }
+
+    for (const entry of inspected) {
+      const current = inspectOutputTarget(entry.target);
+      invariant(
+        current.canonical_path === entry.canonical_path
+          && current.exists === entry.exists
+          && current.existing_sha256 === entry.existing_sha256,
+        `output target changed during transaction: ${entry.target}`,
+      );
+    }
+
+    const backedUp = [];
+    const committed = [];
+    try {
+      for (const entry of inspected) {
+        if (entry.exists) {
+          renameSync(entry.target, entry.backup);
+          backedUp.push(entry);
+        }
+      }
+      for (const entry of inspected) {
+        renameSync(entry.temporary, entry.target);
+        committed.push(entry);
+      }
+    } catch (error) {
+      const rollbackErrors = [];
+      for (const entry of committed.reverse()) {
+        try {
+          rmSync(entry.target, { force: true });
+        } catch (rollbackError) {
+          rollbackErrors.push(rollbackError);
+        }
+      }
+      for (const entry of backedUp.reverse()) {
+        try {
+          if (existsSync(entry.backup)) renameSync(entry.backup, entry.target);
+        } catch (rollbackError) {
+          rollbackErrors.push(rollbackError);
+        }
+      }
+      if (rollbackErrors.length > 0) {
+        throw new Error(
+          `output transaction failed and rollback was incomplete: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+      throw error;
+    }
+
+    for (const entry of inspected) rmSync(entry.backup, { force: true });
   } finally {
-    rmSync(temporary, { force: true });
+    for (const entry of inspected) rmSync(entry.temporary, { force: true });
   }
 }
 
@@ -222,12 +512,15 @@ function validatePacket(
   existingReviews,
   currentAssessment,
   expectedExactMain,
+  expectedPacketSha256,
 ) {
   invariant(packet.schema_version === 'tai.expert-review-packet.v1', 'packet schema mismatch');
   invariant(SHA1.test(packet.exact_main_sha), 'packet exact_main_sha is invalid');
   invariant(packet.exact_main_sha === expectedExactMain, 'packet exact-main mismatch');
-  timestamp(packet.generated_at, 'packet.generated_at');
+  const generatedAt = timestamp(packet.generated_at, 'packet.generated_at');
+  invariant(SHA256.test(expectedPacketSha256), 'expected packet SHA-256 is invalid');
   invariant(SHA256.test(packet.packet_sha256), 'packet SHA-256 is invalid');
+  invariant(packet.packet_sha256 === expectedPacketSha256, 'packet does not match trusted digest');
   const payload = { ...packet };
   delete payload.packet_sha256;
   const expected = expectedPacketPayload(
@@ -242,7 +535,7 @@ function validatePacket(
     packet.packet_sha256 === expectedDigest && sha256(payload) === expectedDigest,
     'packet does not match current governed packet authority',
   );
-  return timestamp(packet.generated_at, 'packet.generated_at');
+  return generatedAt;
 }
 
 function validateReviewRecord(review, index, context) {
@@ -255,13 +548,16 @@ function validateReviewRecord(review, index, context) {
   invariant(context.allowedCases.has(caseId), `${reviewId}: case is outside reviewer track`);
   const caseValue = context.caseMap.get(caseId);
   invariant(review.case_sha256 === caseValue.case_sha256, `${reviewId}: stale case digest`);
-  invariant(review.reviewer_role === context.track.reviewer_role, `${reviewId}: reviewer role does not match track`);
+  invariant(
+    review.reviewer_role === context.track.reviewer_role,
+    `${reviewId}: reviewer role does not match track`,
+  );
   invariant(ALLOWED_DECISIONS.has(review.decision), `${reviewId}: unsupported decision`);
-  invariant(SHA256.test(review.evidence_sha256), `${reviewId}: evidence SHA-256 is invalid`);
+  evidenceSha256(review.evidence_sha256, `${reviewId}.evidence_sha256`);
   const reviewedAt = timestamp(review.reviewed_at, `${reviewId}.reviewed_at`);
   invariant(reviewedAt >= context.packetGeneratedAt, `${reviewId}: review predates packet`);
   invariant(reviewedAt <= context.submittedAt, `${reviewId}: review is after submission`);
-  invariant(reviewedAt <= context.latestAllowedTime, `${reviewId}: review is in the future`);
+  invariant(reviewedAt <= context.evaluatedAt, `${reviewId}: review is in the future`);
   invariant(
     review.disagreement_with_review_id === null
       || (typeof review.disagreement_with_review_id === 'string'
@@ -282,17 +578,24 @@ export function ingestExpertReviewSubmission({
   submissionPath,
   existingReviewsPath,
   exactMainSha,
+  expectedPacketSha256,
   evaluatedAt,
   outputReviewsPath,
   outputAssessmentPath,
   outputReportPath,
 }) {
   invariant(SHA1.test(exactMainSha), 'exact-main must be a full Git SHA');
+  invariant(SHA256.test(expectedPacketSha256), 'expected packet SHA-256 is invalid');
   const evaluatedAtMs = timestamp(evaluatedAt, 'evaluated_at');
-  const latestAllowedTime = evaluatedAtMs + 5 * 60 * 1000;
-  const packet = parseJson(packetPath, 'packet');
-  const submission = parseJson(submissionPath, 'submission');
-  const existingReviews = parseJson(existingReviewsPath, 'existing reviews');
+  const packetDocument = parseJsonDocument(packetPath, 'packet');
+  const submissionDocument = parseJsonDocument(submissionPath, 'submission');
+  const existingReviewsDocument = parseJsonDocument(
+    existingReviewsPath,
+    'existing reviews',
+  );
+  const packet = packetDocument.value;
+  const submission = submissionDocument.value;
+  const existingReviews = existingReviewsDocument.value;
 
   const corpus = buildCorpus();
   const caseMap = validateCorpus(corpus);
@@ -304,21 +607,29 @@ export function ingestExpertReviewSubmission({
     existingReviews,
     currentAssessment,
     exactMainSha,
+    expectedPacketSha256,
   );
+  invariant(packetGeneratedAt <= evaluatedAtMs, 'packet generation timestamp is in the future');
 
   exactKeys(submission, ROOT_KEYS, 'submission');
   invariant(
     submission.schema_version === 'tai.expert-review-submission.v1',
     'submission schema mismatch',
   );
-  invariant(submission.exact_main_sha === packet.exact_main_sha, 'submission exact-main mismatch');
+  invariant(
+    submission.exact_main_sha === packet.exact_main_sha,
+    'submission exact-main mismatch',
+  );
   invariant(submission.corpus_sha256 === packet.corpus_sha256, 'submission corpus mismatch');
   invariant(submission.packet_sha256 === packet.packet_sha256, 'submission packet mismatch');
   const submitterId = humanId(submission.submitter_id, 'submission.submitter_id');
   const submittedAt = timestamp(submission.submitted_at, 'submission.submitted_at');
   invariant(submittedAt >= packetGeneratedAt, 'submission predates packet');
-  invariant(submittedAt <= latestAllowedTime, 'submission timestamp is in the future');
-  invariant(Array.isArray(submission.reviews) && submission.reviews.length > 0, 'submission reviews must be non-empty');
+  invariant(submittedAt <= evaluatedAtMs, 'submission timestamp is in the future');
+  invariant(
+    Array.isArray(submission.reviews) && submission.reviews.length > 0,
+    'submission reviews must be non-empty',
+  );
 
   const trackId = portableId(submission.track_id, 'submission.track_id');
   const track = packet.reviewer_tracks.find((item) => item.track_id === trackId);
@@ -330,7 +641,7 @@ export function ingestExpertReviewSubmission({
   const allById = new Map();
   for (const review of existingReviews.reviews) {
     existingIds.add(review.review_id);
-    existingPairs.add(`${review.case_id}:${review.reviewer_id}`);
+    existingPairs.add(JSON.stringify([review.case_id, review.reviewer_id]));
     allById.set(review.review_id, review);
   }
   const submissionIds = new Set();
@@ -339,7 +650,7 @@ export function ingestExpertReviewSubmission({
   const context = {
     allowedCases,
     caseMap,
-    latestAllowedTime,
+    evaluatedAt: evaluatedAtMs,
     packetGeneratedAt,
     submittedAt,
     track,
@@ -347,11 +658,14 @@ export function ingestExpertReviewSubmission({
   for (let index = 0; index < submission.reviews.length; index += 1) {
     const review = submission.reviews[index];
     const { reviewId, caseId, reviewerId } = validateReviewRecord(review, index, context);
-    const pair = `${caseId}:${reviewerId}`;
+    const pair = JSON.stringify([caseId, reviewerId]);
     invariant(!existingIds.has(reviewId), `${reviewId}: review ID already exists`);
     invariant(!existingPairs.has(pair), `${reviewId}: reviewer/case pair already exists`);
     invariant(!submissionIds.has(reviewId), `${reviewId}: duplicate review ID in submission`);
-    invariant(!submissionPairs.has(pair), `${reviewId}: duplicate reviewer/case pair in submission`);
+    invariant(
+      !submissionPairs.has(pair),
+      `${reviewId}: duplicate reviewer/case pair in submission`,
+    );
     submissionIds.add(reviewId);
     submissionPairs.add(pair);
     allById.set(reviewId, review);
@@ -362,8 +676,18 @@ export function ingestExpertReviewSubmission({
     if (review.disagreement_with_review_id !== null) {
       const target = allById.get(review.disagreement_with_review_id);
       invariant(target, `${review.review_id}: disagreement target does not exist`);
-      invariant(target.case_id === review.case_id, `${review.review_id}: disagreement target must concern the same case`);
-      invariant(target.reviewer_id !== review.reviewer_id, `${review.review_id}: self-disagreement is forbidden`);
+      invariant(
+        target.case_id === review.case_id,
+        `${review.review_id}: disagreement target must concern the same case`,
+      );
+      invariant(
+        target.reviewer_id !== review.reviewer_id,
+        `${review.review_id}: self-disagreement is forbidden`,
+      );
+      invariant(
+        target.decision !== review.decision,
+        `${review.review_id}: disagreement target must have a different decision`,
+      );
     }
   }
 
@@ -385,12 +709,13 @@ export function ingestExpertReviewSubmission({
     exact_main_sha: exactMainSha,
     evaluated_at: evaluatedAt,
     packet_sha256: packet.packet_sha256,
+    packet_file_sha256: packetDocument.file_sha256,
     corpus_sha256: packet.corpus_sha256,
     track_id: trackId,
     reviewer_role: track.reviewer_role,
     submitter_id: submitterId,
-    submission_sha256: fileSha256(submissionPath),
-    existing_reviews_sha256: fileSha256(existingReviewsPath),
+    submission_sha256: submissionDocument.file_sha256,
+    existing_reviews_sha256: existingReviewsDocument.file_sha256,
     reviews_added: parsed.length,
     candidate_review_count: candidateReviews.reviews.length,
     candidate_reviews_sha256: sha256(candidateReviews),
@@ -407,11 +732,18 @@ export function ingestExpertReviewSubmission({
   };
   report.report_sha256 = sha256(report);
 
-  const outputs = [outputReviewsPath, outputAssessmentPath, outputReportPath].map((value) => resolve(value));
-  invariant(new Set(outputs).size === outputs.length, 'output paths must be distinct');
-  atomicJson(outputReviewsPath, candidateReviews);
-  atomicJson(outputAssessmentPath, candidateAssessment);
-  atomicJson(outputReportPath, report);
+  writeJsonTransaction(
+    [
+      { path: outputReviewsPath, value: candidateReviews },
+      { path: outputAssessmentPath, value: candidateAssessment },
+      { path: outputReportPath, value: report },
+    ],
+    new Set([
+      packetDocument.canonical_path,
+      submissionDocument.canonical_path,
+      existingReviewsDocument.canonical_path,
+    ]),
+  );
   return report;
 }
 
@@ -421,6 +753,7 @@ function parseArgs(argv) {
     submissionPath: '',
     existingReviewsPath: '',
     exactMainSha: '',
+    expectedPacketSha256: '',
     evaluatedAt: '',
     outputReviewsPath: '',
     outputAssessmentPath: '',
@@ -431,6 +764,7 @@ function parseArgs(argv) {
     '--submission': 'submissionPath',
     '--existing-reviews': 'existingReviewsPath',
     '--exact-main': 'exactMainSha',
+    '--expected-packet-sha256': 'expectedPacketSha256',
     '--evaluated-at': 'evaluatedAt',
     '--output-reviews': 'outputReviewsPath',
     '--output-assessment': 'outputAssessmentPath',

--- a/apps/tai/model-artifacts/expert-review-submission-intake.mjs
+++ b/apps/tai/model-artifacts/expert-review-submission-intake.mjs
@@ -19,6 +19,7 @@ import {
   validateCorpus,
   validateReviews,
 } from '../../../docs/platform-v7/autopilot/tai-ap-14c/gold-set-authority.mjs';
+import { REVIEWER_TRACKS } from './expert-review-packet.mjs';
 
 const SHA1 = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
@@ -135,52 +136,112 @@ function atomicJson(path, value) {
   }
 }
 
-function validatePacket(packet, currentAssessment, caseMap, expectedExactMain) {
+function caseContract(caseValue, policy) {
+  const critical = caseValue.criticality === 'CRITICAL';
+  return {
+    case_id: caseValue.case_id,
+    case_sha256: caseValue.case_sha256,
+    prompt_sha256: caseValue.prompt_sha256,
+    domain: caseValue.domain,
+    criticality: caseValue.criticality,
+    variant_kind: caseValue.variant_kind,
+    prompts: caseValue.prompts,
+    expected_statuses: caseValue.expected_statuses,
+    required_concepts: caseValue.required_concepts,
+    forbidden_claims: caseValue.forbidden_claims,
+    expected_citations: caseValue.expected_citations,
+    abstention_reason_codes: caseValue.abstention_reason_codes,
+    required_review: {
+      minimum_independent_approvals: critical
+        ? policy.minimum_independent_approvals_for_critical
+        : policy.minimum_approvals_per_case,
+      primary_role: policy.required_primary_role_by_domain[caseValue.domain],
+      secondary_roles: critical ? policy.critical_secondary_roles : [],
+    },
+  };
+}
+
+function expectedPacketPayload(packet, corpus, existingReviews, currentAssessment) {
+  const cases = [...corpus.platform.cases, ...corpus.agro.cases];
+  const tracks = REVIEWER_TRACKS.map((track) => {
+    const selected = cases.filter(
+      (caseValue) => track.domains.includes(caseValue.domain)
+        && (!track.critical_only || caseValue.criticality === 'CRITICAL'),
+    );
+    return {
+      ...track,
+      case_count: selected.length,
+      critical_case_count: selected.filter(
+        (caseValue) => caseValue.criticality === 'CRITICAL',
+      ).length,
+      case_ids: selected.map((caseValue) => caseValue.case_id),
+    };
+  });
+  return {
+    schema_version: 'tai.expert-review-packet.v1',
+    exact_main_sha: packet.exact_main_sha,
+    generated_at: packet.generated_at,
+    corpus_version: corpus.platform.version,
+    corpus_sha256: currentAssessment.corpus_sha256,
+    baseline_assessment_sha256: currentAssessment.assessment_sha256,
+    required_locales: corpus.platform.required_locales,
+    counts: {
+      total_cases: cases.length,
+      platform_cases: corpus.platform.cases.length,
+      agro_cases: corpus.agro.cases.length,
+      critical_cases: cases.filter(
+        (caseValue) => caseValue.criticality === 'CRITICAL',
+      ).length,
+      existing_reviews: existingReviews.reviews.length,
+    },
+    review_policy: existingReviews.policy,
+    reviewer_tracks: tracks,
+    cases: cases.map((caseValue) => caseContract(caseValue, existingReviews.policy)),
+    record_contract: {
+      schema_version: 'tai.expert-reviews.v1',
+      allowed_decisions: ['APPROVED', 'REJECTED', 'NEEDS_CHANGES'],
+      human_identity_required: true,
+      external_evidence_sha256_required: true,
+      timezone_aware_reviewed_at_required: true,
+      review_sha256_rule: 'SHA256_CANONICAL_JSON_EXCLUDING_REVIEW_SHA256',
+      automation_may_create_decision: false,
+    },
+    automation_boundary: 'AUTOMATION_MUST_NOT_CREATE_REVIEW_DECISIONS',
+    maturity_boundary: {
+      expert_review_status: currentAssessment.status,
+      benchmark_status: 'PENDING_BENCHMARK',
+      model_admission_status: 'PENDING_ADMISSION',
+      production_operational_status: 'NOT_ATTESTED',
+    },
+  };
+}
+
+function validatePacket(
+  packet,
+  corpus,
+  existingReviews,
+  currentAssessment,
+  expectedExactMain,
+) {
   invariant(packet.schema_version === 'tai.expert-review-packet.v1', 'packet schema mismatch');
   invariant(SHA1.test(packet.exact_main_sha), 'packet exact_main_sha is invalid');
   invariant(packet.exact_main_sha === expectedExactMain, 'packet exact-main mismatch');
+  timestamp(packet.generated_at, 'packet.generated_at');
   invariant(SHA256.test(packet.packet_sha256), 'packet SHA-256 is invalid');
   const payload = { ...packet };
   delete payload.packet_sha256;
-  invariant(packet.packet_sha256 === sha256(payload), 'packet digest mismatch');
-  invariant(packet.corpus_sha256 === currentAssessment.corpus_sha256, 'packet corpus is stale');
-  invariant(
-    packet.baseline_assessment_sha256 === currentAssessment.assessment_sha256,
-    'packet baseline assessment is stale',
+  const expected = expectedPacketPayload(
+    packet,
+    corpus,
+    existingReviews,
+    currentAssessment,
   );
-  invariant(packet.counts?.total_cases === 58, 'packet total case count mismatch');
-  invariant(packet.counts?.critical_cases === 23, 'packet critical case count mismatch');
-  invariant(Array.isArray(packet.cases) && packet.cases.length === caseMap.size, 'packet case coverage mismatch');
-  const packetCaseIds = new Set();
-  for (const packetCase of packet.cases) {
-    object(packetCase, 'packet case');
-    const caseValue = caseMap.get(packetCase.case_id);
-    invariant(caseValue, `packet contains unknown case ${packetCase.case_id}`);
-    invariant(!packetCaseIds.has(packetCase.case_id), `packet duplicates case ${packetCase.case_id}`);
-    packetCaseIds.add(packetCase.case_id);
-    invariant(packetCase.case_sha256 === caseValue.case_sha256, `${packetCase.case_id}: packet case digest mismatch`);
-    invariant(packetCase.prompt_sha256 === caseValue.prompt_sha256, `${packetCase.case_id}: packet prompt digest mismatch`);
-    invariant(packetCase.domain === caseValue.domain, `${packetCase.case_id}: packet domain mismatch`);
-    invariant(packetCase.criticality === caseValue.criticality, `${packetCase.case_id}: packet criticality mismatch`);
-  }
-  invariant(packetCaseIds.size === caseMap.size, 'packet does not exactly cover current corpus');
-  invariant(Array.isArray(packet.reviewer_tracks), 'packet reviewer_tracks must be an array');
-  const trackIds = new Set();
-  for (const track of packet.reviewer_tracks) {
-    object(track, 'reviewer track');
-    portableId(track.track_id, 'track_id');
-    invariant(!trackIds.has(track.track_id), `duplicate packet track ${track.track_id}`);
-    trackIds.add(track.track_id);
-    invariant(typeof track.reviewer_role === 'string', `${track.track_id}: reviewer role missing`);
-    invariant(Array.isArray(track.case_ids) && track.case_ids.length > 0, `${track.track_id}: case_ids missing`);
-    const trackCaseIds = new Set();
-    for (const caseId of track.case_ids) {
-      invariant(caseMap.has(caseId), `${track.track_id}: unknown case ${caseId}`);
-      invariant(!trackCaseIds.has(caseId), `${track.track_id}: duplicate case ${caseId}`);
-      trackCaseIds.add(caseId);
-    }
-    invariant(track.case_count === track.case_ids.length, `${track.track_id}: case_count mismatch`);
-  }
+  const expectedDigest = sha256(expected);
+  invariant(packet.packet_sha256 === sha256(payload), 'packet digest mismatch');
+  invariant(
+    packet.packet_sha256 === expectedDigest && sha256(payload) === expectedDigest,
+    'packet does not match current governed packet authority',
+  );
   return timestamp(packet.generated_at, 'packet.generated_at');
 }
 
@@ -239,8 +300,9 @@ export function ingestExpertReviewSubmission({
   const currentAssessment = computeAssessment(corpus, existingReviews);
   const packetGeneratedAt = validatePacket(
     packet,
+    corpus,
+    existingReviews,
     currentAssessment,
-    caseMap,
     exactMainSha,
   );
 

--- a/apps/tai/tests/expert-review-packet.test.mjs
+++ b/apps/tai/tests/expert-review-packet.test.mjs
@@ -102,7 +102,7 @@ function testMaterializationIsBoundedAndTemplatesAreBlank() {
       manifest.schema_version,
       'tai.expert-review-packet-manifest.v1',
     );
-    assert.equal(manifest.files.length, 6);
+    assert.equal(manifest.files.length, 10);
     assert.equal(manifest.packet_sha256, value.packet_sha256);
     assert.match(manifest.manifest_sha256, /^[0-9a-f]{64}$/);
     for (const file of manifest.files) {
@@ -132,6 +132,28 @@ function testMaterializationIsBoundedAndTemplatesAreBlank() {
       'version',
     ]);
     assert.deepEqual(submission.reviews, []);
+
+    const intake = json(
+      resolve(directory, 'intake-submission-platform-primary.v1.json'),
+    );
+    assert.deepEqual(Object.keys(intake).sort(), [
+      'corpus_sha256',
+      'exact_main_sha',
+      'packet_sha256',
+      'reviews',
+      'schema_version',
+      'submitted_at',
+      'submitter_id',
+      'track_id',
+    ]);
+    assert.equal(intake.schema_version, 'tai.expert-review-submission.v1');
+    assert.equal(intake.exact_main_sha, value.exact_main_sha);
+    assert.equal(intake.corpus_sha256, value.corpus_sha256);
+    assert.equal(intake.packet_sha256, value.packet_sha256);
+    assert.equal(intake.track_id, 'platform-primary');
+    assert.equal(intake.submitter_id, null);
+    assert.equal(intake.submitted_at, null);
+    assert.deepEqual(intake.reviews, []);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/apps/tai/tests/expert-review-submission-intake.test.mjs
+++ b/apps/tai/tests/expert-review-submission-intake.test.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildExpertReviewPacket,
+  materializeExpertReviewPacket,
+} from '../model-artifacts/expert-review-packet.mjs';
+import { ingestExpertReviewSubmission } from '../model-artifacts/expert-review-submission-intake.mjs';
+import {
+  buildCorpus,
+  computeAssessment,
+  sha256,
+  validateCorpus,
+  validateReviews,
+} from '../../../docs/platform-v7/autopilot/tai-ap-14c/gold-set-authority.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_REVIEWS = resolve(
+  HERE,
+  '../../../docs/platform-v7/autopilot/tai-ap-14c/expert-reviews.v1.json',
+);
+const EXACT_MAIN = 'a'.repeat(40);
+const GENERATED_AT = '2026-07-21T10:00:00Z';
+const SUBMITTED_AT = '2026-07-21T10:20:00Z';
+const EVALUATED_AT = '2026-07-21T10:20:00Z';
+
+function json(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function writeJson(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function reviewRecord(caseValue, reviewerRole, reviewerId, suffix = '01') {
+  const value = {
+    review_id: `review-${caseValue.case_id.replaceAll('.', '-')}-${suffix}`,
+    case_id: caseValue.case_id,
+    case_sha256: caseValue.case_sha256,
+    reviewer_id: reviewerId,
+    reviewer_role: reviewerRole,
+    decision: 'APPROVED',
+    reviewed_at: '2026-07-21T10:10:00Z',
+    evidence_sha256: 'e'.repeat(64),
+    disagreement_with_review_id: null,
+    review_sha256: '',
+  };
+  const payload = { ...value };
+  delete payload.review_sha256;
+  value.review_sha256 = sha256(payload);
+  return value;
+}
+
+function resign(review) {
+  const payload = { ...review };
+  delete payload.review_sha256;
+  review.review_sha256 = sha256(payload);
+  return review;
+}
+
+function submission(packet, trackId, reviews) {
+  return {
+    schema_version: 'tai.expert-review-submission.v1',
+    exact_main_sha: packet.exact_main_sha,
+    corpus_sha256: packet.corpus_sha256,
+    packet_sha256: packet.packet_sha256,
+    track_id: trackId,
+    submitter_id: 'review-coordinator-01',
+    submitted_at: SUBMITTED_AT,
+    reviews,
+  };
+}
+
+function fixture() {
+  const root = mkdtempSync(resolve(tmpdir(), 'tai-review-intake-'));
+  const packetDirectory = resolve(root, 'packet');
+  const packet = buildExpertReviewPacket({
+    exactMainSha: EXACT_MAIN,
+    generatedAt: GENERATED_AT,
+  });
+  materializeExpertReviewPacket(packet, packetDirectory);
+  const existingReviewsPath = resolve(root, 'existing-reviews.json');
+  writeFileSync(existingReviewsPath, readFileSync(REPO_REVIEWS));
+  return {
+    root,
+    packet,
+    packetPath: resolve(packetDirectory, 'expert-review-packet.v1.json'),
+    existingReviewsPath,
+    outputReviewsPath: resolve(root, 'output/expert-reviews.v1.json'),
+    outputAssessmentPath: resolve(root, 'output/baseline-assessment.v1.json'),
+    outputReportPath: resolve(root, 'output/intake-report.v1.json'),
+    submissionPath: resolve(root, 'submission.json'),
+  };
+}
+
+function run(input) {
+  return ingestExpertReviewSubmission({
+    packetPath: input.packetPath,
+    submissionPath: input.submissionPath,
+    existingReviewsPath: input.existingReviewsPath,
+    exactMainSha: EXACT_MAIN,
+    evaluatedAt: EVALUATED_AT,
+    outputReviewsPath: input.outputReviewsPath,
+    outputAssessmentPath: input.outputAssessmentPath,
+    outputReportPath: input.outputReportPath,
+  });
+}
+
+function withFixture(callback) {
+  const input = fixture();
+  try {
+    callback(input);
+  } finally {
+    rmSync(input.root, { recursive: true, force: true });
+  }
+}
+
+withFixture((input) => {
+  const normalPlatform = input.packet.cases.find(
+    (item) => item.domain === 'PLATFORM' && item.criticality !== 'CRITICAL',
+  );
+  assert.ok(normalPlatform);
+  const review = reviewRecord(normalPlatform, 'PLATFORM_OWNER', 'platform-owner-01');
+  writeJson(input.submissionPath, submission(input.packet, 'platform-primary', [review]));
+  const report = run(input);
+  assert.equal(report.status, 'CANDIDATE_WRITTEN_FOR_HUMAN_PR_REVIEW');
+  assert.equal(report.reviews_added, 1);
+  assert.equal(report.automation_created_decisions, false);
+  assert.equal(report.requires_human_pull_request_review, true);
+  assert.equal(report.candidate_assessment_status, 'PENDING_REVIEW');
+  assert.equal(json(input.outputReviewsPath).reviews.length, 1);
+  assert.equal(json(input.outputAssessmentPath).counts.reviewed_cases, 1);
+  assert.equal(json(input.outputReportPath).report_sha256, report.report_sha256);
+});
+
+withFixture((input) => {
+  const critical = input.packet.cases.find((item) => item.criticality === 'CRITICAL');
+  assert.ok(critical);
+  const review = reviewRecord(critical, 'SECURITY_REVIEWER', 'security-reviewer-01');
+  writeJson(input.submissionPath, submission(input.packet, 'critical-security', [review]));
+  const report = run(input);
+  assert.equal(report.reviews_added, 1);
+  assert.equal(report.candidate_accepted, false);
+  assert.equal(json(input.outputAssessmentPath).counts.reviewed_cases, 0);
+});
+
+const negativeCases = [
+  {
+    name: 'stale case digest',
+    mutate(review) {
+      review.case_sha256 = 'f'.repeat(64);
+      resign(review);
+    },
+    expected: /stale case digest/,
+  },
+  {
+    name: 'wrong track role',
+    mutate(review) {
+      review.reviewer_role = 'DOMAIN_EXPERT';
+      resign(review);
+    },
+    expected: /reviewer role does not match track/,
+  },
+  {
+    name: 'future review',
+    mutate(review) {
+      review.reviewed_at = '2026-07-21T10:21:00Z';
+      resign(review);
+    },
+    expected: /review is after submission/,
+  },
+  {
+    name: 'invalid evidence digest',
+    mutate(review) {
+      review.evidence_sha256 = 'invalid';
+      resign(review);
+    },
+    expected: /evidence SHA-256 is invalid/,
+  },
+  {
+    name: 'unknown review field',
+    mutate(review) {
+      review.unknown = true;
+    },
+    expected: /keys invalid/,
+  },
+];
+
+for (const testCase of negativeCases) {
+  withFixture((input) => {
+    const caseValue = input.packet.cases.find(
+      (item) => item.domain === 'PLATFORM' && item.criticality !== 'CRITICAL',
+    );
+    const review = reviewRecord(caseValue, 'PLATFORM_OWNER', 'platform-owner-01');
+    testCase.mutate(review);
+    writeJson(input.submissionPath, submission(input.packet, 'platform-primary', [review]));
+    assert.throws(() => run(input), testCase.expected, testCase.name);
+  });
+}
+
+withFixture((input) => {
+  const cases = input.packet.cases.filter(
+    (item) => item.domain === 'PLATFORM' && item.criticality !== 'CRITICAL',
+  );
+  const first = reviewRecord(cases[0], 'PLATFORM_OWNER', 'platform-owner-01');
+  const second = reviewRecord(cases[1], 'PLATFORM_OWNER', 'platform-owner-02');
+  second.review_id = first.review_id;
+  resign(second);
+  writeJson(input.submissionPath, submission(input.packet, 'platform-primary', [first, second]));
+  assert.throws(() => run(input), /duplicate review ID in submission/);
+});
+
+withFixture((input) => {
+  const caseValue = input.packet.cases.find(
+    (item) => item.domain === 'PLATFORM' && item.criticality !== 'CRITICAL',
+  );
+  const existingReview = reviewRecord(
+    caseValue,
+    'PLATFORM_OWNER',
+    'platform-owner-existing',
+    'existing',
+  );
+  const existing = json(input.existingReviewsPath);
+  existing.reviews = [existingReview];
+  validateReviews(existing, validateCorpus(buildCorpus()));
+  writeJson(input.existingReviewsPath, existing);
+
+  const assessment = computeAssessment(buildCorpus(), existing);
+  const packet = json(input.packetPath);
+  packet.baseline_assessment_sha256 = assessment.assessment_sha256;
+  packet.counts.existing_reviews = 1;
+  const packetPayload = { ...packet };
+  delete packetPayload.packet_sha256;
+  packet.packet_sha256 = sha256(packetPayload);
+  writeJson(input.packetPath, packet);
+  input.packet = packet;
+
+  const replacement = reviewRecord(
+    caseValue,
+    'PLATFORM_OWNER',
+    'platform-owner-existing',
+    'replacement',
+  );
+  writeJson(input.submissionPath, submission(packet, 'platform-primary', [replacement]));
+  assert.throws(() => run(input), /reviewer\/case pair already exists/);
+});
+
+withFixture((input) => {
+  const caseValue = input.packet.cases.find(
+    (item) => item.domain === 'PLATFORM' && item.criticality !== 'CRITICAL',
+  );
+  const review = reviewRecord(caseValue, 'PLATFORM_OWNER', 'platform-owner-01');
+  const envelope = submission(input.packet, 'platform-primary', [review]);
+  envelope.packet_sha256 = '0'.repeat(64);
+  writeJson(input.submissionPath, envelope);
+  assert.throws(() => run(input), /submission packet mismatch/);
+});
+
+process.stdout.write('expert review submission intake tests: PASS\n');

--- a/apps/tai/tests/expert-review-submission-intake.test.mjs
+++ b/apps/tai/tests/expert-review-submission-intake.test.mjs
@@ -1,13 +1,7 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
-import {
-  mkdtempSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -19,7 +13,6 @@ import {
 import { ingestExpertReviewSubmission } from '../model-artifacts/expert-review-submission-intake.mjs';
 import {
   buildCorpus,
-  computeAssessment,
   sha256,
   validateCorpus,
   validateReviews,
@@ -33,34 +26,14 @@ const REPO_REVIEWS = resolve(
 const EXACT_MAIN = 'a'.repeat(40);
 const GENERATED_AT = '2026-07-21T10:00:00Z';
 const SUBMITTED_AT = '2026-07-21T10:20:00Z';
-const EVALUATED_AT = '2026-07-21T10:20:00Z';
+const EVALUATED_AT = SUBMITTED_AT;
 
 function json(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
 }
 
 function writeJson(path, value) {
-  mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
-}
-
-function reviewRecord(caseValue, reviewerRole, reviewerId, suffix = '01') {
-  const value = {
-    review_id: `review-${caseValue.case_id.replaceAll('.', '-')}-${suffix}`,
-    case_id: caseValue.case_id,
-    case_sha256: caseValue.case_sha256,
-    reviewer_id: reviewerId,
-    reviewer_role: reviewerRole,
-    decision: 'APPROVED',
-    reviewed_at: '2026-07-21T10:10:00Z',
-    evidence_sha256: 'e'.repeat(64),
-    disagreement_with_review_id: null,
-    review_sha256: '',
-  };
-  const payload = { ...value };
-  delete payload.review_sha256;
-  value.review_sha256 = sha256(payload);
-  return value;
 }
 
 function resign(review) {
@@ -70,7 +43,22 @@ function resign(review) {
   return review;
 }
 
-function submission(packet, trackId, reviews) {
+function record(caseValue, role, reviewer, suffix = '01') {
+  return resign({
+    review_id: `review-${caseValue.case_id.replaceAll('.', '-')}-${suffix}`,
+    case_id: caseValue.case_id,
+    case_sha256: caseValue.case_sha256,
+    reviewer_id: reviewer,
+    reviewer_role: role,
+    decision: 'APPROVED',
+    reviewed_at: '2026-07-21T10:10:00Z',
+    evidence_sha256: 'e'.repeat(64),
+    disagreement_with_review_id: null,
+    review_sha256: '',
+  });
+}
+
+function envelope(packet, trackId, reviews) {
   return {
     schema_version: 'tai.expert-review-submission.v1',
     exact_main_sha: packet.exact_main_sha,
@@ -83,43 +71,39 @@ function submission(packet, trackId, reviews) {
   };
 }
 
-function fixture() {
+function fixture(existing = null) {
   const root = mkdtempSync(resolve(tmpdir(), 'tai-review-intake-'));
+  const existingReviewsPath = resolve(root, 'existing-reviews.json');
+  writeJson(existingReviewsPath, existing ?? json(REPO_REVIEWS));
   const packetDirectory = resolve(root, 'packet');
   const packet = buildExpertReviewPacket({
     exactMainSha: EXACT_MAIN,
     generatedAt: GENERATED_AT,
+    reviewsPath: existingReviewsPath,
   });
   materializeExpertReviewPacket(packet, packetDirectory);
-  const existingReviewsPath = resolve(root, 'existing-reviews.json');
-  writeFileSync(existingReviewsPath, readFileSync(REPO_REVIEWS));
   return {
     root,
     packet,
-    packetPath: resolve(packetDirectory, 'expert-review-packet.v1.json'),
     existingReviewsPath,
-    outputReviewsPath: resolve(root, 'output/expert-reviews.v1.json'),
-    outputAssessmentPath: resolve(root, 'output/baseline-assessment.v1.json'),
-    outputReportPath: resolve(root, 'output/intake-report.v1.json'),
+    packetPath: resolve(packetDirectory, 'expert-review-packet.v1.json'),
     submissionPath: resolve(root, 'submission.json'),
+    outputReviewsPath: resolve(root, 'candidate-reviews.json'),
+    outputAssessmentPath: resolve(root, 'candidate-assessment.json'),
+    outputReportPath: resolve(root, 'candidate-report.json'),
   };
 }
 
 function run(input) {
   return ingestExpertReviewSubmission({
-    packetPath: input.packetPath,
-    submissionPath: input.submissionPath,
-    existingReviewsPath: input.existingReviewsPath,
+    ...input,
     exactMainSha: EXACT_MAIN,
     evaluatedAt: EVALUATED_AT,
-    outputReviewsPath: input.outputReviewsPath,
-    outputAssessmentPath: input.outputAssessmentPath,
-    outputReportPath: input.outputReportPath,
   });
 }
 
-function withFixture(callback) {
-  const input = fixture();
+function useFixture(existing, callback) {
+  const input = fixture(existing);
   try {
     callback(input);
   } finally {
@@ -127,144 +111,124 @@ function withFixture(callback) {
   }
 }
 
-withFixture((input) => {
-  const normalPlatform = input.packet.cases.find(
+function normalPlatform(packet) {
+  const value = packet.cases.find(
     (item) => item.domain === 'PLATFORM' && item.criticality !== 'CRITICAL',
   );
-  assert.ok(normalPlatform);
-  const review = reviewRecord(normalPlatform, 'PLATFORM_OWNER', 'platform-owner-01');
-  writeJson(input.submissionPath, submission(input.packet, 'platform-primary', [review]));
+  assert.ok(value);
+  return value;
+}
+
+useFixture(null, (input) => {
+  const review = record(normalPlatform(input.packet), 'PLATFORM_OWNER', 'platform-owner-01');
+  writeJson(input.submissionPath, envelope(input.packet, 'platform-primary', [review]));
   const report = run(input);
   assert.equal(report.status, 'CANDIDATE_WRITTEN_FOR_HUMAN_PR_REVIEW');
   assert.equal(report.reviews_added, 1);
   assert.equal(report.automation_created_decisions, false);
-  assert.equal(report.requires_human_pull_request_review, true);
   assert.equal(report.candidate_assessment_status, 'PENDING_REVIEW');
   assert.equal(json(input.outputReviewsPath).reviews.length, 1);
   assert.equal(json(input.outputAssessmentPath).counts.reviewed_cases, 1);
-  assert.equal(json(input.outputReportPath).report_sha256, report.report_sha256);
 });
 
-withFixture((input) => {
+useFixture(null, (input) => {
   const critical = input.packet.cases.find((item) => item.criticality === 'CRITICAL');
   assert.ok(critical);
-  const review = reviewRecord(critical, 'SECURITY_REVIEWER', 'security-reviewer-01');
-  writeJson(input.submissionPath, submission(input.packet, 'critical-security', [review]));
+  const review = record(critical, 'SECURITY_REVIEWER', 'security-reviewer-01');
+  writeJson(input.submissionPath, envelope(input.packet, 'critical-security', [review]));
   const report = run(input);
   assert.equal(report.reviews_added, 1);
   assert.equal(report.candidate_accepted, false);
   assert.equal(json(input.outputAssessmentPath).counts.reviewed_cases, 0);
 });
 
-const negativeCases = [
-  {
-    name: 'stale case digest',
-    mutate(review) {
+const mutations = [
+  [
+    /stale case digest/,
+    (review) => {
       review.case_sha256 = 'f'.repeat(64);
       resign(review);
     },
-    expected: /stale case digest/,
-  },
-  {
-    name: 'wrong track role',
-    mutate(review) {
+  ],
+  [
+    /reviewer role does not match track/,
+    (review) => {
       review.reviewer_role = 'DOMAIN_EXPERT';
       resign(review);
     },
-    expected: /reviewer role does not match track/,
-  },
-  {
-    name: 'future review',
-    mutate(review) {
+  ],
+  [
+    /review is after submission/,
+    (review) => {
       review.reviewed_at = '2026-07-21T10:21:00Z';
       resign(review);
     },
-    expected: /review is after submission/,
-  },
-  {
-    name: 'invalid evidence digest',
-    mutate(review) {
+  ],
+  [
+    /evidence SHA-256 is invalid/,
+    (review) => {
       review.evidence_sha256 = 'invalid';
       resign(review);
     },
-    expected: /evidence SHA-256 is invalid/,
-  },
-  {
-    name: 'unknown review field',
-    mutate(review) {
+  ],
+  [
+    /keys invalid/,
+    (review) => {
       review.unknown = true;
     },
-    expected: /keys invalid/,
-  },
+  ],
 ];
 
-for (const testCase of negativeCases) {
-  withFixture((input) => {
-    const caseValue = input.packet.cases.find(
-      (item) => item.domain === 'PLATFORM' && item.criticality !== 'CRITICAL',
-    );
-    const review = reviewRecord(caseValue, 'PLATFORM_OWNER', 'platform-owner-01');
-    testCase.mutate(review);
-    writeJson(input.submissionPath, submission(input.packet, 'platform-primary', [review]));
-    assert.throws(() => run(input), testCase.expected, testCase.name);
+for (const [expected, mutate] of mutations) {
+  useFixture(null, (input) => {
+    const review = record(normalPlatform(input.packet), 'PLATFORM_OWNER', 'platform-owner-01');
+    mutate(review);
+    writeJson(input.submissionPath, envelope(input.packet, 'platform-primary', [review]));
+    assert.throws(() => run(input), expected);
   });
 }
 
-withFixture((input) => {
+useFixture(null, (input) => {
   const cases = input.packet.cases.filter(
     (item) => item.domain === 'PLATFORM' && item.criticality !== 'CRITICAL',
   );
-  const first = reviewRecord(cases[0], 'PLATFORM_OWNER', 'platform-owner-01');
-  const second = reviewRecord(cases[1], 'PLATFORM_OWNER', 'platform-owner-02');
+  const first = record(cases[0], 'PLATFORM_OWNER', 'platform-owner-01');
+  const second = record(cases[1], 'PLATFORM_OWNER', 'platform-owner-02');
   second.review_id = first.review_id;
   resign(second);
-  writeJson(input.submissionPath, submission(input.packet, 'platform-primary', [first, second]));
+  writeJson(input.submissionPath, envelope(input.packet, 'platform-primary', [first, second]));
   assert.throws(() => run(input), /duplicate review ID in submission/);
 });
 
-withFixture((input) => {
-  const caseValue = input.packet.cases.find(
+{
+  const corpus = buildCorpus();
+  const caseMap = validateCorpus(corpus);
+  const caseValue = [...caseMap.values()].find(
     (item) => item.domain === 'PLATFORM' && item.criticality !== 'CRITICAL',
   );
-  const existingReview = reviewRecord(
-    caseValue,
-    'PLATFORM_OWNER',
-    'platform-owner-existing',
-    'existing',
-  );
-  const existing = json(input.existingReviewsPath);
-  existing.reviews = [existingReview];
-  validateReviews(existing, validateCorpus(buildCorpus()));
-  writeJson(input.existingReviewsPath, existing);
+  assert.ok(caseValue);
+  const existing = json(REPO_REVIEWS);
+  existing.reviews = [
+    record(caseValue, 'PLATFORM_OWNER', 'platform-owner-existing', 'existing'),
+  ];
+  validateReviews(existing, caseMap);
+  useFixture(existing, (input) => {
+    const replacement = record(
+      caseValue,
+      'PLATFORM_OWNER',
+      'platform-owner-existing',
+      'replacement',
+    );
+    writeJson(input.submissionPath, envelope(input.packet, 'platform-primary', [replacement]));
+    assert.throws(() => run(input), /reviewer\/case pair already exists/);
+  });
+}
 
-  const assessment = computeAssessment(buildCorpus(), existing);
-  const packet = json(input.packetPath);
-  packet.baseline_assessment_sha256 = assessment.assessment_sha256;
-  packet.counts.existing_reviews = 1;
-  const packetPayload = { ...packet };
-  delete packetPayload.packet_sha256;
-  packet.packet_sha256 = sha256(packetPayload);
-  writeJson(input.packetPath, packet);
-  input.packet = packet;
-
-  const replacement = reviewRecord(
-    caseValue,
-    'PLATFORM_OWNER',
-    'platform-owner-existing',
-    'replacement',
-  );
-  writeJson(input.submissionPath, submission(packet, 'platform-primary', [replacement]));
-  assert.throws(() => run(input), /reviewer\/case pair already exists/);
-});
-
-withFixture((input) => {
-  const caseValue = input.packet.cases.find(
-    (item) => item.domain === 'PLATFORM' && item.criticality !== 'CRITICAL',
-  );
-  const review = reviewRecord(caseValue, 'PLATFORM_OWNER', 'platform-owner-01');
-  const envelope = submission(input.packet, 'platform-primary', [review]);
-  envelope.packet_sha256 = '0'.repeat(64);
-  writeJson(input.submissionPath, envelope);
+useFixture(null, (input) => {
+  const review = record(normalPlatform(input.packet), 'PLATFORM_OWNER', 'platform-owner-01');
+  const value = envelope(input.packet, 'platform-primary', [review]);
+  value.packet_sha256 = '0'.repeat(64);
+  writeJson(input.submissionPath, value);
   assert.throws(() => run(input), /submission packet mismatch/);
 });
 

--- a/apps/tai/tests/expert-review-submission-intake.test.mjs
+++ b/apps/tai/tests/expert-review-submission-intake.test.mjs
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -36,6 +44,10 @@ function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
 
+function digest(label) {
+  return createHash('sha256').update(`external-evidence:${label}`).digest('hex');
+}
+
 function resign(review) {
   const payload = { ...review };
   delete payload.review_sha256;
@@ -52,7 +64,7 @@ function record(caseValue, role, reviewer, suffix = '01') {
     reviewer_role: role,
     decision: 'APPROVED',
     reviewed_at: '2026-07-21T10:10:00Z',
-    evidence_sha256: 'e'.repeat(64),
+    evidence_sha256: digest(`${caseValue.case_id}:${role}:${reviewer}:${suffix}`),
     disagreement_with_review_id: null,
     review_sha256: '',
   });
@@ -71,14 +83,14 @@ function envelope(packet, trackId, reviews) {
   };
 }
 
-function fixture(existing = null) {
+function fixture(existing = null, generatedAt = GENERATED_AT) {
   const root = mkdtempSync(resolve(tmpdir(), 'tai-review-intake-'));
   const existingReviewsPath = resolve(root, 'existing-reviews.json');
   writeJson(existingReviewsPath, existing ?? json(REPO_REVIEWS));
   const packetDirectory = resolve(root, 'packet');
   const packet = buildExpertReviewPacket({
     exactMainSha: EXACT_MAIN,
-    generatedAt: GENERATED_AT,
+    generatedAt,
     reviewsPath: existingReviewsPath,
   });
   materializeExpertReviewPacket(packet, packetDirectory);
@@ -94,16 +106,18 @@ function fixture(existing = null) {
   };
 }
 
-function run(input) {
+function run(input, overrides = {}) {
   return ingestExpertReviewSubmission({
     ...input,
     exactMainSha: EXACT_MAIN,
+    expectedPacketSha256: input.packet.packet_sha256,
     evaluatedAt: EVALUATED_AT,
+    ...overrides,
   });
 }
 
-function useFixture(existing, callback) {
-  const input = fixture(existing);
+function useFixture(existing, callback, generatedAt = GENERATED_AT) {
+  const input = fixture(existing, generatedAt);
   try {
     callback(input);
   } finally {
@@ -127,6 +141,7 @@ useFixture(null, (input) => {
   assert.equal(report.reviews_added, 1);
   assert.equal(report.automation_created_decisions, false);
   assert.equal(report.candidate_assessment_status, 'PENDING_REVIEW');
+  assert.match(report.packet_file_sha256, /^[0-9a-f]{64}$/);
   assert.equal(json(input.outputReviewsPath).reviews.length, 1);
   assert.equal(json(input.outputAssessmentPath).counts.reviewed_cases, 1);
 });
@@ -165,9 +180,9 @@ const mutations = [
     },
   ],
   [
-    /evidence SHA-256 is invalid/,
+    /non-placeholder SHA-256/,
     (review) => {
-      review.evidence_sha256 = 'invalid';
+      review.evidence_sha256 = 'e'.repeat(64);
       resign(review);
     },
   ],
@@ -230,6 +245,80 @@ useFixture(null, (input) => {
   value.packet_sha256 = '0'.repeat(64);
   writeJson(input.submissionPath, value);
   assert.throws(() => run(input), /submission packet mismatch/);
+});
+
+useFixture(null, (input) => {
+  const review = record(normalPlatform(input.packet), 'PLATFORM_OWNER', 'platform-owner-01');
+  writeJson(input.submissionPath, envelope(input.packet, 'platform-primary', [review]));
+  assert.throws(
+    () => run(input, { expectedPacketSha256: '0'.repeat(64) }),
+    /trusted digest/,
+  );
+});
+
+useFixture(null, (input) => {
+  const review = record(normalPlatform(input.packet), 'PLATFORM_OWNER', 'platform-owner-01');
+  const value = envelope(input.packet, 'platform-primary', [review]);
+  const compact = JSON.stringify(value);
+  const duplicate = compact.replace(
+    '"track_id":"platform-primary"',
+    '"track_id":"platform-primary","track_id":"agro-primary"',
+  );
+  writeFileSync(input.submissionPath, duplicate, 'utf8');
+  assert.throws(() => run(input), /duplicate JSON key "track_id"/);
+});
+
+useFixture(null, (input) => {
+  const review = record(normalPlatform(input.packet), 'PLATFORM_OWNER', 'platform-owner-01');
+  review.reviewed_at = '2026-02-30T10:10:00Z';
+  resign(review);
+  writeJson(input.submissionPath, envelope(input.packet, 'platform-primary', [review]));
+  assert.throws(() => run(input), /day is invalid/);
+});
+
+useFixture(
+  null,
+  (input) => {
+    const review = record(normalPlatform(input.packet), 'PLATFORM_OWNER', 'platform-owner-01');
+    const value = envelope(input.packet, 'platform-primary', [review]);
+    value.submitted_at = '2026-07-21T10:22:00Z';
+    writeJson(input.submissionPath, value);
+    assert.throws(() => run(input), /packet generation timestamp is in the future/);
+  },
+  '2026-07-21T10:21:00Z',
+);
+
+useFixture(null, (input) => {
+  const review = record(normalPlatform(input.packet), 'PLATFORM_OWNER', 'platform-owner-01');
+  writeJson(input.submissionPath, envelope(input.packet, 'platform-primary', [review]));
+  assert.throws(
+    () => run(input, { outputReviewsPath: input.existingReviewsPath }),
+    /output path must not overlap an input/,
+  );
+  assert.equal(existsSync(input.outputAssessmentPath), false);
+  assert.equal(existsSync(input.outputReportPath), false);
+});
+
+useFixture(null, (input) => {
+  const review = record(normalPlatform(input.packet), 'PLATFORM_OWNER', 'platform-owner-01');
+  writeJson(input.submissionPath, envelope(input.packet, 'platform-primary', [review]));
+  assert.throws(
+    () => run(input, { outputAssessmentPath: input.outputReviewsPath }),
+    /canonically distinct/,
+  );
+  assert.equal(existsSync(input.outputReviewsPath), false);
+  assert.equal(existsSync(input.outputReportPath), false);
+});
+
+useFixture(null, (input) => {
+  const review = record(normalPlatform(input.packet), 'PLATFORM_OWNER', 'platform-owner-01');
+  writeJson(input.submissionPath, envelope(input.packet, 'platform-primary', [review]));
+  const symlinkTarget = resolve(input.root, 'symlink-target.json');
+  writeFileSync(symlinkTarget, '{}\n', 'utf8');
+  symlinkSync(symlinkTarget, input.outputAssessmentPath);
+  assert.throws(() => run(input), /must not be a symbolic link/);
+  assert.equal(existsSync(input.outputReviewsPath), false);
+  assert.equal(existsSync(input.outputReportPath), false);
 });
 
 process.stdout.write('expert review submission intake tests: PASS\n');

--- a/apps/tai/tests/expert-review-submission-packet-authority.test.mjs
+++ b/apps/tai/tests/expert-review-submission-packet-authority.test.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import {
+  buildExpertReviewPacket,
+  materializeExpertReviewPacket,
+} from '../model-artifacts/expert-review-packet.mjs';
+import { ingestExpertReviewSubmission } from '../model-artifacts/expert-review-submission-intake.mjs';
+import { sha256 } from '../../../docs/platform-v7/autopilot/tai-ap-14c/gold-set-authority.mjs';
+
+const exactMain = 'b'.repeat(40);
+const root = mkdtempSync(resolve(tmpdir(), 'tai-forged-review-packet-'));
+
+try {
+  const packetDirectory = resolve(root, 'packet');
+  const packet = buildExpertReviewPacket({
+    exactMainSha: exactMain,
+    generatedAt: '2026-07-21T10:00:00Z',
+  });
+  materializeExpertReviewPacket(packet, packetDirectory);
+
+  const packetPath = resolve(packetDirectory, 'expert-review-packet.v1.json');
+  const forged = JSON.parse(readFileSync(packetPath, 'utf8'));
+  const agroCase = forged.cases.find((item) => item.domain === 'AGRO');
+  assert.ok(agroCase);
+  const platformTrack = forged.reviewer_tracks.find(
+    (item) => item.track_id === 'platform-primary',
+  );
+  assert.ok(platformTrack);
+  platformTrack.case_ids.push(agroCase.case_id);
+  platformTrack.case_count += 1;
+  const forgedPayload = { ...forged };
+  delete forgedPayload.packet_sha256;
+  forged.packet_sha256 = sha256(forgedPayload);
+  writeFileSync(packetPath, `${JSON.stringify(forged, null, 2)}\n`, 'utf8');
+
+  const review = {
+    review_id: 'forged-cross-domain-review-01',
+    case_id: agroCase.case_id,
+    case_sha256: agroCase.case_sha256,
+    reviewer_id: 'platform-owner-01',
+    reviewer_role: 'PLATFORM_OWNER',
+    decision: 'APPROVED',
+    reviewed_at: '2026-07-21T10:10:00Z',
+    evidence_sha256: 'e'.repeat(64),
+    disagreement_with_review_id: null,
+    review_sha256: '',
+  };
+  const reviewPayload = { ...review };
+  delete reviewPayload.review_sha256;
+  review.review_sha256 = sha256(reviewPayload);
+
+  const submissionPath = resolve(root, 'submission.json');
+  writeFileSync(
+    submissionPath,
+    `${JSON.stringify({
+      schema_version: 'tai.expert-review-submission.v1',
+      exact_main_sha: exactMain,
+      corpus_sha256: forged.corpus_sha256,
+      packet_sha256: forged.packet_sha256,
+      track_id: 'platform-primary',
+      submitter_id: 'review-coordinator-01',
+      submitted_at: '2026-07-21T10:20:00Z',
+      reviews: [review],
+    }, null, 2)}\n`,
+    'utf8',
+  );
+
+  assert.throws(
+    () => ingestExpertReviewSubmission({
+      packetPath,
+      submissionPath,
+      existingReviewsPath: resolve(
+        'docs/platform-v7/autopilot/tai-ap-14c/expert-reviews.v1.json',
+      ),
+      exactMainSha: exactMain,
+      evaluatedAt: '2026-07-21T10:20:00Z',
+      outputReviewsPath: resolve(root, 'candidate-reviews.json'),
+      outputAssessmentPath: resolve(root, 'candidate-assessment.json'),
+      outputReportPath: resolve(root, 'candidate-report.json'),
+    }),
+    /packet does not match current governed packet authority/,
+  );
+
+  process.stdout.write('expert review packet authority adversarial test: PASS\n');
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/apps/tai/tests/expert-review-submission-packet-authority.test.mjs
+++ b/apps/tai/tests/expert-review-submission-packet-authority.test.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import {
   mkdtempSync,
   readFileSync,
@@ -51,7 +52,9 @@ try {
     reviewer_role: 'PLATFORM_OWNER',
     decision: 'APPROVED',
     reviewed_at: '2026-07-21T10:10:00Z',
-    evidence_sha256: 'e'.repeat(64),
+    evidence_sha256: createHash('sha256')
+      .update('external-evidence:forged-cross-domain-review-01')
+      .digest('hex'),
     disagreement_with_review_id: null,
     review_sha256: '',
   };
@@ -83,6 +86,7 @@ try {
         'docs/platform-v7/autopilot/tai-ap-14c/expert-reviews.v1.json',
       ),
       exactMainSha: exactMain,
+      expectedPacketSha256: forged.packet_sha256,
       evaluatedAt: '2026-07-21T10:20:00Z',
       outputReviewsPath: resolve(root, 'candidate-reviews.json'),
       outputAssessmentPath: resolve(root, 'candidate-assessment.json'),


### PR DESCRIPTION
## Scope

Adds the offline fail-closed intake contour for real externally completed AP-14C expert-review submissions.

## Delivered

- exact packet, trusted packet SHA-256, corpus, exact-main and reviewer-track binding;
- reconstruction of the governed packet authority, so an internally self-consistent forged packet cannot redefine tracks, cases or policy;
- four track-bound intake templates with authority fields fixed and human-only fields blank;
- strict duplicate-key and unknown-field rejection;
- stale case, wrong track/role, placeholder identity/evidence, invalid or future timestamp, invalid digest, duplicate/conflict and replacement rejection;
- independent same-case disagreement validation;
- input/output alias rejection;
- rollback-capable local transaction for candidate reviews, assessment and report;
- deterministic candidate `expert-reviews.v1.json`, `baseline-assessment.v1.json` and intake report;
- dedicated exact-head Node gate covering packet compatibility, positive/negative intake paths and a self-signed forged-packet attack;
- bounded stdout/stderr evidence and operational runbook.

## Authority boundary

Automation creates no `APPROVED`, `REJECTED` or `NEEDS_CHANGES` decision. It cannot write to GitHub, accept the corpus, close #2973, run a model or start a benchmark. Outputs are local candidates requiring external evidence verification and a separate human-reviewed pull request.

## Current maturity

- expert review: `PENDING_REVIEW`;
- benchmark: `PENDING_BENCHMARK`;
- model admission: `PENDING_ADMISSION`;
- production operational status: `NOT_ATTESTED`.

Refs #2986, #2973, #2788 and #2726.